### PR TITLE
Add output to Graylog via GELF HTTP input.

### DIFF
--- a/docs/graylog/README.rst
+++ b/docs/graylog/README.rst
@@ -39,7 +39,7 @@ Restart Cowrie
 Graylog Configuration
 *********************
 
-Using Syslog
+Syslog Input
 ============
 
 Open the Graylog web interface and click on the **System** drop-down in the top menu. From the drop-down menu select **Inputs**. Select **Syslog UDP** from the drop-down menu and click the **Launch new input** button. In the modal dialog enter the following information::
@@ -50,8 +50,8 @@ Open the Graylog web interface and click on the **System** drop-down in the top 
 
 Then click **Launch.**
 
-Using GELF HTTP Input
-=====================
+GELF HTTP Input
+===============
 
 Open the Graylog web interface and click on the **System** drop-down in the top menu. From the drop-down menu select **Inputs**. Select **GELF HTTP** from the drop-down menu and click the **Launch new input** button. In the modal dialog enter the information about your input.
 

--- a/docs/graylog/README.rst
+++ b/docs/graylog/README.rst
@@ -1,15 +1,15 @@
 How to send Cowrie output to Graylog via syslog
-####################################
+###############################################
 
 
 Prerequisites
-======================
+=============
 
 * Working Cowrie installation
 * Working Graylog installation
 
 Cowrie Configuration
-======================
+====================
 
 Open the Cowrie configuration file and uncomment these 3 lines::
 
@@ -20,7 +20,7 @@ Open the Cowrie configuration file and uncomment these 3 lines::
 Restart Cowrie
 
 Graylog Configuration
-======================
+=====================
 
 Open the Graylog web interface and click on the **System** drop-down in the top menu. From the drop-down menu select **Inputs**. Select **Syslog UDP** from the drop-down menu and click the **Launch new input** button. In the modal dialog enter the following information::
 
@@ -31,7 +31,7 @@ Open the Graylog web interface and click on the **System** drop-down in the top 
 Then click **Launch.**
 
 Syslog Configuration
-======================
+====================
 
 Create a rsyslog configuration file in /etc/rsyslog.d::
 
@@ -47,46 +47,63 @@ Restart rsyslog::
     $ sudo service rsyslog restart
 
 How to send Cowrie output to Graylog via HTTP GELF input
-####################################
+########################################################
 
 
 Prerequisites
-======================
+=============
 
 * Working Cowrie installation
 * Working Graylog installation
 * Working HTTP Gelf Input on Graylog
 
 Cowrie Configuration
-======================
+====================
 
 Open the Cowrie configuration file and find this block ::
 
-    [output_graylog_gelf]
+    [output_graylog]
     enabled = false
     url = http://127.0.0.1:12201/gelf
-    tls = False
-    cert =
-    key =
-    verify =
 
 Enable this block and specify url of your input.
-
-- If you need tls - change status to True, and specify path to your tls cert and key.
-
-- If your using self signed certificatet you can disable certificate validation with key **False** or specify path to you can provide a custom certificate authority bundle
 
 Restart Cowrie
 
 Graylog Configuration
-======================
+=====================
 
 Open the Graylog web interface and click on the **System** drop-down in the top menu. From the drop-down menu select **Inputs**. Select **GELF HTTP** from the drop-down menu and click the **Launch new input** button. In the modal dialog enter the information about your input.
+
+Click **Manage Extractors** near created input. On new page click **Actions** -> **Import extractors**  and paste this config ::
+
+    {
+      "extractors": [
+        {
+          "title": "Cowrie Json Parser",
+          "extractor_type": "json",
+          "converters": [],
+          "order": 0,
+          "cursor_strategy": "copy",
+          "source_field": "message",
+          "target_field": "",
+          "extractor_config": {
+            "list_separator": ", ",
+            "kv_separator": "=",
+            "key_prefix": "",
+            "key_separator": "_",
+            "replace_key_whitespace": false,
+            "key_whitespace_replacement": "_"
+          },
+          "condition_type": "none",
+          "condition_value": ""
+        }
+      ],
+      "version": "4.2.1"
+    }
 
 Then click **Launch.**
 
 Note:
-
-- If TLS is enabled - in URL block you must specify **https://**
 
 - Do not remove **/gelf** from the end of URL block, expect of case when your proxing this address behind nginx;

--- a/docs/graylog/README.rst
+++ b/docs/graylog/README.rst
@@ -1,4 +1,4 @@
-How to send Cowrie output to Graylog
+How to send Cowrie output to Graylog via syslog
 ####################################
 
 
@@ -46,4 +46,43 @@ Restart rsyslog::
 
     $ sudo service rsyslog restart
 
+How to send Cowrie output to Graylog via HTTP GELF input
+####################################
 
