### PR TITLE
HTTPS + Credentials + GeoIP support in Elasticsearch output

### DIFF
--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -727,7 +727,15 @@ epoch_timestamp = false
 #host = localhost
 #port = 9200
 #index = cowrie
-#type = cowrie
+# type has been deprecated since ES 6.0.0
+# use _doc which is the default type. See
+# https://stackoverflow.com/a/53688626 for
+# more information
+#type = _doc
+# set pipeline = geoip to map src_ip to
+# geo location data. You can use a custom
+# pipeline but you must ensure it exists
+# in elasticsearch.
 #pipeline = geoip
 #
 # Authentication. When x-pack.security is enabled

--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -729,7 +729,27 @@ epoch_timestamp = false
 #index = cowrie
 #type = cowrie
 #pipeline = geoip
-
+#
+# Authentication. When x-pack.security is enabled
+# in ES, default users have been created and requests
+# must be authenticated.
+#
+# Credentials
+#username = elastic
+#password = 
+#
+# TLS encryption. Communications between the client (cowrie) 
+# and the ES server should naturally be protected by encryption
+# if requests are authenticated (to prevent from man-in-the-middle 
+# attacks). The following options are then paramount
+# if username and password are provided.
+#
+# use ssl/tls
+#ssl = true
+# Path to trusted CA certs on disk
+#ca_certs = /cowrie/cowrie-git/etc/elastic_ca.crt
+# verify SSL certificates
+#verify_certs = true
 
 # Send login attemp information to SANS DShield
 # See https://isc.sans.edu/ssh.html

--- a/src/cowrie/output/elasticsearch.py
+++ b/src/cowrie/output/elasticsearch.py
@@ -46,6 +46,12 @@ class Output(cowrie.core.output.Output):
         # self.es = Elasticsearch('{0}:{1}'.format(self.host, self.port))
 
         self.check_index()
+        # ensure geoip pipeline is well set up
+        if self.pipeline == "geoip":
+            # create a new feature if it does not exist yet
+            self.check_geoip_mapping()
+            # ensure the geoip pipeline is setup
+            self.check_geoip_pipeline()
 
     def check_index(self):
         """

--- a/src/cowrie/output/elasticsearch.py
+++ b/src/cowrie/output/elasticsearch.py
@@ -38,8 +38,9 @@ class Output(cowrie.core.output.Output):
             options["scheme"] = "https"
             options["use_ssl"] = self.use_ssl
             options["ssl_show_warn"] = False
-            options["ca_certs"] = self.ca_certs
             options["verify_certs"] = self.verify_certs
+            if self.verify_certs:
+                options["ca_certs"] = self.ca_certs
 
         # connect
         self.es = Elasticsearch("{0}:{1}".format(self.host, self.port), **options)

--- a/src/cowrie/output/elasticsearch.py
+++ b/src/cowrie/output/elasticsearch.py
@@ -61,8 +61,10 @@ class Output(cowrie.core.output.Output):
         to convert source ip (src_ip) into geo data 
         """
         if self.es.indices.exists(index=self.index):
