### PR TITLE
Chmod fix + getopt

### DIFF
--- a/src/cowrie/commands/__init__.py
+++ b/src/cowrie/commands/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     'base64',
     'busybox',
     'cat',
+    'chmod',
     'chpasswd',
     'crontab',
     'curl',

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -671,51 +671,6 @@ commands['/bin/sh'] = command_sh
 commands['sh'] = command_sh
 
 
-class command_chmod(HoneyPotCommand):
-
-    def call(self):
-        # at least 2 arguments are expected
-        if len(self.args) == 0:
-            self.write('chmod: missing operand\n')
-            self.write('Try \'chmod --help\' for more information.\n')
-            return
-        elif len(self.args) == 1:
-            self.write('chmod: missing operand after ‘{}’\n'.format(self.args[0]))
-            self.write('Try \'chmod --help\' for more information.\n')
-            return
-
-        # extract mode, options and files from the command arguments
-        mode = None
-        options = []
-        files = []
-
-        for arg in self.args:
-            if re.match('-[cfvR]+', arg) or arg.startswith('--'):
-                options.append(arg)
-            elif mode is None:
-                mode = arg
-            else:
-                files.append(arg)
-
-        # mode has to match this regex
-        mode_regex = '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=][0-7]+'
-        if not re.match(mode_regex, mode):
-            # invalid mode was specified
-            self.write('chmod: invalid mode: ‘{}’\n'.format(mode))
-            self.write('Try \'chmod --help\' for more information.\n')
-            return
-
-        # go through the list of files and check whether they exist
-        for file in files:
-            path = self.fs.resolve_path(file, self.protocol.cwd)
-            if not self.fs.exists(path):
-                self.write('chmod: cannot access \'{}\': No such file or directory\n'.format(file))
-
-
-commands['/bin/chmod'] = command_chmod
-commands['chmod'] = command_chmod
-
-
 class command_php(HoneyPotCommand):
 
     def start(self):

--- a/src/cowrie/commands/chmod.py
+++ b/src/cowrie/commands/chmod.py
@@ -90,15 +90,13 @@ class command_chmod(HoneyPotCommand):
                     self.write('chmod: cannot access \'{}\': No such file or directory\n'.format(file))
 
     def parse_args(self):
-        opts = []
         mode = None
-        files = []
 
-        # before parsing with getopt, remove the mode spec from self.args
-        # getopt would incorrectly raise an error for arguments like -r, -w, etc
+        # a mode specification starting with '-' would cause the getopt parser to throw an error
+        # therefore, remove the first such argument self.args before parsing with getopt
         args_new = []
         for arg in self.args:
-            if arg.startswith('-') and re.fullmatch(MODE_REGEX, arg):
+            if not mode and arg.startswith('-') and re.fullmatch(MODE_REGEX, arg):
                 mode = arg
             else:
                 args_new.append(arg)

--- a/src/cowrie/commands/chmod.py
+++ b/src/cowrie/commands/chmod.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import, division
 
+import getopt
 import re
 
 from cowrie.shell.command import HoneyPotCommand
@@ -10,47 +11,119 @@ from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
 
+CHMOD_HELP = """Usage: chmod [OPTION]... MODE[,MODE]... FILE...
+  or:  chmod [OPTION]... OCTAL-MODE FILE...
+  or:  chmod [OPTION]... --reference=RFILE FILE...
+Change the mode of each FILE to MODE.
+With --reference, change the mode of each FILE to that of RFILE.
+
+  -c, --changes          like verbose but report only when a change is made
+  -f, --silent, --quiet  suppress most error messages
+  -v, --verbose          output a diagnostic for every file processed
+      --no-preserve-root  do not treat '/' specially (the default)
+      --preserve-root    fail to operate recursively on '/'
+      --reference=RFILE  use RFILE's mode instead of MODE values
+  -R, --recursive        change files and directories recursively
+      --help     display this help and exit
+      --version  output version information and exit
+
+Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=][0-7]+'.
+
+GNU coreutils online help: <https://www.gnu.org/software/coreutils/>
+Full documentation at: <https://www.gnu.org/software/coreutils/chmod>
+or available locally via: info '(coreutils) chmod invocation'
+"""
+
+CHMOD_VERSION = """chmod (GNU coreutils) 8.25
+Copyright (C) 2016 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+
+Written by David MacKenzie and Jim Meyering.
+"""
+
+MODE_REGEX = '^[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+$'
+TRY_CHMOD_HELP_MSG = "Try 'chmod --help' for more information.\n"
+
 
 class command_chmod(HoneyPotCommand):
 
     def call(self):
