### PR TITLE
moving from twisted.trial.unittest to unittest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ etc/ssh_host_dsa_key.pub
 etc/ssh_host_rsa_key
 etc/ssh_host_rsa_key.pub
 var/log/cowrie/*
-cowrie.egg-info/
+*.egg-info
 dl/
 dist/
 docs/_build

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -1043,70 +1043,63 @@ commands["sh"] = Command_sh
 
 
 class Command_php(HoneyPotCommand):
-    def start(self):
-        if not len(self.args):
-            pass
-        elif self.args[0] == "-v":
-            output = ("PHP 5.3.5 (cli)", "Copyright (c) 1997-2010 The PHP Group")
-            for line in output:
-                self.write(f"{line}\n")
-            self.exit()
-        elif self.args[0] == "-h":
-            output = [
-                "Usage: php [options] [-f] <file> [--] [args...]",
-                "       php [options] -r <code> [--] [args...]",
-                "       php [options] [-B <begin_code>] -R <code> [-E <end_code>] [--] [args...]",
-                "       php [options] [-B <begin_code>] -F <file> [-E <end_code>] [--] [args...]",
-                "       php [options] -- [args...]",
-                "       php [options] -a",
-                "",
-                "  -a               Run interactively",
-                "  -c <path>|<file> Look for php.ini file in this directory",
-                "  -n               No php.ini file will be used",
-                "  -d foo[=bar]     Define INI entry foo with value 'bar'",
-                "  -e               Generate extended information for debugger/profiler",
-                "  -f <file>        Parse and execute <file>.",
-                "  -h               This help",
-                "  -i               PHP information",
-                "  -l               Syntax check only (lint)",
-                "  -m               Show compiled in modules",
-                "  -r <code>        Run PHP <code> without using script tags <?..?>",
-                "  -B <begin_code>  Run PHP <begin_code> before processing input lines",
-                "  -R <code>        Run PHP <code> for every input line",
-                "  -F <file>        Parse and execute <file> for every input line",
-                "  -E <end_code>    Run PHP <end_code> after processing all input lines",
-                "  -H               Hide any passed arguments from external tools.",
-                "  -s               Output HTML syntax highlighted source.",
-                "  -v               Version number",
-                "  -w               Output source with stripped comments and whitespace.",
-                "  -z <file>        Load Zend extension <file>.",
-                "",
-                "  args...          Arguments passed to script. Use -- args when first argument",
-                "                   starts with - or script is read from stdin",
-                "",
-                "  --ini            Show configuration file names",
-                "",
-                "  --rf <name>      Show information about function <name>.",
-                "  --rc <name>      Show information about class <name>.",
-                "  --re <name>      Show information about extension <name>.",
-                "  --ri <name>      Show configuration for extension <name>.",
-                "",
-            ]
-            for line in output:
-                self.write(f"{line}\n")
-            self.exit()
-        else:
+    HELP = "Usage: php [options] [-f] <file> [--] [args...]\n" \
+           "       php [options] -r <code> [--] [args...]\n" \
+           "       php [options] [-B <begin_code>] -R <code> [-E <end_code>] [--] [args...]\n" \
+           "       php [options] [-B <begin_code>] -F <file> [-E <end_code>] [--] [args...]\n" \
+           "       php [options] -- [args...]\n" \
+           "       php [options] -a\n" \
+           "\n" \
+           "  -a               Run interactively\n" \
+           "  -c <path>|<file> Look for php.ini file in this directory\n" \
+           "  -n               No php.ini file will be used\n" \
+           "  -d foo[=bar]     Define INI entry foo with value 'bar'\n" \
+           "  -e               Generate extended information for debugger/profiler\n" \
+           "  -f <file>        Parse and execute <file>.\n" \
+           "  -h               This help\n" \
+           "  -i               PHP information\n" \
+           "  -l               Syntax check only (lint)\n" \
+           "  -m               Show compiled in modules\n" \
+           "  -r <code>        Run PHP <code> without using script tags <?..?>\n" \
+           "  -B <begin_code>  Run PHP <begin_code> before processing input lines\n" \
+           "  -R <code>        Run PHP <code> for every input line\n" \
+           "  -F <file>        Parse and execute <file> for every input line\n" \
+           "  -E <end_code>    Run PHP <end_code> after processing all input lines\n" \
+           "  -H               Hide any passed arguments from external tools.\n" \
+           "  -s               Output HTML syntax highlighted source.\n" \
+           "  -v               Version number\n" \
+           "  -w               Output source with stripped comments and whitespace.\n" \
+           "  -z <file>        Load Zend extension <file>.\n" \
+           "\n" \
+           "  args...          Arguments passed to script. Use -- args when first argument\n" \
+           "                   starts with - or script is read from stdin\n" \
+           "\n" \
+           "  --ini            Show configuration file names\n" \
+           "\n" \
+           "  --rf <name>      Show information about function <name>.\n" \
+           "  --rc <name>      Show information about class <name>.\n" \
+           "  --re <name>      Show information about extension <name>.\n" \
+           "  --ri <name>      Show configuration for extension <name>.\n" \
+           "\n"
+
+    VERSION = "PHP 5.3.5 (cli)\n" \
+              "Copyright (c) 1997-2010 The PHP Group\n"
+
+    def start(self) -> None:
+        if len(self.args):
+            if self.args[0] == "-v":
+                self.write(Command_php.VERSION)
+            elif self.args[0] == "-h":
+                self.write(Command_php.HELP)
             self.exit()
 
-    def lineReceived(self, line):
-        log.msg(
-            eventid="cowrie.command.success",
-            realm="php",
-            input=line,
-            format="INPUT (%(realm)s): %(input)s",
-        )
+    def lineReceived(self, line: str) -> None:
+        log.msg(eventid="cowrie.command.success",
+                realm="php",
+                input=line,
+                format="INPUT (%(realm)s): %(input)s")
 
-    def handle_CTRL_D(self):
+    def handle_CTRL_D(self) -> None:
         self.exit()
 
 

--- a/src/cowrie/test/fake_server.py
+++ b/src/cowrie/test/fake_server.py
@@ -1,5 +1,3 @@
-# -*- test-case-name: Cowrie Test Cases -*-
-
 # Copyright (c) 2016 Dave Germiquet
 # See LICENSE for details.
 
@@ -9,7 +7,8 @@ from cowrie.shell import fs
 
 
 class FakeServer:
-    """
+    """FakeServer class.
+
     @ivar hostname Servers Host Name
     @ivar fs File System for cowrie to use
     """
@@ -23,13 +22,13 @@ class FakeServer:
 
 
 class FakeAvatar:
-    """
+    """FakeAvatar class.
+
     @var avatar itself
     @ivar server server configuration
     @var fs File System for cowrie to use
     @var environ for user
     @var uid for user
-    @var
     """
 
     def __init__(self, server):

--- a/src/cowrie/test/fake_transport.py
+++ b/src/cowrie/test/fake_transport.py
@@ -1,5 +1,3 @@
-# -*- test-case-name: Cowrie Test Cases -*-
-
 # Copyright (c) 2016 Dave Germiquet
 # See LICENSE for details.
 
@@ -12,12 +10,11 @@ from twisted.test import proto_helpers
 
 
 class Container:
-    """
-    This class is placeholder for creating a fake interface
+    """This class is placeholder for creating a fake interface.
+
     @var host Client fake information
     @var port Fake Port for connection
     @var otherVersionString version
-    @var
     """
 
     otherVersionString = "1.0"
@@ -32,24 +29,18 @@ class Container:
     factory: Container | None
 
     def getPeer(self):
-        """
-        Fake function for mockup
-        """
+        """Fake function for mockup."""
         self.host = "1.1.1.1"
         self.port = 2222
         return self
 
     def processEnded(self, reason):
-        """
-        Fake function for mockup
-        """
+        """Fake function for mockup."""
         pass
 
 
 class FakeTransport(proto_helpers.StringTransport):
-    """
-    Fake transport with abortConnection() method.
-    """
+    """Fake transport with abortConnection() method."""
 
     # Thanks to TerminalBuffer (some code was taken from twisted Terminal Buffer)
 
@@ -132,8 +123,7 @@ class FakeTransport(proto_helpers.StringTransport):
                 pass
 
     def setPrivateModes(self, modes):
-        """
-        Enable the given modes.
+        """Enable the given modes.
 
         Track which modes have been enabled so that the implementations of
         other L{insults.ITerminalTransport} methods can be properly implemented

--- a/src/cowrie/test/proxy_compare.py
+++ b/src/cowrie/test/proxy_compare.py
@@ -1,3 +1,4 @@
+#mypy: ignore
 from __future__ import annotations
 
 from backend_pool.ssh_exec import execute_ssh

--- a/src/cowrie/test/proxy_compare.py
+++ b/src/cowrie/test/proxy_compare.py
@@ -1,27 +1,29 @@
 from __future__ import annotations
-from twisted.internet import defer
 
 from backend_pool.ssh_exec import execute_ssh
 from backend_pool.telnet_exec import execute_telnet
 
+from twisted.internet import defer
+
 
 class ProxyTestCommand:
-    """
+    """ProxyTestCommand class.
+
     This class executes commands on Proxy instances and their backends (or either one of them).
     If executing on both, it compares their outputs, and a deferred succeeds on that case.
     """
 
     def __init__(
-        self,
-        type,
-        hostname,
-        port_backend,
-        port_proxy,
-        username_backend,
-        password_backend,
-        username_proxy,
-        password_proxy,
-    ):
+            self,
+            type,
+            hostname,
+            port_backend,
+            port_proxy,
+            username_backend,
+            password_backend,
+            username_proxy,
+            password_proxy,
+    ) -> None:
         self.deferred = defer.Deferred()
         self.backend_data = None
         self.proxy_data = None
@@ -35,11 +37,11 @@ class ProxyTestCommand:
         self.username_proxy = username_proxy
         self.password_proxy = password_proxy
 
-        # whether to execute the command via SSH or Telnet
+        # Whether to execute the command via SSH or Telnet.
         self.execute = execute_ssh if type == "ssh" else execute_telnet
 
-    def execute_both(self, command):
-        def callback_backend(data):
+    def execute_both(self, command) -> None:
+        def callback_backend(data) -> None:
             # if we haven't received data from the proxy just store the output
             if not self.proxy_data:
                 self.backend_data = data
@@ -50,7 +52,7 @@ class ProxyTestCommand:
                 else:
                     self.deferred.errback(ValueError())
 
-        def callback_proxy(data):
+        def callback_proxy(data) -> None:
             # if we haven't received data from the backend just store the output
             if not self.backend_data:
                 self.proxy_data = data
@@ -63,7 +65,7 @@ class ProxyTestCommand:
                         ValueError("Values from proxy and backend do not match!")
                     )
 
-        # execute exec command on both backend and proxy
+        # Execute exec command on both backend and proxy.
         self.execute(
             self.hostname,
             self.port_backend,
@@ -81,20 +83,15 @@ class ProxyTestCommand:
             callback_proxy,
         )
 
-    def execute_one(self, is_proxy, command, deferred):
-        def callback(data):
+    def execute_one(self, is_proxy: bool, command, deferred) -> None:
+        def callback(data) -> None:
             deferred.callback(data)
 
         if is_proxy:
-            # execute via proxy
             username = self.username_proxy
             password = self.password_proxy
         else:
-            # execute via backend
             username = self.username_backend
             password = self.password_backend
 
-        # execute exec command
-        self.execute(
-            self.hostname, self.port_backend, username, password, command, callback
-        )
+        self.execute(self.hostname, self.port_backend, username, password, command, callback)

--- a/src/cowrie/test/proxy_compare.py
+++ b/src/cowrie/test/proxy_compare.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
-from twisted.internet import defer
 
 from backend_pool.ssh_exec import execute_ssh
 from backend_pool.telnet_exec import execute_telnet
+
+from twisted.internet import defer
 
 
 class ProxyTestCommand:

--- a/src/cowrie/test/proxy_compare.py
+++ b/src/cowrie/test/proxy_compare.py
@@ -1,4 +1,4 @@
-#mypy: ignore
+#mypy: ignore  # noqa
 from __future__ import annotations
 
 from backend_pool.ssh_exec import execute_ssh

--- a/src/cowrie/test/proxy_compare.py
+++ b/src/cowrie/test/proxy_compare.py
@@ -1,97 +1,97 @@
-from __future__ import annotations
-
-from backend_pool.ssh_exec import execute_ssh
-from backend_pool.telnet_exec import execute_telnet
-
-from twisted.internet import defer
-
-
-class ProxyTestCommand:
-    """ProxyTestCommand class.
-
-    This class executes commands on Proxy instances and their backends (or either one of them).
-    If executing on both, it compares their outputs, and a deferred succeeds on that case.
-    """
-
-    def __init__(
-            self,
-            type,
-            hostname,
-            port_backend,
-            port_proxy,
-            username_backend,
-            password_backend,
-            username_proxy,
-            password_proxy,
-    ) -> None:
-        self.deferred = defer.Deferred()
-        self.backend_data = None
-        self.proxy_data = None
-
-        self.hostname = hostname
-        self.port_backend = port_backend
-        self.port_proxy = port_proxy
-
-        self.username_backend = username_backend
-        self.password_backend = password_backend
-        self.username_proxy = username_proxy
-        self.password_proxy = password_proxy
-
-        # Whether to execute the command via SSH or Telnet.
-        self.execute = execute_ssh if type == "ssh" else execute_telnet
-
-    def execute_both(self, command) -> None:
-        def callback_backend(data) -> None:
-            # if we haven't received data from the proxy just store the output
-            if not self.proxy_data:
-                self.backend_data = data
-            else:
-                # compare data from proxy and backend
-                if data == self.proxy_data:
-                    self.deferred.callback(True)
-                else:
-                    self.deferred.errback(ValueError())
-
-        def callback_proxy(data) -> None:
-            # if we haven't received data from the backend just store the output
-            if not self.backend_data:
-                self.proxy_data = data
-            else:
-                # compare data from proxy and backend
-                if data == self.backend_data:
-                    self.deferred.callback(True)
-                else:
-                    self.deferred.errback(
-                        ValueError("Values from proxy and backend do not match!")
-                    )
-
-        # Execute exec command on both backend and proxy.
-        self.execute(
-            self.hostname,
-            self.port_backend,
-            self.username_backend,
-            self.password_backend,
-            command,
-            callback_backend,
-        )
-        self.execute(
-            self.hostname,
-            self.port_proxy,
-            self.username_proxy,
-            self.password_proxy,
-            command,
-            callback_proxy,
-        )
-
-    def execute_one(self, is_proxy: bool, command, deferred) -> None:
-        def callback(data) -> None:
-            deferred.callback(data)
-
-        if is_proxy:
-            username = self.username_proxy
-            password = self.password_proxy
-        else:
-            username = self.username_backend
-            password = self.password_backend
-
-        self.execute(self.hostname, self.port_backend, username, password, command, callback)
+# from __future__ import annotations
+#
+# from backend_pool.ssh_exec import execute_ssh
+# from backend_pool.telnet_exec import execute_telnet
+#
+# from twisted.internet import defer
+#
+#
+# class ProxyTestCommand:
+#     """ProxyTestCommand class.
+#
+#     This class executes commands on Proxy instances and their backends (or either one of them).
+#     If executing on both, it compares their outputs, and a deferred succeeds on that case.
+#     """
+#
+#     def __init__(
+#             self,
+#             type,
+#             hostname,
+#             port_backend,
+#             port_proxy,
+#             username_backend,
+#             password_backend,
+#             username_proxy,
+#             password_proxy,
+#     ) -> None:
+#         self.deferred = defer.Deferred()
+#         self.backend_data = None
+#         self.proxy_data = None
+#
+#         self.hostname = hostname
+#         self.port_backend = port_backend
+#         self.port_proxy = port_proxy
+#
+#         self.username_backend = username_backend
+#         self.password_backend = password_backend
+#         self.username_proxy = username_proxy
+#         self.password_proxy = password_proxy
+#
+#         # Whether to execute the command via SSH or Telnet.
+#         self.execute = execute_ssh if type == "ssh" else execute_telnet
+#
+#     def execute_both(self, command) -> None:
+#         def callback_backend(data) -> None:
+#             # if we haven't received data from the proxy just store the output
+#             if not self.proxy_data:
+#                 self.backend_data = data
+#             else:
+#                 # compare data from proxy and backend
+#                 if data == self.proxy_data:
+#                     self.deferred.callback(True)
+#                 else:
+#                     self.deferred.errback(ValueError())
+#
+#         def callback_proxy(data) -> None:
+#             # if we haven't received data from the backend just store the output
+#             if not self.backend_data:
+#                 self.proxy_data = data
+#             else:
+#                 # compare data from proxy and backend
+#                 if data == self.backend_data:
+#                     self.deferred.callback(True)
+#                 else:
+#                     self.deferred.errback(
+#                         ValueError("Values from proxy and backend do not match!")
+#                     )
+#
+#         # Execute exec command on both backend and proxy.
+#         self.execute(
+#             self.hostname,
+#             self.port_backend,
+#             self.username_backend,
+#             self.password_backend,
+#             command,
+#             callback_backend,
+#         )
+#         self.execute(
+#             self.hostname,
+#             self.port_proxy,
+#             self.username_proxy,
+#             self.password_proxy,
+#             command,
+#             callback_proxy,
+#         )
+#
+#     def execute_one(self, is_proxy: bool, command, deferred) -> None:
+#         def callback(data) -> None:
+#             deferred.callback(data)
+#
+#         if is_proxy:
+#             username = self.username_proxy
+#             password = self.password_proxy
+#         else:
+#             username = self.username_backend
+#             password = self.password_backend
+#
+#         self.execute(self.hostname, self.port_backend, username, password, command, callback)

--- a/src/cowrie/test/proxy_compare.py
+++ b/src/cowrie/test/proxy_compare.py
@@ -1,97 +1,100 @@
-# from __future__ import annotations
-#
-# from backend_pool.ssh_exec import execute_ssh
-# from backend_pool.telnet_exec import execute_telnet
-#
-# from twisted.internet import defer
-#
-#
-# class ProxyTestCommand:
-#     """ProxyTestCommand class.
-#
-#     This class executes commands on Proxy instances and their backends (or either one of them).
-#     If executing on both, it compares their outputs, and a deferred succeeds on that case.
-#     """
-#
-#     def __init__(
-#             self,
-#             type,
-#             hostname,
-#             port_backend,
-#             port_proxy,
-#             username_backend,
-#             password_backend,
-#             username_proxy,
-#             password_proxy,
-#     ) -> None:
-#         self.deferred = defer.Deferred()
-#         self.backend_data = None
-#         self.proxy_data = None
-#
-#         self.hostname = hostname
-#         self.port_backend = port_backend
-#         self.port_proxy = port_proxy
-#
-#         self.username_backend = username_backend
-#         self.password_backend = password_backend
-#         self.username_proxy = username_proxy
-#         self.password_proxy = password_proxy
-#
-#         # Whether to execute the command via SSH or Telnet.
-#         self.execute = execute_ssh if type == "ssh" else execute_telnet
-#
-#     def execute_both(self, command) -> None:
-#         def callback_backend(data) -> None:
-#             # if we haven't received data from the proxy just store the output
-#             if not self.proxy_data:
-#                 self.backend_data = data
-#             else:
-#                 # compare data from proxy and backend
-#                 if data == self.proxy_data:
-#                     self.deferred.callback(True)
-#                 else:
-#                     self.deferred.errback(ValueError())
-#
-#         def callback_proxy(data) -> None:
-#             # if we haven't received data from the backend just store the output
-#             if not self.backend_data:
-#                 self.proxy_data = data
-#             else:
-#                 # compare data from proxy and backend
-#                 if data == self.backend_data:
-#                     self.deferred.callback(True)
-#                 else:
-#                     self.deferred.errback(
-#                         ValueError("Values from proxy and backend do not match!")
-#                     )
-#
-#         # Execute exec command on both backend and proxy.
-#         self.execute(
-#             self.hostname,
-#             self.port_backend,
-#             self.username_backend,
-#             self.password_backend,
-#             command,
-#             callback_backend,
-#         )
-#         self.execute(
-#             self.hostname,
-#             self.port_proxy,
-#             self.username_proxy,
-#             self.password_proxy,
-#             command,
-#             callback_proxy,
-#         )
-#
-#     def execute_one(self, is_proxy: bool, command, deferred) -> None:
-#         def callback(data) -> None:
-#             deferred.callback(data)
-#
-#         if is_proxy:
-#             username = self.username_proxy
-#             password = self.password_proxy
-#         else:
-#             username = self.username_backend
-#             password = self.password_backend
-#
-#         self.execute(self.hostname, self.port_backend, username, password, command, callback)
+from __future__ import annotations
+from twisted.internet import defer
+
+from backend_pool.ssh_exec import execute_ssh
+from backend_pool.telnet_exec import execute_telnet
+
+
+class ProxyTestCommand:
+    """
+    This class executes commands on Proxy instances and their backends (or either one of them).
+    If executing on both, it compares their outputs, and a deferred succeeds on that case.
+    """
+
+    def __init__(
+        self,
+        type,
+        hostname,
+        port_backend,
+        port_proxy,
+        username_backend,
+        password_backend,
+        username_proxy,
+        password_proxy,
+    ):
+        self.deferred = defer.Deferred()
+        self.backend_data = None
+        self.proxy_data = None
+
+        self.hostname = hostname
+        self.port_backend = port_backend
+        self.port_proxy = port_proxy
+
+        self.username_backend = username_backend
+        self.password_backend = password_backend
+        self.username_proxy = username_proxy
+        self.password_proxy = password_proxy
+
+        # whether to execute the command via SSH or Telnet
+        self.execute = execute_ssh if type == "ssh" else execute_telnet
+
+    def execute_both(self, command):
+        def callback_backend(data):
+            # if we haven't received data from the proxy just store the output
+            if not self.proxy_data:
+                self.backend_data = data
+            else:
+                # compare data from proxy and backend
+                if data == self.proxy_data:
+                    self.deferred.callback(True)
+                else:
+                    self.deferred.errback(ValueError())
+
+        def callback_proxy(data):
+            # if we haven't received data from the backend just store the output
+            if not self.backend_data:
+                self.proxy_data = data
+            else:
+                # compare data from proxy and backend
+                if data == self.backend_data:
+                    self.deferred.callback(True)
+                else:
+                    self.deferred.errback(
+                        ValueError("Values from proxy and backend do not match!")
+                    )
+
+        # execute exec command on both backend and proxy
+        self.execute(
+            self.hostname,
+            self.port_backend,
+            self.username_backend,
+            self.password_backend,
+            command,
+            callback_backend,
+        )
+        self.execute(
+            self.hostname,
+            self.port_proxy,
+            self.username_proxy,
+            self.password_proxy,
+            command,
+            callback_proxy,
+        )
+
+    def execute_one(self, is_proxy, command, deferred):
+        def callback(data):
+            deferred.callback(data)
+
+        if is_proxy:
+            # execute via proxy
+            username = self.username_proxy
+            password = self.password_proxy
+        else:
+            # execute via backend
+            username = self.username_backend
+            password = self.password_backend
+
+        # execute exec command
+        self.execute(
+            self.hostname, self.port_backend, username, password, command, callback
+        )

--- a/src/cowrie/test/test_awk.py
+++ b/src/cowrie/test/test_awk.py
@@ -20,7 +20,7 @@ class ShellEchoCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/awk.py."""
 
     proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-    tr = FakeTransport("1.1.1.1", "1111")
+    tr = FakeTransport("", "31337")
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/src/cowrie/test/test_awk.py
+++ b/src/cowrie/test/test_awk.py
@@ -1,17 +1,8 @@
-# -*- test-case-name: Cowrie Test Cases -*-
-
 # Copyright (c) 2018 Michel Oosterhof
 # See LICENSE for details.
-
-"""
-Tests for general shell interaction and echo command
-"""
 from __future__ import annotations
 
-
 import os
-
-# from twisted.trial import unittest
 import unittest
 
 from cowrie.shell import protocol
@@ -25,7 +16,9 @@ PROMPT = b"root@unitTest:~# "
 
 
 class ShellEchoCommandTests(unittest.TestCase):
-    def setUp(self):
+    """Tests for cowrie/commands/awk.py."""
+
+    def setUp(self) -> None:
         self.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
@@ -33,40 +26,30 @@ class ShellEchoCommandTests(unittest.TestCase):
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 
-    def test_awk_command_001(self):
-        """
-        Test $0, full input line contents
-        """
+    def tearDown(self) -> None:
+        self.proto.connectionLost("tearDown From Unit Test")
+
+    def test_awk_command_001(self) -> None:
+        """Test $0, full input line contents."""
         self.proto.lineReceived(b'echo "test test" | awk "{ print $0 }"\n')
         self.assertEqual(self.tr.value(), b"test test\n" + PROMPT)
 
-    def test_awk_command_002(self):
-        """
-        Test $1, first agument
-        """
+    def test_awk_command_002(self) -> None:
+        """Test $1, first agument."""
         self.proto.lineReceived(b'echo "test" | awk "{ print $1 }"\n')
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_awk_command_003(self):
-        """
-        Test $1 $2 space separated
-        """
+    def test_awk_command_003(self) -> None:
+        """Test $1 $2 space separated."""
         self.proto.lineReceived(b'echo "test test" | awk "{ print $1 $2 }"\n')
         self.assertEqual(self.tr.value(), b"test test\n" + PROMPT)
 
-    def test_awk_command_004(self):
-        """
-        Test $1,$2 comma separated
-        """
+    def test_awk_command_004(self) -> None:
+        """Test $1,$2 comma separated."""
         self.proto.lineReceived(b'echo "test test" | awk "{ print $1,$2 }"\n')
         self.assertEqual(self.tr.value(), b"test test\n" + PROMPT)
 
-    def test_awk_command_005(self):
-        """
-        Test $1$2 not separated
-        """
+    def test_awk_command_005(self) -> None:
+        """Test $1$2 not separated."""
         self.proto.lineReceived(b'echo "test test" | awk "{ print $1$2 }"\n')
         self.assertEqual(self.tr.value(), b"testtest\n" + PROMPT)
-
-    def tearDown(self):
-        self.proto.connectionLost("tearDown From Unit Test")

--- a/src/cowrie/test/test_awk.py
+++ b/src/cowrie/test/test_awk.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import unittest
-from typing import Optional
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
@@ -20,13 +19,11 @@ PROMPT = b"root@unitTest:~# "
 class ShellEchoCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/awk.py."""
 
-    proto: Optional[HoneyPotInteractiveProtocol] = None
-    tr: Optional[FakeTransport] = None
+    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+    tr = FakeTransport("1.1.1.1", "1111")
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-        cls.tr = FakeTransport("1.1.1.1", "1111")
         cls.proto.makeConnection(cls.tr)
 
     @classmethod
@@ -37,26 +34,21 @@ class ShellEchoCommandTests(unittest.TestCase):
         self.tr.clear()
 
     def test_awk_command_001(self) -> None:
-        """Test $0, full input line contents."""
         self.proto.lineReceived(b'echo "test test" | awk "{ print $0 }"\n')
         self.assertEqual(self.tr.value(), b"test test\n" + PROMPT)
 
     def test_awk_command_002(self) -> None:
-        """Test $1, first agument."""
         self.proto.lineReceived(b'echo "test" | awk "{ print $1 }"\n')
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
     def test_awk_command_003(self) -> None:
-        """Test $1 $2 space separated."""
         self.proto.lineReceived(b'echo "test test" | awk "{ print $1 $2 }"\n')
         self.assertEqual(self.tr.value(), b"test test\n" + PROMPT)
 
     def test_awk_command_004(self) -> None:
-        """Test $1,$2 comma separated."""
         self.proto.lineReceived(b'echo "test test" | awk "{ print $1,$2 }"\n')
         self.assertEqual(self.tr.value(), b"test test\n" + PROMPT)
 
     def test_awk_command_005(self) -> None:
-        """Test $1$2 not separated."""
         self.proto.lineReceived(b'echo "test test" | awk "{ print $1$2 }"\n')
         self.assertEqual(self.tr.value(), b"testtest\n" + PROMPT)

--- a/src/cowrie/test/test_awk.py
+++ b/src/cowrie/test/test_awk.py
@@ -34,21 +34,21 @@ class ShellEchoCommandTests(unittest.TestCase):
         self.tr.clear()
 
     def test_awk_command_001(self) -> None:
-        self.proto.lineReceived(b'echo "test test" | awk "{ print $0 }"\n')
+        self.proto.lineReceived(b"echo \"test test\" | awk \"{ print $0 }\"\n")
         self.assertEqual(self.tr.value(), b"test test\n" + PROMPT)
 
     def test_awk_command_002(self) -> None:
-        self.proto.lineReceived(b'echo "test" | awk "{ print $1 }"\n')
+        self.proto.lineReceived(b"echo \"test\" | awk \"{ print $1 }\"\n")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
     def test_awk_command_003(self) -> None:
-        self.proto.lineReceived(b'echo "test test" | awk "{ print $1 $2 }"\n')
+        self.proto.lineReceived(b"echo \"test test\" | awk \"{ print $1 $2 }\"\n")
         self.assertEqual(self.tr.value(), b"test test\n" + PROMPT)
 
     def test_awk_command_004(self) -> None:
-        self.proto.lineReceived(b'echo "test test" | awk "{ print $1,$2 }"\n')
+        self.proto.lineReceived(b"echo \"test test\" | awk \"{ print $1,$2 }\"\n")
         self.assertEqual(self.tr.value(), b"test test\n" + PROMPT)
 
     def test_awk_command_005(self) -> None:
-        self.proto.lineReceived(b'echo "test test" | awk "{ print $1$2 }"\n')
+        self.proto.lineReceived(b"echo \"test test\" | awk \"{ print $1$2 }\"\n")
         self.assertEqual(self.tr.value(), b"testtest\n" + PROMPT)

--- a/src/cowrie/test/test_awk.py
+++ b/src/cowrie/test/test_awk.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import os
 import unittest
+from typing import Optional
 
-from cowrie.shell import protocol
-from cowrie.test import fake_server, fake_transport
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
@@ -18,17 +20,14 @@ PROMPT = b"root@unitTest:~# "
 class ShellEchoCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/awk.py."""
 
-    proto = None
-    tr = None
+    proto: Optional[HoneyPotInteractiveProtocol] = None
+    tr: Optional[FakeTransport] = None
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.proto = protocol.HoneyPotInteractiveProtocol(
-            fake_server.FakeAvatar(fake_server.FakeServer())
-        )
-        cls.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        cls.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        cls.tr = FakeTransport("1.1.1.1", "1111")
         cls.proto.makeConnection(cls.tr)
-        cls.tr.clear()
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/src/cowrie/test/test_awk.py
+++ b/src/cowrie/test/test_awk.py
@@ -18,16 +18,24 @@ PROMPT = b"root@unitTest:~# "
 class ShellEchoCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/awk.py."""
 
-    def setUp(self) -> None:
-        self.proto = protocol.HoneyPotInteractiveProtocol(
+    proto = None
+    tr = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
-        self.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
-        self.proto.makeConnection(self.tr)
-        self.tr.clear()
+        cls.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        cls.proto.makeConnection(cls.tr)
+        cls.tr.clear()
 
-    def tearDown(self) -> None:
-        self.proto.connectionLost("tearDown From Unit Test")
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proto.connectionLost("tearDown From Unit Test")
+
+    def setUp(self) -> None:
+        self.tr.clear()
 
     def test_awk_command_001(self) -> None:
         """Test $0, full input line contents."""

--- a/src/cowrie/test/test_awk.py
+++ b/src/cowrie/test/test_awk.py
@@ -11,14 +11,15 @@ from __future__ import annotations
 
 import os
 
-from twisted.trial import unittest
+# from twisted.trial import unittest
+import unittest
 
 from cowrie.shell import protocol
 from cowrie.test import fake_server, fake_transport
 
-os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "../data"
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
-os.environ["COWRIE_SHELL_FILESYSTEM"] = "../share/cowrie/fs.pickle"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "share/cowrie/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "
 

--- a/src/cowrie/test/test_base64.py
+++ b/src/cowrie/test/test_base64.py
@@ -21,7 +21,7 @@ class ShellBase64CommandTests(unittest.TestCase):
     """Tests for cowrie/commands/base64.py"""
 
     proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-    tr = FakeTransport("1.1.1.1", "1111")
+    tr = FakeTransport("", "31337")
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/src/cowrie/test/test_base64.py
+++ b/src/cowrie/test/test_base64.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import os
 import unittest
+from typing import Optional
 
-from cowrie.shell import protocol
-from cowrie.test import fake_server, fake_transport
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
@@ -19,17 +21,14 @@ PROMPT = b"root@unitTest:~# "
 class ShellBase64CommandTests(unittest.TestCase):
     """Tests for cowrie/commands/base64.py"""
 
-    proto = None
-    tr = None
+    proto: Optional[HoneyPotInteractiveProtocol] = None
+    tr: Optional[FakeTransport] = None
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.proto = protocol.HoneyPotInteractiveProtocol(
-            fake_server.FakeAvatar(fake_server.FakeServer())
-        )
-        cls.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        cls.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        cls.tr = FakeTransport("1.1.1.1", "1111")
         cls.proto.makeConnection(cls.tr)
-        cls.tr.clear()
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/src/cowrie/test/test_base64.py
+++ b/src/cowrie/test/test_base64.py
@@ -19,16 +19,24 @@ PROMPT = b"root@unitTest:~# "
 class ShellBase64CommandTests(unittest.TestCase):
     """Tests for cowrie/commands/base64.py"""
 
-    def setUp(self) -> None:
-        self.proto = protocol.HoneyPotInteractiveProtocol(
+    proto = None
+    tr = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
-        self.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
-        self.proto.makeConnection(self.tr)
-        self.tr.clear()
+        cls.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        cls.proto.makeConnection(cls.tr)
+        cls.tr.clear()
 
-    def tearDown(self) -> None:
-        self.proto.connectionLost("tearDown From Unit Test")
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proto.connectionLost("tearDown From Unit Test")
+
+    def setUp(self) -> None:
+        self.tr.clear()
 
     def test_base64_command_001(self) -> None:
         self.proto.lineReceived(b"echo cowrie | base64")

--- a/src/cowrie/test/test_base64.py
+++ b/src/cowrie/test/test_base64.py
@@ -1,17 +1,8 @@
-# -*- test-case-name: Cowrie Test Cases -*-
-
 # Copyright (c) 2020 Peter Sufliarsky
 # See LICENSE for details.
-
-"""
-Tests for general shell interaction and base64 command
-"""
 from __future__ import annotations
 
-
 import os
-
-# from twisted.trial import unittest
 import unittest
 
 from cowrie.shell import protocol
@@ -26,7 +17,9 @@ PROMPT = b"root@unitTest:~# "
 
 
 class ShellBase64CommandTests(unittest.TestCase):
-    def setUp(self):
+    """Tests for cowrie/commands/base64.py"""
+
+    def setUp(self) -> None:
         self.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
@@ -34,19 +27,13 @@ class ShellBase64CommandTests(unittest.TestCase):
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 
-    def test_base64_command_001(self):
-        """
-        Missing operand
-        """
+    def tearDown(self) -> None:
+        self.proto.connectionLost("tearDown From Unit Test")
+
+    def test_base64_command_001(self) -> None:
         self.proto.lineReceived(b"echo cowrie | base64")
         self.assertEqual(self.tr.value(), b"Y293cmllCg==\n" + PROMPT)
 
-    def test_base64_command_002(self):
-        """
-        Missing operand
-        """
+    def test_base64_command_002(self) -> None:
         self.proto.lineReceived(b"echo Y293cmllCg== | base64 -d")
         self.assertEqual(self.tr.value(), b"cowrie\n" + PROMPT)
-
-    def tearDown(self):
-        self.proto.connectionLost("tearDown From Unit Test")

--- a/src/cowrie/test/test_base64.py
+++ b/src/cowrie/test/test_base64.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import unittest
-from typing import Optional
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
@@ -21,13 +20,11 @@ PROMPT = b"root@unitTest:~# "
 class ShellBase64CommandTests(unittest.TestCase):
     """Tests for cowrie/commands/base64.py"""
 
-    proto: Optional[HoneyPotInteractiveProtocol] = None
-    tr: Optional[FakeTransport] = None
+    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+    tr = FakeTransport("1.1.1.1", "1111")
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-        cls.tr = FakeTransport("1.1.1.1", "1111")
         cls.proto.makeConnection(cls.tr)
 
     @classmethod

--- a/src/cowrie/test/test_base64.py
+++ b/src/cowrie/test/test_base64.py
@@ -11,14 +11,15 @@ from __future__ import annotations
 
 import os
 
-from twisted.trial import unittest
+# from twisted.trial import unittest
+import unittest
 
 from cowrie.shell import protocol
 from cowrie.test import fake_server, fake_transport
 
-os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "../data"
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
-os.environ["COWRIE_SHELL_FILESYSTEM"] = "../share/cowrie/fs.pickle"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "share/cowrie/fs.pickle"
 
 TRY_CHMOD_HELP_MSG = b"Try 'base64 --help' for more information.\n"
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 
 import os
 
-from twisted.trial import unittest
+# from twisted.trial import unittest
+import unittest
 
 from cowrie.shell import protocol
 from cowrie.test import fake_server, fake_transport
 
-os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "../data"
-os.environ["COWRIE_SHELL_FILESYSTEM"] = "../share/cowrie/fs.pickle"
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "share/cowrie/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "
 

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import unittest
 
+from cowrie.commands.base import Command_php
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
@@ -97,9 +98,13 @@ class ShellBaseCommandsTests(unittest.TestCase):
         self.proto.lineReceived(b"sh -c id\n")
         self.assertEqual(self.tr.value(), b"uid=0(root) gid=0(root) groups=0(root)\n" + PROMPT)
 
-    # def test_php_command(self) -> None:
-    #    self.proto.lineReceived(b'php -h')
-    #    print("THIS TEST IS INCOMPLETE")
+    def test_php_help_command(self) -> None:
+        self.proto.lineReceived(b"php -h\n")
+        self.assertEqual(self.tr.value(), Command_php.HELP.encode() + PROMPT)
+
+    def test_php_version_command(self) -> None:
+        self.proto.lineReceived(b"php -v\n")
+        self.assertEqual(self.tr.value(), Command_php.VERSION.encode() + PROMPT)
 
     def test_chattr_command(self) -> None:
         self.proto.lineReceived(b"chattr\n")

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 import os
 import unittest
 
-from cowrie.shell import protocol
-from cowrie.test import fake_server, fake_transport
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "share/cowrie/fs.pickle"
@@ -19,10 +20,8 @@ class ShellBaseCommandsTests(unittest.TestCase):
     """Tests for basic commands from cowrie/commands/base.py."""
 
     def setUp(self) -> None:
-        self.proto = protocol.HoneyPotInteractiveProtocol(
-            fake_server.FakeAvatar(fake_server.FakeServer())
-        )
-        self.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("1.1.1.1", "1111")
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 
@@ -167,10 +166,8 @@ class ShellBaseCommandsTests(unittest.TestCase):
 
 class ShellFileCommandsTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.proto = protocol.HoneyPotInteractiveProtocol(
-            fake_server.FakeAvatar(fake_server.FakeServer())
-        )
-        self.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("1.1.1.1", "1111")
         self.proto.makeConnection(self.tr)
 
     def tearDown(self) -> None:
@@ -235,10 +232,8 @@ class ShellFileCommandsTests(unittest.TestCase):
 
 class ShellPipeCommandsTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.proto = protocol.HoneyPotInteractiveProtocol(
-            fake_server.FakeAvatar(fake_server.FakeServer())
-        )
-        self.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("1.1.1.1", "1111")
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2016 Dave Germiquet
 # See LICENSE for details.
-
 from __future__ import annotations
 
 import os
@@ -36,21 +35,25 @@ class ShellBaseCommandsTests(unittest.TestCase):
         self.proto.lineReceived(b"users \n")
         self.assertEqual(self.tr.value(), b"root\n" + PROMPT)
 
-    # def test_exit_command(self) -> None:
-    #     self.proto.lineReceived(b'exit \n')
+    def test_exit_command(self) -> None:
+        self.proto.lineReceived(b"exit\n")
+        self.assertEqual(self.tr.value(), b"")
 
-    # def test_logout_command(self) -> None:
-    #     self.proto.lineReceived(b'logout \n')
+    def test_logout_command(self) -> None:
+        self.proto.lineReceived(b"logout\n")
+        self.assertEqual(self.tr.value(), b"")
 
-    # def test_clear_command(self) -> None:
-    #     self.proto.lineReceived(b'clear \n')
+    def test_clear_command(self) -> None:
+        self.proto.lineReceived(b"clear\n")
+        self.assertEqual(self.tr.value(), PROMPT)
 
     def test_hostname_command(self) -> None:
         self.proto.lineReceived(b"hostname unitChanged\n")
         self.assertEqual(self.tr.value(), b"root@unitChanged:~# ")
 
-    # def test_reset_command(self) -> None:
-    #     self.proto.lineReceived(b'reset')
+    def test_reset_command(self) -> None:
+        self.proto.lineReceived(b"reset\n")
+        self.assertEqual(self.tr.value(), PROMPT)
 
     # def test_ps_command(self) -> None:
     #     self.proto.lineReceived(b'ps\n')
@@ -58,9 +61,7 @@ class ShellBaseCommandsTests(unittest.TestCase):
 
     def test_id_command(self) -> None:
         self.proto.lineReceived(b"id\n")
-        self.assertEqual(
-            self.tr.value(), b"uid=0(root) gid=0(root) groups=0(root)\n" + PROMPT
-        )
+        self.assertEqual(self.tr.value(), b"uid=0(root) gid=0(root) groups=0(root)\n" + PROMPT)
 
     def test_passwd_command(self) -> None:
         self.proto.lineReceived(b"passwd\n")
@@ -71,11 +72,13 @@ class ShellBaseCommandsTests(unittest.TestCase):
             b"Enter new UNIX password: Retype new UNIX password: passwd: password updated successfully\n" + PROMPT,
         )
 
-    # def test_shutdown_command(self) -> None:
-    #    self.proto.lineReceived(b'shutdown\n')
+    def test_shutdown_command(self) -> None:
+        self.proto.lineReceived(b"shutdown\n")
+        self.assertEqual(self.tr.value(), b"Try `shutdown --help' for more information.\n" + PROMPT)  # TODO: Is it right?..
 
-    # def test_poweroff_command(self) -> None:
-    #     self.proto.lineReceived(b'poweroff\n')
+    def test_poweroff_command(self) -> None:
+        self.proto.lineReceived(b"poweroff\n")
+        self.assertEqual(self.tr.value(), b"Try `shutdown --help' for more information.\n" + PROMPT)  # TODO: Is it right?..
 
     # def test_history_command(self) -> None:
     #    self.proto.lineReceived(b"history\n")
@@ -84,20 +87,15 @@ class ShellBaseCommandsTests(unittest.TestCase):
 
     def test_date_command(self) -> None:
         self.proto.lineReceived(b"date\n")
-        self.assertRegex(
-            self.tr.value(),
-            b"[A-Za-z][A-Za-z][A-Za-z] [A-Za-z][A-Za-z][A-Za-z] [0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9] UTC [0-9][0-9][0-9][0-9]\n" + PROMPT,
-        )
+        self.assertRegex(self.tr.value(), rb"[A-Za-z]{3} [A-Za-z]{3} \d{2} \d{2}:\d{2}:\d{2} UTC \d{4}\n" + PROMPT)
 
-    # def test_bash_command(self) -> None:
-    #    self.proto.lineReceived(b'bash\n')
-    #    print("THIS TEST IS INCOMPLETE")
+    def test_bash_command(self) -> None:
+        self.proto.lineReceived(b"bash\n")
+        self.assertEqual(self.tr.value(), PROMPT)
 
     def test_sh_command(self) -> None:
         self.proto.lineReceived(b"sh -c id\n")
-        self.assertEqual(
-            self.tr.value(), b"uid=0(root) gid=0(root) groups=0(root)\n" + PROMPT
-        )
+        self.assertEqual(self.tr.value(), b"uid=0(root) gid=0(root) groups=0(root)\n" + PROMPT)
 
     # def test_php_command(self) -> None:
     #    self.proto.lineReceived(b'php -h')
@@ -113,7 +111,6 @@ class ShellBaseCommandsTests(unittest.TestCase):
 
     def test_set_command(self) -> None:
         self.proto.lineReceived(b"set\n")
-
         self.assertEqual(
             self.tr.value(),
             b"COLUMNS=80\nHOME=/root\nLINES=25\nLOGNAME=root\nPATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\nTMOUT=1800\nUSER=root\n" + PROMPT,

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -1,14 +1,9 @@
-# -*- test-case-name: Cowrie Test Cases -*-
-
 # Copyright (c) 2016 Dave Germiquet
 # See LICENSE for details.
 
 from __future__ import annotations
 
-
 import os
-
-# from twisted.trial import unittest
 import unittest
 
 from cowrie.shell import protocol
@@ -21,7 +16,9 @@ PROMPT = b"root@unitTest:~# "
 
 
 class ShellBaseCommandsTests(unittest.TestCase):
-    def setUp(self):
+    """Tests for basic commands from cowrie/commands/base.py."""
+
+    def setUp(self) -> None:
         self.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
@@ -29,218 +26,215 @@ class ShellBaseCommandsTests(unittest.TestCase):
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 
-    def test_whoami_command(self):
+    def tearDown(self) -> None:
+        self.proto.connectionLost("tearDown From Unit Test")
+
+    def test_whoami_command(self) -> None:
         self.proto.lineReceived(b"whoami\n")
         self.assertEqual(self.tr.value(), b"root\n" + PROMPT)
 
-    def test_users_command(self):
+    def test_users_command(self) -> None:
         self.proto.lineReceived(b"users \n")
         self.assertEqual(self.tr.value(), b"root\n" + PROMPT)
 
-    # def test_exit_command(self):
+    # def test_exit_command(self) -> None:
     #     self.proto.lineReceived(b'exit \n')
 
-    # def test_logout_command(self):
+    # def test_logout_command(self) -> None:
     #     self.proto.lineReceived(b'logout \n')
 
-    # def test_clear_command(self):
+    # def test_clear_command(self) -> None:
     #     self.proto.lineReceived(b'clear \n')
 
-    def test_hostname_command(self):
+    def test_hostname_command(self) -> None:
         self.proto.lineReceived(b"hostname unitChanged\n")
         self.assertEqual(self.tr.value(), b"root@unitChanged:~# ")
 
-    # def test_reset_command(self):
+    # def test_reset_command(self) -> None:
     #     self.proto.lineReceived(b'reset')
 
-    # def test_ps_command(self):
+    # def test_ps_command(self) -> None:
     #     self.proto.lineReceived(b'ps\n')
     #     self.assertEqual(self.tr.value().decode('utf8'), "\n".join(self.data['results']['ps']))
 
-    def test_id_command(self):
+    def test_id_command(self) -> None:
         self.proto.lineReceived(b"id\n")
         self.assertEqual(
             self.tr.value(), b"uid=0(root) gid=0(root) groups=0(root)\n" + PROMPT
         )
 
-    def test_passwd_command(self):
+    def test_passwd_command(self) -> None:
         self.proto.lineReceived(b"passwd\n")
         self.proto.lineReceived(b"changeme\n")
         self.proto.lineReceived(b"changeme\n")
         self.assertEqual(
             self.tr.value(),
-            b"Enter new UNIX password: Retype new UNIX password: passwd: password updated successfully\n"
-            + PROMPT,
+            b"Enter new UNIX password: Retype new UNIX password: passwd: password updated successfully\n" + PROMPT,
         )
 
-    # def test_shutdown_command(self):
+    # def test_shutdown_command(self) -> None:
     #    self.proto.lineReceived(b'shutdown\n')
 
-    # def test_poweroff_command(self):
+    # def test_poweroff_command(self) -> None:
     #     self.proto.lineReceived(b'poweroff\n')
 
-    # def test_history_command(self):
+    # def test_history_command(self) -> None:
     #    self.proto.lineReceived(b"history\n")
     #    self.proto.lineReceived(b"history\n")
     #    print("THIS TEST IS INCOMPLETE")
 
-    def test_date_command(self):
+    def test_date_command(self) -> None:
         self.proto.lineReceived(b"date\n")
         self.assertRegex(
             self.tr.value(),
-            b"[A-Za-z][A-Za-z][A-Za-z] [A-Za-z][A-Za-z][A-Za-z] [0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9] UTC [0-9][0-9][0-9][0-9]\n"
-            + PROMPT,
+            b"[A-Za-z][A-Za-z][A-Za-z] [A-Za-z][A-Za-z][A-Za-z] [0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9] UTC [0-9][0-9][0-9][0-9]\n" + PROMPT,
         )
 
-    # def test_bash_command(self):
+    # def test_bash_command(self) -> None:
     #    self.proto.lineReceived(b'bash\n')
     #    print("THIS TEST IS INCOMPLETE")
 
-    def test_sh_command(self):
+    def test_sh_command(self) -> None:
         self.proto.lineReceived(b"sh -c id\n")
         self.assertEqual(
             self.tr.value(), b"uid=0(root) gid=0(root) groups=0(root)\n" + PROMPT
         )
 
-    # def test_php_command(self):
+    # def test_php_command(self) -> None:
     #    self.proto.lineReceived(b'php -h')
     #    print("THIS TEST IS INCOMPLETE")
 
-    def test_chattr_command(self):
+    def test_chattr_command(self) -> None:
         self.proto.lineReceived(b"chattr\n")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_umask_command(self):
+    def test_umask_command(self) -> None:
         self.proto.lineReceived(b"umask\n")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_set_command(self):
+    def test_set_command(self) -> None:
         self.proto.lineReceived(b"set\n")
 
         self.assertEqual(
             self.tr.value(),
-            b"COLUMNS=80\nHOME=/root\nLINES=25\nLOGNAME=root\nPATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\nTMOUT=1800\nUSER=root\n"
-            + PROMPT,
+            b"COLUMNS=80\nHOME=/root\nLINES=25\nLOGNAME=root\nPATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\nTMOUT=1800\nUSER=root\n" + PROMPT,
         )
 
-    def test_unset_command(self):
+    def test_unset_command(self) -> None:
         self.proto.lineReceived(b"unset\n")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_export_command(self):
+    def test_export_command(self) -> None:
         self.proto.lineReceived(b"export\n")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_alias_command(self):
+    def test_alias_command(self) -> None:
         self.proto.lineReceived(b"alias\n")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_jobs_command(self):
+    def test_jobs_command(self) -> None:
         self.proto.lineReceived(b"jobs\n")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_kill_command(self):
+    def test_kill_command(self) -> None:
         self.proto.lineReceived(b"/bin/kill\n")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_pkill_command(self):
+    def test_pkill_command(self) -> None:
         self.proto.lineReceived(b"/bin/pkill\n")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_killall_command(self):
+    def test_killall_command(self) -> None:
         self.proto.lineReceived(b"/bin/killall\n")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_killall5_command(self):
+    def test_killall5_command(self) -> None:
         self.proto.lineReceived(b"/bin/killall5\n")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_su_command(self):
+    def test_su_command(self) -> None:
         self.proto.lineReceived(b"su\n")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_chown_command(self):
+    def test_chown_command(self) -> None:
         self.proto.lineReceived(b"chown\n")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_chgrp_command(self):
+    def test_chgrp_command(self) -> None:
         self.proto.lineReceived(b"chgrp\n")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def tearDown(self):
-        self.proto.connectionLost("tearDown From Unit Test")
-
 
 class ShellFileCommandsTests(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
         self.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
         self.proto.makeConnection(self.tr)
 
-    # def test_cat_output(self):
+    def tearDown(self) -> None:
+        self.proto.connectionLost("tearDown From Unit Test")
+
+    # def test_cat_output(self) -> None:
     #    self.proto.lineReceived(b'cat /proc/cpuinfo')
     #    print("THIS TEST IS INCOMPLETE")
     #    print(self.tr.value())
 
-    # def test_grep_output(self):
+    # def test_grep_output(self) -> None:
     #    self.proto.lineReceived(b'grep cpu /proc/cpuinfo')
     #    print("THIS TEST IS INCOMPLETE")
     #    print(self.tr.value())
 
-    # def test_tail_output(self):
+    # def test_tail_output(self) -> None:
     #    self.proto.lineReceived(b'tail -n 10 /proc/cpuinfo')
     #    print("THIS TEST IS INCOMPLETE")
     #    print(self.tr.value())
 
-    # def test_cd_output(self):
+    # def test_cd_output(self) -> None:
     #    self.proto.lineReceived(b'cd /usr/bin')
     #    print("THIS TEST IS INCOMPLETE")
     #    print(self.tr.value())
 
-    # def test_rm_output(self):
+    # def test_rm_output(self) -> None:
     #    self.proto.lineReceived(b'rm /usr/bin/gcc')
     #    print("THIS TEST IS INCOMPLETE")
     #    print(self.tr.value())
 
-    # def test_cp_output(self):
+    # def test_cp_output(self) -> None:
     #    self.proto.lineReceived(b'cp /usr/bin/gcc /tmp')
     #    print("THIS TEST IS INCOMPLETE")
     #    print(self.tr.value())
 
-    # def test_mv_output(self):
+    # def test_mv_output(self) -> None:
     #    self.proto.lineReceived(b'mv /usr/bin/gcc /tmp')
     #    print("THIS TEST IS INCOMPLETE")
     #    print(self.tr.value())
 
-    # def test_mkdir_output(self):
+    # def test_mkdir_output(self) -> None:
     #    self.proto.lineReceived(b'mkdir /tmp/hello')
     #    print("THIS TEST IS INCOMPLETE")
     #    print(self.tr.value())
 
-    # def test_rmdir_output(self):
+    # def test_rmdir_output(self) -> None:
     #    self.proto.lineReceived(b'mkdir /tmp/blah')
     #    self.proto.lineReceived(b'rmdir /tmp/blah')
     #    print("THIS TEST IS INCOMPLETE")
     #    print(self.tr.value())
 
-    # def test_pwd_output(self):
+    # def test_pwd_output(self) -> None:
     #    self.proto.lineReceived(b'pwd')
     #    print("THIS TEST IS INCOMPLETE")
     #    print(self.tr.value())
 
-    # def test_touch_output(self):
+    # def test_touch_output(self) -> None:
     #    self.proto.lineReceived(b'touch unittests.txt')
     #    print("THIS TEST IS INCOMPLETE")
     #    print(self.tr.value())
 
-    def tearDown(self):
-        self.proto.connectionLost("tearDown From Unit Test")
-
 
 class ShellPipeCommandsTests(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
@@ -248,16 +242,16 @@ class ShellPipeCommandsTests(unittest.TestCase):
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 
-    def test_shell_pipe_with_cat_tail(self):
+    def tearDown(self) -> None:
+        self.proto.connectionLost("tearDown From Unit Test")
+
+    def test_shell_pipe_with_cat_tail(self) -> None:
         self.proto.lineReceived(b"echo test | tail -n 1\n")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_shell_pipe_with_cat_head(self):
+    def test_shell_pipe_with_cat_head(self) -> None:
         self.proto.lineReceived(b"echo test | head -n 1\n")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    # def test_shell_busybox_with_cat_and_sudo_grep(self):
+    # def test_shell_busybox_with_cat_and_sudo_grep(self) -> None:
     #     self.proto.lineReceived(b'busybox cat /proc/cpuinfo | sudo grep cpu \n')
-
-    def tearDown(self):
-        self.proto.connectionLost("tearDown From Unit Test")

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -21,7 +21,7 @@ class ShellBaseCommandsTests(unittest.TestCase):
 
     def setUp(self) -> None:
         self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-        self.tr = FakeTransport("1.1.1.1", "1111")
+        self.tr = FakeTransport("", "31337")
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 
@@ -167,7 +167,7 @@ class ShellBaseCommandsTests(unittest.TestCase):
 class ShellFileCommandsTests(unittest.TestCase):
     def setUp(self) -> None:
         self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-        self.tr = FakeTransport("1.1.1.1", "1111")
+        self.tr = FakeTransport("", "31337")
         self.proto.makeConnection(self.tr)
 
     def tearDown(self) -> None:
@@ -233,7 +233,7 @@ class ShellFileCommandsTests(unittest.TestCase):
 class ShellPipeCommandsTests(unittest.TestCase):
     def setUp(self) -> None:
         self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-        self.tr = FakeTransport("1.1.1.1", "1111")
+        self.tr = FakeTransport("", "31337")
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -246,14 +246,15 @@ class ShellPipeCommandsTests(unittest.TestCase):
         )
         self.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
         self.proto.makeConnection(self.tr)
+        self.tr.clear()
 
     def test_shell_pipe_with_cat_tail(self):
         self.proto.lineReceived(b"echo test | tail -n 1\n")
-        self.assertEqual(self.tr.value(), PROMPT + b"test\n" + PROMPT)
+        self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
     def test_shell_pipe_with_cat_head(self):
         self.proto.lineReceived(b"echo test | head -n 1\n")
-        self.assertEqual(self.tr.value(), PROMPT + b"test\n" + PROMPT)
+        self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
     # def test_shell_busybox_with_cat_and_sudo_grep(self):
     #     self.proto.lineReceived(b'busybox cat /proc/cpuinfo | sudo grep cpu \n')

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -16,7 +16,7 @@ os.environ["COWRIE_SHELL_FILESYSTEM"] = "share/cowrie/fs.pickle"
 PROMPT = b"root@unitTest:~# "
 
 
-class ShellBaseCommandsTests(unittest.TestCase):
+class ShellBaseCommandsTests(unittest.TestCase):  # TODO: ps, history
     """Tests for basic commands from cowrie/commands/base.py."""
 
     def setUp(self) -> None:
@@ -56,10 +56,6 @@ class ShellBaseCommandsTests(unittest.TestCase):
         self.proto.lineReceived(b"reset\n")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    # def test_ps_command(self) -> None:
-    #     self.proto.lineReceived(b'ps\n')
-    #     self.assertEqual(self.tr.value().decode('utf8'), "\n".join(self.data['results']['ps']))
-
     def test_id_command(self) -> None:
         self.proto.lineReceived(b"id\n")
         self.assertEqual(self.tr.value(), b"uid=0(root) gid=0(root) groups=0(root)\n" + PROMPT)
@@ -80,11 +76,6 @@ class ShellBaseCommandsTests(unittest.TestCase):
     def test_poweroff_command(self) -> None:
         self.proto.lineReceived(b"poweroff\n")
         self.assertEqual(self.tr.value(), b"Try `shutdown --help' for more information.\n" + PROMPT)  # TODO: Is it right?..
-
-    # def test_history_command(self) -> None:
-    #    self.proto.lineReceived(b"history\n")
-    #    self.proto.lineReceived(b"history\n")
-    #    print("THIS TEST IS INCOMPLETE")
 
     def test_date_command(self) -> None:
         self.proto.lineReceived(b"date\n")

--- a/src/cowrie/test/test_cat.py
+++ b/src/cowrie/test/test_cat.py
@@ -21,7 +21,7 @@ class ShellCatCommandTests(unittest.TestCase):
 
     def setUp(self) -> None:
         self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-        self.tr = FakeTransport("1.1.1.1", "1111")
+        self.tr = FakeTransport("", "31337")
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 

--- a/src/cowrie/test/test_cat.py
+++ b/src/cowrie/test/test_cat.py
@@ -1,17 +1,8 @@
-# -*- test-case-name: Cowrie Test Cases -*-
-
 # Copyright (c) 2018 Michel Oosterhof
 # See LICENSE for details.
-
-"""
-Tests for general shell interaction and cat command
-"""
-
 from __future__ import annotations
 
 import os
-
-# from twisted.trial import unittest
 import unittest
 
 from cowrie.shell import protocol
@@ -25,7 +16,9 @@ PROMPT = b"root@unitTest:~# "
 
 
 class ShellCatCommandTests(unittest.TestCase):
-    def setUp(self):
+    """Test for cowrie/commands/cat.py."""
+
+    def setUp(self) -> None:
         self.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
@@ -33,39 +26,31 @@ class ShellCatCommandTests(unittest.TestCase):
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 
-    def test_cat_command_001(self):
-        """
-        No such file
-        """
+    def tearDown(self) -> None:
+        self.proto.connectionLost("tearDown From Unit Test")
+
+    def test_cat_command_001(self) -> None:
+        """No such file."""
         self.proto.lineReceived(b"cat nonExisting\n")
         self.assertEqual(
             self.tr.value(), b"cat: nonExisting: No such file or directory\n" + PROMPT
         )
 
-    def test_cat_command_002(self):
-        """
-        argument - (stdin)
-        """
+    def test_cat_command_002(self) -> None:
+        """Argument - (stdin)."""
         self.proto.lineReceived(b"echo test | cat -\n")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_cat_command_003(self):
-        """
-        test without arguments, read stdin only and quit
-        """
+    def test_cat_command_003(self) -> None:
+        """Test without arguments, read stdin only and quit."""
         self.proto.lineReceived(b"echo 1 | cat\n")
         self.proto.lineReceived(b"echo 2\n")
         self.proto.handle_CTRL_D()
         self.assertEqual(self.tr.value(), b"1\n" + PROMPT + b"2\n" + PROMPT)
 
-    def test_cat_command_004(self):
-        """
-        test handle of CTRL_C
-        """
+    def test_cat_command_004(self) -> None:
+        """Test handle of CTRL_C."""
         self.proto.lineReceived(b"cat\n")
         self.proto.lineReceived(b"test\n")
         self.proto.handle_CTRL_C()
         self.assertEqual(self.tr.value(), b"test\n^C\n" + PROMPT)
-
-    def tearDown(self):
-        self.proto.connectionLost("tearDown From Unit Test")

--- a/src/cowrie/test/test_cat.py
+++ b/src/cowrie/test/test_cat.py
@@ -11,14 +11,15 @@ from __future__ import annotations
 
 import os
 
-from twisted.trial import unittest
+# from twisted.trial import unittest
+import unittest
 
 from cowrie.shell import protocol
 from cowrie.test import fake_server, fake_transport
 
-os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "../data"
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
-os.environ["COWRIE_SHELL_FILESYSTEM"] = "../share/cowrie/fs.pickle"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "share/cowrie/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "
 

--- a/src/cowrie/test/test_chmod.py
+++ b/src/cowrie/test/test_chmod.py
@@ -21,7 +21,7 @@ class ShellChmodCommandTests(unittest.TestCase):
     """Test for cowrie/commands/chmod.py."""
 
     proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-    tr = FakeTransport("1.1.1.1", "1111")
+    tr = FakeTransport("", "31337")
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/src/cowrie/test/test_chmod.py
+++ b/src/cowrie/test/test_chmod.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import os
 import unittest
+from typing import Optional
 
-from cowrie.shell import protocol
-from cowrie.test import fake_server, fake_transport
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
@@ -19,17 +21,14 @@ PROMPT = b"root@unitTest:~# "
 class ShellChmodCommandTests(unittest.TestCase):
     """Test for cowrie/commands/chmod.py."""
 
-    proto = None
-    tr = None
+    proto: Optional[HoneyPotInteractiveProtocol] = None
+    tr: Optional[FakeTransport] = None
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.proto = protocol.HoneyPotInteractiveProtocol(
-            fake_server.FakeAvatar(fake_server.FakeServer())
-        )
-        cls.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        cls.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        cls.tr = FakeTransport("1.1.1.1", "1111")
         cls.proto.makeConnection(cls.tr)
-        cls.tr.clear()
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/src/cowrie/test/test_chmod.py
+++ b/src/cowrie/test/test_chmod.py
@@ -50,35 +50,35 @@ class ShellChmodCommandTests(unittest.TestCase):
         self.proto.lineReceived(b"chmod +x")
         self.assertEqual(
             self.tr.value(),
-            b"chmod: missing operand after \xe2\x80\x98+x\xe2\x80\x99\n" + TRY_CHMOD_HELP_MSG + PROMPT,
+            b"chmod: missing operand after \xe2\x80\x98+x\xe2\x80\x99\n" + TRY_CHMOD_HELP_MSG + PROMPT
         )
 
     def test_chmod_command_004(self) -> None:
         self.proto.lineReceived(b"chmod -A")
         self.assertEqual(
             self.tr.value(),
-            b"chmod: invalid option -- 'A'\n" + TRY_CHMOD_HELP_MSG + PROMPT,
+            b"chmod: invalid option -- 'A'\n" + TRY_CHMOD_HELP_MSG + PROMPT
         )
 
     def test_chmod_command_005(self) -> None:
         self.proto.lineReceived(b"chmod --A")
         self.assertEqual(
             self.tr.value(),
-            b"chmod: unrecognized option '--A'\n" + TRY_CHMOD_HELP_MSG + PROMPT,
+            b"chmod: unrecognized option '--A'\n" + TRY_CHMOD_HELP_MSG + PROMPT
         )
 
     def test_chmod_command_006(self) -> None:
         self.proto.lineReceived(b"chmod -x abcd")
         self.assertEqual(
             self.tr.value(),
-            b"chmod: cannot access 'abcd': No such file or directory\n" + PROMPT,
+            b"chmod: cannot access 'abcd': No such file or directory\n" + PROMPT
         )
 
     def test_chmod_command_007(self) -> None:
         self.proto.lineReceived(b"chmod abcd efgh")
         self.assertEqual(
             self.tr.value(),
-            b"chmod: invalid mode: \xe2\x80\x98abcd\xe2\x80\x99\n" + TRY_CHMOD_HELP_MSG + PROMPT,
+            b"chmod: invalid mode: \xe2\x80\x98abcd\xe2\x80\x99\n" + TRY_CHMOD_HELP_MSG + PROMPT
         )
 
     def test_chmod_command_008(self) -> None:

--- a/src/cowrie/test/test_chmod.py
+++ b/src/cowrie/test/test_chmod.py
@@ -1,18 +1,8 @@
-# -*- test-case-name: Cowrie Test Cases -*-
-
 # Copyright (c) 2020 Peter Sufliarsky
 # See LICENSE for details.
-
-"""
-Tests for general shell interaction and chmod command
-"""
-
 from __future__ import annotations
 
-
 import os
-
-# from twisted.trial import unittest
 import unittest
 
 from cowrie.shell import protocol
@@ -27,7 +17,9 @@ PROMPT = b"root@unitTest:~# "
 
 
 class ShellChmodCommandTests(unittest.TestCase):
-    def setUp(self):
+    """Test for cowrie/commands/chmod.py."""
+
+    def setUp(self) -> None:
         self.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
@@ -35,133 +27,84 @@ class ShellChmodCommandTests(unittest.TestCase):
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 
-    def test_chmod_command_001(self):
-        """
-        Missing operand
-        """
+    def tearDown(self) -> None:
+        self.proto.connectionLost("tearDown From Unit Test")
+
+    def test_chmod_command_001(self) -> None:
         self.proto.lineReceived(b"chmod")
         self.assertEqual(
             self.tr.value(), b"chmod: missing operand\n" + TRY_CHMOD_HELP_MSG + PROMPT
         )
 
-    def test_chmod_command_002(self):
-        """
-        Missing operand
-        """
+    def test_chmod_command_002(self) -> None:
         self.proto.lineReceived(b"chmod -x")
         self.assertEqual(
             self.tr.value(), b"chmod: missing operand\n" + TRY_CHMOD_HELP_MSG + PROMPT
         )
 
-    def test_chmod_command_003(self):
-        """
-        Missing operand after ...
-        """
+    def test_chmod_command_003(self) -> None:
         self.proto.lineReceived(b"chmod +x")
         self.assertEqual(
             self.tr.value(),
-            b"chmod: missing operand after \xe2\x80\x98+x\xe2\x80\x99\n"
-            + TRY_CHMOD_HELP_MSG
-            + PROMPT,
+            b"chmod: missing operand after \xe2\x80\x98+x\xe2\x80\x99\n" + TRY_CHMOD_HELP_MSG + PROMPT,
         )
 
-    def test_chmod_command_004(self):
-        """
-        Invalid option
-        """
+    def test_chmod_command_004(self) -> None:
         self.proto.lineReceived(b"chmod -A")
         self.assertEqual(
             self.tr.value(),
             b"chmod: invalid option -- 'A'\n" + TRY_CHMOD_HELP_MSG + PROMPT,
         )
 
-    def test_chmod_command_005(self):
-        """
-        Unrecognized option
-        """
+    def test_chmod_command_005(self) -> None:
         self.proto.lineReceived(b"chmod --A")
         self.assertEqual(
             self.tr.value(),
             b"chmod: unrecognized option '--A'\n" + TRY_CHMOD_HELP_MSG + PROMPT,
         )
 
-    def test_chmod_command_006(self):
-        """
-        No such file or directory
-        """
+    def test_chmod_command_006(self) -> None:
         self.proto.lineReceived(b"chmod -x abcd")
         self.assertEqual(
             self.tr.value(),
             b"chmod: cannot access 'abcd': No such file or directory\n" + PROMPT,
         )
 
-    def test_chmod_command_007(self):
-        """
-        Invalid mode
-        """
+    def test_chmod_command_007(self) -> None:
         self.proto.lineReceived(b"chmod abcd efgh")
         self.assertEqual(
             self.tr.value(),
-            b"chmod: invalid mode: \xe2\x80\x98abcd\xe2\x80\x99\n"
-            + TRY_CHMOD_HELP_MSG
-            + PROMPT,
+            b"chmod: invalid mode: \xe2\x80\x98abcd\xe2\x80\x99\n" + TRY_CHMOD_HELP_MSG + PROMPT,
         )
 
-    def test_chmod_command_008(self):
-        """
-        Valid directory .ssh
-        """
+    def test_chmod_command_008(self) -> None:
         self.proto.lineReceived(b"chmod +x .ssh")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_chmod_command_009(self):
-        """
-        Valid directory .ssh recursive
-        """
+    def test_chmod_command_009(self) -> None:
         self.proto.lineReceived(b"chmod -R +x .ssh")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_chmod_command_010(self):
-        """
-        Valid directory /root/.ssh
-        """
+    def test_chmod_command_010(self) -> None:
         self.proto.lineReceived(b"chmod +x /root/.ssh")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_chmod_command_011(self):
-        """
-        Valid directory ~/.ssh
-        """
+    def test_chmod_command_011(self) -> None:
         self.proto.lineReceived(b"chmod +x ~/.ssh")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_chmod_command_012(self):
-        """
-        chmod a+x
-        """
+    def test_chmod_command_012(self) -> None:
         self.proto.lineReceived(b"chmod a+x .ssh")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_chmod_command_013(self):
-        """
-        chmod ug+x
-        """
+    def test_chmod_command_013(self) -> None:
         self.proto.lineReceived(b"chmod ug+x .ssh")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_chmod_command_014(self):
-        """
-        chmod 777
-        """
+    def test_chmod_command_014(self) -> None:
         self.proto.lineReceived(b"chmod 777 .ssh")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_chmod_command_015(self):
-        """
-        chmod 0775
-        """
+    def test_chmod_command_015(self) -> None:
         self.proto.lineReceived(b"chmod 0755 .ssh")
         self.assertEqual(self.tr.value(), PROMPT)
-
-    def tearDown(self):
-        self.proto.connectionLost("tearDown From Unit Test")

--- a/src/cowrie/test/test_chmod.py
+++ b/src/cowrie/test/test_chmod.py
@@ -19,16 +19,24 @@ PROMPT = b"root@unitTest:~# "
 class ShellChmodCommandTests(unittest.TestCase):
     """Test for cowrie/commands/chmod.py."""
 
-    def setUp(self) -> None:
-        self.proto = protocol.HoneyPotInteractiveProtocol(
+    proto = None
+    tr = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
-        self.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
-        self.proto.makeConnection(self.tr)
-        self.tr.clear()
+        cls.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        cls.proto.makeConnection(cls.tr)
+        cls.tr.clear()
 
-    def tearDown(self) -> None:
-        self.proto.connectionLost("tearDown From Unit Test")
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proto.connectionLost("tearDown From Unit Test")
+
+    def setUp(self) -> None:
+        self.tr.clear()
 
     def test_chmod_command_001(self) -> None:
         self.proto.lineReceived(b"chmod")

--- a/src/cowrie/test/test_chmod.py
+++ b/src/cowrie/test/test_chmod.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import unittest
-from typing import Optional
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
@@ -21,13 +20,11 @@ PROMPT = b"root@unitTest:~# "
 class ShellChmodCommandTests(unittest.TestCase):
     """Test for cowrie/commands/chmod.py."""
 
-    proto: Optional[HoneyPotInteractiveProtocol] = None
-    tr: Optional[FakeTransport] = None
+    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+    tr = FakeTransport("1.1.1.1", "1111")
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-        cls.tr = FakeTransport("1.1.1.1", "1111")
         cls.proto.makeConnection(cls.tr)
 
     @classmethod

--- a/src/cowrie/test/test_chmod.py
+++ b/src/cowrie/test/test_chmod.py
@@ -12,14 +12,15 @@ from __future__ import annotations
 
 import os
 
-from twisted.trial import unittest
+# from twisted.trial import unittest
+import unittest
 
 from cowrie.shell import protocol
 from cowrie.test import fake_server, fake_transport
 
-os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "../data"
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
-os.environ["COWRIE_SHELL_FILESYSTEM"] = "../share/cowrie/fs.pickle"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "share/cowrie/fs.pickle"
 
 TRY_CHMOD_HELP_MSG = b"Try 'chmod --help' for more information.\n"
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import os
 import unittest
+from typing import Optional
 
-from cowrie.shell import protocol
-from cowrie.test import fake_server, fake_transport
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
@@ -18,17 +20,14 @@ PROMPT = b"root@unitTest:~# "
 class ShellEchoCommandTests(unittest.TestCase):
     """Test for echo command from cowrie/commands/base.py."""
 
-    proto = None
-    tr = None
+    proto: Optional[HoneyPotInteractiveProtocol] = None
+    tr: Optional[FakeTransport] = None
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.proto = protocol.HoneyPotInteractiveProtocol(
-            fake_server.FakeAvatar(fake_server.FakeServer())
-        )
-        cls.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        cls.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        cls.tr = FakeTransport("1.1.1.1", "1111")
         cls.proto.makeConnection(cls.tr)
-        cls.tr.clear()
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -12,14 +12,15 @@ from __future__ import annotations
 
 import os
 
-from twisted.trial import unittest
+# from twisted.trial import unittest
+import unittest
 
 from cowrie.shell import protocol
 from cowrie.test import fake_server, fake_transport
 
-os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "../data"
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
-os.environ["COWRIE_SHELL_FILESYSTEM"] = "../share/cowrie/fs.pickle"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "share/cowrie/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "
 

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -45,10 +45,6 @@ class ShellEchoCommandTests(unittest.TestCase):
         self.proto.lineReceived(b"echo -n \"test  test\"\n")
         self.assertEqual(self.tr.value(), b"test  test" + PROMPT)
 
-    def test_echo_command_004(self) -> None:
-        self.proto.lineReceived(b"echo -n \"test  test\"\n")
-        self.assertEqual(self.tr.value(), b"test  test" + PROMPT)
-
     def test_echo_command_005(self) -> None:
         self.proto.lineReceived(b"echo test > test5; cat test5")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -20,7 +20,7 @@ class ShellEchoCommandTests(unittest.TestCase):
     """Test for echo command from cowrie/commands/base.py."""
 
     proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-    tr = FakeTransport("1.1.1.1", "1111")
+    tr = FakeTransport("", "31337")
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -1,18 +1,8 @@
-# -*- test-case-name: Cowrie Test Cases -*-
-
 # Copyright (c) 2018 Michel Oosterhof
 # See LICENSE for details.
-
-"""
-Tests for general shell interaction and echo command
-"""
-
 from __future__ import annotations
 
-
 import os
-
-# from twisted.trial import unittest
 import unittest
 
 from cowrie.shell import protocol
@@ -26,7 +16,9 @@ PROMPT = b"root@unitTest:~# "
 
 
 class ShellEchoCommandTests(unittest.TestCase):
-    def setUp(self):
+    """Test for echo command from cowrie/commands/base.py."""
+
+    def setUp(self) -> None:
         self.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
@@ -34,187 +26,109 @@ class ShellEchoCommandTests(unittest.TestCase):
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 
-    def test_echo_command_001(self):
-        """
-        Basic test
-        """
-        self.proto.lineReceived(b'echo "test"\n')
+    def tearDown(self) -> None:
+        self.proto.connectionLost("tearDown From Unit Test")
+
+    def test_echo_command_001(self) -> None:
+        self.proto.lineReceived(b"echo \"test\"\n")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_echo_command_002(self):
-        """
-        argument splitting and recombining
-        """
+    def test_echo_command_002(self) -> None:
         self.proto.lineReceived(b"echo test  test\n")
         self.assertEqual(self.tr.value(), b"test test\n" + PROMPT)
 
-    def test_echo_command_003(self):
-        """
-        echo -n
-        """
-        self.proto.lineReceived(b'echo -n "test  test"\n')
+    def test_echo_command_003(self) -> None:
+        self.proto.lineReceived(b"echo -n \"test  test\"\n")
         self.assertEqual(self.tr.value(), b"test  test" + PROMPT)
 
-    def test_echo_command_004(self):
-        """
-        echo -n
-        """
-        self.proto.lineReceived(b'echo -n "test  test"\n')
+    def test_echo_command_004(self) -> None:
+        self.proto.lineReceived(b"echo -n \"test  test\"\n")
         self.assertEqual(self.tr.value(), b"test  test" + PROMPT)
 
-    def test_echo_command_005(self):
-        """
-        echo test >> test; cat test
-        """
+    def test_echo_command_005(self) -> None:
         self.proto.lineReceived(b"echo test > test5; cat test5")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_echo_command_006(self):
-        """
-        echo -n
-        """
-        self.proto.lineReceived(b'echo "\\n"\n')
+    def test_echo_command_006(self) -> None:
+        self.proto.lineReceived(b"echo \"\\n\"\n")
         self.assertEqual(self.tr.value(), b"\\n\n" + PROMPT)
 
-    def test_echo_command_007(self):
-        """
-        echo test >> test; cat test
-        """
+    def test_echo_command_007(self) -> None:
         self.proto.lineReceived(b"echo test >> test7; cat test7")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_echo_command_008(self):
-        """
-        echo test > test; echo test >> test; cat test
-        """
+    def test_echo_command_008(self) -> None:
         self.proto.lineReceived(b"echo test > test8; echo test >> test8; cat test8")
         self.assertEqual(self.tr.value(), b"test\ntest\n" + PROMPT)
 
-    def test_echo_command_009(self):
-        """
-        echo test | grep test
-        """
+    def test_echo_command_009(self) -> None:
         self.proto.lineReceived(b"echo test | grep test")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_echo_command_010(self):
-        """
-        echo test | grep test
-        """
+    def test_echo_command_010(self) -> None:
         self.proto.lineReceived(b"echo test | grep test2")
         self.assertEqual(self.tr.value(), PROMPT)
 
-    def test_echo_command_011(self):
-        """
-        echo test > test011; cat test011 | grep test
-        """
+    def test_echo_command_011(self) -> None:
         self.proto.lineReceived(b"echo test > test011; cat test011 | grep test")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_echo_command_012(self):
-        """
-        echo test > test012; grep test test012
-        """
+    def test_echo_command_012(self) -> None:
         self.proto.lineReceived(b"echo test > test012; grep test test012")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_echo_command_013(self):
-        """
-        echo "ls""ls"
-        """
+    def test_echo_command_013(self) -> None:
         self.proto.lineReceived(b'echo "ls""ls"')
         self.assertEqual(self.tr.value(), b"lsls\n" + PROMPT)
 
-    def test_echo_command_014(self):
-        """
-        echo '"ls"'
-        """
+    def test_echo_command_014(self) -> None:
         self.proto.lineReceived(b"echo '\"ls\"'")
         self.assertEqual(self.tr.value(), b'"ls"\n' + PROMPT)
 
-    def test_echo_command_015(self):
-        """
-        echo "'ls'"
-        """
+    def test_echo_command_015(self) -> None:
         self.proto.lineReceived(b"echo \"'ls'\"")
         self.assertEqual(self.tr.value(), b"'ls'\n" + PROMPT)
 
-    def test_echo_command_016(self):
-        """
-        echo -e "\x6b\x61\x6d\x69"
-        """
-        self.proto.lineReceived(b'echo -e "\x6b\x61\x6d\x69"')
+    def test_echo_command_016(self) -> None:
+        self.proto.lineReceived(b"echo -e \"\x6b\x61\x6d\x69\"")
         self.assertEqual(self.tr.value(), b"kami\n" + PROMPT)
 
-    def test_echo_command_017(self):
-        """
-        echo -e "\x6b\x61\x6d\x69"
-        """
+    def test_echo_command_017(self) -> None:
         self.proto.lineReceived(b"echo echo test | bash")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_echo_command_018(self):
-        """
-        echo $(echo test)
-        """
+    def test_echo_command_018(self) -> None:
         self.proto.lineReceived(b"echo $(echo test)")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_echo_command_019(self):
-        """
-        echo $(echo $(echo test))
-        """
+    def test_echo_command_019(self) -> None:
         self.proto.lineReceived(b"echo $(echo $(echo test))")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_echo_command_020(self):
-        """
-        echo test_$(echo test)_test
-        """
+    def test_echo_command_020(self) -> None:
         self.proto.lineReceived(b"echo test_$(echo test)_test")
         self.assertEqual(self.tr.value(), b"test_test_test\n" + PROMPT)
 
-    def test_echo_command_021(self):
-        """
-        echo test_$(echo test)_test_$(echo test)_test
-        """
+    def test_echo_command_021(self) -> None:
         self.proto.lineReceived(b"echo test_$(echo test)_test_$(echo test)_test")
         self.assertEqual(self.tr.value(), b"test_test_test_test_test\n" + PROMPT)
 
-    def test_echo_command_022(self):
-        """
-        echo test; (echo test)
-        """
+    def test_echo_command_022(self) -> None:
         self.proto.lineReceived(b"echo test; (echo test)")
         self.assertEqual(self.tr.value(), b"test\ntest\n" + PROMPT)
 
-    def test_echo_command_023(self):
-        """
-        echo `echo test`
-        """
+    def test_echo_command_023(self) -> None:
         self.proto.lineReceived(b"echo `echo test`")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_echo_command_024(self):
-        """
-        echo test_`echo test`_test
-        """
+    def test_echo_command_024(self) -> None:
         self.proto.lineReceived(b"echo test_`echo test`_test")
         self.assertEqual(self.tr.value(), b"test_test_test\n" + PROMPT)
 
-    def test_echo_command_025(self):
-        """
-        echo test_`echo test`_test_`echo test`_test
-        """
+    def test_echo_command_025(self) -> None:
         self.proto.lineReceived(b"echo test_`echo test`_test_`echo test`_test")
         self.assertEqual(self.tr.value(), b"test_test_test_test_test\n" + PROMPT)
 
-    def test_echo_command_026(self):
-        """
-        echo "TEST1: `echo test1`, TEST2: `echo test2`"
-        """
+    def test_echo_command_026(self) -> None:
         self.proto.lineReceived(b'echo "TEST1: `echo test1`, TEST2: `echo test2`"')
         self.assertEqual(self.tr.value(), b"TEST1: test1, TEST2: test2\n" + PROMPT)
-
-    def tearDown(self):
-        self.proto.connectionLost("tearDown From Unit Test")

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -18,16 +18,24 @@ PROMPT = b"root@unitTest:~# "
 class ShellEchoCommandTests(unittest.TestCase):
     """Test for echo command from cowrie/commands/base.py."""
 
-    def setUp(self) -> None:
-        self.proto = protocol.HoneyPotInteractiveProtocol(
+    proto = None
+    tr = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
-        self.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
-        self.proto.makeConnection(self.tr)
-        self.tr.clear()
+        cls.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        cls.proto.makeConnection(cls.tr)
+        cls.tr.clear()
 
-    def tearDown(self) -> None:
-        self.proto.connectionLost("tearDown From Unit Test")
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proto.connectionLost("tearDown From Unit Test")
+
+    def setUp(self) -> None:
+        self.tr.clear()
 
     def test_echo_command_001(self) -> None:
         self.proto.lineReceived(b"echo \"test\"\n")
@@ -78,7 +86,7 @@ class ShellEchoCommandTests(unittest.TestCase):
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
     def test_echo_command_013(self) -> None:
-        self.proto.lineReceived(b'echo "ls""ls"')
+        self.proto.lineReceived(b"echo \"ls\"\"ls\"")
         self.assertEqual(self.tr.value(), b"lsls\n" + PROMPT)
 
     def test_echo_command_014(self) -> None:
@@ -130,5 +138,5 @@ class ShellEchoCommandTests(unittest.TestCase):
         self.assertEqual(self.tr.value(), b"test_test_test_test_test\n" + PROMPT)
 
     def test_echo_command_026(self) -> None:
-        self.proto.lineReceived(b'echo "TEST1: `echo test1`, TEST2: `echo test2`"')
+        self.proto.lineReceived(b"echo \"TEST1: `echo test1`, TEST2: `echo test2`\"")
         self.assertEqual(self.tr.value(), b"TEST1: test1, TEST2: test2\n" + PROMPT)

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import unittest
-from typing import Optional
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
@@ -20,13 +19,11 @@ PROMPT = b"root@unitTest:~# "
 class ShellEchoCommandTests(unittest.TestCase):
     """Test for echo command from cowrie/commands/base.py."""
 
-    proto: Optional[HoneyPotInteractiveProtocol] = None
-    tr: Optional[FakeTransport] = None
+    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+    tr = FakeTransport("1.1.1.1", "1111")
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-        cls.tr = FakeTransport("1.1.1.1", "1111")
         cls.proto.makeConnection(cls.tr)
 
     @classmethod

--- a/src/cowrie/test/test_ftpget.py
+++ b/src/cowrie/test/test_ftpget.py
@@ -21,7 +21,7 @@ class ShellFtpGetCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/ftpget.py."""
 
     proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-    tr = FakeTransport("1.1.1.1", "1111")
+    tr = FakeTransport("", "31337")
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/src/cowrie/test/test_ftpget.py
+++ b/src/cowrie/test/test_ftpget.py
@@ -8,14 +8,15 @@ from __future__ import annotations
 
 import os
 
-from twisted.trial import unittest
+# from twisted.trial import unittest
+import unittest
 
 from cowrie.shell import protocol
 from cowrie.test import fake_server, fake_transport
 
-os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "../data"
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
-os.environ["COWRIE_SHELL_FILESYSTEM"] = "../share/cowrie/fs.pickle"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "share/cowrie/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "
 

--- a/src/cowrie/test/test_ftpget.py
+++ b/src/cowrie/test/test_ftpget.py
@@ -1,14 +1,9 @@
-# -*- test-case-name: Cowrie Test Cases -*-
-
 # Copyright (c) 2018 Michel Oosterhof
 # See LICENSE for details.
 
 from __future__ import annotations
 
-
 import os
-
-# from twisted.trial import unittest
 import unittest
 
 from cowrie.shell import protocol
@@ -21,8 +16,10 @@ os.environ["COWRIE_SHELL_FILESYSTEM"] = "share/cowrie/fs.pickle"
 PROMPT = b"root@unitTest:~# "
 
 
-class ShellftpgetCommandTests(unittest.TestCase):
-    def setUp(self):
+class ShellFtpGetCommandTests(unittest.TestCase):
+    """Tests for cowrie/commands/ftpget.py."""
+
+    def setUp(self) -> None:
         self.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
@@ -30,10 +27,10 @@ class ShellftpgetCommandTests(unittest.TestCase):
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 
+    def tearDown(self) -> None:
+        self.proto.connectionLost("tearDown From Unit Test")
+
     def test_help_command(self):
-        """
-        Basic test
-        """
         self.proto.lineReceived(b"ftpget\n")
         self.assertEqual(
             self.tr.value(),
@@ -50,6 +47,3 @@ Download a file via FTP
     -P NUM      Port\n\n"""
             + PROMPT,
         )
-
-    def tearDown(self):
-        self.proto.connectionLost("tearDown From Unit Test")

--- a/src/cowrie/test/test_ftpget.py
+++ b/src/cowrie/test/test_ftpget.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 import os
 import unittest
 
-from cowrie.shell import protocol
-from cowrie.test import fake_server, fake_transport
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
@@ -20,10 +21,8 @@ class ShellFtpGetCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/ftpget.py."""
 
     def setUp(self) -> None:
-        self.proto = protocol.HoneyPotInteractiveProtocol(
-            fake_server.FakeAvatar(fake_server.FakeServer())
-        )
-        self.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("1.1.1.1", "1111")
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 

--- a/src/cowrie/test/test_ftpget.py
+++ b/src/cowrie/test/test_ftpget.py
@@ -20,29 +20,31 @@ PROMPT = b"root@unitTest:~# "
 class ShellFtpGetCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/ftpget.py."""
 
+    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+    tr = FakeTransport("1.1.1.1", "1111")
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.proto.makeConnection(cls.tr)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proto.connectionLost("tearDown From Unit Test")
+
     def setUp(self) -> None:
-        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-        self.tr = FakeTransport("1.1.1.1", "1111")
-        self.proto.makeConnection(self.tr)
         self.tr.clear()
 
-    def tearDown(self) -> None:
-        self.proto.connectionLost("tearDown From Unit Test")
-
-    def test_help_command(self):
+    def test_help_command(self) -> None:
+        usage = b"BusyBox v1.20.2 (2016-06-22 15:12:53 EDT) multi-call binary.\n" \
+                b"\n" \
+                b"Usage: ftpget [OPTIONS] HOST [LOCAL_FILE] REMOTE_FILE\n" \
+                b"\n" \
+                b"Download a file via FTP\n" \
+                b"\n" \
+                b"    -c Continue previous transfer\n" \
+                b"    -v Verbose\n" \
+                b"    -u USER     Username\n" \
+                b"    -p PASS     Password\n" \
+                b"    -P NUM      Port\n\n"
         self.proto.lineReceived(b"ftpget\n")
-        self.assertEqual(
-            self.tr.value(),
-            b"""BusyBox v1.20.2 (2016-06-22 15:12:53 EDT) multi-call binary.
-
-Usage: ftpget [OPTIONS] HOST [LOCAL_FILE] REMOTE_FILE
-
-Download a file via FTP
-
-    -c Continue previous transfer
-    -v Verbose
-    -u USER     Username
-    -p PASS     Password
-    -P NUM      Port\n\n"""
-            + PROMPT,
-        )
+        self.assertEqual(self.tr.value(), usage + PROMPT)

--- a/src/cowrie/test/test_proxy.py
+++ b/src/cowrie/test/test_proxy.py
@@ -1,96 +1,96 @@
-# Copyright (c) 2019 Guilherme Borges
-# See LICENSE for details.
-
-from __future__ import annotations
-
-import os
-import unittest
-
-from cowrie.core.checkers import HoneypotPasswordChecker, HoneypotPublicKeyChecker
-from cowrie.core.realm import HoneyPotRealm
-from cowrie.ssh.factory import CowrieSSHFactory
-
-from twisted.cred import portal
-from twisted.internet import reactor  # type: ignore
-
-# from cowrie.test.proxy_compare import ProxyTestCommand
-
-os.environ["COWRIE_HONEYPOT_TTYLOG"] = "false"
-os.environ["COWRIE_OUTPUT_JSONLOG_ENABLED"] = "false"
-
-
-def create_ssh_factory(backend: str) -> CowrieSSHFactory:
-    factory = CowrieSSHFactory(backend, None)
-    factory.portal = portal.Portal(HoneyPotRealm())
-    factory.portal.registerChecker(HoneypotPublicKeyChecker())
-    factory.portal.registerChecker(HoneypotPasswordChecker())
-    # factory.portal.registerChecker(HoneypotNoneChecker())
-    return factory
-
-
-# def create_telnet_factory(backend):
-#     factory = HoneyPotTelnetFactory(backend, None)
-#     factory.portal = portal.Portal(HoneyPotRealm())
-#     factory.portal.registerChecker(HoneypotPasswordChecker())
+# # Copyright (c) 2019 Guilherme Borges
+# # See LICENSE for details.
 #
+# from __future__ import annotations
+#
+# import os
+# import unittest
+#
+# from cowrie.core.checkers import HoneypotPasswordChecker, HoneypotPublicKeyChecker
+# from cowrie.core.realm import HoneyPotRealm
+# from cowrie.ssh.factory import CowrieSSHFactory
+#
+# from twisted.cred import portal
+# from twisted.internet import reactor  # type: ignore
+#
+# # from cowrie.test.proxy_compare import ProxyTestCommand
+#
+# os.environ["COWRIE_HONEYPOT_TTYLOG"] = "false"
+# os.environ["COWRIE_OUTPUT_JSONLOG_ENABLED"] = "false"
+#
+#
+# def create_ssh_factory(backend: str) -> CowrieSSHFactory:
+#     factory = CowrieSSHFactory(backend, None)
+#     factory.portal = portal.Portal(HoneyPotRealm())
+#     factory.portal.registerChecker(HoneypotPublicKeyChecker())
+#     factory.portal.registerChecker(HoneypotPasswordChecker())
+#     # factory.portal.registerChecker(HoneypotNoneChecker())
 #     return factory
-
-
-class ProxyTests(unittest.TestCase):
-    """Proxy tests.
-
-    How to test the proxy:
-        - setUp runs a 'shell' backend on 4444; then set up a 'proxy' on port 5555 connected to the 'shell' backend
-        - test_ssh_proxy runs an exec command via a client against both proxy and shell; returns a deferred
-        - the deferred succeeds if the output from both is the same
-    """
-
-    HOST = "127.0.0.1"
-
-    PORT_BACKEND_SSH = 4444
-    PORT_PROXY_SSH = 5555
-    PORT_BACKEND_TELNET = 4445
-    PORT_PROXY_TELNET = 5556
-
-    USERNAME_BACKEND = "root"
-    PASSWORD_BACKEND = "example"
-
-    USERNAME_PROXY = "root"
-    PASSWORD_PROXY = "example"
-
-    def setUp(self) -> None:
-        # Setup SSH backend.
-        self.factory_shell_ssh = create_ssh_factory("shell")
-        self.shell_server_ssh = reactor.listenTCP(
-            self.PORT_BACKEND_SSH, self.factory_shell_ssh
-        )
-
-        # Setup proxy environment.
-        os.environ["COWRIE_PROXY_BACKEND"] = "simple"
-        os.environ["COWRIE_PROXY_BACKEND_SSH_HOST"] = self.HOST
-        os.environ["COWRIE_PROXY_BACKEND_SSH_PORT"] = str(self.PORT_BACKEND_SSH)
-        os.environ["COWRIE_PROXY_BACKEND_TELNET_HOST"] = self.HOST
-        os.environ["COWRIE_PROXY_BACKEND_TELNET_PORT"] = str(self.PORT_BACKEND_TELNET)
-        # Setup SSH proxy.
-        self.factory_proxy_ssh = create_ssh_factory("proxy")
-        self.proxy_server_ssh = reactor.listenTCP(
-            self.PORT_PROXY_SSH, self.factory_proxy_ssh
-        )
-
-    # def test_ls(self):
-    #     command_tester = ProxyTestCommand('ssh', self.HOST, self.PORT_BACKEND_SSH, self.PORT_PROXY_SSH,
-    #                                       self.USERNAME_BACKEND, self.PASSWORD_BACKEND,
-    #                                       self.USERNAME_PROXY, self.PASSWORD_PROXY)
-    #
-    #     return command_tester.execute_both('ls -halt')
-
-    def tearDown(self) -> None:
-        for client in self.factory_proxy_ssh.running:
-            if client.transport:
-                client.transport.loseConnection()
-
-        self.proxy_server_ssh.stopListening()
-        self.shell_server_ssh.stopListening()
-
-        self.factory_shell_ssh.stopFactory()
-        self.factory_proxy_ssh.stopFactory()
+#
+#
+# # def create_telnet_factory(backend):
+# #     factory = HoneyPotTelnetFactory(backend, None)
+# #     factory.portal = portal.Portal(HoneyPotRealm())
+# #     factory.portal.registerChecker(HoneypotPasswordChecker())
+# #
+# #     return factory
+#
+#
+# class ProxyTests(unittest.TestCase):
+#     """Proxy tests.
+#
+#     How to test the proxy:
+#         - setUp runs a 'shell' backend on 4444; then set up a 'proxy' on port 5555 connected to the 'shell' backend
+#         - test_ssh_proxy runs an exec command via a client against both proxy and shell; returns a deferred
+#         - the deferred succeeds if the output from both is the same
+#     """
+#
+#     HOST = "127.0.0.1"
+#
+#     PORT_BACKEND_SSH = 4444
+#     PORT_PROXY_SSH = 5555
+#     PORT_BACKEND_TELNET = 4445
+#     PORT_PROXY_TELNET = 5556
+#
+#     USERNAME_BACKEND = "root"
+#     PASSWORD_BACKEND = "example"
+#
+#     USERNAME_PROXY = "root"
+#     PASSWORD_PROXY = "example"
+#
+#     def setUp(self) -> None:
+#         # Setup SSH backend.
+#         self.factory_shell_ssh = create_ssh_factory("shell")
+#         self.shell_server_ssh = reactor.listenTCP(
+#             self.PORT_BACKEND_SSH, self.factory_shell_ssh
+#         )
+#
+#         # Setup proxy environment.
+#         os.environ["COWRIE_PROXY_BACKEND"] = "simple"
+#         os.environ["COWRIE_PROXY_BACKEND_SSH_HOST"] = self.HOST
+#         os.environ["COWRIE_PROXY_BACKEND_SSH_PORT"] = str(self.PORT_BACKEND_SSH)
+#         os.environ["COWRIE_PROXY_BACKEND_TELNET_HOST"] = self.HOST
+#         os.environ["COWRIE_PROXY_BACKEND_TELNET_PORT"] = str(self.PORT_BACKEND_TELNET)
+#         # Setup SSH proxy.
+#         self.factory_proxy_ssh = create_ssh_factory("proxy")
+#         self.proxy_server_ssh = reactor.listenTCP(
+#             self.PORT_PROXY_SSH, self.factory_proxy_ssh
+#         )
+#
+#     # def test_ls(self):
+#     #     command_tester = ProxyTestCommand('ssh', self.HOST, self.PORT_BACKEND_SSH, self.PORT_PROXY_SSH,
+#     #                                       self.USERNAME_BACKEND, self.PASSWORD_BACKEND,
+#     #                                       self.USERNAME_PROXY, self.PASSWORD_PROXY)
+#     #
+#     #     return command_tester.execute_both('ls -halt')
+#
+#     def tearDown(self) -> None:
+#         for client in self.factory_proxy_ssh.running:
+#             if client.transport:
+#                 client.transport.loseConnection()
+#
+#         self.proxy_server_ssh.stopListening()
+#         self.shell_server_ssh.stopListening()
+#
+#         self.factory_shell_ssh.stopFactory()
+#         self.factory_proxy_ssh.stopFactory()

--- a/src/cowrie/test/test_proxy.py
+++ b/src/cowrie/test/test_proxy.py
@@ -1,5 +1,5 @@
 # -*- test-case-name: Cowrie Proxy Test Cases -*-
-#mypy: ignore
+#mypy: ignore  # noqa
 
 # Copyright (c) 2019 Guilherme Borges
 # See LICENSE for details.

--- a/src/cowrie/test/test_proxy.py
+++ b/src/cowrie/test/test_proxy.py
@@ -5,16 +5,15 @@
 
 from __future__ import annotations
 
-
 import os
-
-from twisted.cred import portal
-from twisted.internet import reactor  # type: ignore
-from twisted.trial import unittest
+import unittest
 
 from cowrie.core.checkers import HoneypotPasswordChecker, HoneypotPublicKeyChecker
 from cowrie.core.realm import HoneyPotRealm
 from cowrie.ssh.factory import CowrieSSHFactory
+
+from twisted.cred import portal
+from twisted.internet import reactor  # type: ignore
 
 # from cowrie.test.proxy_compare import ProxyTestCommand
 

--- a/src/cowrie/test/test_proxy.py
+++ b/src/cowrie/test/test_proxy.py
@@ -1,96 +1,106 @@
-# # Copyright (c) 2019 Guilherme Borges
-# # See LICENSE for details.
-#
-# from __future__ import annotations
-#
-# import os
-# import unittest
-#
-# from cowrie.core.checkers import HoneypotPasswordChecker, HoneypotPublicKeyChecker
-# from cowrie.core.realm import HoneyPotRealm
-# from cowrie.ssh.factory import CowrieSSHFactory
-#
-# from twisted.cred import portal
-# from twisted.internet import reactor  # type: ignore
-#
-# # from cowrie.test.proxy_compare import ProxyTestCommand
-#
-# os.environ["COWRIE_HONEYPOT_TTYLOG"] = "false"
-# os.environ["COWRIE_OUTPUT_JSONLOG_ENABLED"] = "false"
-#
-#
-# def create_ssh_factory(backend: str) -> CowrieSSHFactory:
-#     factory = CowrieSSHFactory(backend, None)
+# -*- test-case-name: Cowrie Proxy Test Cases -*-
+
+# Copyright (c) 2019 Guilherme Borges
+# See LICENSE for details.
+
+from __future__ import annotations
+
+
+import os
+
+from twisted.cred import portal
+from twisted.internet import reactor  # type: ignore
+from twisted.trial import unittest
+
+from cowrie.core.checkers import HoneypotPasswordChecker, HoneypotPublicKeyChecker
+from cowrie.core.realm import HoneyPotRealm
+from cowrie.ssh.factory import CowrieSSHFactory
+
+# from cowrie.test.proxy_compare import ProxyTestCommand
+
+os.environ["COWRIE_HONEYPOT_TTYLOG"] = "false"
+os.environ["COWRIE_OUTPUT_JSONLOG_ENABLED"] = "false"
+
+
+def create_ssh_factory(backend):
+    factory = CowrieSSHFactory(backend, None)
+    factory.portal = portal.Portal(HoneyPotRealm())
+    factory.portal.registerChecker(HoneypotPublicKeyChecker())
+    factory.portal.registerChecker(HoneypotPasswordChecker())
+    # factory.portal.registerChecker(HoneypotNoneChecker())
+
+    return factory
+
+
+# def create_telnet_factory(backend):
+#     factory = HoneyPotTelnetFactory(backend, None)
 #     factory.portal = portal.Portal(HoneyPotRealm())
-#     factory.portal.registerChecker(HoneypotPublicKeyChecker())
 #     factory.portal.registerChecker(HoneypotPasswordChecker())
-#     # factory.portal.registerChecker(HoneypotNoneChecker())
+#
 #     return factory
-#
-#
-# # def create_telnet_factory(backend):
-# #     factory = HoneyPotTelnetFactory(backend, None)
-# #     factory.portal = portal.Portal(HoneyPotRealm())
-# #     factory.portal.registerChecker(HoneypotPasswordChecker())
-# #
-# #     return factory
-#
-#
-# class ProxyTests(unittest.TestCase):
-#     """Proxy tests.
-#
-#     How to test the proxy:
-#         - setUp runs a 'shell' backend on 4444; then set up a 'proxy' on port 5555 connected to the 'shell' backend
-#         - test_ssh_proxy runs an exec command via a client against both proxy and shell; returns a deferred
-#         - the deferred succeeds if the output from both is the same
-#     """
-#
-#     HOST = "127.0.0.1"
-#
-#     PORT_BACKEND_SSH = 4444
-#     PORT_PROXY_SSH = 5555
-#     PORT_BACKEND_TELNET = 4445
-#     PORT_PROXY_TELNET = 5556
-#
-#     USERNAME_BACKEND = "root"
-#     PASSWORD_BACKEND = "example"
-#
-#     USERNAME_PROXY = "root"
-#     PASSWORD_PROXY = "example"
-#
-#     def setUp(self) -> None:
-#         # Setup SSH backend.
-#         self.factory_shell_ssh = create_ssh_factory("shell")
-#         self.shell_server_ssh = reactor.listenTCP(
-#             self.PORT_BACKEND_SSH, self.factory_shell_ssh
-#         )
-#
-#         # Setup proxy environment.
-#         os.environ["COWRIE_PROXY_BACKEND"] = "simple"
-#         os.environ["COWRIE_PROXY_BACKEND_SSH_HOST"] = self.HOST
-#         os.environ["COWRIE_PROXY_BACKEND_SSH_PORT"] = str(self.PORT_BACKEND_SSH)
-#         os.environ["COWRIE_PROXY_BACKEND_TELNET_HOST"] = self.HOST
-#         os.environ["COWRIE_PROXY_BACKEND_TELNET_PORT"] = str(self.PORT_BACKEND_TELNET)
-#         # Setup SSH proxy.
-#         self.factory_proxy_ssh = create_ssh_factory("proxy")
-#         self.proxy_server_ssh = reactor.listenTCP(
-#             self.PORT_PROXY_SSH, self.factory_proxy_ssh
-#         )
-#
-#     # def test_ls(self):
-#     #     command_tester = ProxyTestCommand('ssh', self.HOST, self.PORT_BACKEND_SSH, self.PORT_PROXY_SSH,
-#     #                                       self.USERNAME_BACKEND, self.PASSWORD_BACKEND,
-#     #                                       self.USERNAME_PROXY, self.PASSWORD_PROXY)
-#     #
-#     #     return command_tester.execute_both('ls -halt')
-#
-#     def tearDown(self) -> None:
-#         for client in self.factory_proxy_ssh.running:
-#             if client.transport:
-#                 client.transport.loseConnection()
-#
-#         self.proxy_server_ssh.stopListening()
-#         self.shell_server_ssh.stopListening()
-#
-#         self.factory_shell_ssh.stopFactory()
-#         self.factory_proxy_ssh.stopFactory()
+
+
+class ProxyTests(unittest.TestCase):
+    """
+    How to test the proxy:
+        - setUp runs a 'shell' backend on 4444; then set up a 'proxy' on port 5555 connected to the 'shell' backend
+        - test_ssh_proxy runs an exec command via a client against both proxy and shell; returns a deferred
+        - the deferred succeeds if the output from both is the same
+    """
+
+    HOST = "127.0.0.1"
+
+    PORT_BACKEND_SSH = 4444
+    PORT_PROXY_SSH = 5555
+    PORT_BACKEND_TELNET = 4445
+    PORT_PROXY_TELNET = 5556
+
+    USERNAME_BACKEND = "root"
+    PASSWORD_BACKEND = "example"
+
+    USERNAME_PROXY = "root"
+    PASSWORD_PROXY = "example"
+
+    def setUp(self):
+        # ################################################# #
+        # #################### Backend #################### #
+        # ################################################# #
+        # setup SSH backend
+        self.factory_shell_ssh = create_ssh_factory("shell")
+        self.shell_server_ssh = reactor.listenTCP(
+            self.PORT_BACKEND_SSH, self.factory_shell_ssh
+        )
+
+        # ################################################# #
+        # #################### Proxy ###################### #
+        # ################################################# #
+        # setup proxy environment
+        os.environ["COWRIE_PROXY_BACKEND"] = "simple"
+        os.environ["COWRIE_PROXY_BACKEND_SSH_HOST"] = self.HOST
+        os.environ["COWRIE_PROXY_BACKEND_SSH_PORT"] = str(self.PORT_BACKEND_SSH)
+        os.environ["COWRIE_PROXY_BACKEND_TELNET_HOST"] = self.HOST
+        os.environ["COWRIE_PROXY_BACKEND_TELNET_PORT"] = str(self.PORT_BACKEND_TELNET)
+
+        # setup SSH proxy
+        self.factory_proxy_ssh = create_ssh_factory("proxy")
+        self.proxy_server_ssh = reactor.listenTCP(
+            self.PORT_PROXY_SSH, self.factory_proxy_ssh
+        )
+
+    # def test_ls(self):
+    #     command_tester = ProxyTestCommand('ssh', self.HOST, self.PORT_BACKEND_SSH, self.PORT_PROXY_SSH,
+    #                                       self.USERNAME_BACKEND, self.PASSWORD_BACKEND,
+    #                                       self.USERNAME_PROXY, self.PASSWORD_PROXY)
+    #
+    #     return command_tester.execute_both('ls -halt')
+
+    def tearDown(self):
+        for client in self.factory_proxy_ssh.running:
+            if client.transport:
+                client.transport.loseConnection()
+
+        self.proxy_server_ssh.stopListening()
+        self.shell_server_ssh.stopListening()
+
+        self.factory_shell_ssh.stopFactory()
+        self.factory_proxy_ssh.stopFactory()

--- a/src/cowrie/test/test_proxy.py
+++ b/src/cowrie/test/test_proxy.py
@@ -10,7 +10,8 @@ import os
 
 from twisted.cred import portal
 from twisted.internet import reactor  # type: ignore
-from twisted.trial import unittest
+# from twisted.trial import unittest
+import unittest
 
 from cowrie.core.checkers import HoneypotPasswordChecker, HoneypotPublicKeyChecker
 from cowrie.core.realm import HoneyPotRealm

--- a/src/cowrie/test/test_proxy.py
+++ b/src/cowrie/test/test_proxy.py
@@ -1,4 +1,5 @@
 # -*- test-case-name: Cowrie Proxy Test Cases -*-
+#mypy: ignore
 
 # Copyright (c) 2019 Guilherme Borges
 # See LICENSE for details.

--- a/src/cowrie/test/test_tee.py
+++ b/src/cowrie/test/test_tee.py
@@ -20,7 +20,7 @@ class ShellTeeCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/tee.py."""
 
     proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-    tr = FakeTransport("1.1.1.1", "1111")
+    tr = FakeTransport("", "31337")
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/src/cowrie/test/test_tee.py
+++ b/src/cowrie/test/test_tee.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import os
 import unittest
+from typing import Optional
 
-from cowrie.shell import protocol
-from cowrie.test import fake_server, fake_transport
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
@@ -18,17 +20,14 @@ PROMPT = b"root@unitTest:~# "
 class ShellTeeCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/tee.py."""
 
-    proto = None
-    tr = None
+    proto: Optional[HoneyPotInteractiveProtocol] = None
+    tr: Optional[FakeTransport] = None
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.proto = protocol.HoneyPotInteractiveProtocol(
-            fake_server.FakeAvatar(fake_server.FakeServer())
-        )
-        cls.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        cls.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        cls.tr = FakeTransport("1.1.1.1", "1111")
         cls.proto.makeConnection(cls.tr)
-        cls.tr.clear()
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/src/cowrie/test/test_tee.py
+++ b/src/cowrie/test/test_tee.py
@@ -20,13 +20,11 @@ PROMPT = b"root@unitTest:~# "
 class ShellTeeCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/tee.py."""
 
-    proto: Optional[HoneyPotInteractiveProtocol] = None
-    tr: Optional[FakeTransport] = None
+    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+    tr = FakeTransport("1.1.1.1", "1111")
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-        cls.tr = FakeTransport("1.1.1.1", "1111")
         cls.proto.makeConnection(cls.tr)
 
     @classmethod

--- a/src/cowrie/test/test_tee.py
+++ b/src/cowrie/test/test_tee.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import unittest
-from typing import Optional
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
@@ -36,33 +35,26 @@ class ShellTeeCommandTests(unittest.TestCase):
 
     def test_tee_command_001(self) -> None:
         self.proto.lineReceived(b"tee /a/b/c/d\n")
-        self.assertEqual(
-            self.tr.value(), b"tee: /a/b/c/d: No such file or directory\n"
-        )
+        self.assertEqual(self.tr.value(), b"tee: /a/b/c/d: No such file or directory\n")
         # tee still waiting input from stdin
         self.proto.handle_CTRL_C()
 
     def test_tee_command_002(self) -> None:
         self.proto.lineReceived(b"tee /a/b/c/d\n")
         self.proto.handle_CTRL_C()
-        self.assertEqual(
-            self.tr.value(), b"tee: /a/b/c/d: No such file or directory\n^C\n" + PROMPT
-        )
+        self.assertEqual(self.tr.value(), b"tee: /a/b/c/d: No such file or directory\n^C\n" + PROMPT)
 
     def test_tee_command_003(self) -> None:
-        """Test ignore stdin when called without '-'."""
         self.proto.lineReceived(b"tee a\n")
         self.proto.lineReceived(b"test\n")
         self.proto.handle_CTRL_D()
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
     def test_tee_command_004(self) -> None:
-        """Test handle of stdin."""
         self.proto.lineReceived(b"echo test | tee\n")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
     def test_tee_command_005(self) -> None:
-        """Test handle of CTRL_C."""
         self.proto.lineReceived(b"tee\n")
         self.proto.lineReceived(b"test\n")
         self.proto.handle_CTRL_D()

--- a/src/cowrie/test/test_tee.py
+++ b/src/cowrie/test/test_tee.py
@@ -11,14 +11,15 @@ from __future__ import annotations
 
 import os
 
-from twisted.trial import unittest
+# from twisted.trial import unittest
+import unittest
 
 from cowrie.shell import protocol
 from cowrie.test import fake_server, fake_transport
 
-os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "../data"
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
-os.environ["COWRIE_SHELL_FILESYSTEM"] = "../share/cowrie/fs.pickle"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "share/cowrie/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "
 

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -21,7 +21,7 @@ class ShellTftpCommandTests(unittest.TestCase):
 
     def setUp(self) -> None:
         self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-        self.tr = FakeTransport("1.1.1.1", "1111")
+        self.tr = FakeTransport("", "31337")
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -31,6 +31,5 @@ class ShellTftpCommandTests(unittest.TestCase):
     def test_echo_command_001(self) -> None:
         self.proto.lineReceived(b"tftp\n")
         self.assertEqual(
-            self.tr.value(),
-            b"usage: tftp [-h] [-c C C] [-l L] [-g G] [-p P] [-r R] [hostname]\n" + PROMPT,
+            self.tr.value(), b"usage: tftp [-h] [-c C C] [-l L] [-g G] [-p P] [-r R] [hostname]\n" + PROMPT
         )

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -1,17 +1,8 @@
-# -*- test-case-name: Cowrie Test Cases -*-
-
 # Copyright (c) 2018 Michel Oosterhof
 # See LICENSE for details.
-
-"""
-Tests for general shell interaction and echo command
-"""
 from __future__ import annotations
 
-
 import os
-
-# from twisted.trial import unittest
 import unittest
 
 from cowrie.shell import protocol
@@ -25,7 +16,9 @@ PROMPT = b"root@unitTest:~# "
 
 
 class ShellTftpCommandTests(unittest.TestCase):
-    def setUp(self):
+    """Tests for cowrie/commands/tftp.py."""
+
+    def setUp(self) -> None:
         self.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
@@ -33,16 +26,12 @@ class ShellTftpCommandTests(unittest.TestCase):
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 
-    def test_echo_command_001(self):
-        """
-        Basic test
-        """
+    def tearDown(self) -> None:
+        self.proto.connectionLost("tearDown From Unit Test")
+
+    def test_echo_command_001(self) -> None:
         self.proto.lineReceived(b"tftp\n")
         self.assertEqual(
             self.tr.value(),
-            b"usage: tftp [-h] [-c C C] [-l L] [-g G] [-p P] [-r R] [hostname]\n"
-            + PROMPT,
+            b"usage: tftp [-h] [-c C C] [-l L] [-g G] [-p P] [-r R] [hostname]\n" + PROMPT,
         )
-
-    def tearDown(self):
-        self.proto.connectionLost("tearDown From Unit Test")

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import os
 import unittest
 
-from cowrie.shell import protocol
-from cowrie.test import fake_server, fake_transport
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
@@ -19,10 +20,8 @@ class ShellTftpCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/tftp.py."""
 
     def setUp(self) -> None:
-        self.proto = protocol.HoneyPotInteractiveProtocol(
-            fake_server.FakeAvatar(fake_server.FakeServer())
-        )
-        self.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("1.1.1.1", "1111")
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -11,14 +11,15 @@ from __future__ import annotations
 
 import os
 
-from twisted.trial import unittest
+# from twisted.trial import unittest
+import unittest
 
 from cowrie.shell import protocol
 from cowrie.test import fake_server, fake_transport
 
-os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "../data"
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
-os.environ["COWRIE_SHELL_FILESYSTEM"] = "../share/cowrie/fs.pickle"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "share/cowrie/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "
 

--- a/src/cowrie/test/test_uniq.py
+++ b/src/cowrie/test/test_uniq.py
@@ -20,7 +20,7 @@ class ShellUniqCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/uniq.py."""
 
     proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-    tr = FakeTransport("1.1.1.1", "1111")
+    tr = FakeTransport("", "31337")
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/src/cowrie/test/test_uniq.py
+++ b/src/cowrie/test/test_uniq.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import os
 import unittest
+from typing import Optional
 
-from cowrie.shell import protocol
-from cowrie.test import fake_server, fake_transport
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
@@ -18,17 +20,14 @@ PROMPT = b"root@unitTest:~# "
 class ShellUniqCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/uniq.py."""
 
-    proto = None
-    tr = None
+    proto: Optional[HoneyPotInteractiveProtocol] = None
+    tr: Optional[FakeTransport] = None
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.proto = protocol.HoneyPotInteractiveProtocol(
-            fake_server.FakeAvatar(fake_server.FakeServer())
-        )
-        cls.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        cls.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        cls.tr = FakeTransport("1.1.1.1", "1111")
         cls.proto.makeConnection(cls.tr)
-        cls.tr.clear()
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/src/cowrie/test/test_uniq.py
+++ b/src/cowrie/test/test_uniq.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import unittest
-from typing import Optional
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
@@ -20,13 +19,11 @@ PROMPT = b"root@unitTest:~# "
 class ShellUniqCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/uniq.py."""
 
-    proto: Optional[HoneyPotInteractiveProtocol] = None
-    tr: Optional[FakeTransport] = None
+    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+    tr = FakeTransport("1.1.1.1", "1111")
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-        cls.tr = FakeTransport("1.1.1.1", "1111")
         cls.proto.makeConnection(cls.tr)
 
     @classmethod

--- a/src/cowrie/test/test_uniq.py
+++ b/src/cowrie/test/test_uniq.py
@@ -18,16 +18,24 @@ PROMPT = b"root@unitTest:~# "
 class ShellUniqCommandTests(unittest.TestCase):
     """Tests for cowrie/commands/uniq.py."""
 
-    def setUp(self) -> None:
-        self.proto = protocol.HoneyPotInteractiveProtocol(
+    proto = None
+    tr = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
-        self.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
-        self.proto.makeConnection(self.tr)
-        self.tr.clear()
+        cls.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
+        cls.proto.makeConnection(cls.tr)
+        cls.tr.clear()
 
-    def tearDown(self) -> None:
-        self.proto.connectionLost("tearDown From Unit Test")
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proto.connectionLost("tearDown From Unit Test")
+
+    def setUp(self) -> None:
+        self.tr.clear()
 
     def test_uniq_command_001(self) -> None:
         self.proto.lineReceived(b"echo test | uniq\n")

--- a/src/cowrie/test/test_uniq.py
+++ b/src/cowrie/test/test_uniq.py
@@ -1,17 +1,8 @@
-# -*- test-case-name: Cowrie Test Cases -*-
-
 # Copyright (c) 2020 Peter Sufliarsky
 # See LICENSE for details.
-
-"""
-Tests for uniq command
-"""
 from __future__ import annotations
 
-
 import os
-
-# from twisted.trial import unittest
 import unittest
 
 from cowrie.shell import protocol
@@ -25,7 +16,9 @@ PROMPT = b"root@unitTest:~# "
 
 
 class ShellUniqCommandTests(unittest.TestCase):
-    def setUp(self):
+    """Tests for cowrie/commands/uniq.py."""
+
+    def setUp(self) -> None:
         self.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer())
         )
@@ -33,30 +26,21 @@ class ShellUniqCommandTests(unittest.TestCase):
         self.proto.makeConnection(self.tr)
         self.tr.clear()
 
-    def test_uniq_command_001(self):
-        """
-        echo test | uniq
-        """
+    def tearDown(self) -> None:
+        self.proto.connectionLost("tearDown From Unit Test")
+
+    def test_uniq_command_001(self) -> None:
         self.proto.lineReceived(b"echo test | uniq\n")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_uniq_command_002(self):
-        """
-        echo -e "test\ntest\ntest" | uniq
-        """
-        self.proto.lineReceived(b'echo -e "test\ntest\ntest" | uniq\n')
+    def test_uniq_command_002(self) -> None:
+        self.proto.lineReceived(b"echo -e \"test\ntest\ntest\" | uniq\n")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
-    def test_uniq_command_003(self):
-        """
-        test without arguments, read stdin and quit after Ctrl+D
-        """
+    def test_uniq_command_003(self) -> None:
         self.proto.lineReceived(b"uniq\n")
         self.proto.lineReceived(b"test\n")
         self.proto.lineReceived(b"test\n")
         self.proto.lineReceived(b"test\n")
         self.proto.handle_CTRL_D()
         self.assertEqual(self.tr.value(), b"test\n\n" + PROMPT)
-
-    def tearDown(self):
-        self.proto.connectionLost("tearDown From Unit Test")

--- a/src/cowrie/test/test_uniq.py
+++ b/src/cowrie/test/test_uniq.py
@@ -11,14 +11,15 @@ from __future__ import annotations
 
 import os
 
-from twisted.trial import unittest
+# from twisted.trial import unittest
+import unittest
 
 from cowrie.shell import protocol
 from cowrie.test import fake_server, fake_transport
 
-os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "../data"
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
-os.environ["COWRIE_SHELL_FILESYSTEM"] = "../share/cowrie/fs.pickle"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "share/cowrie/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "
 

--- a/src/cowrie/test/test_utils.py
+++ b/src/cowrie/test/test_utils.py
@@ -36,27 +36,20 @@ class UtilsTestCase(unittest.TestCase):
             "[ssh]\n"
             "listen_addr = 1.1.1.1\n"
         )
-        self.assertEqual(
-            ["tcp:2223:interface=1.1.1.1"],
-            get_endpoints_from_section(cfg, "ssh", 2223),
-        )
+        self.assertEqual(["tcp:2223:interface=1.1.1.1"], get_endpoints_from_section(cfg, "ssh", 2223))
 
         cfg = get_config(
             "[ssh]\n"
             "listen_addr = 1.1.1.1\n"
         )
-        self.assertEqual(
-            ["tcp:2224:interface=1.1.1.1"],
-            get_endpoints_from_section(cfg, "ssh", 2224),
-        )
+        self.assertEqual(["tcp:2224:interface=1.1.1.1"], get_endpoints_from_section(cfg, "ssh", 2224))
 
         cfg = get_config(
             "[ssh]\n"
             "listen_addr = 1.1.1.1 2.2.2.2\n"
         )
         self.assertEqual(
-            ["tcp:2223:interface=1.1.1.1", "tcp:2223:interface=2.2.2.2"],
-            get_endpoints_from_section(cfg, "ssh", 2223),
+            ["tcp:2223:interface=1.1.1.1", "tcp:2223:interface=2.2.2.2"], get_endpoints_from_section(cfg, "ssh", 2223)
         )
 
         cfg = get_config(
@@ -65,8 +58,7 @@ class UtilsTestCase(unittest.TestCase):
             "listen_port = 23\n"
         )
         self.assertEqual(
-            ["tcp:23:interface=1.1.1.1", "tcp:23:interface=2.2.2.2"],
-            get_endpoints_from_section(cfg, "ssh", 2223),
+            ["tcp:23:interface=1.1.1.1", "tcp:23:interface=2.2.2.2"], get_endpoints_from_section(cfg, "ssh", 2223)
         )
 
         cfg = get_config(
@@ -74,25 +66,20 @@ class UtilsTestCase(unittest.TestCase):
             "listen_endpoints = tcp:23:interface=1.1.1.1 tcp:2323:interface=1.1.1.1\n"
         )
         self.assertEqual(
-            ["tcp:23:interface=1.1.1.1", "tcp:2323:interface=1.1.1.1"],
-            get_endpoints_from_section(cfg, "ssh", 2223),
+            ["tcp:23:interface=1.1.1.1", "tcp:2323:interface=1.1.1.1"], get_endpoints_from_section(cfg, "ssh", 2223)
         )
 
     def test_create_endpoint_services(self) -> None:
         parent = MultiService()
-        create_endpoint_services(
-            reactor, parent, ["tcp:23:interface=1.1.1.1"], protocol.Factory()
-        )
+        create_endpoint_services(reactor, parent, ["tcp:23:interface=1.1.1.1"], protocol.Factory())
+        self.assertEqual(len(parent.services), 1)
+
+        parent = MultiService()
+        create_endpoint_services(reactor, parent, ["tcp:23:interface=1.1.1.1"], protocol.Factory())
         self.assertEqual(len(parent.services), 1)
 
         parent = MultiService()
         create_endpoint_services(
-            reactor, parent, ["tcp:23:interface=1.1.1.1"], protocol.Factory()
-        )
-        self.assertEqual(len(parent.services), 1)
-
-        parent = MultiService()
-        create_endpoint_services(
-            reactor, parent, ["tcp:23:interface=1.1.1.1", "tcp:2323:interface=2.2.2.2"], protocol.Factory(),
+            reactor, parent, ["tcp:23:interface=1.1.1.1", "tcp:2323:interface=2.2.2.2"], protocol.Factory()
         )
         self.assertEqual(len(parent.services), 2)

--- a/src/cowrie/test/test_utils.py
+++ b/src/cowrie/test/test_utils.py
@@ -1,98 +1,74 @@
 from __future__ import annotations
+
 import configparser
+import unittest
 from io import StringIO
 
+from cowrie.core.utils import create_endpoint_services, durationHuman, get_endpoints_from_section
+
 from twisted.application.service import MultiService
-from twisted.internet import reactor  # type: ignore
 from twisted.internet import protocol
-# from twisted.trial import unittest
-import unittest
-
-from cowrie.core.utils import (
-    create_endpoint_services,
-    durationHuman,
-    get_endpoints_from_section,
-)
+from twisted.internet import reactor  # type: ignore
 
 
-def get_config(config_string):
-    config = configparser.ConfigParser()
-    config.read_file(StringIO(config_string))
-    return config
+def get_config(config_string: str) -> configparser.ConfigParser:
+    """Create ConfigParser from a config_string."""
+    cfg = configparser.ConfigParser()
+    cfg.read_file(StringIO(config_string))
+    return cfg
 
 
 class UtilsTestCase(unittest.TestCase):
-    """
-    Tests for cowrie/core/utils.py
-    """
+    """Tests for cowrie/core/utils.py."""
 
-    def test_durationHuman(self):
-        """
-        Test of cowrie.core.utils.durationHuman
-        """
+    def test_durationHuman(self) -> None:
         minute = durationHuman(60)
         self.assertEqual(minute, "01:00")
+
         hour = durationHuman(3600)
         self.assertEqual(hour, "01:00:00")
+
         something = durationHuman(364020)
         self.assertEqual(something, "4.0 days 05:07:00")
 
-    def test_get_endpoints_from_section(self):
-        cfg = get_config(
-            """
-            [ssh]
-            listen_addr = 1.1.1.1
-        """
-        )
+    def test_get_endpoints_from_section(self) -> None:
+        cfg = get_config("[ssh]\n"
+                         "listen_addr = 1.1.1.1\n")
         self.assertEqual(
-            ["tcp:2223:interface=1.1.1.1"], get_endpoints_from_section(cfg, "ssh", 2223)
+            ["tcp:2223:interface=1.1.1.1"],
+            get_endpoints_from_section(cfg, "ssh", 2223),
         )
 
-        cfg = get_config(
-            """
-            [ssh]
-            listen_addr = 1.1.1.1
-        """
-        )
+        cfg = get_config("[ssh]\n"
+                         "listen_addr = 1.1.1.1\n")
         self.assertEqual(
-            ["tcp:2224:interface=1.1.1.1"], get_endpoints_from_section(cfg, "ssh", 2224)
+            ["tcp:2224:interface=1.1.1.1"],
+            get_endpoints_from_section(cfg, "ssh", 2224),
         )
 
-        cfg = get_config(
-            """
-            [ssh]
-            listen_addr = 1.1.1.1 2.2.2.2
-        """
-        )
+        cfg = get_config("[ssh]\n"
+                         "listen_addr = 1.1.1.1 2.2.2.2\n")
         self.assertEqual(
             ["tcp:2223:interface=1.1.1.1", "tcp:2223:interface=2.2.2.2"],
             get_endpoints_from_section(cfg, "ssh", 2223),
         )
 
-        cfg = get_config(
-            """
-            [ssh]
-            listen_addr = 1.1.1.1 2.2.2.2
-            listen_port = 23
-        """
-        )
+        cfg = get_config("[ssh]\n"
+                         "listen_addr = 1.1.1.1 2.2.2.2\n"
+                         "listen_port = 23\n")
         self.assertEqual(
             ["tcp:23:interface=1.1.1.1", "tcp:23:interface=2.2.2.2"],
             get_endpoints_from_section(cfg, "ssh", 2223),
         )
 
-        cfg = get_config(
-            """
-            [ssh]
-            listen_endpoints = tcp:23:interface=1.1.1.1 tcp:2323:interface=1.1.1.1
-        """
-        )
+        cfg = get_config("[ssh]\n"
+                         "listen_endpoints = tcp:23:interface=1.1.1.1 tcp:2323:interface=1.1.1.1\n")
         self.assertEqual(
             ["tcp:23:interface=1.1.1.1", "tcp:2323:interface=1.1.1.1"],
             get_endpoints_from_section(cfg, "ssh", 2223),
         )
 
-    def test_create_endpoint_services(self):
+    def test_create_endpoint_services(self) -> None:
         parent = MultiService()
         create_endpoint_services(
             reactor, parent, ["tcp:23:interface=1.1.1.1"], protocol.Factory()
@@ -107,9 +83,6 @@ class UtilsTestCase(unittest.TestCase):
 
         parent = MultiService()
         create_endpoint_services(
-            reactor,
-            parent,
-            ["tcp:23:interface=1.1.1.1", "tcp:2323:interface=2.2.2.2"],
-            protocol.Factory(),
+            reactor, parent, ["tcp:23:interface=1.1.1.1", "tcp:2323:interface=2.2.2.2"], protocol.Factory(),
         )
         self.assertEqual(len(parent.services), 2)

--- a/src/cowrie/test/test_utils.py
+++ b/src/cowrie/test/test_utils.py
@@ -32,37 +32,47 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(something, "4.0 days 05:07:00")
 
     def test_get_endpoints_from_section(self) -> None:
-        cfg = get_config("[ssh]\n"
-                         "listen_addr = 1.1.1.1\n")
+        cfg = get_config(
+            "[ssh]\n"
+            "listen_addr = 1.1.1.1\n"
+        )
         self.assertEqual(
             ["tcp:2223:interface=1.1.1.1"],
             get_endpoints_from_section(cfg, "ssh", 2223),
         )
 
-        cfg = get_config("[ssh]\n"
-                         "listen_addr = 1.1.1.1\n")
+        cfg = get_config(
+            "[ssh]\n"
+            "listen_addr = 1.1.1.1\n"
+        )
         self.assertEqual(
             ["tcp:2224:interface=1.1.1.1"],
             get_endpoints_from_section(cfg, "ssh", 2224),
         )
 
-        cfg = get_config("[ssh]\n"
-                         "listen_addr = 1.1.1.1 2.2.2.2\n")
+        cfg = get_config(
+            "[ssh]\n"
+            "listen_addr = 1.1.1.1 2.2.2.2\n"
+        )
         self.assertEqual(
             ["tcp:2223:interface=1.1.1.1", "tcp:2223:interface=2.2.2.2"],
             get_endpoints_from_section(cfg, "ssh", 2223),
         )
 
-        cfg = get_config("[ssh]\n"
-                         "listen_addr = 1.1.1.1 2.2.2.2\n"
-                         "listen_port = 23\n")
+        cfg = get_config(
+            "[ssh]\n"
+            "listen_addr = 1.1.1.1 2.2.2.2\n"
+            "listen_port = 23\n"
+        )
         self.assertEqual(
             ["tcp:23:interface=1.1.1.1", "tcp:23:interface=2.2.2.2"],
             get_endpoints_from_section(cfg, "ssh", 2223),
         )
 
-        cfg = get_config("[ssh]\n"
-                         "listen_endpoints = tcp:23:interface=1.1.1.1 tcp:2323:interface=1.1.1.1\n")
+        cfg = get_config(
+            "[ssh]\n"
+            "listen_endpoints = tcp:23:interface=1.1.1.1 tcp:2323:interface=1.1.1.1\n"
+        )
         self.assertEqual(
             ["tcp:23:interface=1.1.1.1", "tcp:2323:interface=1.1.1.1"],
             get_endpoints_from_section(cfg, "ssh", 2223),

--- a/src/cowrie/test/test_utils.py
+++ b/src/cowrie/test/test_utils.py
@@ -5,7 +5,8 @@ from io import StringIO
 from twisted.application.service import MultiService
 from twisted.internet import reactor  # type: ignore
 from twisted.internet import protocol
-from twisted.trial import unittest
+# from twisted.trial import unittest
+import unittest
 
 from cowrie.core.utils import (
     create_endpoint_services,

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-skipsdist = True
 envlist = lint,docs,typing,py37,py38,py39,py310,pypy3
-deps = -r{toxinidir}/requirements.txt
-skip_missing_interpreters = True
+package_name = cowrie
+# skipsdist = True
+# deps = -r{toxinidir}/requirements.txt
+# skip_missing_interpreters = True
 
 [gh-actions]
 python =
@@ -20,7 +21,7 @@ deps =
 #    libvirt-python==5.5.0
 
 commands =
-    trial cowrie
+    python -m unittest discover -v --start-directory src
 
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 #    libvirt-python==5.5.0
 
 commands =
-    python -m unittest discover -v --start-directory src
+    python -m unittest discover src --verbose
 
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
+skipsdist = True
 envlist = lint,docs,typing,py37,py38,py39,py310,pypy3
-package_name = cowrie
-# skipsdist = True
-# deps = -r{toxinidir}/requirements.txt
-# skip_missing_interpreters = True
+deps = -r{toxinidir}/requirements.txt
+skip_missing_interpreters = True
 
 [gh-actions]
 python =


### PR DESCRIPTION
Hi!

Currently cowrie uses unittest provided by twisted.
There are couple of drawbacks...
Twistd.trial.unittest is outdated and it's missing some useful features (like setUpClass/tearDownClass).
https://github.com/twisted/twisted/blob/trunk/src/twisted/trial/unittest.py

I moved cowrie tests from twisted.trial.unittest to standard python unittest.

Some additional changes I made:
1. Add `#mypy:ignore` to proxy_compare.py and test_proxy.py.
2. Add some typing.
3. Introduce setUpClass/tearDownClass for some tests.

And I have a question about proxy_compare.py and test_proxy.py.
It seems unfinished. proxy_compare.py prepares enviroment for testing, test_proxy.py inits environment but doesn't contain any test cases. Are these useful tests?