### PR TITLE
Treat python stdin as sourcefile

### DIFF
--- a/src/cowrie/commands/python.py
+++ b/src/cowrie/commands/python.py
@@ -104,7 +104,7 @@ class command_python(HoneyPotCommand):
         for value in args:
             sourcefile = self.fs.resolve_path(value, self.protocol.cwd)
 
-            if self.fs.exists(sourcefile):
+            if self.fs.exists(sourcefile) or value == '-':
                 self.exit()
             else:
 


### PR DESCRIPTION
Attacker used ```wget <file> | python -``` as a means to quickly execute code. This small fix treats the python stdin as a real file and does not output "Errno 2".