### PR TITLE
Update resolv.conf

### DIFF
--- a/honeyfs/etc/resolv.conf
+++ b/honeyfs/etc/resolv.conf
@@ -1,2 +1,1 @@
 nameserver 8.8.8.8
-nameserver 8.8.4.4


### PR DESCRIPTION
Hackers generally tend to change resolv.conf to use 8.8.8.8, showing the backup 8.8.4.4 will flag it as a honeypot.