-        # at least 2 arguments are expected
-        if len(self.args) == 0:
-            self.write('chmod: missing operand\n')
-            self.write('Try \'chmod --help\' for more information.\n')
-            return
-        elif len(self.args) == 1:
-            self.write('chmod: missing operand after ‘{}’\n'.format(self.args[0]))
-            self.write('Try \'chmod --help\' for more information.\n')
+        # parse the command line arguments
+        opts, mode, files, getopt_err = self.parse_args()
+        if getopt_err:
             return
 
-        # extract mode, options and files from the command arguments
-        mode = None
-        options = []
-        files = []
+        # if --help or --version is present, we don't care about the rest
+        for o in opts:
+            if o == '--help':
+                self.write(CHMOD_HELP)
+                return
+            if o == '--version':
+                self.write(CHMOD_VERSION)
+                return
 
-        for arg in self.args:
-            if re.match('-[cfvR]+', arg) or arg.startswith('--'):
-                options.append(arg)
-            elif mode is None:
-                mode = arg
-            else:
-                files.append(arg)
+        # check for presence of mode and files in arguments
+        if (not mode or mode.startswith('-')) and not files:
+            self.write('chmod: missing operand\n' + TRY_CHMOD_HELP_MSG)
+            return
+        if mode and not files:
+            self.write('chmod: missing operand after ‘{}’\n'.format(mode) + TRY_CHMOD_HELP_MSG)
+            return
 
-        # mode has to match this regex
-        mode_regex = '^[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]{1,4}$'
-        if not re.match(mode_regex, mode):
-            # invalid mode was specified
-            self.write('chmod: invalid mode: ‘{}’\n'.format(mode))
-            self.write('Try \'chmod --help\' for more information.\n')
+        # mode has to match the regex
+        if not re.fullmatch(MODE_REGEX, mode):
+            self.write('chmod: invalid mode: ‘{}’\n'.format(mode) + TRY_CHMOD_HELP_MSG)
             return
 
         # go through the list of files and check whether they exist
         for file in files:
-            if file != '*':
+            if file == '*':
+                # if the current directory is empty, return 'No such file or directory'
+                files = self.fs.get_path(self.protocol.cwd)[:]
+                if not files:
+                    self.write('chmod: cannot access \'*\': No such file or directory\n')
+            else:
                 path = self.fs.resolve_path(file, self.protocol.cwd)
                 if not self.fs.exists(path):
                     self.write('chmod: cannot access \'{}\': No such file or directory\n'.format(file))
+
+    def parse_args(self):
+        opts = []
+        mode = None
+        files = []
+
+        # before parsing with getopt, remove the mode spec from self.args
+        # getopt would incorrectly raise an error for arguments like -r, -w, etc
+        args_new = []
+        for arg in self.args:
+            if arg.startswith('-') and re.fullmatch(MODE_REGEX, arg):
+                mode = arg
+            else:
+                args_new.append(arg)
+
+        # parse the command line options with getopt
+        try:
+            opts, args = getopt.gnu_getopt(args_new, 'cfvR', ['changes', 'silent', 'quiet', 'verbose',
+                                                              'no-preserve-root', 'preserve-root', 'reference=',
+                                                              'recursive', 'help', 'version'])
+        except getopt.GetoptError as err:
+            failed_opt = err.msg.split(' ')[1]
+            if failed_opt.startswith("--"):
+                self.errorWrite("chmod: unrecognized option '--{}'\n".format(err.opt) + TRY_CHMOD_HELP_MSG)
+            else:
+                self.errorWrite("chmod: invalid option -- '{}'\n".format(err.opt) + TRY_CHMOD_HELP_MSG)
+            return [], None, [], True
+
+        # if mode was not found before, use the first arg as mode
+        if not mode and len(args) > 0:
+            mode = args.pop(0)
+
+        # the rest of args should be files
+        files = args
+
+        return opts, mode, files, False
 
 
 commands['/bin/chmod'] = command_chmod

