### PR TITLE
Add flavor: Debian or RedHat. Will affect prompt and commands

### DIFF
--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -28,6 +28,12 @@
 # (default: svr04)
 hostname = svr04
 
+# Flavor to emulate: Debian or RedHat. This will make a difference in 
+# the prompt and the available commands
+#
+# (default: Debian)
+flavor = Debian
+
 
 # Directory where to save log files in.
 #

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -11,6 +11,7 @@ import sys
 from twisted.internet import error
 from twisted.python import failure, log
 
+from cowrie.core.config import CONFIG
 from cowrie.shell import fs
 
 # From Python3.6 we get the new shlex version
@@ -232,7 +233,16 @@ class HoneyPotShell(object):
 
         # Example: [root@svr03 ~]#   (More of a "CentOS" feel)
         # Example: root@svr03:~#     (More of a "Debian" feel)
-        prompt = '{0}@{1}:{2}'.format(self.protocol.user.username, self.protocol.hostname, cwd)
+        try:
+            self.flavor = CONFIG.getboolean('honeypot', 'flavor')
+        except Exception:
+            self.flavor = 'Debian'
+
+        if self.flavor == 'Debian':
+            prompt = '{0}@{1}:{2}'.format(self.protocol.user.username, self.protocol.hostname, cwd)
+        else:
+            prompt = '[{0}@{1} {2}]'.format(self.protocol.user.username, self.protocol.hostname, cwd)
+
         if not self.protocol.user.uid:
             prompt += '# '  # "Root" user
         else:


### PR DESCRIPTION
Actually this is not done yet. What I also want to do is to enable `yum` only for RedHat based systems and enable `apt` only for Debian based systems (default). Within my setup I used to modify `commands/__init.__py` . I thought about putting conditions into that file and modify `__all__` according to the flavor in the configurations. Or is there a better way?