### PR TITLE
Fix qemu-img add backing format option

### DIFF
--- a/src/backend_pool/libvirt/snapshot_handler.py
+++ b/src/backend_pool/libvirt/snapshot_handler.py
@@ -17,7 +17,7 @@ def create_disk_snapshot(source_img, destination_img):
 
     # could use `capture_output=True` instead of `stdout` and `stderr` args in Python 3.7
     out = subprocess.run(
-        ["qemu-img", "create", "-f", "qcow2", "-b", source_img, destination_img],
+        ["qemu-img", "create", "-f", "qcow2", "-F", "qcow2", "-b", source_img, destination_img],
         capture_output=True,
     )
     return out.returncode == 0


### PR DESCRIPTION
Hi,

When I try to use cowrie in proxy mode with qemu, it fails with the log message "There was a problem creating the disk snapshot" and the exception QemuGuesError() in src/backend_pool/libvirt/guest_handler.py line 75

After some investigation, I found that the error came from the qemu-img command returning a non-zero code in src/backend_pool/libvirt/snapshot_handler.py

After checking what the output of the qemu-img command was, I saw the following message :

```
qemu-img: /home/ubuntu/cowrie/var/lib/cowrie/snapshots/snapshot-ubuntu18.04-9ab2b0af97954ccf946b125162ee689b.qcow2: Backing file specified without backing format
Detected format of qcow2.(env)
```

It seems that on more recent version of qemu the -F argument is necessary for the snapshot creation to work. I haven't tested it on older versions of qemu but with Ubuntu 22.04 LTS this was the solution.