--- a/src/cowrie/commands/chmod.py
+++ b/src/cowrie/commands/chmod.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2020 Peter Sufliarsky <sufliarskyp@gmail.com>
+# See the COPYRIGHT file for more information
+
+from __future__ import absolute_import, division
+
+import re
+
+from cowrie.shell.command import HoneyPotCommand
+
+
+commands = {}
+
+
+class command_chmod(HoneyPotCommand):
+
+    def call(self):
+        # at least 2 arguments are expected
+        if len(self.args) == 0:
+            self.write('chmod: missing operand\n')
+            self.write('Try \'chmod --help\' for more information.\n')
+            return
+        elif len(self.args) == 1:
+            self.write('chmod: missing operand after ‘{}’\n'.format(self.args[0]))
+            self.write('Try \'chmod --help\' for more information.\n')
+            return
+
+        # extract mode, options and files from the command arguments
+        mode = None
+        options = []
+        files = []
+
+        for arg in self.args:
+            if re.match('-[cfvR]+', arg) or arg.startswith('--'):
+                options.append(arg)
+            elif mode is None:
+                mode = arg
+            else:
+                files.append(arg)
+
+        # mode has to match this regex
+        mode_regex = '^[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]{1,4}$'
+        if not re.match(mode_regex, mode):
+            # invalid mode was specified
+            self.write('chmod: invalid mode: ‘{}’\n'.format(mode))
+            self.write('Try \'chmod --help\' for more information.\n')
+            return
+
+        # go through the list of files and check whether they exist
+        for file in files:
+            if file != '*':
+                path = self.fs.resolve_path(file, self.protocol.cwd)
+                if not self.fs.exists(path):
+                    self.write('chmod: cannot access \'{}\': No such file or directory\n'.format(file))
+
+
+commands['/bin/chmod'] = command_chmod
+commands['chmod'] = command_chmod

--- a/src/cowrie/test/test_chmod.py
+++ b/src/cowrie/test/test_chmod.py
@@ -23,7 +23,7 @@ os.environ["SHELL_FILESYSTEM"] = "../share/cowrie/fs.pickle"
 PROMPT = b"root@unitTest:~# "
 
 
-class ShellTeeCommandTests(unittest.TestCase):
+class ShellChmodCommandTests(unittest.TestCase):
 
     def setUp(self):
         self.proto = protocol.HoneyPotInteractiveProtocol(fake_server.FakeAvatar(fake_server.FakeServer()))
@@ -119,6 +119,34 @@ class ShellTeeCommandTests(unittest.TestCase):
         Valid directory ~/.ssh
         """
         self.proto.lineReceived(b"chmod +x ~/.ssh")
+        self.assertEquals(self.tr.value(), PROMPT)
+
+    def test_chmod_command_011(self):
+        """
+        chmod a+x
+        """
+        self.proto.lineReceived(b"chmod a+x .ssh")
+        self.assertEquals(self.tr.value(), PROMPT)
+
+    def test_chmod_command_012(self):
+        """
+        chmod ug+x
+        """
+        self.proto.lineReceived(b"chmod ug+x .ssh")
+        self.assertEquals(self.tr.value(), PROMPT)
+
+    def test_chmod_command_013(self):
+        """
+        chmod 777
+        """
+        self.proto.lineReceived(b"chmod 777 .ssh")
+        self.assertEquals(self.tr.value(), PROMPT)
+
+    def test_chmod_command_014(self):
+        """
+        chmod 0775
+        """
+        self.proto.lineReceived(b"chmod 0755 .ssh")
         self.assertEquals(self.tr.value(), PROMPT)
 
     def tearDown(self):

--- a/src/cowrie/test/test_chmod.py
+++ b/src/cowrie/test/test_chmod.py
@@ -20,6 +20,7 @@ os.environ["HONEYPOT_DATA_PATH"] = "../data"
 os.environ["HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
 os.environ["SHELL_FILESYSTEM"] = "../share/cowrie/fs.pickle"
 
+TRY_CHMOD_HELP_MSG = b"Try 'chmod --help' for more information.\n"
 PROMPT = b"root@unitTest:~# "
 
 
@@ -38,67 +39,65 @@ class ShellChmodCommandTests(unittest.TestCase):
         self.proto.lineReceived(b"chmod")
         self.assertEquals(
             self.tr.value(),
-            b"chmod: missing operand\nTry 'chmod --help' for more information.\n"
-            + PROMPT
+            b"chmod: missing operand\n" + TRY_CHMOD_HELP_MSG + PROMPT
         )
 
     def test_chmod_command_002(self):
         """
-        Missing operand after...
+        Missing operand
         """
-        self.proto.lineReceived(b"chmod arg")
+        self.proto.lineReceived(b"chmod -x")
         self.assertEquals(
             self.tr.value(),
-            b"chmod: missing operand after \xe2\x80\x98arg\xe2\x80\x99\nTry 'chmod --help' for more information.\n"
-            + PROMPT
+            b"chmod: missing operand\n" + TRY_CHMOD_HELP_MSG + PROMPT
         )
 
     def test_chmod_command_003(self):
         """
