### PR TITLE
Fix tomcat/oracle directory change error

### DIFF
--- a/src/cowrie/shell/pwd.py
+++ b/src/cowrie/shell/pwd.py
@@ -117,7 +117,7 @@ class Passwd(object):
         """
 
         # ensure consistent uid and gid
-        seed_id = crc32(name)
+        seed_id = crc32(name.encode("utf-8"))
         seed(seed_id)
 
         e = {}


### PR DESCRIPTION
Fixes #1062 	

So the problem was that password was authorized but when trying to change into the directory there was an error produced

```
current.result = callback(current.result, *args, **kw)
File "cowrie/src/cowrie/core/realm.py", line 58, in requestAvatar
user = shellavatar.CowrieUser(avatarId, serv)
File "cowrie/src/cowrie/shell/avatar.py", line 35, in __init__
pwentry = pwd.Passwd().setpwentry(self.username)
File "cowrie/src/cowrie/shell/pwd.py", line 120, in setpwentry
seed_id = crc32(name)
builtins.TypeError: a bytes-like object is required, not 'str'
```

Encoding that object fixes the issue