### PR TITLE
Log the command before output in ttylog

### DIFF
--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -59,15 +59,17 @@ class LoggingServerProtocol(insults.ServerProtocol):
 
         if self.type == 'e':
             self.stdinlogOpen = True
+            # log the command into ttylog
+            if self.ttylogEnabled:
+                (sess, cmd) = self.protocolArgs
+                ttylog.ttylog_write(self.ttylogFile, len(cmd), ttylog.TYPE_INTERACT, time.time(), cmd)
         else:
             self.stdinlogOpen = False
 
         insults.ServerProtocol.connectionMade(self)
 
         if self.type == 'e':
-            cmd = self.terminalProtocol.execcmd.encode('utf8')
-            if self.ttylogEnabled:
-                ttylog.ttylog_write(self.ttylogFile, len(cmd), ttylog.TYPE_INTERACT, time.time(), cmd)
+            self.terminalProtocol.execcmd.encode('utf8')
 
     def write(self, data):
         if self.ttylogEnabled and self.ttylogOpen:


### PR DESCRIPTION
Fixes #1425 

Make sure, the command is saved to ttylog first and the output after that.

Currently, if the visitors are using SSH in non-interactive mode, cowrie saves the command output first and the command (input) is saved after the command execution.