-        Missing operand
+        Missing operand after ...
         """
         self.proto.lineReceived(b"chmod +x")
         self.assertEquals(
             self.tr.value(),
-            b"chmod: missing operand after \xe2\x80\x98+x\xe2\x80\x99\nTry 'chmod --help' for more information.\n"
-            + PROMPT
+            b"chmod: missing operand after \xe2\x80\x98+x\xe2\x80\x99\n" + TRY_CHMOD_HELP_MSG + PROMPT
         )
 
     def test_chmod_command_004(self):
         """
-        No such file or directory
+        Invalid option
         """
-        self.proto.lineReceived(b"chmod +x abcd")
-        self.assertEquals(self.tr.value(), b"chmod: cannot access 'abcd': No such file or directory\n" + PROMPT)
+        self.proto.lineReceived(b"chmod -A")
+        self.assertEquals(
+            self.tr.value(),
+            b"chmod: invalid option -- 'A'\n" + TRY_CHMOD_HELP_MSG + PROMPT
+        )
 
-    # does not work properly
-    # def test_chmod_command_005(self):
-    #     """
-    #     Invalid option
-    #     """
-    #     self.proto.lineReceived(b"chmod -A +x abcd")
-    #     self.assertEquals(
-    #         self.tr.value(),
-    #         b"chmod: invalid option -- 'A'\nTry 'chmod --help' for more information.\n" + PROMPT
-    #     )
+    def test_chmod_command_005(self):
+        """
+        Unrecognized option
+        """
+        self.proto.lineReceived(b"chmod --A")
+        self.assertEquals(
+            self.tr.value(),
+            b"chmod: unrecognized option '--A'\n" + TRY_CHMOD_HELP_MSG + PROMPT
+        )
 
     def test_chmod_command_006(self):
+        """
+        No such file or directory
+        """
+        self.proto.lineReceived(b"chmod -x abcd")
+        self.assertEquals(self.tr.value(), b"chmod: cannot access 'abcd': No such file or directory\n" + PROMPT)
+
+    def test_chmod_command_007(self):
         """
         Invalid mode
         """
         self.proto.lineReceived(b"chmod abcd efgh")
         self.assertEquals(
             self.tr.value(),
-            b"chmod: invalid mode: \xe2\x80\x98abcd\xe2\x80\x99\nTry 'chmod --help' for more information.\n"
-            + PROMPT
+            b"chmod: invalid mode: \xe2\x80\x98abcd\xe2\x80\x99\n" + TRY_CHMOD_HELP_MSG + PROMPT
         )
-
-    def test_chmod_command_007(self):
-        """
-        Valid directory .ssh recursive
-        """
-        self.proto.lineReceived(b"chmod -R +x .ssh")
-        self.assertEquals(self.tr.value(), PROMPT)
 
     def test_chmod_command_008(self):
         """
@@ -109,40 +108,47 @@ class ShellChmodCommandTests(unittest.TestCase):
 
     def test_chmod_command_009(self):
         """
+        Valid directory .ssh recursive
+        """
+        self.proto.lineReceived(b"chmod -R +x .ssh")
+        self.assertEquals(self.tr.value(), PROMPT)
+
+    def test_chmod_command_010(self):
+        """
         Valid directory /root/.ssh
         """
         self.proto.lineReceived(b"chmod +x /root/.ssh")
         self.assertEquals(self.tr.value(), PROMPT)
 
-    def test_chmod_command_010(self):
+    def test_chmod_command_011(self):
         """
         Valid directory ~/.ssh
         """
         self.proto.lineReceived(b"chmod +x ~/.ssh")
         self.assertEquals(self.tr.value(), PROMPT)
 
-    def test_chmod_command_011(self):
+    def test_chmod_command_012(self):
         """
         chmod a+x
         """
         self.proto.lineReceived(b"chmod a+x .ssh")
         self.assertEquals(self.tr.value(), PROMPT)
 
-    def test_chmod_command_012(self):
+    def test_chmod_command_013(self):
         """
         chmod ug+x
         """
         self.proto.lineReceived(b"chmod ug+x .ssh")
         self.assertEquals(self.tr.value(), PROMPT)
 
-    def test_chmod_command_013(self):
+    def test_chmod_command_014(self):
         """
         chmod 777
         """
         self.proto.lineReceived(b"chmod 777 .ssh")
         self.assertEquals(self.tr.value(), PROMPT)
 
-    def test_chmod_command_014(self):
+    def test_chmod_command_015(self):
         """
         chmod 0775
         """


### PR DESCRIPTION
There is a problem with the regexp which I was originally using to check the mode format in chmod. I actually copied and pasted it from the chmod man page:

`[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=][0-7]+`

This does not work properly. For example mode specification like 777 do not match the regexp. Therefore, I changed the regexp to this:

`[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+`

Also I changed chmod to use getopt for argument parsing and I extracted the chmod implementation to a separate python source file.