### PR TITLE
Close tftp artifact object

### DIFF
--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -61,6 +61,8 @@ class Command_tftp(HoneyPotCommand):
             if tclient and tclient.context and not tclient.context.fileobj.closed:
                 tclient.context.fileobj.close()
 
+        self.artifactFile.close()
+
         if url:
             # log to cowrie.log
             log.msg(


### PR DESCRIPTION
In tftp command, artifactFile object previously was not closed causing files to be stored in downloads folder using temporary name and fields using file hash were not correctly populated in logs.