### PR TITLE
Enhanced command substitution functionality

### DIFF
--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -41,14 +41,16 @@ class HoneyPotShell(object):
         self.lexer = shlex.shlex(instream=line, punctuation_chars=True, posix=True)
         # Add these special characters that are not in the default lexer
         self.lexer.wordchars += '@%{}=$:+^,()'
+
         tokens = []
         subshell_tokens = []  # stack of subshell tokens
         last_parc_token = False  # control the command substitution tokens processing
         last_subshell_token = False  # control the subshell token processing
+
         while True:
             try:
                 if not last_parc_token:
-                    # if we are processing the command substitution dont read token
+                    # if we are processing the command substitution don't read token
                     tok = self.lexer.get_token()
                     # log.msg("tok: %s" % (repr(tok)))
 
@@ -61,7 +63,6 @@ class HoneyPotShell(object):
                             subshell_tokens.append(tok)
 
                     if not tok or last_subshell_token:
-                        cmds = " ".join(subshell_tokens)
                         self.cmdpending.append((subshell_tokens))
                         last_subshell_token = False
                         subshell_tokens = []
@@ -72,16 +73,7 @@ class HoneyPotShell(object):
                         self.cmdpending.append((tokens))
                         tokens = []
                     break
-                """
-                Why do we ignore parentheses?
-                We cant have this for shell command substitution  to work
-                # Ignore parentheses
-                tok_len = len(tok)
-                tok = tok.strip('(')
-                tok = tok.strip(')')
-                if len(tok) != tok_len and tok == '':
-                    continue
-                """
+
                 # For now, treat && and || same as ;, just execute without checking return code
                 if tok == '&&' or tok == '||':
                     if tokens:
@@ -103,7 +95,6 @@ class HoneyPotShell(object):
                         break
                 elif tok == '$?':
                     tok = "0"
-
                 elif tok[0] == '(':
                     subshell_tokens.append(tok[1:])
                     if tok[-1] == ')':
@@ -130,6 +121,7 @@ class HoneyPotShell(object):
                             tok = self.environ[envMatch]
                         else:
                             continue
+
                 tokens.append(tok)
             except Exception as e:
                 self.protocol.terminal.write(
@@ -139,6 +131,7 @@ class HoneyPotShell(object):
                 self.cmdpending = []
                 self.showPrompt()
                 return
+
         if self.cmdpending:
             self.runCommand()
         else:

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -137,10 +137,12 @@ class HoneyPotShell(object):
             elif dollar_expr[pos] == ')':
                 closing_count += 1
                 if opening_count == closing_count:
-                    # execute the command in () or $() and retrieve the output
+
                     if dollar_expr[0] == '(':
+                        # return the command in () without executing it
                         result = dollar_expr[1:pos]
                     else:
+                        # execute the command in $() and retrieve the output
                         cmd = dollar_expr[2:pos]
                         # instantiate new shell with redirect output
                         self.protocol.cmdstack.append(HoneyPotShell(self.protocol, interactive=False, redirect=True))

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -159,6 +159,20 @@ class ShellEchoCommandTests(unittest.TestCase):
 
     def test_echo_command_019(self):
         """
+        echo $(echo $(echo test))
+        """
+        self.proto.lineReceived(b'echo $(echo $(echo test))')
+        self.assertEquals(self.tr.value(), b'test\n' + PROMPT)
+
+    def test_echo_command_020(self):
+        """
+        echo test_$(echo test)_test
+        """
+        self.proto.lineReceived(b'echo test_$(echo test)_test')
+        self.assertEquals(self.tr.value(), b'test_test_test\n' + PROMPT)
+
+    def test_echo_command_021(self):
+        """
         (echo test)
         """
         self.proto.lineReceived(b'(echo test)')

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -173,6 +173,13 @@ class ShellEchoCommandTests(unittest.TestCase):
 
     def test_echo_command_021(self):
         """
+        echo test_$(echo test)_test_$(echo test)_test
+        """
+        self.proto.lineReceived(b'echo test_$(echo test)_test_$(echo test)_test')
+        self.assertEquals(self.tr.value(), b'test_test_test_test_test\n' + PROMPT)
+
+    def test_echo_command_022(self):
+        """
         (echo test)
         """
         self.proto.lineReceived(b'(echo test)')


### PR DESCRIPTION
Fixes #1416 

Implemented command substitution which should properly handle inputs like these:
```
root@cowrie:~# echo test $(uname)
test Linux
root@cowrie:~# echo test_$(uname)
test_Linux
root@cowrie:~# echo test_$(uname)_test
test_Linux_test
root@cowrie:~# echo test_$(which ls)
test_/bin/ls
```