### PR TITLE
Log directly to stdout

### DIFF
--- a/bin/cowrie
+++ b/bin/cowrie
@@ -9,6 +9,9 @@ AUTHBIND_ENABLED=no
 #Change the below to -n to disable daemonizing (for instance when using supervisor)
 DAEMONIZE=""
 
+# Log to stdout instead of a separate file (same behaviour as Docker)
+STDOUT="yes"
+
 ################################################################################
 ## don't modify below here ##
 ################################################################################
@@ -74,7 +77,7 @@ cowrie_start() {
     TWISTEDARGS="${DAEMONIZE} ${XARGS} --umask=0022 --pidfile=${PIDFILE}"
 
     # For Docker log to stdout, for non-Docker log to file
-    if [ "$DOCKER" = "yes" ]; then
+    if [ "$STDOUT" = "yes" ]; then
         TWISTEDARGS="${TWISTEDARGS} -l -"
     else
         TWISTEDARGS="${TWISTEDARGS} --logger cowrie.python.logfile.logger"
@@ -178,7 +181,7 @@ for dir in ${COWRIEDIR}/twisted ${COWRIEDIR}/cowrie; do
 done
 
 # Don't store pidfile on Docker persistent volume
-if [ "$DOCKER" = "yes" ]; then
+if [ "$STDOUT" = "yes" ]; then
         PIDFILE=""
 else
         PIDFILE=var/run/cowrie.pid


### PR DESCRIPTION
With these changes, it will be easy to log directly to stdout and there wouldn't be any log file in play. This can be activated by changing 
```
DAEMONIZE="-n"

STDOUT="yes"
```

If someone would like to continue to log to a file then they can keep the value of `DAEMONIZE=""` empty string and then everything will be logged to a file.

This actually gives a similar behaviour of a docker.