### PR TITLE
Expose SSH key exchange parameters in config file

### DIFF
--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -360,6 +360,55 @@ dsa_private_key = ${honeypot:state_path}/ssh_host_dsa_key
 # (default: "SSH-2.0-SSH-2.0-OpenSSH_6.0p1 Debian-4+deb7u2")
 version = SSH-2.0-OpenSSH_6.0p1 Debian-4+deb7u2
 
+# Cipher encryption algorithms to be used.
+#
+# MUST be supplied as a comma-separated string without
+# any spaces or newlines.
+#
+# Use ciphers to limit to more secure algorithms only
+# any spaces.
+# Supported ciphers:
+#
+# aes128-ctr
+# aes192-ctr
+# aes256-ctr
+# aes256-cbc
+# aes192-cbc
+# aes128-cbc
+# 3des-cbc
+# blowfish-cbc
+# cast128-cbc
+ciphers = aes128-ctr,aes192-ctr,aes256-ctr,aes256-cbc,aes192-cbc,aes128-cbc,3des-cbc,blowfish-cbc,cast128-cbc
+
+
+# MAC Algorithm to be used.
+#
+# MUST be supplied as a comma-separated string without
+# any spaces or newlines.
+#
+# hmac-sha1 and hmac-md5 are considered insecure now, and
+# instead MACs with higher number of bits should be used.
+#
+# Supported HMACs: 
+# hmac-sha2-512
+# hmac-sha2-384
+# hmac-sha2-256
+# hmac-sha1
+# hmac-md5
+macs = hmac-sha2-512,hmac-sha2-384,hmac-sha2-56,hmac-sha1,hmac-md5
+
+
+# Compression Method to be used.
+#
+# MUST be supplied as a comma-separated string without
+# any spaces or newlines.
+#
+# Supported Compression Methods: 
+# zlib@openssh.com
+# zlib
+# none
+compression = zlib@openssh.com,zlib,none
+
 
 # IP addresses to listen for incoming SSH connections.
 # (DEPRECATED: use listen_endpoints instead)

--- a/src/cowrie/ssh/factory.py
+++ b/src/cowrie/ssh/factory.py
@@ -106,22 +106,51 @@ class CowrieSSHFactory(factory.SSHFactory):
                 ske.remove(b'diffie-hellman-group-exchange-sha256')
                 log.msg("No moduli, no diffie-hellman-group-exchange-sha256")
             t.supportedKeyExchanges = ske
+        
+        try:
+            t.supportedCiphers = [bytearray(i, 'utf-8') for i in CONFIG.get('ssh', 'ciphers').split(',')]
+        except:
+            # Reorder supported ciphers to resemble current openssh more
+            t.supportedCiphers = [
+                b'aes128-ctr',
+                b'aes192-ctr',
+                b'aes256-ctr',
+                b'aes256-cbc',
+                b'aes192-cbc',
+                b'aes128-cbc',
+                b'3des-cbc',
+                b'blowfish-cbc',
+                b'cast128-cbc',
+            ]
+        
+        try:
+            t.supportedMACs = [bytearray(i, 'utf-8') for i in CONFIG.get('ssh', 'macs').split(',')]
+        except:
+            # SHA1 and MD5 are considered insecure now. Use better algos
+            # like SHA-256 and SHA-384
+            t.supportedMACs = [
+                    b'hmac-sha2-512',
+                    b'hmac-sha2-384',
+                    b'hmac-sha2-256',
+                    b'hmac-sha1',
+                    b'hmac-md5'
+                ]
 
-        # Reorder supported ciphers to resemble current openssh more
-        t.supportedCiphers = [
-            b'aes128-ctr',
-            b'aes192-ctr',
-            b'aes256-ctr',
-            b'aes128-cbc',
-            b'3des-cbc',
-            b'blowfish-cbc',
-            b'cast128-cbc',
-            b'aes192-cbc',
-            b'aes256-cbc'
-        ]
+        try:
+            t.supportedCompressions = [bytearray(i, 'utf-8') for i in CONFIG.get('ssh', 'compression').split(',')]
+        except:
+            t.supportedCompressions = [b'zlib@openssh.com', b'zlib', b'none']
+
+        # TODO: Newer versions of SSH will use ECDSA keys too as mentioned
+        # at https://tools.ietf.org/html/draft-miller-ssh-agent-02#section-4.2.2
+        # 
+        # Twisted only supports below two keys 
         t.supportedPublicKeys = [b'ssh-rsa', b'ssh-dss']
