### PR TITLE
Add username wildcard example in 'userdb.example' file

### DIFF
--- a/etc/userdb.example
+++ b/etc/userdb.example
@@ -8,7 +8,7 @@
 # Field #1 contains the username
 # Field #2 is currently unused
 # Field #3 contains the password 
-# '*' for password allows any password
+# '*' for any username or password
 # '!' at the start of a password will not grant this password access
 # '/' can be used to write a regular expression 
 #
@@ -18,3 +18,5 @@ root:x:!/honeypot/i
 root:x:*
 tomcat:x:*
 oracle:x:*
+*:x:somepassword
+*:x:*


### PR DESCRIPTION
I wanted cowrie to accept any username password combination for my usecase. I looked up both `'UserDB'` auth mechanism and subsequently read `userdb.example` file to understand its working. It did not mention that username wildcards are supported until I hit [this issue on Github](https://github.com/cowrie/cowrie/issues/635) which was merged in [this pull request](https://github.com/cowrie/cowrie/pull/687/files).

I think addition of username wildcard example in `userdb.example` will really help people understand working of `UserDB` auth class.