### PR TITLE
Update fsctl to use utf-8 encoding

### DIFF
--- a/bin/fsctl
+++ b/bin/fsctl
@@ -99,7 +99,7 @@ class fseditCmd(cmd.Cmd):
             sys.exit(1)
 
         try:
-            self.fs = pickle.load(pickle_file)
+            self.fs = pickle.load(pickle_file, encoding="utf-8")
         except:
             print(("Unable to load file '%s'. " + \
                     "Are you sure it is a valid pickle file?") % \


### PR DESCRIPTION
I noticed in some cases that the file does not want to load and gives an error that it was "not a valid pickle file". Upon research I found out that the encoding for python3 was utf-8, however pickle demanded an unicode file. This should fix the issue.