### PR TITLE
Add Redis to requirements-output.txt

### DIFF
--- a/requirements-output.txt
+++ b/requirements-output.txt
@@ -39,3 +39,5 @@ wokkel==18.0.0
 # misp
 pymisp==2.4.148.1
 
+# redis
+redis==3.5.3


### PR DESCRIPTION
Currently Redis (Pip module) is not installed when the Docker container is built. I am not sure if this is the best way to add a new dependency though. 

See current version number here: https://pypi.org/project/redis/

Michael