### PR TITLE
problem: csirtg plugin fails when system key is not present

### DIFF
--- a/src/cowrie/output/csirtg.py
+++ b/src/cowrie/output/csirtg.py
@@ -39,9 +39,10 @@ class Output(cowrie.core.output.Output):
     def write(self, e):
         peerIP = e['src_ip']
         ts = e['timestamp']
-        system = e['system']
+        system = e.get('system', None)
 
-        if system not in ['cowrie.ssh.factory.CowrieSSHFactory', 'cowrie.telnet.transport.HoneyPotTelnetFactory']:
+        if system not in ['cowrie.ssh.factory.CowrieSSHFactory',
+                          'cowrie.telnet.transport.HoneyPotTelnetFactory']:
             return
 
         today = str(datetime.now().date())


### PR DESCRIPTION
solution: use `e.get('system')` instead of `e['system']`.

this is just a simple work-around.

fixes #676