### PR TITLE
Fix super() of ftpget for python2

### DIFF
--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -21,7 +21,7 @@ class FTP(ftplib.FTP):
 
     def __init__(self, *args, **kwargs):
         self.source_address = kwargs.pop("source_address", None)
-        super(FTP, self).__init__(*args, **kwargs)
+        ftplib.FTP.__init__(self, *args, **kwargs)
 
     def connect(self, host='', port=0, timeout=-999, source_address=None):
         if host != '':


### PR DESCRIPTION
Fixes #988 
These changes also work with python3.

