### PR TITLE
Handle redirection in shell

### DIFF
--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -43,6 +43,9 @@ class HoneyPotCommand(object):
         # MS-DOS style redirect handling, inside the command
         # TODO: handle >>, 2>, etc
         if '>' in self.args or '>>' in self.args:
+            if self.args[-1] in ['>', ">>"]:
+                self.errorWrite("-bash: parse error near '\\n' \n")
+                return
             self.writtenBytes = 0
             self.writefn = self.write_to_file
             if '>>' in self.args:


### PR DESCRIPTION
Fixes #854 

Running a command like `sudo >` or `do >` or `echo "hello" >` i.e any kind of redirection without providing the location, we get an out of index error.

This PR fixes that issue by checking whether the last arg passed is `>` or `>>` if yes then it prompts the parse error.

The error message `-bash: parse error near '\n'` is used because this is an error we get when we execute the above-mentioned commands on a normal Linux system.

P.S - when we run `do >` we get an error `-bash: parse error near do'` but for most of the other commands we get ``-bash: parse error near '\\n'`` that is why I've used this parse message.
