### PR TITLE
New ThreatJammer output module

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ Welcome to Cowrie's documentation!
    squid/README.rst
    supervisor/README.rst
    systemd/README.rst
+   threatjammer/README.rst
 
 Indices and tables
 ==================

--- a/docs/threatjammer/README.rst
+++ b/docs/threatjammer/README.rst
@@ -1,0 +1,100 @@
+How to send Cowrie output to Threat Jammer
+##########################################
+
+.. image:: https://threatjammer.com/threatjammer-risk-score.png
+    :align: center
+    :width: 400
+    :height: 200
+    :alt: threatjammer.com
+
+
+Threat Jammer Prerequisites
+***************************
+
+* Working Cowrie installation
+* A Threat Jammer API Key
+
+Threat Jammer Introduction
+**************************
+
+What is Threat Jammer
+=====================
+`Threat Jammer <https://threatjammer.com>`_ is a service to access high-quality threat intelligence data from a variety of sources and integrate it into their applications with the sole purpose of detecting and blocking malicious activity. This output module feeds the private denylists of Threat Jammer with successful and unsuccessful login attempts thanks to the asynchronous `Reporting API of Threat Jammer <https://threatjammer.com/docs/introduction-threat-jammer-report-api>`_. The user can use the denylists in their own infrastructure firewalls or WAFs, or use it for forensic analysis.
+
+When users feed Threat Jammer with their data using the Reporting API, they increase the chance of finding malicious activity and reducing the false positives. Crowdsourced Intelligence means that our users can report their data to the Threat Jammer system, and Threat Jammer will assess the data and decide whether aggregate the data to the crowdsourced intelligence database. If the data has enough quality and is ready to consume, Threat Jammer will share it with the community.
+
+Anybody can sign up and use the service for free forever. 
+
+Cowrie Configuration for Threat Jammer
+**************************************
+
+Quick start
+===========
+To use the output module the user must `sign up and obtain an API KEY <https://threatjammer.com/docs/threat-jammer-api-keys>`_. The sign-up is free forever. 
+
+Once the developers have obtained an API Key, they have to open the configuration file of cowrie::
+
+    [output_threatjammer]
+    enabled = false
+    bearer_token = THREATJAMMER_API_TOKEN
+    #api_url=https://dublin.report.threatjammer.com/v1/ip
+    #track_login = true
+    #track_session = false
+    #ttl = 86400
+    #category = ABUSE
+    #tags = COWRIE,LOGIN,SESSION
+
+and edit the section ``[output_threatjammer]`` as follows:
+
+* Change the ``enabled`` parameter to  ``true``.
+* Change the ``THREATJAMMER_API_TOKEN`` placeholder with the real API Key of the user in the ``bearer_token`` parameter.
+
+[Re]start Cowrie. If the output module was initialized succeessfully, the user will see the following message in the Cowrie log::
+
+    [-] ThreatJammer.com output plugin successfully initialized. Category=ABUSE. TTL=86400. Session Tracking=False. Login Tracking=True
+
+Other parameters
+================
+The following parameters can change how the output module works, so use it with caution:
+
+api_url
+-------
+Points to the server running the Report API. By default it points to the Dublin Region, but more regions will be deployed in the future.
+
+track_login
+-----------
+Send information about the IP addresses that tried to login successfully or not. By default is  ``true``.
+
+track_session
+-------------
+Send information about the IP addresses that created a session. By default is ``false``.
+
+ttl
+---
+Time to Live in seconds of the reported IP addresses in the private denylist in Threat Jammer. When the TTL expires, the IP address will be automatically removed. If the same IP address is reported more than once, the TTL resets. The default value is ``86400``.
+
+category
+--------
+The category to classify the IP address. By default is ``ABUSE``. See `Platform Datasets <https://threatjammer.com/docs/introduction-threat-jammer-user-api#platform-datasets>`_ for the list of categories.
+
+tags
+----
+Comma separated list of tags to classify the IP addresses. Must be alphanumeric and uppercase. By default, ``COWRIE,LOGIN,SESSION``.
+
+Rate limits and buffers
+=======================
+The output module will send the information every 60 seconds or if the buffer of pending IP addresses to send to the Report API is 1000. The first condition will trigger the send action to the Report API server.
+
+There is a limit of 6 hits per minute per API Key. If the limit is reached, the service returns a 429 response code. A single honeypot should never trigger the rate limit.
+
+About the Module
+****************
+Python and OS versions
+======================
+The code has passed the tests implemented in the CI workflows, as expected. This module is compatible with versions of Python from v3.7 and up.
+
+The code does not use any library not already present in the project. It uses ``twisted`` extensively to communicate with the server.
+
+The code has been extensively tested with the Docker build files with buster-slim and bullseye-slim provided by the project. It was also tested on an Ubuntu 20.04 with Python 3.8. 
+
+Minimal testing was done using other versions of Python, and no other operating systems were used throughout the tests. This plugin is thus a beta version.

