### PR TITLE
[#1009] - correct fs error message and provide pickle fs encoding

### DIFF
--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -29,7 +29,7 @@ except UnicodeDecodeError:
     with open(CONFIG.get('shell', 'filesystem'), 'rb') as f:
         PICKLE = pickle.load(f, encoding='utf8')
 except Exception as e:
-    print("ERROR: Failed to load filesystem: ", e)
+    log.err(e, "ERROR: Failed to load filesystem")
     exit(2)
 
 A_NAME, A_TYPE, A_UID, A_GID, A_SIZE, A_MODE, A_CTIME, A_CONTENTS, A_TARGET, A_REALFILE = list(range(0, 10))

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -23,9 +23,9 @@ from cowrie.core.config import CONFIG
 # At the moment this is the first place a config file is used
 # Put extra help here in case it goes wrong
 try:
-    PICKLE = pickle.load(open(CONFIG.get('shell', 'filesystem'), 'rb'))
-except Exception:
-    print("ERROR: Config file not found: etc/cowrie.cfg.dist")
+    PICKLE = pickle.load(open(CONFIG.get('shell', 'filesystem'), 'rb'), encoding='utf8')
+except Exception as e:
+    print("ERROR: Failed to load filesystem: ", e)
     exit(2)
 
 A_NAME, A_TYPE, A_UID, A_GID, A_SIZE, A_MODE, A_CTIME, A_CONTENTS, A_TARGET, A_REALFILE = list(range(0, 10))

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -23,7 +23,11 @@ from cowrie.core.config import CONFIG
 # At the moment this is the first place a config file is used
 # Put extra help here in case it goes wrong
 try:
-    PICKLE = pickle.load(open(CONFIG.get('shell', 'filesystem'), 'rb'), encoding='utf8')
+    with open(CONFIG.get('shell', 'filesystem'), 'rb') as f:
+        PICKLE = pickle.load(f)
+except UnicodeDecodeError:
+    with open(CONFIG.get('shell', 'filesystem'), 'rb') as f:
+        PICKLE = pickle.load(f, encoding='utf8')
 except Exception as e:
     print("ERROR: Failed to load filesystem: ", e)
     exit(2)


### PR DESCRIPTION
this pull request addresses the issue with the cryptic error message and allows the filesystem to load using 'utf8' encoding rather than 'ascii' encoding.