### PR TITLE
Adding kill to list of most-used commands

### DIFF
--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -1153,6 +1153,7 @@ commands["unset"] = command_nop
 commands["export"] = command_nop
 commands["alias"] = command_nop
 commands["jobs"] = command_nop
+commands["kill"] = command_nop
 commands["/bin/kill"] = command_nop
 commands["/bin/pkill"] = command_nop
 commands["/bin/killall"] = command_nop


### PR DESCRIPTION
Command "Kill" does only work with /bin/kill, however "kill" should work the same way in newer versions that use "/usr/bin/kill".