--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -1030,3 +1030,16 @@ enabled = false
 # WARNING: A binary file is read from this directory on start-up. Do not
 # change unless you understand the security implications!
 #dump_path = ${honeypot:state_path}/abuseipdb
+
+# Report login and session tracking attempts via the ThreatJammer.com Report API.
+# ThreatJammer.com is a risk assessment tool <https://threatjammer.com>
+# Read the docs for more information: https://cowrie.readthedocs.io/en/latest/threatjammer/README.html
+[output_threatjammer]
+enabled = false
+bearer_token = THREATJAMMER_API_TOKEN
+#api_url=https://dublin.report.threatjammer.com/v1/ip
+#track_login = true
+#track_session = false
+#ttl = 86400
+#category = ABUSE
+#tags = COWRIE,LOGIN,SESSION

--- a/src/cowrie/output/threatjammer.py
+++ b/src/cowrie/output/threatjammer.py
@@ -1,0 +1,203 @@
+# Copyright 2022 by GOODDATA LABS SL
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Cowrie plugin for reporting login attempts via the ThreatJammer.com Report API.
+"ThreatJammer.com is a tool to track and detect attacks" <https://threatjammer.com>
+"""
+
+
+__author__ = "Diego Parrilla Santamaria"
+__version__ = "0.1.0"
+
+import datetime
+from typing import Generator, List, Set
+
+from treq import post
+
+from twisted.internet import defer
+from twisted.python import log
+from twisted.web import http
+
+from cowrie.core import output
+from cowrie.core.config import CowrieConfig
+
+# Buffer flush frequency (in minutes)
+BUFFER_FLUSH_FREQUENCY: int = 1
+
+# Buffer flush max size
+BUFFER_FLUSH_MAX_SIZE: int = 1000
+
+# API URL
+THREATJAMMER_REPORT_URL: str = "https://dublin.report.threatjammer.com/v1/ip"
+
+# Default Time To Live (TTL) in the ThreatJammer.com private blocklist. In minutes.
+THREATJAMMER_DEFAULT_TTL: int = 86400
+
+# Default category to store the ip address.
+THREATJAMMER_DEFAULT_CATEGORY: str = "ABUSE"
+
+# Track the login event
+THREATJAMMER_DEFAULT_TRACK_LOGIN: bool = True
+
+# Track the session event
+THREATJAMMER_DEFAULT_TRACK_SESSION: bool = False
+
+# Default tags to store the ip address.
+THREATJAMMER_DEFAULT_TAGS: str = "COWRIE"
+
+
+class HTTPClient:
+    """
+    HTTP client to report the IP adress set
+    """
+
+    def __init__(self, api_url: str, bearer_token: str):
+        self.headers = {
+            "User-Agent": "Cowrie Honeypot ThreatJammer.com output plugin",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {bearer_token}",
+        }
+        self.api_url = api_url
+
+    def report(
+        self, ip_set: Set[str], category: str, ttl: int = 0, tags: List[str] = []
+    ) -> None:
+        payload: dict = {
+            "addresses": list(ip_set),
+            "type": category,
+            "ttl": ttl,
+            "tags": tags,
+        }
+        self._post(payload)
+
+    @defer.inlineCallbacks
+    def _post(self, payload: dict) -> Generator:
+        try:
+            response = yield post(
+                url=self.api_url,
+                headers=self.headers,
+                json=payload,
+            )
+
+        except Exception as e:
+            log.msg(
+                eventid="cowrie.threatjammer.reportfail",
+                format="ThreatJammer.com output plugin failed when reporting the payload %(payload)s. "
+                "Exception raised: %(exception)s.",
+                payload=str(payload),
+                exception=repr(e),
+            )
+            return
+
+        if response.code != http.ACCEPTED:
+            reason = yield response.text()
+            log.msg(
+                eventid="cowrie.threatjammer.reportfail",
+                format="ThreatJammer.com output plugin failed to report the payload %(payload)s. Returned the\
+ HTTP status code %(response)s. Reason: %(reason)s.",
+                payload=str(payload),
+                response=response.code,
+                reason=reason,
+            )
+        else:
+            log.msg(
+                eventid="cowrie.threatjammer.reportedipset",
+                format="ThreatJammer.com output plugin successfully reported %(payload)s.",
+                payload=str(payload),
+            )
+        return
+
+
+class Output(output.Output):
+    def start(self):
+        self.api_url = CowrieConfig.get(
+            "output_threatjammer",
+            "api_url",
+            fallback=THREATJAMMER_REPORT_URL,
+        )
+        self.default_ttl = CowrieConfig.getint(
+            "output_threatjammer", "ttl", fallback=THREATJAMMER_DEFAULT_TTL
+        )
+        self.default_category = CowrieConfig.get(
+            "output_threatjammer",
+            "category",
+            fallback=THREATJAMMER_DEFAULT_CATEGORY,
+        )
+        self.track_login = CowrieConfig.getboolean(
+            "output_threatjammer",
+            "track_login",
+            fallback=THREATJAMMER_DEFAULT_TRACK_LOGIN,
+        )
+        self.track_session = CowrieConfig.getboolean(
+            "output_threatjammer",
+            "track_session",
+            fallback=THREATJAMMER_DEFAULT_TRACK_SESSION,
+        )
+        self.bearer_token = CowrieConfig.get("output_threatjammer", "bearer_token")
+        self.tags = CowrieConfig.get("output_threatjammer", "tags").split(",")
+
+        self.last_report: int = -1
+        self.report_bucket: int = BUFFER_FLUSH_MAX_SIZE
+        self.ip_set: Set[str] = set()
+
+        self.track_events = []
+        if self.track_login:
+            self.track_events.append("cowrie.login")
+
+        if self.track_session:
+            self.track_events.append("cowrie.session")
+
+        self.http_client = HTTPClient(self.api_url, self.bearer_token)
+        log.msg(
+            eventid="cowrie.threatjammer.reporterinitialized",
+            format="ThreatJammer.com output plugin successfully initialized.\
+ Category=%(category)s. TTL=%(ttl)s. Session Tracking=%(session_tracking)s. Login Tracking=%(login_tracking)s",
+            category=self.default_category,
+            ttl=self.default_ttl,
+            session_tracking=self.track_session,
+            login_tracking=self.track_login,
+        )
+
+    def stop(self):
+        log.msg(
+            eventid="cowrie.threatjammer.reporterterminated",
+            format="ThreatJammer.com output plugin successfully terminated. Bye!",
+        )
+
+    def write(self, ev):
+        if ev["eventid"].rsplit(".", 1)[0] in self.track_events:
+            source_ip: str = ev["src_ip"]
+            self.ip_set.add(source_ip)
+
+            if self.last_report == -1:
+                # Never execute in this cycle. Store timestamp of the first element.
+                self.last_report = int(datetime.datetime.utcnow().timestamp())
+            self.report_bucket -= 1
+            if (
+                self.report_bucket == 0
+                or (int(datetime.datetime.utcnow().timestamp()) - self.last_report)
+                > BUFFER_FLUSH_FREQUENCY * 60
+            ):
+                # Flush the ip_set if 1000 ips counted or more than 10 minutes since last flush
+                self.http_client.report(
+                    ip_set=self.ip_set,
+                    category=self.default_category,
+                    ttl=self.default_ttl,
+                    tags=self.tags,
+                )
+                self.ip_set = set()
+                self.report_bucket = BUFFER_FLUSH_MAX_SIZE
+                self.last_report = -1


### PR DESCRIPTION
# ThreatJammer output module
<p align="center">
<img src="https://threatjammer.com/threatjammer-risk-score.png"  width="400" height="200" />
</p>

## Introduction
### Why an output module for Threat Jammer?

This output module feeds the private denylists of [Threat Jammer](https://threatjammer.com) with successful and unsuccessful login attempts thanks to the asynchronous [Reporting API of Threat Jammer](https://threatjammer.com/docs/introduction-threat-jammer-report-api).

The user can use the denylists in their own infrastructure firewalls or WAFs, or use it for forensic analysis.

### What is Threat Jammer
[ThreatJammer.com](https://threatjammer.com/) is a service that allows developers, security engineers, and other IT professionals to access high-quality threat intelligence data from a variety of sources and integrate it into their applications with the sole purpose of detecting and blocking malicious activity.

Crowdsourced Intelligence means that our users can report their data to the Threat Jammer system. When users feed Threat Jammer with their data using the [Report API](https://threatjammer.com/docs/introduction-threat-jammer-report-api), they increase the chance of finding malicious activity and reducing the false positives.

If a user reports malicious activity, Threat Jammer will assess the data and decide whether aggregate the data to the crowdsourced intelligence database. If the data has enough quality and is ready to consume, Threat Jammer will share it with the community.

Anybody can sign up and use the service for free forever. 

## Getting Started
### Quick start

To use the output module the user must [sign up and obtain an API KEY](https://threatjammer.com/docs/threat-jammer-api-keys). The sign-up is free forever. 

Once the developers have obtained an API Key, they must open the configuration of cowrie and edit the section `[output_threatjammer]` as follows:

* Change the `enabled` parameter to  `true`.
* Change the `THREATJAMMER_API_TOKEN` placeholder with the real API Key of the user in the `bearer_token` parameter.

[Re]start Cowrie

### Other parameters

The following parameters can change how the output module works, so use it with caution:

#### api_url
Points to the server running the Report API. By default it points to the Dublin Region, but more regions will be deployed in the future.

#### track_login
Send information about the IP addresses that tried to login successfully or not. By default is  `true`.

#### track_session
Send information about the IP addresses that created a session. By default is `false`.

#### ttl
Time to Live in seconds of the reported IP addresses in the private denylist in Threat Jammer. When the TTL expires, the IP address will be automatically removed. If the same IP address is reported more than once, the TTL resets. The default value is `86400`.

#### category
The category to classify the IP address. By default is `ABUSE`. See [Platform Datasets](https://threatjammer.com/docs/introduction-threat-jammer-user-api#platform-datasets) for the list of categories.

#### tags
Comma separated list of tags to classify the IP addresses. Must be alphanumeric and uppercase. By default, `COWRIE,LOGIN,SESSION`.

### Rate limits and buffers

The output module will send the information every 60 seconds or if the buffer of pending IP addresses to send to the Report API is 1000. The first condition will trigger the send action to the Report API server.

There is a limit of 6 hits per minute per API Key. If the limit is reached, the service returns a 429 response code. A single honeypot should never trigger the rate limit.

## About the Module
### Python and OS versions

The code has passed the tests implemented in the CI workflows, as expected. This module is compatible with versions of Python from v3.7 and up.

The code does not use any library not already present in the project. It uses `twisted` extensively to communicate with the server.

The code has been extensively tested with the Docker build files with buster-slim and bullseye-slim provided by the project. It has been running for more than six months 24/7 without issues. It was also tested on an Ubuntu 20.04 with Python 3.8. 

Minimal testing was done using other versions of Python, and no other operating systems were used throughout the tests. This plugin is thus a beta version.









