### PR TITLE
Handle timeout error

### DIFF
--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -807,6 +807,7 @@ topic = cowrie
 
 #[output_greynoise]
 #enabled = true
+#debug=False
 # Name of the tags separated by comma, for which the IP has to be scanned for.
 # Example "SHODAN,JBOSS_WORM,CPANEL_SCANNER_LOW"
 # If there isn't any specific tag then just leave it "all"

--- a/src/cowrie/output/greynoise.py
+++ b/src/cowrie/output/greynoise.py
@@ -59,10 +59,14 @@ class Output(cowrie.core.output.Output):
         headers = ({'User-Agent': [COWRIE_USER_AGENT]})
         fields = {'key': self.apiKey, 'ip': entry['src_ip']}
 
-        response = yield treq.post(
-            url=gnUrl,
-            data=fields,
-            headers=headers)
+        try:
+            response = yield treq.post(
+                url=gnUrl,
+                data=fields,
+                headers=headers,
+                timeout=10)
+        except defer.CancelledError:
+            log.msg("GreyNoise requests timeout")
 
         if response.code != 200:
             rsp = yield response.text()

--- a/src/cowrie/output/greynoise.py
+++ b/src/cowrie/output/greynoise.py
@@ -5,6 +5,7 @@ Send attackers IP to GreyNoise
 from __future__ import absolute_import, division
 
 import treq
+
 from twisted.internet import defer, error
 from twisted.python import log
 


### PR DESCRIPTION
Fixes #1086 

I have used the `timeout` option in the treq request which gives `CancelledError` when the time in timeout is exceeded.

If wanted we can add the `timeout` option in the config file so user can provide that.