### PR TITLE
Fixed the Slack output since it was using an old interface of slackclient

### DIFF
--- a/src/cowrie/output/slack.py
+++ b/src/cowrie/output/slack.py
@@ -55,7 +55,7 @@ class Output(cowrie.core.output.Output):
                 del logentry[i]
 
         self.sc = WebClient(self.slack_token)
-        self.sc.api_call(
+        self.sc.chat_postMessage(
             channel=self.slack_channel,
             text="{} {}".format(
                 time.strftime("%Y-%m-%d %H:%M:%S"),

--- a/src/cowrie/output/slack.py
+++ b/src/cowrie/output/slack.py
@@ -30,7 +30,7 @@
 import json
 import time
 
-from slack import SlackClient
+from slack import WebClient
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -54,9 +54,8 @@ class Output(cowrie.core.output.Output):
             if i.startswith("log_"):
                 del logentry[i]
 
-        self.sc = SlackClient(self.slack_token)
+        self.sc = WebClient(self.slack_token)
         self.sc.api_call(
-            "chat.postMessage",
             channel=self.slack_channel,
             text="{} {}".format(
                 time.strftime("%Y-%m-%d %H:%M:%S"),


### PR DESCRIPTION
The Slack output is currently not working since it was built based on the old 1.x interface of the `slackclient` library.

This PR makes the necessary adjustments to get the output to work with modern versions of the library. It was tested against a running instance of Cowrie and is confirmed to be working that way