### PR TITLE
Added an event trigger to the twisted reactor: calls output plugins' stop() methods before shutting down

### DIFF
--- a/src/cowrie/core/output.py
+++ b/src/cowrie/core/output.py
@@ -104,7 +104,7 @@ class Output(object):
             self.timeFormat = '%Y-%m-%dT%H:%M:%S.%f%z'
 
         # Event trigger so that stop() is called by the reactor when stopping
-        reactor.addSystemEventTrigger('before', 'shutdown', self.stop)            
+        reactor.addSystemEventTrigger('before', 'shutdown', self.stop)
 
         self.start()
 

--- a/src/cowrie/core/output.py
+++ b/src/cowrie/core/output.py
@@ -103,6 +103,9 @@ class Output(object):
         else:
             self.timeFormat = '%Y-%m-%dT%H:%M:%S.%f%z'
 
+        # Event trigger so that stop() is called by the reactor when stopping
+        reactor.addSystemEventTrigger('before', 'shutdown', self.stop)            
+
         self.start()
 
     def logDispatch(self, *msg, **kw):

--- a/src/cowrie/core/output.py
+++ b/src/cowrie/core/output.py
@@ -34,6 +34,7 @@ import socket
 import time
 from os import environ
 
+from twisted.internet import reactor
 from twisted.logger import formatTime
 
 from cowrie.core.config import CowrieConfig


### PR DESCRIPTION
Currently, the `stop()` method of the Output class is not called when Cowrie is stopped. I am proposing to add a system event trigger at class instantiation to the twisted reactor. This will call the `stop()` method before shutting down.

As this method is currently 'required' by plugins, this should not cause any problems of the 'object has no attribute...' variety for existing plugins. However, any plugin that does anything with the stop method is, effectively, untested as its `stop()` method has never been called before.