### PR TITLE
Not all file_download events have 'url' set

### DIFF
--- a/src/cowrie/output/hpfeeds3.py
+++ b/src/cowrie/output/hpfeeds3.py
@@ -94,8 +94,9 @@ class Output(cowrie.core.output.Output):
             self.meta[session]["unknownCommands"].append(uc)
 
         elif entry["eventid"] == "cowrie.session.file_download":
-            url = entry["url"]
-            self.meta[session]["urls"].append(url)
+            if "url" in entry:
+                url = entry["url"]
+                self.meta[session]["urls"].append(url)
             self.meta[session]["hashes"].add(entry["shasum"])
 
         elif entry["eventid"] == "cowrie.session.file_upload":


### PR DESCRIPTION
`scp` data emits `file_download` events, but they don't have a url. Make sure that hpeeds doesn't throw an error in that case.