### PR TITLE
Fixed default vaules for S3 Output

### DIFF
--- a/src/cowrie/output/s3.py
+++ b/src/cowrie/output/s3.py
@@ -39,8 +39,8 @@ class Output(cowrie.core.output.Output):
         self.client = self.session.create_client(
             's3',
             region_name=CowrieConfig().get("output_s3", "region"),
-            endpoint_url=CowrieConfig().get("output_s3", "endpoint") or None,
-            verify=False if CowrieConfig().get("output_s3", "verify") == "no" else True,
+            endpoint_url=CowrieConfig().get("output_s3", "endpoint", fallback=None),
+            verify=CowrieConfig().getboolean("output_s3", "verify", fallback=True)
         )
 
     def stop(self):


### PR DESCRIPTION
If I do not specify the `endpoint` a KeyError was raised but this ought to be an optional parameter. So I fixed this.
While playing around with this output I noticed that it did not upload anything, in my environment the `Cowrie.session.file_*` event is not propagated properly. But I will open a separate issue for this. I mention this just in case you test this PR.