+
+Prerequisites
+======================
+
+* Working Cowrie installation
+* Working Graylog installation
+* Working HTTP Gelf Input on Graylog
+
+Cowrie Configuration
+======================
+
+Open the Cowrie configuration file and find this block ::
+
+    [output_graylog_gelf]
+    enabled = false
+    url = http://127.0.0.1:12201/gelf
+    tls = False
+    cert =
+    key =
+
+Enable this block and specify url of your input.
+If you need tls - change status to True and specify path to your tls cert and key.
+
+Restart Cowrie
+
+Graylog Configuration
+======================
+
+Open the Graylog web interface and click on the **System** drop-down in the top menu. From the drop-down menu select **Inputs**. Select **GELF HTTP** from the drop-down menu and click the **Launch new input** button. In the modal dialog enter the information about your input.
+
+Then click **Launch.**
+
+Note:
+
+- If TLS is enabled - in URL block you must specify **https://**
+
+- Do not remove **/gelf** from the end of URL block, expect of case when your proxing this address behind nginx;

--- a/docs/graylog/README.rst
+++ b/docs/graylog/README.rst
@@ -68,9 +68,13 @@ Open the Cowrie configuration file and find this block ::
     tls = False
     cert =
     key =
+    verify =
 
 Enable this block and specify url of your input.
-If you need tls - change status to True and specify path to your tls cert and key.
+
+- If you need tls - change status to True, and specify path to your tls cert and key.
+
+- If your using self signed certificatet you can disable certificate validation with key **False** or specify path to you can provide a custom certificate authority bundle
 
 Restart Cowrie
 

--- a/docs/graylog/README.rst
+++ b/docs/graylog/README.rst
@@ -1,26 +1,46 @@
-How to send Cowrie output to Graylog via syslog
-###############################################
+How to send Cowrie output to Graylog
+####################################
 
+This guide describes how to configure send cowrie outputs to graylog via syslog and http gelf input.
 
 Prerequisites
-=============
+*************
 
 * Working Cowrie installation
 * Working Graylog installation
 
 Cowrie Configuration
-====================
+********************
+
+Using Syslog
+============
 
 Open the Cowrie configuration file and uncomment these 3 lines::
 
     [output_localsyslog]
-    facility = USER
-    format = text
+    facility * USER
+    format * text
+
+Restart Cowrie
+
+Using GELF HTTP Input
+=====================
+
+Open the Cowrie configuration file and find this block ::
+
+    [output_graylog]
+    enabled * false
+    url * http://127.0.0.1:12201/gelf
+
+Enable this block and specify url of your input.
 
 Restart Cowrie
 
 Graylog Configuration
-=====================
+*********************
+
+Using Syslog
+============
 
 Open the Graylog web interface and click on the **System** drop-down in the top menu. From the drop-down menu select **Inputs**. Select **Syslog UDP** from the drop-down menu and click the **Launch new input** button. In the modal dialog enter the following information::
 
@@ -30,47 +50,7 @@ Open the Graylog web interface and click on the **System** drop-down in the top 
 
 Then click **Launch.**
 
-Syslog Configuration
-====================
-
-Create a rsyslog configuration file in /etc/rsyslog.d::
-
-    $ sudo nano /etc/rsyslog.d/85-graylog.conf
-
-Add the following lines to the file::
-
-    $template GRAYLOGRFC5424,"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msg%\n"
-    *.* @127.0.0.1:8514;GRAYLOGRFC5424
-
-Restart rsyslog::
-
-    $ sudo service rsyslog restart
-
-How to send Cowrie output to Graylog via HTTP GELF input
-########################################################
-
-
-Prerequisites
-=============
-
-* Working Cowrie installation
-* Working Graylog installation
-* Working HTTP Gelf Input on Graylog
-
-Cowrie Configuration
-====================
-
-Open the Cowrie configuration file and find this block ::
-
-    [output_graylog]
-    enabled = false
-    url = http://127.0.0.1:12201/gelf
-
-Enable this block and specify url of your input.
-
-Restart Cowrie
-
-Graylog Configuration
+Using GELF HTTP Input
 =====================
 
 Open the Graylog web interface and click on the **System** drop-down in the top menu. From the drop-down menu select **Inputs**. Select **GELF HTTP** from the drop-down menu and click the **Launch new input** button. In the modal dialog enter the information about your input.
