### PR TITLE
Add ecdsa and ed25519 keys

### DIFF
--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -500,7 +500,13 @@ rsa_public_key = ${honeypot:state_path}/ssh_host_rsa_key.pub
 rsa_private_key = ${honeypot:state_path}/ssh_host_rsa_key
 dsa_public_key = ${honeypot:state_path}/ssh_host_dsa_key.pub
 dsa_private_key = ${honeypot:state_path}/ssh_host_dsa_key
+ecdsa_public_key = ${honeypot:state_path}/ssh_host_ecdsa_key.pub
+ecdsa_private_key = ${honeypot:state_path}/ssh_host_ecdsa_key
+ed25519_public_key = ${honeypot:state_path}/ssh_host_ed25519_key.pub
+ed25519_private_key = ${honeypot:state_path}/ssh_host_ed25519_key
 
+# Public keys supported are: ssh-rsa, ssh-dss, ecdsa-sha2-nistp256, ssh-ed25519
+public_key_auth = ssh-rsa,ecdsa-sha2-nistp256,ssh-ed25519
 
 # SSH version string as present to the client.
 #

--- a/src/cowrie/ssh/keys.py
+++ b/src/cowrie/ssh/keys.py
@@ -60,3 +60,47 @@ def getDSAKeys():
         with open(privateKeyFile, "rb") as f:
             privateKeyString = f.read()
     return publicKeyString, privateKeyString
+
+
+def getECDSAKeys():
+    publicKeyFile: str = CowrieConfig.get("ssh", "ecdsa_public_key")
+    privateKeyFile: str = CowrieConfig.get("ssh", "ecdsa_private_key")
+    if not (os.path.exists(publicKeyFile) and os.path.exists(privateKeyFile)):
+        log.msg("Generating new ECDSA keypair...")
+        from cryptography.hazmat.primitives.asymmetric import ec
+
+        ecdsaKey = ec.generate_private_key(ec.SECP256R1())
+        publicKeyString = keys.Key(ecdsaKey).public().toString("openssh")
+        privateKeyString = keys.Key(ecdsaKey).toString("openssh")
+        with open(publicKeyFile, "w+b") as f:
+            f.write(publicKeyString)
+        with open(privateKeyFile, "w+b") as f:
+            f.write(privateKeyString)
+    else:
+        with open(publicKeyFile, "rb") as f:
+            publicKeyString = f.read()
+        with open(privateKeyFile, "rb") as f:
+            privateKeyString = f.read()
+    return publicKeyString, privateKeyString
+
+
+def geted25519Keys():
+    publicKeyFile: str = CowrieConfig.get("ssh", "ed25519_public_key")
+    privateKeyFile: str = CowrieConfig.get("ssh", "ed25519_private_key")
+    if not (os.path.exists(publicKeyFile) and os.path.exists(privateKeyFile)):
+        log.msg("Generating new ed25519 keypair...")
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        ed25519Key = Ed25519PrivateKey.generate()
+        publicKeyString = keys.Key(ed25519Key).public().toString("openssh")
+        privateKeyString = keys.Key(ed25519Key).toString("openssh")
+        with open(publicKeyFile, "w+b") as f:
+            f.write(publicKeyString)
+        with open(privateKeyFile, "w+b") as f:
+            f.write(privateKeyString)
+    else:
+        with open(publicKeyFile, "rb") as f:
+            publicKeyString = f.read()
+        with open(privateKeyFile, "rb") as f:
+            privateKeyString = f.read()
+    return publicKeyString, privateKeyString


### PR DESCRIPTION
Following this IEFT https://datatracker.ietf.org/doc/html/draft-miller-ssh-agent-02#section-4.2.2

I added ECDSA and ED25519 keys and removed DSA key as currently OpenSSH only lists the three (RSA, ECDSA and ED25519) as ssh-hostkeys.