### PR TITLE
Add retro-compatibility for Python 2.7

### DIFF
--- a/src/backend_pool/ssh_exec.py
+++ b/src/backend_pool/ssh_exec.py
@@ -2,6 +2,7 @@ from twisted.conch.ssh import channel, common, connection, transport, userauth
 from twisted.internet import defer, protocol, reactor
 
 
+# object is added for Python 2.7 compatibility (#1198) - as is super with args
 class PasswordAuth(userauth.SSHUserAuthClient, object):
     def __init__(self, user, password, conn):
         super(PasswordAuth, self).__init__(user, conn)

--- a/src/backend_pool/ssh_exec.py
+++ b/src/backend_pool/ssh_exec.py
@@ -4,7 +4,7 @@ from twisted.internet import defer, protocol, reactor
 
 class PasswordAuth(userauth.SSHUserAuthClient):
     def __init__(self, user, password, conn):
-        super().__init__(user, conn)
+        super(PasswordAuth, self).__init__(user, conn)
         self.password = password
 
     def getPassword(self, prompt=None):
@@ -15,7 +15,7 @@ class CommandChannel(channel.SSHChannel):
     name = 'session'
 
     def __init__(self, command, done_deferred, callback, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(CommandChannel, self).__init__(*args, **kwargs)
         self.command = command
         self.done_deferred = done_deferred
         self.callback = callback
@@ -42,7 +42,7 @@ class CommandChannel(channel.SSHChannel):
 
 class ClientConnection(connection.SSHConnection):
     def __init__(self, cmd, done_deferred, callback):
-        super().__init__()
+        super(ClientConnection, self).__init__()
         self.command = cmd
         self.done_deferred = done_deferred
         self.callback = callback

--- a/src/backend_pool/ssh_exec.py
+++ b/src/backend_pool/ssh_exec.py
@@ -2,7 +2,7 @@ from twisted.conch.ssh import channel, common, connection, transport, userauth
 from twisted.internet import defer, protocol, reactor
 
 
-class PasswordAuth(userauth.SSHUserAuthClient):
+class PasswordAuth(userauth.SSHUserAuthClient, object):
     def __init__(self, user, password, conn):
         super(PasswordAuth, self).__init__(user, conn)
         self.password = password
@@ -11,7 +11,7 @@ class PasswordAuth(userauth.SSHUserAuthClient):
         return defer.succeed(self.password)
 
 
-class CommandChannel(channel.SSHChannel):
+class CommandChannel(channel.SSHChannel, object):
     name = 'session'
 
     def __init__(self, command, done_deferred, callback, *args, **kwargs):
@@ -40,7 +40,7 @@ class CommandChannel(channel.SSHChannel):
             self.callback(self.data)
 
 
-class ClientConnection(connection.SSHConnection):
+class ClientConnection(connection.SSHConnection, object):
     def __init__(self, cmd, done_deferred, callback):
         super(ClientConnection, self).__init__()
         self.command = cmd

--- a/src/cowrie/ssh/factory.py
+++ b/src/cowrie/ssh/factory.py
@@ -24,7 +24,7 @@ from cowrie.ssh_proxy import server_transport as proxyTransport
 from cowrie.ssh_proxy.userauth import ProxySSHAuthServer
 
 
-class CowrieSSHFactory(factory.SSHFactory):
+class CowrieSSHFactory(factory.SSHFactory, object):
     """
     This factory creates HoneyPotSSHTransport instances
     They listen directly to the TCP port

--- a/src/cowrie/ssh/factory.py
+++ b/src/cowrie/ssh/factory.py
@@ -48,7 +48,7 @@ class CowrieSSHFactory(factory.SSHFactory):
             b'ssh-userauth': ProxySSHAuthServer if self.backend == 'proxy' else HoneyPotSSHUserAuthServer,
             b'ssh-connection': connection.CowrieSSHConnection,
         }
-        super().__init__()
+        super(CowrieSSHFactory, self).__init__()
 
     def logDispatch(self, *msg, **args):
         """

--- a/src/cowrie/ssh/factory.py
+++ b/src/cowrie/ssh/factory.py
@@ -24,6 +24,7 @@ from cowrie.ssh_proxy import server_transport as proxyTransport
 from cowrie.ssh_proxy.userauth import ProxySSHAuthServer
 
 
+# object is added for Python 2.7 compatibility (#1198) - as is super with args
 class CowrieSSHFactory(factory.SSHFactory, object):
     """
     This factory creates HoneyPotSSHTransport instances

--- a/src/cowrie/ssh_proxy/userauth.py
+++ b/src/cowrie/ssh_proxy/userauth.py
@@ -8,6 +8,7 @@ from twisted.conch.ssh.common import getNS
 from cowrie.ssh import userauth
 
 
+# object is added for Python 2.7 compatibility (#1198) - as is super with args
 class ProxySSHAuthServer(userauth.HoneyPotSSHUserAuthServer, object):
     def __init__(self):
         super(ProxySSHAuthServer, self).__init__()

--- a/src/cowrie/ssh_proxy/userauth.py
+++ b/src/cowrie/ssh_proxy/userauth.py
@@ -10,7 +10,7 @@ from cowrie.ssh import userauth
 
 class ProxySSHAuthServer(userauth.HoneyPotSSHUserAuthServer):
     def __init__(self):
-        super().__init__()
+        super(ProxySSHAuthServer, self).__init__()
         self.triedPassword = None
 
     def auth_password(self, packet):
@@ -19,7 +19,7 @@ class ProxySSHAuthServer(userauth.HoneyPotSSHUserAuthServer):
         """
         self.triedPassword = getNS(packet[1:])[0]
 
-        return super().auth_password(packet)
+        return super(ProxySSHAuthServer, self).auth_password(packet)
 
     def _cbFinishedAuth(self, result):
         """

--- a/src/cowrie/ssh_proxy/userauth.py
+++ b/src/cowrie/ssh_proxy/userauth.py
@@ -8,7 +8,7 @@ from twisted.conch.ssh.common import getNS
 from cowrie.ssh import userauth
 
 
-class ProxySSHAuthServer(userauth.HoneyPotSSHUserAuthServer):
+class ProxySSHAuthServer(userauth.HoneyPotSSHUserAuthServer, object):
     def __init__(self):
         super(ProxySSHAuthServer, self).__init__()
         self.triedPassword = None

--- a/src/cowrie/telnet/factory.py
+++ b/src/cowrie/telnet/factory.py
@@ -32,7 +32,7 @@ class HoneyPotTelnetFactory(protocol.ServerFactory):
     def __init__(self, backend, pool_handler):
         self.backend = backend
         self.pool_handler = pool_handler
-        super().__init__()
+        super(HoneyPotTelnetFactory, self).__init__()
 
     # TODO logging clarity can be improved: see what SSH does
     def logDispatch(self, *msg, **args):

--- a/src/cowrie/telnet/factory.py
+++ b/src/cowrie/telnet/factory.py
@@ -19,6 +19,7 @@ from cowrie.telnet.userauth import HoneyPotTelnetAuthProtocol
 from cowrie.telnet_proxy.server_transport import FrontendTelnetTransport
 
 
+# object is added for Python 2.7 compatibility (#1198) - as is super with args
 class HoneyPotTelnetFactory(protocol.ServerFactory, object):
     """
     This factory creates HoneyPotTelnetAuthProtocol instances

--- a/src/cowrie/telnet/factory.py
+++ b/src/cowrie/telnet/factory.py
@@ -19,7 +19,7 @@ from cowrie.telnet.userauth import HoneyPotTelnetAuthProtocol
 from cowrie.telnet_proxy.server_transport import FrontendTelnetTransport
 
 
-class HoneyPotTelnetFactory(protocol.ServerFactory):
+class HoneyPotTelnetFactory(protocol.ServerFactory, object):
     """
     This factory creates HoneyPotTelnetAuthProtocol instances
     They listen directly to the TCP port

--- a/src/cowrie/telnet_proxy/client_transport.py
+++ b/src/cowrie/telnet_proxy/client_transport.py
@@ -7,7 +7,7 @@ from twisted.protocols.policies import TimeoutMixin
 from twisted.python import log
 
 
-class BackendTelnetTransport(TelnetTransport, TimeoutMixin):
+class BackendTelnetTransport(TelnetTransport, TimeoutMixin, object):
     def __init__(self):
         # self.delayedPacketsToFrontend = []
         self.backendConnected = False

--- a/src/cowrie/telnet_proxy/client_transport.py
+++ b/src/cowrie/telnet_proxy/client_transport.py
@@ -7,6 +7,7 @@ from twisted.protocols.policies import TimeoutMixin
 from twisted.python import log
 
 
+# object is added for Python 2.7 compatibility (#1198) - as is super with args
 class BackendTelnetTransport(TelnetTransport, TimeoutMixin, object):
     def __init__(self):
         # self.delayedPacketsToFrontend = []

--- a/src/cowrie/telnet_proxy/client_transport.py
+++ b/src/cowrie/telnet_proxy/client_transport.py
@@ -26,7 +26,7 @@ class BackendTelnetTransport(TelnetTransport, TimeoutMixin):
             self.transport.write(packet)
         self.factory.server.delayedPacketsToBackend = []
 
-        super().connectionMade()
+        super(TelnetTransport, self).connectionMade()
         # TODO timeout if no backend available
 
     def connectionLost(self, reason):

--- a/src/cowrie/telnet_proxy/server_transport.py
+++ b/src/cowrie/telnet_proxy/server_transport.py
@@ -21,6 +21,7 @@ from cowrie.telnet_proxy import client_transport
 from cowrie.telnet_proxy.handler import TelnetHandler
 
 
+# object is added for Python 2.7 compatibility (#1198) - as is super with args
 class FrontendTelnetTransport(TelnetTransport, TimeoutMixin, object):
     def __init__(self):
         super(FrontendTelnetTransport, self).__init__()

--- a/src/cowrie/telnet_proxy/server_transport.py
+++ b/src/cowrie/telnet_proxy/server_transport.py
@@ -21,7 +21,7 @@ from cowrie.telnet_proxy import client_transport
 from cowrie.telnet_proxy.handler import TelnetHandler
 
 
-class FrontendTelnetTransport(TelnetTransport, TimeoutMixin):
+class FrontendTelnetTransport(TelnetTransport, TimeoutMixin, object):
     def __init__(self):
         super(FrontendTelnetTransport, self).__init__()
 

--- a/src/cowrie/telnet_proxy/server_transport.py
+++ b/src/cowrie/telnet_proxy/server_transport.py
@@ -23,7 +23,7 @@ from cowrie.telnet_proxy.handler import TelnetHandler
 
 class FrontendTelnetTransport(TelnetTransport, TimeoutMixin):
     def __init__(self):
-        super().__init__()
+        super(FrontendTelnetTransport, self).__init__()
 
         self.peer_ip = None
         self.peer_port = 0


### PR DESCRIPTION
This should be the Python 2.7 conversion to fix the issue. I can't setup Python 2.7 in my machine today, so if you can test it I'd appreciate it @micheloosterhof.

#1193