@@ -89,7 +69,7 @@ Click **Manage Extractors** near created input. On new page click **Actions** ->
           "target_field": "",
           "extractor_config": {
             "list_separator": ", ",
-            "kv_separator": "=",
+            "kv_separator": "*",
             "key_prefix": "",
             "key_separator": "_",
             "replace_key_whitespace": false,
@@ -107,3 +87,20 @@ Then click **Launch.**
 Note:
 
 - Do not remove **/gelf** from the end of URL block, expect of case when your proxing this address behind nginx;
+
+Syslog Configuration (For Syslog Output only)
+*********************************************
+
+Create a rsyslog configuration file in /etc/rsyslog.d::
+
+    $ sudo nano /etc/rsyslog.d/85-graylog.conf
+
+Add the following lines to the file::
+
+    $template GRAYLOGRFC5424,"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msg%\n"
+    *.* @127.0.0.1:8514;GRAYLOGRFC5424
+
+Restart rsyslog::
+
+    $ sudo service rsyslog restart
+

--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -775,8 +775,15 @@ enabled = false
 userid = userid_here
 auth_key = auth_key_here
 batch_size = 100
-
-
+#
+# Graylog Extended Log Format (GELF) HTTP logging module
+[output_graylog_gelf]
+enabled = false
+url = http://127.0.0.1:12201/gelf
+tls = False
+cert =
+key =
+#
 # Local Syslog output module
 #
 # This sends log messages to the local syslog daemon.

--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -783,6 +783,7 @@ url = http://127.0.0.1:12201/gelf
 tls = False
 cert =
 key =
+verify = True
 #
 # Local Syslog output module
 #

--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -776,14 +776,10 @@ userid = userid_here
 auth_key = auth_key_here
 batch_size = 100
 #
-# Graylog Extended Log Format (GELF) HTTP logging module
-[output_graylog_gelf]
+# Graylog logging module for GELF http input
+[output_graylog]
 enabled = false
-url = http://127.0.0.1:12201/gelf
-tls = False
-cert =
-key =
-verify = True
+url = http://graylog.example.com:122011/gelf
 #
 # Local Syslog output module
 #

--- a/src/cowrie/output/graylog.py
+++ b/src/cowrie/output/graylog.py
@@ -50,7 +50,7 @@ class Output(cowrie.core.output.Output):
         )
 
         body = FileBodyProducer(BytesIO(json.dumps(entry).encode("utf8")))
-        req = self.agent.request(b"POST", self.url, headers, body)
+        self.agent.request(b"POST", self.url, headers, body)
 
 
 class WebClientContextFactory(ClientContextFactory):

--- a/src/cowrie/output/graylog.py
+++ b/src/cowrie/output/graylog.py
@@ -1,0 +1,60 @@
+"""
+Simple Graylog HTTP Graylog Extended Log Format (GELF) logger.
+"""
+
+import cowrie.core.output
+import json
+import os
+import requests
+import time
+
+from cowrie.core.config import CowrieConfig
+
+
+url: bytes
+
+
+class Output(cowrie.core.output.Output):
+    def start(self):
+        self.url = CowrieConfig.get("output_graylog_gelf", "url")
+        self.tls = CowrieConfig.get("output_graylog_gelf", "tls")
+        if 'True' in self.tls:
+            self.cert = CowrieConfig.get("output_graylog_gelf", "cert")
+            self.cert_key = CowrieConfig.get("output_graylog_gelf", "key")
+
+        self.headers = {
+            'Content-Type': 'application/json'
+        }
+        self.hostname = os.uname()[1]
+
+    def stop(self):
+        pass
+
+    def write(self, logentry):
+        for i in list(logentry.keys()):
+            # Remove twisted 15 legacy keys
+            if i.startswith("log_"):
+                del logentry[i]
+
+        self.gelf_message = {
+            'version': '1.1',
+            'host': self.hostname,
+            'timestamp': time.time(),
+            'short_message': json.dumps(logentry),
+            'level': 1,
+        }
+
+        if 'False' in self.tls:
+            self.gelf = requests.post(
+                self.url,
+                headers=self.headers,
+                data=json.dumps(self.gelf_message)
+            )
+        else:
+            self.gelf = requests.post(
+                self.url,
+                verify=False,
+                cert=(self.cert, self.cert_key),
+                headers=self.headers,
+                data=json.dumps(self.gelf_message)
+            )

--- a/src/cowrie/output/graylog.py
+++ b/src/cowrie/output/graylog.py
@@ -21,6 +21,7 @@ class Output(cowrie.core.output.Output):
         if 'True' in self.tls:
             self.cert = CowrieConfig.get("output_graylog_gelf", "cert")
             self.cert_key = CowrieConfig.get("output_graylog_gelf", "key")
+            self.verify = CowrieConfig.get("output_graylog_gelf", "verify")
 
         self.headers = {
             'Content-Type': 'application/json'
@@ -53,7 +54,7 @@ class Output(cowrie.core.output.Output):
         else:
             self.gelf = requests.post(
                 self.url,
-                verify=False,
+                verify=self.verify,
                 cert=(self.cert, self.cert_key),
                 headers=self.headers,
                 data=json.dumps(self.gelf_message)


### PR DESCRIPTION
Add output to Graylog via GELF HTTP input.
* Working with default requirements.txt of cowrie;
* Tested with latest Cowrie and Graylog 4.1.1 and Graylog 4.2.1 version;
* Support GELF Input with enabled TLS;