### PR TITLE
Open socket file in 'r' mode instead of 'rb'

### DIFF
--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -34,7 +34,7 @@ class FTP(ftplib.FTP):
             (self.host, self.port), self.timeout, self.source_address
         )
         self.af = self.sock.family
-        self.file = self.sock.makefile(mode="rb")
+        self.file = self.sock.makefile(mode="r")
         self.welcome = self.getresp()
         return self.welcome
 


### PR DESCRIPTION
Python ftplib.FTP opens socket file in 'r' mode, opening it in 'rb' mode is not supported.

https://github.com/python/cpython/blob/f42a06ba279c916fb67289e47f9bc60dc5dee4ee/Lib/ftplib.py#L161

https://github.com/python/cpython/blob/f42a06ba279c916fb67289e47f9bc60dc5dee4ee/Lib/ftplib.py#L219

Note that CRLF is a string, not a bytes obj. It's not valid to compare bytes to a string.

Also see this comment: https://github.com/cowrie/cowrie/issues/1394#issuecomment-873494458

.. and this Python issue:
https://bugs.python.org/issue43418