### PR TITLE
Update hpfeeds3 plugin to use config named hpfeeds3

### DIFF
--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -836,6 +836,17 @@ epoch_timestamp = false
 #debug=false
 
 
+# HPFeeds3
+# Python3 implementation of HPFeeds
+#[output_hpfeeds3]
+#enabled = false
+#server = hpfeeds.mysite.org
+#port = 10000
+#identifier = abc123
+#secret = secret
+#debug=false
+
+
 # VirusTotal output module
 # You must signup for an api key.
 #

--- a/src/cowrie/output/hpfeeds3.py
+++ b/src/cowrie/output/hpfeeds3.py
@@ -26,25 +26,25 @@ class Output(cowrie.core.output.Output):
     def start(self):
         log.msg("WARNING: Beta version of new hpfeeds enabled. This will become hpfeeds in a future release.")
 
-        if CowrieConfig().has_option('output_hpfeeds', 'channel'):
-            self.channel = CowrieConfig().get('output_hpfeeds', 'channel')
+        if CowrieConfig().has_option('output_hpfeeds3', 'channel'):
+            self.channel = CowrieConfig().get('output_hpfeeds3', 'channel')
 
-        if CowrieConfig().has_option('output_hpfeeds', 'endpoint'):
-            endpoint = CowrieConfig().get('output_hpfeeds', 'endpoint')
+        if CowrieConfig().has_option('output_hpfeeds3', 'endpoint'):
+            endpoint = CowrieConfig().get('output_hpfeeds3', 'endpoint')
         else:
-            server = CowrieConfig().get('output_hpfeeds', 'server')
-            port = CowrieConfig().getint('output_hpfeeds', 'port')
+            server = CowrieConfig().get('output_hpfeeds3', 'server')
+            port = CowrieConfig().getint('output_hpfeeds3', 'port')
 
-            if CowrieConfig().has_option('output_hpfeeds', 'tlscert'):
-                with open(CowrieConfig().get('output_hpfeeds', 'tlscert')) as fp:
+            if CowrieConfig().has_option('output_hpfeeds3', 'tlscert'):
+                with open(CowrieConfig().get('output_hpfeeds3', 'tlscert')) as fp:
                     authority = ssl.Certificate.loadPEM(fp.read())
                 options = ssl.optionsForClientTLS(server, authority)
                 endpoint = endpoints.SSL4ClientEndpoint(reactor, server, port, options)
             else:
                 endpoint = endpoints.HostnameEndpoint(reactor, server, port)
 
-        ident = CowrieConfig().get('output_hpfeeds', 'identifier')
-        secret = CowrieConfig().get('output_hpfeeds', 'secret')
+        ident = CowrieConfig().get('output_hpfeeds3', 'identifier')
+        secret = CowrieConfig().get('output_hpfeeds3', 'secret')
 
         self.meta = {}
 


### PR DESCRIPTION
This should make usage of the hpfeeds3 plugin more intuitive.  #1191 should also be at least partially addressed.