-            # add mapping (to add geo field -> for geoip)
-            # the new feature is named 'geo'
+            # Add mapping (to add geo field -> for geoip)
+            # The new feature is named 'geo'.
+            # You can put mappings several times, if it exists the
+            # PUT requests will be ignored.
             self.es.indices.put_mapping(
                 index=self.index,
                 body={

--- a/src/cowrie/output/elasticsearch.py
+++ b/src/cowrie/output/elasticsearch.py
@@ -20,12 +20,18 @@ class Output(cowrie.core.output.Output):
         self.type = CowrieConfig().get("output_elasticsearch", "type")
         self.pipeline = CowrieConfig().get("output_elasticsearch", "pipeline")
         # new options (creds + https)
-        self.username = CowrieConfig().get("output_elasticsearch", "username")
-        self.password = CowrieConfig().get("output_elasticsearch", "password")
+        self.username = CowrieConfig().get(
+            "output_elasticsearch", "username", fallback=None
+        )
+        self.password = CowrieConfig().get(
+            "output_elasticsearch", "password", fallback=None
+        )
         self.use_ssl = CowrieConfig().getboolean(
             "output_elasticsearch", "ssl", fallback=False
         )
-        self.ca_certs = CowrieConfig().get("output_elasticsearch", "ca_certs")
+        self.ca_certs = CowrieConfig().get(
+            "output_elasticsearch", "ca_certs", fallback=None
+        )
         self.verify_certs = CowrieConfig().getboolean(
             "output_elasticsearch", "verify_certs", fallback=True
         )
@@ -47,6 +53,7 @@ class Output(cowrie.core.output.Output):
         # self.es = Elasticsearch('{0}:{1}'.format(self.host, self.port))
 
         self.check_index()
+
         # ensure geoip pipeline is well set up
         if self.pipeline == "geoip":
             # create a new feature if it does not exist yet

--- a/src/cowrie/output/elasticsearch.py
+++ b/src/cowrie/output/elasticsearch.py
@@ -72,7 +72,7 @@ class Output(cowrie.core.output.Output):
     def check_geoip_mapping(self):
         """
         This function ensures that the right mapping is set up
-        to convert source ip (src_ip) into geo data 
+        to convert source ip (src_ip) into geo data.
         """
         if self.es.indices.exists(index=self.index):
             # Add mapping (to add geo field -> for geoip)

--- a/src/cowrie/output/elasticsearch.py
+++ b/src/cowrie/output/elasticsearch.py
@@ -45,6 +45,16 @@ class Output(cowrie.core.output.Output):
         self.es = Elasticsearch("{0}:{1}".format(self.host, self.port), **options)
         # self.es = Elasticsearch('{0}:{1}'.format(self.host, self.port))
 
+        self.check_index()
+
+    def check_index(self):
+        """
+        This function check whether the index exists.
+        """
+        if not self.es.indices.exists(index=self.index):
+            #  create index
+            self.es.indices.create(index=self.index)
+
     def stop(self):
         pass
 

--- a/src/cowrie/output/elasticsearch.py
+++ b/src/cowrie/output/elasticsearch.py
@@ -55,6 +55,23 @@ class Output(cowrie.core.output.Output):
             #  create index
             self.es.indices.create(index=self.index)
 
+    def check_geoip_mapping(self):
+        """
+        This function ensures that the right mapping is set up
+        to convert source ip (src_ip) into geo data 
+        """
+        if self.es.indices.exists(index=self.index):
+            # add mapping (to add geo field -> for geoip)
+            # the new feature is named 'geo'
+            self.es.indices.put_mapping(
+                index=self.index,
+                body={
+                    "properties": {
+                        "geo": {"properties": {"location": {"type": "geo_point"}}}
+                    }
+                },
+            )
+
     def stop(self):
         pass
 

--- a/src/cowrie/output/elasticsearch.py
+++ b/src/cowrie/output/elasticsearch.py
@@ -14,12 +14,36 @@ class Output(cowrie.core.output.Output):
     """
 
     def start(self):
-        self.host = CowrieConfig().get('output_elasticsearch', 'host')
-        self.port = CowrieConfig().get('output_elasticsearch', 'port')
-        self.index = CowrieConfig().get('output_elasticsearch', 'index')
-        self.type = CowrieConfig().get('output_elasticsearch', 'type')
-        self.pipeline = CowrieConfig().get('output_elasticsearch', 'pipeline')
-        self.es = Elasticsearch('{0}:{1}'.format(self.host, self.port))
+        self.host = CowrieConfig().get("output_elasticsearch", "host")
+        self.port = CowrieConfig().get("output_elasticsearch", "port")
+        self.index = CowrieConfig().get("output_elasticsearch", "index")
+        self.type = CowrieConfig().get("output_elasticsearch", "type")
+        self.pipeline = CowrieConfig().get("output_elasticsearch", "pipeline")
+        # new options (creds + https)
+        self.username = CowrieConfig().get("output_elasticsearch", "username")
+        self.password = CowrieConfig().get("output_elasticsearch", "password")
+        self.use_ssl = CowrieConfig().getboolean(
+            "output_elasticsearch", "ssl", fallback=False
+        )
+        self.ca_certs = CowrieConfig().get("output_elasticsearch", "ca_certs")
+        self.verify_certs = CowrieConfig().getboolean(
+            "output_elasticsearch", "verify_certs", fallback=True
+        )
+
+        options = {}
+        # connect
+        if (self.username is not None) and (self.password is not None):
+            options["http_auth"] = (self.username, self.password)
+        if self.use_ssl:
+            options["scheme"] = "https"
+            options["use_ssl"] = self.use_ssl
+            options["ssl_show_warn"] = False
+            options["ca_certs"] = self.ca_certs
+            options["verify_certs"] = self.verify_certs
+
+        # connect
+        self.es = Elasticsearch("{0}:{1}".format(self.host, self.port), **options)
+        # self.es = Elasticsearch('{0}:{1}'.format(self.host, self.port))
 
     def stop(self):
         pass
@@ -27,7 +51,9 @@ class Output(cowrie.core.output.Output):
     def write(self, logentry):
         for i in list(logentry.keys()):
             # remove twisted 15 legacy keys
-            if i.startswith('log_'):
+            if i.startswith("log_"):
                 del logentry[i]
 
-        self.es.index(index=self.index, doc_type=self.type, body=logentry, pipeline=self.pipeline)
+        self.es.index(
+            index=self.index, doc_type=self.type, body=logentry, pipeline=self.pipeline
+        )


### PR DESCRIPTION
The current Elasticsearch (ES) output works well.
I merely added some features.

**New features**
 - Authentication to ES
 - HTTPS connection to ES
 - GeoIP pipeline/mapping

**Purposes**
 - Connection to a secure ES instance
 - Secure access to a Kibana dashboard presenting cowrie infos
 - Extraction of GeoIP infos

### Elasticsearch in secure mode

By default HTTPS and Authentication are not activated within Elasticsearch.
To enable these features, the `x-pack` must be activated. Authentication 
and HTTPS can then be configured.

On the client side you can access to a secure instance of ES by adding some options:
```python
options = {
    "http_auth": ("<username>", "<password>"),
    "use_ssl": True,
    "verify_certs": True,
    "ca_certs": "</path/to/ca.crt>",
}

es = Elasticsearch("127.0.0.1:9200", **options)
``` 

Where `<username>/<password>` are some valid credentials and `</path/to/ca.crt>` is the 
path to the CA authority which signs ES certificate.
Basically this code has been added to `cowrie/output/elasticsearch.py`, and new corresponding
options (with fallback) have been added in `cowrie.cfg.dist`.

### GeoIP

Cowrie provides many information. In particular we have the source addresses (`src_addr`) of the curious folks who connect to the honeypot. 
From this information we can estimate their location with geoip mapping.

For this purpose, we first need to add this feature in the data index through a mapping:

```python
"properties": {
    "geo": {
        "properties": {
            "location": {
                "type": "geo_point"
                }
            }
    }
}
```

Then the pipeline which really maps `src_ip` to `geo` must also be
added to ES:

```python
"processors": [
    {
        "geoip": {
            "field": "src_ip",  # input field of the pipeline (source address)
            "target_field": "geo",  # output field of the pipeline (geo data)
            "database_file": "GeoLite2-City.mmdb",
        }
    }
]
```

Both have been added to the ES output.

### Attached files

I attached some files:

- [`insecure.tar.gz`](https://github.com/cowrie/cowrie/files/4456101/insecure.tar.gz): it is merely a docker-compose file with elasticsearch and cowrie (with new `elasticserch.py` and new `cowrie.cfg`). However, the new options are not activated (legacy)
- [`secure.tar.gz`](https://github.com/cowrie/cowrie/files/4456102/secure.tar.gz): also a docker-compose file but with a secure ES instance and the new options activated within cowrie
- `kibana.png`: a basic screenshot of a kibana dashboard presenting cowrie GeoIP infos in production (see below)


![kibana](https://user-images.githubusercontent.com/31479857/78895019-65bb8200-7a6e-11ea-8644-7e221b0065c7.png)

[insecure.tar.gz](https://github.com/cowrie/cowrie/files/4456101/insecure.tar.gz)
[secure.tar.gz](https://github.com/cowrie/cowrie/files/4456102/secure.tar.gz)
