### PR TITLE
Format expression cleanup

### DIFF
--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -624,7 +624,7 @@ class command_yes(HoneyPotCommand):
 
     def y(self):
         if len(self.args):
-            self.write("{0}{1}".format(' '.join(self.args, '\n')))
+            self.write("{0}\n".format(' '.join(self.args, '\n')))
         else:
             self.write('y\n')
         self.scheduled = reactor.callLater(0.01, self.y)

--- a/src/cowrie/commands/yum.py
+++ b/src/cowrie/commands/yum.py
@@ -63,7 +63,7 @@ class command_yum(HoneyPotCommand):
         randhash = hashlib.sha1(b'{}'.format(randnum)).hexdigest()
         randhash2 = hashlib.sha1(b'{}'.format(randnum2)).hexdigest()
         yield self.sleep(1, 2)
-        self.write('Installed: 7/{0}  {1}:{2}\n'.format((arch, random.randint(500, 800), randhash)))
+        self.write('Installed: 7/{0}  {1}:{2}\n'.format(arch, random.randint(500, 800), randhash))
         self.write('Group-Installed: yum 13:{}\n'.format(randhash2))
         self.write('version\n')
         self.exit()


### PR DESCRIPTION
I've noticed two `.format()` expressions which appear incorrect and corrected the issue.

It appears that in [one case](https://lgtm.com/projects/g/cowrie/cowrie/snapshot/6777d1b24846118c0ead2ecae5904fa3f9783e6b/files/src/cowrie/commands/yum.py?sort=name&dir=ASC&mode=heatmap#x6fd9fe7d8e9b7455:1), that would have led to the write being incomplete; the [other time](https://lgtm.com/projects/g/cowrie/cowrie/snapshot/6777d1b24846118c0ead2ecae5904fa3f9783e6b/files/src/cowrie/commands/base.py?sort=name&dir=ASC&mode=heatmap#xa530c8b9f82200e1:1) it could have led to an error.

Full disclosure: I was alerted to those issues by LGTM.com, a code analysis platform which I also work for.