### PR TITLE
Update rm implementation

### DIFF
--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -306,21 +306,21 @@ or available locally via: info '(coreutils) rm invocation'\n"""
             return
 
         try:
-            optlist, args = getopt.gnu_getopt(self.args,'rTfvh', ['help','recursive','force','verbose'])
+            optlist, args = getopt.gnu_getopt(self.args, 'rTfvh', ['help', 'recursive', 'force', 'verbose'])
         except getopt.GetoptError as err:
-            self.errorWrite("rm: invalid option -- '{}'\n".format(c))
+            self.errorWrite("rm: invalid option -- '{}'\n".format(err.opt))
             self.paramError()
             self.exit()
             return
 
-        for o,a in optlist:
-            if o in ('--rescursive','-r','-R'):
+        for o, a in optlist:
+            if o in ('--rescursive', '-r', '-R'):
                 recursive = True
-            elif o in ('--force','-f'):
+            elif o in ('--force', '-f'):
                 force = True
-            elif o in ('--verbose','-v'):
+            elif o in ('--verbose', '-v'):
                 verbose = True
-            elif o in ('--help','-h'):
+            elif o in ('--help', '-h'):
                 self.help()
                 return
 

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -293,10 +293,9 @@ Full documentation at: <http://www.gnu.org/software/coreutils/rm>
 or available locally via: info '(coreutils) rm invocation'\n"""
         )
 
-
     def paramError(self):
         self.errorWrite("Try 'rm --help' for more information\n")
-        
+
     def call(self):
         recursive = False
         force = False
@@ -309,7 +308,7 @@ or available locally via: info '(coreutils) rm invocation'\n"""
             if f.startswith('--'):
                 if f == '--rescursive':
                     recursive = True
-                elif f =='--force':
+                elif f == '--force':
                     force = True
                 elif f == '--verbose':
                     verbose = True
@@ -337,7 +336,6 @@ or available locally via: info '(coreutils) rm invocation'\n"""
                         self.errorWrite("rm: invalid option -- '{}'\n".format(c))
                         self.paramError()
                         return
-
 
         for f in self.args:
             if f.startswith('-') and len(f) > 1:

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -304,42 +304,27 @@ or available locally via: info '(coreutils) rm invocation'\n"""
             self.errorWrite("rm: missing operand\n")
             self.paramError()
             return
-        for f in self.args:
-            if f.startswith('--'):
-                if f == '--rescursive':
-                    recursive = True
-                elif f == '--force':
-                    force = True
-                elif f == '--verbose':
-                    verbose = True
-                elif f == '--help':
-                    self.help()
-                    return
-                else:
-                    self.errorWrite("rm: invalid option -- '{}'\n".format(f))
-                    self.paramError()
-                    return
-            elif f.startswith('-') and len(f) > 1:
-                for c in f:
-                    if '-' in c:
-                        continue
-                    elif 'r' in c or 'R' in c:
-                        recursive = True
-                    elif 'f' in c:
-                        force = True
-                    elif 'v' in c:
-                        verbose = True
-                    elif 'h' in f:
-                        self.help()
-                        return
-                    else:
-                        self.errorWrite("rm: invalid option -- '{}'\n".format(c))
-                        self.paramError()
-                        return
 
-        for f in self.args:
-            if f.startswith('-') and len(f) > 1:
-                continue
+        try:
+            optlist, args = getopt.gnu_getopt(self.args,'rTfvh', ['help','recursive','force','verbose'])
+        except getopt.GetoptError as err:
+            self.errorWrite("rm: invalid option -- '{}'\n".format(c))
+            self.paramError()
+            self.exit()
+            return
+
+        for o,a in optlist:
+            if o in ('--rescursive','-r','-R'):
+                recursive = True
+            elif o in ('--force','-f'):
+                force = True
+            elif o in ('--verbose','-v'):
+                verbose = True
+            elif o in ('--help','-h'):
+                self.help()
+                return
+
+        for f in args:
             pname = self.fs.resolve_path(f, self.protocol.cwd)
             try:
                 # verify path to file exists

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -259,6 +259,8 @@ class command_rm(HoneyPotCommand):
             if f.startswith('-') and 'r' in f:
                 recursive = True
         for f in self.args:
+            if f.startswith('-'):
+                continue
             pname = self.fs.resolve_path(f, self.protocol.cwd)
             try:
                 # verify path to file exists

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -314,7 +314,7 @@ or available locally via: info '(coreutils) rm invocation'\n"""
             return
 
         for o, a in optlist:
-            if o in ('--rescursive', '-r', '-R'):
+            if o in ('--recursive', '-r', '-R'):
                 recursive = True
             elif o in ('--force', '-f'):
                 force = True


### PR DESCRIPTION
Skip parameters if start with '-' to avoid message like : "rm: cannot remove '-f': No such file or directory"
it is a temporary solution for the issue #1116 