### PR TITLE
Fix wget for links with IP

### DIFF
--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -161,8 +161,8 @@ class Command_wget(HoneyPotCommand):
                         host, host
                     )
                 )
-            self.errorWrite("wget: unable to resolve host address ‘{}’\n".format(host))
-            return None
+                self.errorWrite("wget: unable to resolve host address ‘{}’\n".format(host))
+                return None
         except ValueError:
             pass
 


### PR DESCRIPTION
Seems like indentation was incorrect in https://github.com/cowrie/cowrie/commit/b8be378586c6e68d8625a5129a31200dc452b9a9 , so any wget to an IP fails now (e.g. `wget http://1.1.1.1`)