-        t.supportedMACs = [b'hmac-md5', b'hmac-sha1']
-        t.supportedCompressions = [b'zlib@openssh.com', b'zlib', b'none']
+
+        log.msg(t.supportedCiphers)
+        log.msg(t.supportedMACs)
+        log.msg(t.supportedCompressions)
+        log.msg(t.supportedPublicKeys)
 
         t.factory = self
         return t

--- a/src/cowrie/ssh/factory.py
+++ b/src/cowrie/ssh/factory.py
@@ -147,10 +147,5 @@ class CowrieSSHFactory(factory.SSHFactory):
         # Twisted only supports below two keys 
         t.supportedPublicKeys = [b'ssh-rsa', b'ssh-dss']
 
-        log.msg(t.supportedCiphers)
-        log.msg(t.supportedMACs)
-        log.msg(t.supportedCompressions)
-        log.msg(t.supportedPublicKeys)
-
         t.factory = self
         return t

--- a/src/cowrie/ssh/factory.py
+++ b/src/cowrie/ssh/factory.py
@@ -106,10 +106,10 @@ class CowrieSSHFactory(factory.SSHFactory):
                 ske.remove(b'diffie-hellman-group-exchange-sha256')
                 log.msg("No moduli, no diffie-hellman-group-exchange-sha256")
             t.supportedKeyExchanges = ske
-        
+
         try:
             t.supportedCiphers = [bytearray(i, 'utf-8') for i in CONFIG.get('ssh', 'ciphers').split(',')]
-        except:
+        except NoOptionError:
             # Reorder supported ciphers to resemble current openssh more
             t.supportedCiphers = [
                 b'aes128-ctr',
@@ -122,10 +122,10 @@ class CowrieSSHFactory(factory.SSHFactory):
                 b'blowfish-cbc',
                 b'cast128-cbc',
             ]
-        
+
         try:
             t.supportedMACs = [bytearray(i, 'utf-8') for i in CONFIG.get('ssh', 'macs').split(',')]
-        except:
+        except NoOptionError:
             # SHA1 and MD5 are considered insecure now. Use better algos
             # like SHA-256 and SHA-384
             t.supportedMACs = [
@@ -138,13 +138,13 @@ class CowrieSSHFactory(factory.SSHFactory):
 
         try:
             t.supportedCompressions = [bytearray(i, 'utf-8') for i in CONFIG.get('ssh', 'compression').split(',')]
-        except:
+        except NoOptionError:
             t.supportedCompressions = [b'zlib@openssh.com', b'zlib', b'none']
 
         # TODO: Newer versions of SSH will use ECDSA keys too as mentioned
         # at https://tools.ietf.org/html/draft-miller-ssh-agent-02#section-4.2.2
-        # 
-        # Twisted only supports below two keys 
+        #
+        # Twisted only supports below two keys
         t.supportedPublicKeys = [b'ssh-rsa', b'ssh-dss']
 
         t.factory = self


### PR DESCRIPTION
Enhancement requested in #889 

For key-exchange algorithm, I couldn't understand one thing in this line (https://github.com/cowrie/cowrie/blob/ce6452c204b7e9026383ae85e0e34b1cdb0688c7/src/cowrie/ssh/factory.py#L100-L108) 

Why have you just excluded two of the algorithms instead of doing what had been done here 
(https://github.com/twisted/twisted/blob/132aa9f0f2c8f25a1386d518ddb92bd0e1e3b045/src/twisted/conch/ssh/factory.py#L59-L66) ?

One more question, even though I tested manually, how do we run automated local unit tests?
