### PR TITLE
Add support for output to a Discord webhook

### DIFF
--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -1043,3 +1043,8 @@ bearer_token = THREATJAMMER_API_TOKEN
 #ttl = 86400
 #category = ABUSE
 #tags = COWRIE,LOGIN,SESSION
+
+# Send output to a Discord webhook
+[output_discord]
+enabled = false
+url = https://discord.com/api/webhooks/id/token

--- a/src/cowrie/output/discord.py
+++ b/src/cowrie/output/discord.py
@@ -1,0 +1,53 @@
+"""
+Simple Discord webhook logger
+"""
+
+from __future__ import annotations
+
+import json
+
+from io import BytesIO
+from twisted.internet import reactor
+from twisted.internet.ssl import ClientContextFactory
+from twisted.web import client, http_headers
+from twisted.web.client import FileBodyProducer
+
+import cowrie.core.output
+from cowrie.core.config import CowrieConfig
+
+
+class Output(cowrie.core.output.Output):
+    def start(self):
+        self.url = CowrieConfig.get("output_discord", "url").encode("utf8")
+        contextFactory = WebClientContextFactory()
+        self.agent = client.Agent(reactor, contextFactory)
+
+    def stop(self):
+        pass
+
+    def write(self, logentry):
+        webhook_message = "__New logentry__\n"
+
+        for i in list(logentry.keys()):
+            # Remove twisted 15 legacy keys
+            if i.startswith("log_"):
+                del logentry[i]
+            else:
+                webhook_message += f"{i}: `{logentry[i]}`\n"
+
+        self.postentry({"content": webhook_message})
+
+    def postentry(self, entry):
+        headers = http_headers.Headers(
+            {
+                b"Content-Type": [b"application/json"],
+            }
+        )
+
+        body = FileBodyProducer(BytesIO(json.dumps(entry).encode("utf8")))
+        self.agent.request(b"POST", self.url, headers, body)
+
+
+class WebClientContextFactory(ClientContextFactory):
+    def getContext(self, hostname, port):
+        return ClientContextFactory.getContext(self)


### PR DESCRIPTION
I wanted to be able to log into a Discord channel using a webhook. I've adapted the Graylog output plugin to be able to send the output to Discord without changing any dependencies.