### PR TITLE
Fix sendall problem with Python3

### DIFF
--- a/src/cowrie/output/socketlog.py
+++ b/src/cowrie/output/socketlog.py
@@ -35,10 +35,10 @@ class Output(cowrie.core.output.Output):
         message = json.dumps(logentry) + '\n'
 
         try:
-            self.sock.sendall(message)
+            self.sock.sendall(message.encode())
         except socket.error as ex:
             if ex.errno == 32:  # Broken pipe
                 self.start()
-                self.sock.sendall(message)
+                self.sock.sendall(message.encode())
             else:
                 raise


### PR DESCRIPTION
In python3, messages must be "bytes" to send them, not str.  ".encode()" encodes these strings so they're sent.  In Python2 ".encode()" returns another string, and there things must be "str" to send - so this will not immediately break Python2.

I was a little worried about strange edge cases - things like unicode or non-ascii characters getting to ".encode()", which would then error out.  However - the message going to ".encode()" comes from json.dumps, which _by default_ escapes all non-ascii characters.  We should be good.

Fixes bug #1036 