### PR TITLE
Disallow the usage of -i & -b flag together for playlog

### DIFF
--- a/bin/playlog
+++ b/bin/playlog
@@ -104,6 +104,11 @@ if __name__ == '__main__':
         print('Error: %s\n' % error)
         help()
 
+    options = [x[0] for x in optlist]
+    if '-b' in options and '-i' in options:
+        print("Error: -i and -b cannot be used together. Please select only one flag")
+        sys.exit(1)
+
     for o, a in optlist:
         if o == '-f':
             settings['tail'] = 1


### PR DESCRIPTION
Fix #1207 

@micheloosterhof the method you suggested didn't worked i.e
```python
if '-b' in optlist and '-i' in optlist:
```
Because `optlist` is actually a list of tuples something like
```
[('-i', ''), ('-b', '')]
```
