### PR TITLE
Add requested in issue  logon type to telegram output plugin

### DIFF
--- a/src/cowrie/output/telegram.py
+++ b/src/cowrie/output/telegram.py
@@ -26,9 +26,17 @@ class Output(cowrie.core.output.Output):
             if i.startswith('log_'):
                 del logentry[i]
 
+        logon_type = None
+        # Prepare logon type
+        if 'HoneyPotSSHTransport' in (logentry['system'].split(','))[0]:
+            logon_type = 'SSH'
+        elif 'CowrieTelnetTransport' in (logentry['system'].split(','))[0]:
+            logon_type = 'Telnet'
+
         # Prepare base message
         msgtxt = "<strong>[Cowrie " + logentry['sensor'] + "]</strong>"
         msgtxt += "\nEvent: " + logentry["eventid"]
+        msgtxt += "\nLogon type: " + logon_type
         msgtxt += "\nSource: <code>" + logentry['src_ip'] + "</code>"
         msgtxt += "\nSession: <code>" + logentry['session'] + "</code>"
 

--- a/src/cowrie/output/telegram.py
+++ b/src/cowrie/output/telegram.py
@@ -26,7 +26,7 @@ class Output(cowrie.core.output.Output):
             if i.startswith('log_'):
                 del logentry[i]
 
-        logon_type = None
+        logon_type = ""
         # Prepare logon type
         if 'HoneyPotSSHTransport' in (logentry['system'].split(','))[0]:
             logon_type = 'SSH'


### PR DESCRIPTION
Based on [issue](https://github.com/cowrie/cowrie/issues/1686) pull request.
Added in telegram output field **Logon type**

Output examples:

```
[Cowrie test]
Event: cowrie.login.success
Logon type: SSH
Source: xxx.xxx.xxx.xxx
Session: 371171ff0787
Username: root
Password: test

[Cowrie test]
Event: cowrie.command.input
Logon type: SSH
Source: xxx.xxx.xxx.xxx
Session: 371171ff0787
Command: cd /tmp/

[Cowrie test]
Event: cowrie.login.success
Logon type: Telnet
Source: yyy.yyy.yyy.yyy
Session: 58b306d438e5
Username: root
Password: test

[Cowrie test]
Event: cowrie.command.input
Logon type: Telnet
Source: yyy.yyy.yyy.yyy
Session: 58b306d438e5
Command: ls
```