### PR TITLE
Release 2.5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Release Notes
 #############
 
+Release 2.5.0
+*************
+
+* Datadog output module (Fred Baguelin <frederic.baguelin@datadoghq.com>)
+* General improvements to shell expansion handling
+* New version of Twisted supported
+* Python 3.11 support
+* Pypy 3.9 support
+* Add session type to Telegram output
+
 Release 2.4.0
 *************
 

--- a/src/cowrie/_version.py
+++ b/src/cowrie/_version.py
@@ -9,5 +9,5 @@ from __future__ import annotations
 
 from incremental import Version
 
-__version__ = Version("cowrie", 2, 3, 0)
+__version__ = Version("cowrie", 2, 5, 0)
 __all__: list[str] = ["__version__"]


### PR DESCRIPTION
Release 2.5.0
*************

* Datadog output module (Fred Baguelin <frederic.baguelin@datadoghq.com>)
* General improvements to shell expansion handling
* New version of Twisted supported
* Python 3.11 support
* Pypy 3.9 support
* Add session type to Telegram output