### PR TITLE
Fix config usage order and root dir

### DIFF
--- a/src/cowrie/core/config.py
+++ b/src/cowrie/core/config.py
@@ -47,8 +47,8 @@ def readConfigFile(cfgfile):
 def get_config_path():
     """Get absolute path to the config file
     """
-    config_files = ["etc/cowrie/cowrie.cfg", "etc/cowrie.cfg",
-                    "cowrie.cfg", "etc/cowrie.cfg.dist"]
+    config_files = ["etc/cowrie.cfg.dist", "etc/cowrie/cowrie.cfg",
+                    "etc/cowrie.cfg", "cowrie.cfg"]
     current_path = abspath(dirname(__file__))
     root = "/".join(current_path.split("/")[:-3])
 

--- a/src/cowrie/core/config.py
+++ b/src/cowrie/core/config.py
@@ -52,7 +52,7 @@ def get_config_path():
 
     config_files = [join(root, "etc/cowrie.cfg.dist"), "/etc/cowrie/cowrie.cfg",
                     join(root, "etc/cowrie.cfg"), join(root, "cowrie.cfg")]
-    found_confs = [path for path in conf_abs_paths if exists(path)]
+    found_confs = [path for path in config_files if exists(path)]
 
     if found_confs:
         return found_confs

--- a/src/cowrie/core/config.py
+++ b/src/cowrie/core/config.py
@@ -47,12 +47,11 @@ def readConfigFile(cfgfile):
 def get_config_path():
     """Get absolute path to the config file
     """
-    config_files = ["etc/cowrie.cfg.dist", "etc/cowrie/cowrie.cfg",
-                    "etc/cowrie.cfg", "cowrie.cfg"]
     current_path = abspath(dirname(__file__))
     root = "/".join(current_path.split("/")[:-3])
 
-    conf_abs_paths = (join(root, file) for file in config_files)
+    config_files = [join(root, "etc/cowrie.cfg.dist"), "/etc/cowrie/cowrie.cfg",
+                    join(root, "etc/cowrie.cfg"), join(root, "cowrie.cfg")]
     found_confs = [path for path in conf_abs_paths if exists(path)]
 
     if found_confs:


### PR DESCRIPTION
Two issues I didn't notice earlier back with #1022 - commit  253ed34370ff28ddaf6d82ef0f1469607a581f0f also changed the order of the config files...  With the .dist last in the list, configparser causes its settings to override other config files.  This is not the intended functionality.  It should be first in the list.  This pull request changes config file ordering back to what it was originally.

While doing that - I noticed that "/etc/cowrie/cowrie.cfg" (starting at actual filesystem root) was no longer a valid config file.  It would always get pulled as a relative path, instead of being absolute.  This pull also changes that by applying the join only to the other config files.  Since this file needed to be second, my code is pretty inelegant.  But at least it's clear.

I'm interested in how we can add checks for intended config file order to the test suite...  I'll bring that up over in #1022 though...