### PR TITLE
Docker cacheing and python2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM debian:stable-slim as python-base
-RUN apt-get update && \
-  apt-get install --no-install-recommends -y libffi6 python python-pip  && \
-  adduser --system --shell /bin/bash --group --disabled-password --no-create-home --home /cowrie cowrie && \
-  mkdir -p /cowrie/var/lib/cowrie/downloads && \
-  mkdir -p /cowrie/var/lib/cowrie/tty && \
-  mkdir -p /cowrie/var/log/cowrie/ && \
-  chown -R cowrie:cowrie /cowrie && \
-  chmod -R a+rX /cowrie
+RUN apt-get update
+RUN  apt-get install --no-install-recommends -y libffi6 python python-pip
+RUN  adduser --system --shell /bin/bash --group --disabled-password --no-create-home --home /cowrie cowrie
+RUN  mkdir -p /cowrie/var/lib/cowrie/downloads
+RUN  mkdir -p /cowrie/var/lib/cowrie/tty
+RUN  mkdir -p /cowrie/var/log/cowrie/
+RUN  chown -R cowrie:cowrie /cowrie
+RUN  chmod -R a+rX /cowrie
 COPY requirements.txt .
 COPY requirements-output.txt .
 COPY honeyfs /cowrie/honeyfs
@@ -14,14 +14,14 @@ COPY share /cowrie/share
 COPY etc /cowrie/etc
 
 FROM python-base as builder
-RUN apt-get install --no-install-recommends -y python-wheel python-setuptools build-essential libssl-dev libffi-dev python-dev libsnappy-dev default-libmysqlclient-dev && \
-  pip wheel --wheel-dir=/root/wheelhouse -r requirements.txt && \
-  pip wheel --wheel-dir=/root/wheelhouse -r requirements-output.txt
+RUN apt-get install --no-install-recommends -y python-wheel python-setuptools build-essential libssl-dev libffi-dev python-dev libsnappy-dev default-libmysqlclient-dev
+RUN  pip wheel --wheel-dir=/root/wheelhouse -r requirements.txt
+RUN  pip wheel --wheel-dir=/root/wheelhouse -r requirements-output.txt
 
 FROM python-base as post-builder
 COPY --from=builder /root/wheelhouse /root/wheelhouse
-RUN pip install -r requirements.txt --no-index --find-links=/root/wheelhouse && \
-  pip install -r requirements-output.txt --no-index --find-links=/root/wheelhouse
+RUN pip install -r requirements.txt --no-index --find-links=/root/wheelhouse
+RUN  pip install -r requirements-output.txt --no-index --find-links=/root/wheelhouse
 
 FROM post-builder as pre-devel
 RUN pip install flake8 flake8-import-order pytest

--- a/Dockerfile.python2
+++ b/Dockerfile.python2
@@ -1,6 +1,6 @@
-FROM debian:stable-slim as python3-base
+FROM debian:stable-slim as python-base
 RUN apt-get update
-RUN  apt-get install --no-install-recommends -y libffi6 python3 python3-pip
+RUN  apt-get install --no-install-recommends -y libffi6 python python-pip
 RUN  adduser --system --shell /bin/bash --group --disabled-password --no-create-home --home /cowrie cowrie
 RUN  mkdir -p /cowrie/var/lib/cowrie/downloads
 RUN  mkdir -p /cowrie/var/lib/cowrie/tty
@@ -13,18 +13,18 @@ COPY honeyfs /cowrie/honeyfs
 COPY share /cowrie/share
 COPY etc /cowrie/etc
 
-FROM python3-base as builder
-RUN apt-get install --no-install-recommends -y python3-wheel python3-setuptools build-essential libssl-dev libffi-dev python3-dev libsnappy-dev default-libmysqlclient-dev
-RUN  pip3 wheel --wheel-dir=/root/wheelhouse -r requirements.txt
-RUN  pip3 wheel --wheel-dir=/root/wheelhouse -r requirements-output.txt
+FROM python-base as builder
+RUN apt-get install --no-install-recommends -y python-wheel python-setuptools build-essential libssl-dev libffi-dev python-dev libsnappy-dev default-libmysqlclient-dev
+RUN  pip wheel --wheel-dir=/root/wheelhouse -r requirements.txt
+RUN  pip wheel --wheel-dir=/root/wheelhouse -r requirements-output.txt
 
-FROM python3-base as post-builder
+FROM python-base as post-builder
 COPY --from=builder /root/wheelhouse /root/wheelhouse
-RUN pip3 install -r requirements.txt --no-index --find-links=/root/wheelhouse
-RUN  pip3 install -r requirements-output.txt --no-index --find-links=/root/wheelhouse
+RUN pip install -r requirements.txt --no-index --find-links=/root/wheelhouse
+RUN  pip install -r requirements-output.txt --no-index --find-links=/root/wheelhouse
 
 FROM post-builder as pre-devel
-RUN pip3 install flake8 flake8-import-order pytest
+RUN pip install flake8 flake8-import-order pytest
 
 FROM pre-devel as devel
 USER cowrie
@@ -37,7 +37,7 @@ RUN flake8 --count --application-import-names cowrie --max-line-length=120 --sta
   trial cowrie
 
 FROM post-builder as pre-release
-RUN apt-get remove -y python3-pip && \
+RUN apt-get remove -y python-pip && \
   apt-get autoremove -y && \
   apt-get autoclean -y && \
   rm -rf /root/wheelhouse && \
@@ -54,4 +54,4 @@ WORKDIR /cowrie
 EXPOSE 2222/tcp
 EXPOSE 2223/tcp
 USER cowrie
-CMD /usr/bin/python3 /usr/local/bin/twistd --umask 0022 --nodaemon --pidfile= -l - cowrie
+CMD /usr/bin/python /usr/local/bin/twistd --umask 0022 --nodaemon --pidfile= -l - cowrie


### PR DESCRIPTION
Use more caching features of Docker for building the devel image.
Downsite of this is that for users who heavily build the image it will
eat up more disk space then before.
But I think think only developers are affected here and all others will
pull from the registry.
A regular docker cleanup on the machines will solve this problem.

The main Dockerfile will build now a python3 based image.
A copy of the old python2 file is still available for further testing.