### PR TITLE
update mongodb output to work correctly with pymongo versions >= 3.0

### DIFF
--- a/src/cowrie/output/mongodb.py
+++ b/src/cowrie/output/mongodb.py
@@ -21,7 +21,7 @@ class Output(cowrie.core.output.Output):
 
     def update_one(self, collection, session, doc):
         try:
-            object_id = collection.update({"session": session}, doc)
+            object_id = collection.update_one({"session": session}, { "$set": doc })
             return object_id
         except Exception as e:
             log.msg(f"mongo error - {e}")

--- a/src/cowrie/output/mongodb.py
+++ b/src/cowrie/output/mongodb.py
@@ -21,7 +21,7 @@ class Output(cowrie.core.output.Output):
 
     def update_one(self, collection, session, doc):
         try:
-            object_id = collection.update_one({"session": session}, { "$set": doc })
+            object_id = collection.update_one({"session": session}, {"$set": doc})
             return object_id
         except Exception as e:
             log.msg(f"mongo error - {e}")


### PR DESCRIPTION
Updated mongodb output plugin to work with pymongo versions later than 3.0. The "update" function was no longer supported and replaced with "update_one" and the "$set" operator was set for consistency with newer versions.