### PR TITLE
Update libvirt version (5.5.0 to 6.4.0)

### DIFF
--- a/docs/BACKEND_POOL.rst
+++ b/docs/BACKEND_POOL.rst
@@ -23,7 +23,7 @@ Provided images
 ***************
 
 To allow for a simple setup, we provide two VM images to use with the backend pool: Ubuntu 18.04
-and OpenWRT. You can download them below, and then edit `cowrie.cfg` to match the path of the images.
+and OpenWRT. You can download them below, and then edit `cowrie.cfg`'s `guest_image_path` to match the path of the images.
 In the case of OpenWRT you will need two different files. Note that a separate set of configs is provided
 for each image in the default configuration. Choose the one you want to use and comment the other as needed.
 

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -185,7 +185,7 @@ and their Python interface. In Debian/Ubuntu::
 
 Then install the Python API to run the backend pool::
 
-    (cowrie-env) $ pip install libvirt-python==5.5.0
+    (cowrie-env) $ pip install libvirt-python==6.4.0
 
 To allow Qemu to use disk images and snapshots, set it to run with the user and group of the user running the pool
 (usually called 'cowrie' too::

--- a/docs/SNAPSHOTS.rst
+++ b/docs/SNAPSHOTS.rst
@@ -15,7 +15,7 @@ The tool we'll be using is `virt-diff`, which provides a similar syntax to that 
 
 .. code-block:: bash
 
-    sudo virt-diff -a ~/cowrie-imgs/ubuntu18.04-minimal.qcow2 -A snapshot-ubuntu18.04-a70b9671ad4d44619af2c4a41a28aec0.qcow2
+    $ sudo virt-diff -a ~/cowrie-imgs/ubuntu18.04-minimal.qcow2 -A snapshot-ubuntu18.04-a70b9671ad4d44619af2c4a41a28aec0.qcow2
 
 (the tool might need to be run with sudo due to a permission denied error)
 
@@ -25,7 +25,7 @@ from `virt-diff` is stored in a file diff.txt)
 
 .. code-block:: bash
 
-    grep -aE "^\+ |^- |^= " diff.txt
+    $ grep -aE "^\+ |^- |^= " diff.txt
 
 Here is an example output, in a VM were we created a file called `avirus`::
 
@@ -60,7 +60,7 @@ no good way to eliminate these, but we can use grep to ignore them:
 
 .. code-block:: bash
 
-    grep -aE "^\+ |^- |^= " diff.txt | grep -aEv "/tmp/systemd|/var/log|/var/lib"
+    $ grep -aE "^\+ |^- |^= " diff.txt | grep -aEv "/tmp/systemd|/var/log|/var/lib"
 
 Which now gives us a clearer output::
 
@@ -81,15 +81,15 @@ We start by mounting the image in a temporary dir:
 
 .. code-block:: bash
 
-    mkdir /tmp/mount_qcow2
-    sudo guestmount -a snapshot-ubuntu18.04-a70b9671ad4d44619af2c4a41a28aec0.qcow2 -m /dev/sda1 --ro /tmp/mount_qcow2
+    $ mkdir /tmp/mount_qcow2
+    $ sudo guestmount -a snapshot-ubuntu18.04-a70b9671ad4d44619af2c4a41a28aec0.qcow2 -m /dev/sda1 --ro /tmp/mount_qcow2
 
 If we now search for the file in the mount directory we can see its contents, and then unmount
 the drive:
 
 .. code-block:: bash
 
-    sudo ls -halt /tmp/mount_qcow2/root
+    $ sudo ls -halt /tmp/mount_qcow2/root
     total 32K
     -rw-------  1 root root 1.1K Jul 28 21:45 .bash_history
     drwx------  3 root root 4.0K Jul 28 21:45 .
@@ -100,10 +100,10 @@ the drive:
     -rw-r--r--  1 root root 3.1K Apr  9  2018 .bashrc
     -rw-r--r--  1 root root  148 Aug 17  2015 .profile
 
-    sudo cat /tmp/mount_qcow2/root/avirus
+    $ sudo cat /tmp/mount_qcow2/root/avirus
     virus content
 
-    sudo guestunmount /tmp/mount_qcow2/
+    $ sudo guestunmount /tmp/mount_qcow2/
 
 **Note:** the device to be mounted from the image isn't always `/dev/sda1`. However, if you
 run the command as-is, `guestmount` will check if `/dev/sda1` exists and, if not, it will

--- a/share/cowrie/pool_configs/default_guest.xml
+++ b/share/cowrie/pool_configs/default_guest.xml
@@ -30,7 +30,7 @@
                 <source file='{base_image}'/>
                 <backingStore/>
             </backingStore>
-            <target dev='vdb' bus='virtio'/>
+            <target dev='vda' bus='virtio'/>
             <address type='pci' domain='0x0000' bus='0x03' slot='0x00' function='0x0'/>
         </disk>
 

--- a/share/cowrie/pool_configs/default_guest.xml
+++ b/share/cowrie/pool_configs/default_guest.xml
@@ -25,7 +25,12 @@
         <disk type='file' device='disk'>
             <driver name='qemu' type='qcow2'/>
             <source file='{disk_image}'/>
-            <target dev='vda' bus='virtio'/>
+            <backingStore type='file'>
+                <format type='qcow2'/>
+                <source file='{base_image}'/>
+                <backingStore/>
+            </backingStore>
+            <target dev='vdb' bus='virtio'/>
             <address type='pci' domain='0x0000' bus='0x03' slot='0x00' function='0x0'/>
         </disk>
 

--- a/src/backend_pool/libvirt/guest_handler.py
+++ b/src/backend_pool/libvirt/guest_handler.py
@@ -58,6 +58,7 @@ def create_guest(connection, mac_address, guest_unique_id):
     guest_xml = backend_pool.util.read_file(configuration_file)
     guest_config = guest_xml.format(guest_name='cowrie-' + version_tag + '_' + guest_unique_id,
                                     disk_image=disk_img,
+                                    base_image=base_image,
                                     kernel_image=kernel_image,
                                     hypervisor=hypervisor,
                                     memory=memory,

--- a/src/backend_pool/libvirt/snapshot_handler.py
+++ b/src/backend_pool/libvirt/snapshot_handler.py
@@ -9,7 +9,7 @@ import subprocess
 def create_disk_snapshot(source_img, destination_img):
     try:
         shutil.chown(source_img, getpass.getuser())
-    except Exception:  # TODO should be PermissionError under python 3, but python 2 does not have it
+    except PermissionError:
         # log.msg('Should have root to create snapshot')
         pass
 


### PR DESCRIPTION
Hi @micheloosterhof, this should allow for the backend pool to run in Ubuntu 20.04 by updating the libvirt dependency. I also did some minor corrections on the docs in the meantime.

If there's no objection I'll merge this in a few days.