### PR TITLE
Datadog output module

### DIFF
--- a/docs/datadog/README.rst
+++ b/docs/datadog/README.rst
@@ -1,0 +1,22 @@
+How to send Cowrie output to Datadog Log Management
+###################################################
+
+This guide describes how to configure and send cowrie outputs to Datadog Log Management.
+
+Datadog output module Prerequisites
+***********************************
+
+* Working Cowrie installation
+* Existing Datadog account.
+
+Cowrie Configuration for Datadog output module
+**********************************************
+
+* Modify ``cowrie.cfg`` to enable the ``[output_datadog]`` section.
+* Add an API Key. You may generate one for your organisation from `here <https://app.datadoghq.com/organization-settings/api-keys>`_.
+* Optionally customize ``ddsource``, ``ddtags`` and ``service``. Otherwise, defaults are respectively ``cowrie``, ``env:prod`` and ``honeypot``.
+
+Datadog Configuration
+*********************
+
+JSON logs are handled without further configuration in Datadog.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ Welcome to Cowrie's documentation!
    BACKEND_POOL.rst
    SNAPSHOTS.rst
    OUTPUT.rst
+   datadog/README.rst
    docker/README.rst
    elk/README.rst
    graylog/README.rst

--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -1048,3 +1048,16 @@ bearer_token = THREATJAMMER_API_TOKEN
 [output_discord]
 enabled = false
 url = https://discord.com/api/webhooks/id/token
+
+# Datadog output module
+# sends JSON directly to Datadog
+# mandatory field: api_key
+# optional fields (fallback configured in module): ddsource, ddtags, service
+# For more information on fields https://docs.datadoghq.com/api/latest/logs/#send-logs
+[output_datadog]
+enabled = false
+url = https://http-intake.logs.datadoghq.com/api/v2/logs
+api_key = abcdef1234567890fedcba0987654321
+ddsource = cowrie
+ddtags = env:dev
+service = honeypot

--- a/src/cowrie/output/datadog.py
+++ b/src/cowrie/output/datadog.py
@@ -1,0 +1,65 @@
+"""
+Simple Datadog HTTP logger.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+
+from io import BytesIO
+from twisted.internet import reactor
+from twisted.internet.ssl import ClientContextFactory
+from twisted.python import log
+from twisted.web import client, http_headers
+from twisted.web.client import FileBodyProducer
+
+import cowrie.core.output
+from cowrie.core.config import CowrieConfig
+
+
+class Output(cowrie.core.output.Output):
+    def start(self):
+        self.url = CowrieConfig.get("output_datadog", "url").encode("utf8")
+        self.api_key = CowrieConfig.get("output_datadog", "api_key", fallback="").encode("utf8")
+        if len(self.api_key) == 0:
+            log.msg("Datadog output module: API key is not defined.")
+        self.ddsource = CowrieConfig.get("output_datadog", "ddsource", fallback="cowrie")
+        self.ddtags = CowrieConfig.get("output_datadog", "ddtags", fallback="env:dev")
+        self.service = CowrieConfig.get("output_datadog", "service", fallback="honeypot")
+        contextFactory = WebClientContextFactory()
+        self.agent = client.Agent(reactor, contextFactory)
+
+    def stop(self):
+        pass
+
+    def write(self, logentry):
+        for i in list(logentry.keys()):
+            # Remove twisted 15 legacy keys
+            if i.startswith("log_"):
+                del logentry[i]
+        message = [
+            {
+                "ddsource": self.ddsource,
+                "ddtags": self.ddtags,
+                "hostname": platform.node(),
+                "message": json.dumps(logentry),
+                "service": self.service
+            }
+        ]
+        self.postentry(message)
+
+    def postentry(self, entry):
+        base_headers = {
+            b"Accept": [b"application/json"],
+            b"Content-Type": [b"application/json"],
+            b"DD-API-KEY": [self.api_key]
+        }
+        headers = http_headers.Headers(base_headers)
+        body = FileBodyProducer(BytesIO(json.dumps(entry).encode("utf8")))
+        self.agent.request(b"POST", self.url, headers, body)
+
+
+class WebClientContextFactory(ClientContextFactory):
+    def getContext(self, hostname, port):
+        return ClientContextFactory.getContext(self)


### PR DESCRIPTION
Hello,

I'm submitting this PR to add Datadog output module which sends Cowrie logs to Datadog Log Management.

The Following additions have been made:

* Add Python module in `output` folder
* Add Datadog output module section to `cowrie.cfg.dist`
* Add Datadog output module documentation under `docs/datadog` folder
* Update `docs/index.rst` to add module documentation.

Tests have all passed locally with py39 and py310:

```
  lint: commands succeeded
  docs: commands succeeded
  typing: commands succeeded
SKIPPED:  py38: InterpreterNotFound: python3.8
  py39: commands succeeded
  py310: commands succeeded
SKIPPED:  py311: InterpreterNotFound: python3.11
SKIPPED:  pypy38: InterpreterNotFound: pypy3.8
SKIPPED:  pypy39: InterpreterNotFound: pypy3.9
  congratulations :)
```

Thanks in advance for taking into account!