### PR TITLE
Fix byte error

### DIFF
--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -88,7 +88,7 @@ class Output(cowrie.core.output.Output):
         nonce = base64.b64decode(_nonceb64)
         digest = base64.b64encode(
             hmac.new(
-                '{0}{1}'.format(nonce, self.userid),
+                b'{0}{1}'.format(nonce, self.userid),
                 base64.b64decode(self.auth_key),
                 hashlib.sha256).digest()
         )


### PR DESCRIPTION
@sumodeluxe mentioned a problem with dshield output plugin.
He was having the following error:
```
 [twisted.logger._observer#critical] Temporarily disabling observer LegacyLogObserverWrapper(<bound method Output.emit of <cowrie.output.dshield.Output object at 0x761998f0>>) due to exception: [Failure instance: Traceback: <class 'TypeError'>: key: expected bytes or bytearray, but got 'str'
        /home/cowrie/cowrie/src/cowrie/core/checkers.py:116:checkUserPass
        /home/cowrie/cowrie/cowrie-env/lib/python3.5/site-packages/twisted/python/threadable.py:53:sync
        /home/cowrie/cowrie/cowrie-env/lib/python3.5/site-packages/twisted/python/log.py:286:msg
        /home/cowrie/cowrie/cowrie-env/lib/python3.5/site-packages/twisted/logger/_legacy.py:154:publishToNewObserver
        --- <exception caught here> ---
        /home/cowrie/cowrie/cowrie-env/lib/python3.5/site-packages/twisted/logger/_observer.py:131:__call__
        /home/cowrie/cowrie/cowrie-env/lib/python3.5/site-packages/twisted/logger/_legacy.py:93:__call__
        /home/cowrie/cowrie/src/cowrie/core/output.py:214:emit
        /home/cowrie/cowrie/src/cowrie/output/dshield.py:58:write
        /home/cowrie/cowrie/src/cowrie/output/dshield.py:93:submit_entries
        /home/cowrie/cowrie/cowrie-env/lib/python3.5/hmac.py:144:new
        /home/cowrie/cowrie/cowrie-env/lib/python3.5/hmac.py:42:__init__
        ]
        Traceback (most recent call last):
          File "/home/cowrie/cowrie/src/cowrie/core/checkers.py", line 116, in checkUserPass
            password=thepassword)
          File "/home/cowrie/cowrie/cowrie-env/lib/python3.5/site-packages/twisted/python/threadable.py", line 53, in sync
            return function(self, *args, **kwargs)
          File "/home/cowrie/cowrie/cowrie-env/lib/python3.5/site-packages/twisted/python/log.py", line 286, in msg
            _publishNew(self._publishPublisher, actualEventDict, textFromEventDict)
          File "/home/cowrie/cowrie/cowrie-env/lib/python3.5/site-packages/twisted/logger/_legacy.py", line 154, in publishToNewObserver
            observer(eventDict)
        --- <exception caught here> ---
          File "/home/cowrie/cowrie/cowrie-env/lib/python3.5/site-packages/twisted/logger/_observer.py", line 131, in __call__
            observer(event)
          File "/home/cowrie/cowrie/cowrie-env/lib/python3.5/site-packages/twisted/logger/_legacy.py", line 93, in __call__
            self.legacyObserver(event)
          File "/home/cowrie/cowrie/src/cowrie/core/output.py", line 214, in emit
            self.write(ev)
          File "/home/cowrie/cowrie/src/cowrie/output/dshield.py", line 58, in write
            self.submit_entries(batch_to_send)
          File "/home/cowrie/cowrie/src/cowrie/output/dshield.py", line 93, in submit_entries
            hashlib.sha256).digest()
          File "/home/cowrie/cowrie/cowrie-env/lib/python3.5/hmac.py", line 144, in new
            return HMAC(key, msg, digestmod)
          File "/home/cowrie/cowrie/cowrie-env/lib/python3.5/hmac.py", line 42, in __init__
            raise TypeError("key: expected bytes or bytearray, but got %r" % type(key).__name__)
        builtins.TypeError: key: expected bytes or bytearray, but got 'str'
```

This PR will fix this issue.