### PR TITLE
Telegram bot output

### DIFF
--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -1016,6 +1016,16 @@ verify_cert = true
 publish_event = true
 debug = false
 
+# Send message using Telegram bot
+# 1. Create a bot following https://core.telegram.org/bots#6-botfather to get token.
+# 2. Send message to your bot, then use https://api.telegram.org/bot{bot_token}/getUpdates to find chat_id.
+# N.b. bot will only send messages on cowrie.login.success, cowrie.command.input/.failed, and
+# cowrie.session.file_download, to prevent spam. 
+[output_telegram]
+enabled = false
+bot_token = 123456789:AbCDEfGhiJkLmnOpQRstUVWxYZ
+chat_id = 987654321
+
 # The crashreporter sends data on Python exceptions to api.cowrie.org
 # To disable set `enabled = false` in cowrie.cfg
 [output_crashreporter]

--- a/src/cowrie/output/telegram.py
+++ b/src/cowrie/output/telegram.py
@@ -1,0 +1,54 @@
+# Simple Telegram Bot logger
+
+from __future__ import absolute_import, division
+
+import treq
+from twisted.internet import defer, error
+from twisted.python import log
+import re
+import cowrie.core.output
+from cowrie.core.config import CowrieConfig
+
+
+class Output(cowrie.core.output.Output):
+    """
+    telegram output
+    """
+
+    def start(self):
+        self.bot_token = CowrieConfig.get('output_telegram', 'bot_token')
+        self.chat_id = CowrieConfig.get('output_telegram', 'chat_id')
+
+    def stop(self):
+        pass
+
+    def write(self, logentry):
+        for i in list(logentry.keys()):
+            # remove twisted 15 legacy keys
+            if i.startswith('log_'):
+                del logentry[i]
+
+        # Prepare base message
+        msgtxt = "<strong>[Cowrie "+logentry['sensor']+"]</strong>"
+        msgtxt += "\nEvent: " + logentry["eventid"]
+        msgtxt += "\nSource: <code>" + logentry['src_ip'] + "</code>"
+        msgtxt += "\nSession: <code>" + logentry['session'] + "</code>"
+
+        if logentry['eventid'] == "cowrie.login.success":
+            msgtxt += "\nUsername: <code>" + logentry['username'] + "</code>"
+            msgtxt += "\nPassword: <code>" + logentry['password'] + "</code>"
+            self.send_message(msgtxt)
+        elif logentry["eventid"] in ["cowrie.command.failed", "cowrie.command.input"]:
+            msgtxt += "\nCommand: <pre>" + logentry['input'] + "</pre>"
+            self.send_message(msgtxt)
+        elif logentry["eventid"] == "cowrie.session.file_download":
+            msgtxt += "\nUrl: " + logentry.get("url", "")
+            self.send_message(msgtxt)
+    
+    def send_message(self, message):
+        log.msg("Telegram plugin will try to call TelegramBot")
+        try:
+            r = treq.get('https://api.telegram.org/bot' + self.bot_token + '/sendMessage',
+                     params=[('chat_id', str(self.chat_id)), ('parse_mode','HTML'), ('text', message)])
+        except Exception:
+            log.msg("Telegram plugin request error")

--- a/src/cowrie/output/telegram.py
+++ b/src/cowrie/output/telegram.py
@@ -3,9 +3,7 @@
 from __future__ import absolute_import, division
 
 import treq
-from twisted.internet import defer, error
 from twisted.python import log
-import re
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
 
@@ -29,7 +27,7 @@ class Output(cowrie.core.output.Output):
                 del logentry[i]
 
         # Prepare base message
-        msgtxt = "<strong>[Cowrie "+logentry['sensor']+"]</strong>"
+        msgtxt = "<strong>[Cowrie " + logentry['sensor'] + "]</strong>"
         msgtxt += "\nEvent: " + logentry["eventid"]
         msgtxt += "\nSource: <code>" + logentry['src_ip'] + "</code>"
         msgtxt += "\nSession: <code>" + logentry['session'] + "</code>"
@@ -44,11 +42,11 @@ class Output(cowrie.core.output.Output):
         elif logentry["eventid"] == "cowrie.session.file_download":
             msgtxt += "\nUrl: " + logentry.get("url", "")
             self.send_message(msgtxt)
-    
+
     def send_message(self, message):
         log.msg("Telegram plugin will try to call TelegramBot")
         try:
-            r = treq.get('https://api.telegram.org/bot' + self.bot_token + '/sendMessage',
-                     params=[('chat_id', str(self.chat_id)), ('parse_mode','HTML'), ('text', message)])
+            treq.get('https://api.telegram.org/bot' + self.bot_token + '/sendMessage',
+                     params=[('chat_id', str(self.chat_id)), ('parse_mode', 'HTML'), ('text', message)])
         except Exception:
             log.msg("Telegram plugin request error")


### PR DESCRIPTION
I created a Telegram bot output class, following-up on the issue #1290 by @nuno-carvalho. This bot reports certain Cowrie events via Telegram (`cowrie.login.success`, `cowrie.command.input/.failed`, and `cowrie.session.file_download`). Failed logins etc. are thus not reported since this would likely result in overload of messages, and other output plugins are beter suited for that.

Instructions to create the bot are also provided in `cowrie.cfg.dst`:
1. Create a bot following https://core.telegram.org/bots#6-botfather to get token.
2. Send message to your bot, then use https://api.telegram.org/bot{bot_token}/getUpdates to find chat_id.
3. Configure `cowrie.cfg.dst` with the `bot_token` and `chat_id`, and enable this output plugin.