### PR TITLE
fix automatic authbind detection

### DIFF
--- a/bin/cowrie
+++ b/bin/cowrie
@@ -102,7 +102,7 @@ cowrie_start() {
 
     #Automatically check if the authbind is enabled or not
     authfile="/etc/authbind/byport/22"
-    if [ -x authfile ]; then
+    if [ -x "$authfile" ]; then
         AUTHBIND_ENABLED=yes
     else
         AUTHBIND_ENABLED=no


### PR DESCRIPTION
`authfile` by itself is a filename in that context. It should be a variable, so it's changed to `"$authfile"`.