### PR TITLE
Improving honeypot fingerprinting resistance

### DIFF
--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -507,6 +507,12 @@ class command_touch(HoneyPotCommand):
             if self.fs.exists(pname):
                 # FIXME: modify the timestamp here
                 continue
+            # can't touch in special directories
+            if any([pname.startswith(_p) for _p in fs.SPECIAL_PATHS]):
+                self.errorWrite(
+                    'touch: cannot touch `{}`: Permission denied\n'.format(pname))
+                return
+
             self.fs.mkfile(pname, 0, 0, 0, 33188)
 
 

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -261,7 +261,10 @@ class command_rm(HoneyPotCommand):
         for f in self.args:
             pname = self.fs.resolve_path(f, self.protocol.cwd)
             try:
+                # verify path to file exists
                 dir = self.fs.get_path('/'.join(pname.split('/')[:-1]))
+                # verify that the file itself exists
+                self.fs.get_path(pname)
             except (IndexError, fs.FileNotFound):
                 self.errorWrite(
                     'rm: cannot remove `{}\': No such file or directory\n'.format(f))

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -70,6 +70,12 @@ class HoneyPotCommand(object):
                     self.writefn = self.write_to_failed
                     self.outfile = None
                     self.safeoutfile = None
+                except fs.PermissionDenied:
+                    # The outfile locates in a file-system that doesn't allow file creation
+                    self.protocol.pp.outReceived('-bash: %s: Permission denied\n' % self.outfile)
+                    self.writefn = self.write_to_failed
+                    self.outfile = None
+                    self.safeoutfile = None
 
                 else:
                     with open(self.safeoutfile, 'ab'):

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -66,13 +66,13 @@ class HoneyPotCommand(object):
                     self.fs.mkfile(self.outfile, 0, 0, 0, stat.S_IFREG | perm)
                 except fs.FileNotFound:
                     # The outfile locates at a non-existing directory.
-                    self.protocol.pp.outReceived('-bash: %s: No such file or directory\n' % self.outfile)
+                    self.errorWrite('-bash: %s: No such file or directory\n' % self.outfile)
                     self.writefn = self.write_to_failed
                     self.outfile = None
                     self.safeoutfile = None
                 except fs.PermissionDenied:
                     # The outfile locates in a file-system that doesn't allow file creation
-                    self.protocol.pp.outReceived('-bash: %s: Permission denied\n' % self.outfile)
+                    self.errorWrite('-bash: %s: Permission denied\n' % self.outfile)
                     self.writefn = self.write_to_failed
                     self.outfile = None
                     self.safeoutfile = None

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -58,10 +58,10 @@ class FileNotFound(Exception):
 
 class PermissionDenied(Exception):
     """
-    Our implementation is naive for now and works only on file redirects
+    Our implementation is rather naive for now
 
-    * TODO: PermissionDenied errors when using touch
-    * TODO: Top-level /proc should return no such file not permission denied
+    * TODO: Top-level /proc should return 'no such file' not 'permission
+            denied'. However this seems to vary based on kernel version.
 
     $ sudo touch /sys/.nippon
     touch: cannot touch '/sys/.nippon': Permission denied

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -34,6 +34,7 @@ T_LINK, T_DIR, T_FILE, T_BLK, T_CHR, T_SOCK, T_FIFO = list(range(0, 7))
 
 SPECIAL_PATHS = ['/sys', '/proc', '/dev/pts']
 
+
 class TooManyLevels(Exception):
     """
     62 ELOOP Too many levels of symbolic links.  A path name lookup involved more than 8 symbolic links.
@@ -279,7 +280,7 @@ class HoneyPotFilesystem(object):
         if outfile in [x[A_NAME] for x in _dir]:
             _dir.remove([x for x in _dir if x[A_NAME] == outfile][0])
         _dir.append([outfile, T_FILE, uid, gid, size, mode, ctime, [],
-            None, None])
+                     None, None])
         self.newcount += 1
         return True
 


### PR DESCRIPTION
We exposed Cowrie honeypots on the Internet and implemented steps to avoid being fingerprinted by large botnets. Now we are pushing the changes upstream.

* Deleting a non-existing file should throw and error
* Creating files under special filesystems (`/proc`, `/sys`, `/dev/pts`) should return an error

See these asciinema files to look at the changed behavior: [current cowrie](https://asciinema.org/a/wbZgAmZVDzLzG0NeLtDnMXwIA), [patched cowrie](https://asciinema.org/a/9HBowxdKJX4BY9RaIWcyLxlD9).

This work was done by myself as part of GeekWeek IV, a Cyber defense event led by CCIRC (Canadian CERT), now CCCS (Canadian Centre for Cyber Security). Cleaned up and submitted as part of GeekWeek V. It increased sample collection by more than 230x over a 24 hour period.