### PR TITLE
Remove deprecated functions

### DIFF
--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -79,7 +79,7 @@ class ShellBaseCommandsTests(unittest.TestCase):
 
     def test_date_command(self):
         self.proto.lineReceived(b'date\n')
-        self.assertRegexpMatches(
+        self.assertRegex(
             self.tr.value(),
             b'[A-Za-z][A-Za-z][A-Za-z] [A-Za-z][A-Za-z][A-Za-z] [0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9] UTC [0-9][0-9][0-9][0-9]\n' + PROMPT)  # noqa: E501
 

--- a/src/cowrie/test/test_utils.py
+++ b/src/cowrie/test/test_utils.py
@@ -12,7 +12,7 @@ from cowrie.core.utils import create_endpoint_services, durationHuman, get_endpo
 
 def get_config(config_string):
     config = configparser.RawConfigParser()
-    config.readfp(StringIO(config_string))
+    config.read_file(StringIO(config_string))
     return config
 
 


### PR DESCRIPTION
When running the test pytest gave the following warning:

```
src/cowrie/test/test_base_commands.py::ShellBaseCommandsTests::test_date_command
  /home/mzfr/dev/cowrie/src/cowrie/test/test_base_commands.py:84: DeprecationWarning: Please use assertRegex instead.
    b'[A-Za-z][A-Za-z][A-Za-z] [A-Za-z][A-Za-z][A-Za-z] [0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9] UTC [0-9][0-9][0-9][0-9]\n' + PROMPT)  # noqa: E501

src/cowrie/test/test_utils.py::UtilsTestCase::test_get_endpoints_from_section
src/cowrie/test/test_utils.py::UtilsTestCase::test_get_endpoints_from_section
src/cowrie/test/test_utils.py::UtilsTestCase::test_get_endpoints_from_section
src/cowrie/test/test_utils.py::UtilsTestCase::test_get_endpoints_from_section
src/cowrie/test/test_utils.py::UtilsTestCase::test_get_endpoints_from_section
  /home/mzfr/dev/cowrie/src/cowrie/test/test_utils.py:15: DeprecationWarning: This method will be removed in future versions.  Use 'parser.read_file()' instead.
    config.readfp(StringIO(config_string))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

So just updated those two functions.