### PR TITLE
Create home dir for users not in /etc/passwd

### DIFF
--- a/src/cowrie/shell/avatar.py
+++ b/src/cowrie/shell/avatar.py
@@ -30,13 +30,14 @@ class CowrieUser(avatar.ConchUser):
 
         try:
             pwentry = pwd.Passwd().getpwnam(self.username)
-            self.uid = pwentry['pw_uid']
-            self.gid = pwentry['pw_gid']
-            self.home = pwentry['pw_dir']
+            self.temporary = False
         except Exception:
-            self.uid = 1001
-            self.gid = 1001
-            self.home = '/home'
+            pwentry = pwd.Passwd().setpwentry(self.username)
+            self.temporary = True
+
+        self.uid = pwentry['pw_uid']
+        self.gid = pwentry['pw_gid']
+        self.home = pwentry['pw_dir']
 
         # SFTP support enabled only when option is explicitly set
         if CONFIG.getboolean('ssh', 'sftp_enabled', fallback=False):

--- a/src/cowrie/shell/pwd.py
+++ b/src/cowrie/shell/pwd.py
@@ -27,7 +27,8 @@
 # SUCH DAMAGE.
 
 from __future__ import absolute_import, division
-from random import randint
+from random import randint, seed
+import binascii
 
 from cowrie.core.config import CONFIG
 
@@ -113,6 +114,11 @@ class Passwd(object):
         """
         If the user is not in /etc/passwd, creates a new user entry for the session
         """
+
+        # ensure consistent uid and gid
+        seed_id = binascii.crc32(name)
+        seed(seed_id)
+
         e = {}
         e["pw_name"] = name
         e["pw_passwd"] = "x"

--- a/src/cowrie/shell/pwd.py
+++ b/src/cowrie/shell/pwd.py
@@ -27,6 +27,7 @@
 # SUCH DAMAGE.
 
 from __future__ import absolute_import, division
+from random import randint
 
 from cowrie.core.config import CONFIG
 
@@ -107,6 +108,21 @@ class Passwd(object):
             if uid == _["pw_uid"]:
                 return _
         raise KeyError("getpwuid(): uid not found in passwd file: " + str(uid))
+
+    def setpwentry(self, name):
+        """
+        If the user is not in /etc/passwd, creates a new user entry for the session
+        """
+        e = {}
+        e["pw_name"] = name
+        e["pw_passwd"] = "x"
+        e["pw_gecos"] = 0
+        e["pw_dir"] = "/home/" + name
+        e["pw_shell"] = "/bin/bash"
+        e["pw_uid"] = randint(1500, 10000)
+        e["pw_gid"] = e["pw_uid"]
+        self.passwd.append(e)
+        return e
 
 
 class Group(object):

--- a/src/cowrie/shell/pwd.py
+++ b/src/cowrie/shell/pwd.py
@@ -27,8 +27,9 @@
 # SUCH DAMAGE.
 
 from __future__ import absolute_import, division
+
+from binascii import crc32
 from random import randint, seed
-import binascii
 
 from cowrie.core.config import CONFIG
 
@@ -116,7 +117,7 @@ class Passwd(object):
         """
 
         # ensure consistent uid and gid
-        seed_id = binascii.crc32(name)
+        seed_id = crc32(name)
         seed(seed_id)
 
         e = {}

--- a/src/cowrie/shell/session.py
+++ b/src/cowrie/shell/session.py
@@ -43,6 +43,9 @@ class SSHSessionForCowrieUser(object):
 
         self.server.initFileSystem()
 
+        if self.avatar.temporary:
+            self.server.fs.mkdir(self.avatar.home, self.uid, self.gid, 4096, 755)
+
     def openShell(self, processprotocol):
         self.protocol = insults.LoggingServerProtocol(
             protocol.HoneyPotInteractiveProtocol, self)


### PR DESCRIPTION
**Addressing #1024** 

Users that are not in /etc/passwd have a home dir created for them in their session (useful if using `*:*:*` in userdb, for example)