### PR TITLE
Use  backslashreplace instead of repr() when logging SSH version string

### DIFF
--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -112,7 +112,7 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             self.otherVersionString = self.buf.split(b"\n")[0].strip()
             log.msg(
                 eventid="cowrie.client.version",
-                version=repr(self.otherVersionString),
+                version=self.otherVersionString.decode("utf-8", errors="backslashreplace"),
                 format="Remote SSH version: %(version)s",
             )
             m = re.match(br"SSH-(\d+.\d+)-(.*)", self.otherVersionString)

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -209,7 +209,7 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             self.otherVersionString = self.buf.split(b"\n")[0].strip()
             log.msg(
                 eventid="cowrie.client.version",
-                version=repr(self.otherVersionString),
+                version=self.otherVersionString.decode("utf-8", errors="backslashreplace"),
                 format="Remote SSH version: %(version)s",
             )
             m = re.match(br"SSH-(\d+.\d+)-(.*)", self.otherVersionString)


### PR DESCRIPTION
Fixes https://github.com/cowrie/cowrie/issues/1583.

I looked for other cases I felt confident changing, but e.g. the username/password fields are coming through in hpfeeds just fine so I wasn't sure they needed any changes.