### PR TITLE
Enable utf8 charset on mysql output and small improvement of documentation

### DIFF
--- a/docs/sql/README.rst
+++ b/docs/sql/README.rst
@@ -67,6 +67,7 @@ Uncomment and update the following entries to ~/cowrie/cowrie.cfg under the Outp
     password = PASSWORD HERE
     port = 3306
     debug = false
+    enabled = true
 
 Restart Cowrie::
 

--- a/src/cowrie/output/mysql.py
+++ b/src/cowrie/output/mysql.py
@@ -68,7 +68,9 @@ class Output(cowrie.core.output.Output):
                 passwd=CONFIG.get('output_mysql', 'password', raw=True),
                 port=port,
                 cp_min=1,
-                cp_max=1
+                cp_max=1,
+                charset='utf8mb4',
+                use_unicode=True
             )
         except MySQLdb.Error as e:
             log.msg("output_mysql: Error %d: %s" % (e.args[0], e.args[1]))


### PR DESCRIPTION
Hi,

Added **charset = utf8mb** and **use_unicode=True** options to the _ReconnectingConnectionPool_ provided by adbapi.  This is related to #790.

There is also a commit for improving the documentation of the mysql output. It adds the option **enabled = true** to the README.srt file. If you didn't used the template provided in the etc folder (like me) and follow the current instructions in docs/sql/README.srt for enabling the mysql output, then cowrie won't start.