### PR TITLE
Correct description of the authentication_timeout setting in the conf…

### DIFF
--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -105,8 +105,8 @@ ttylog_path = ${honeypot:state_path}/tty
 interactive_timeout = 180
 
 # Authentication Timeout
-# The server disconnects after this time if the user has not successfully logged in.  If the value is 0,
-# there is no time limit.  The default is 120 seconds.
+# The server disconnects after this time if the user has not successfully logged in. 
+# The default is 120 seconds.
 authentication_timeout = 120
 
 # EXPERIMENTAL: back-end to user for Cowrie, options: proxy or shell


### PR DESCRIPTION
If set authentication_timeout to 0, a timeout exception will be raised immediately after receiving a connection.

```
 (py37)  ~  docker run --rm -e COWRIE_HONEYPOT_AUTHENTICATION_TIMEOUT=0  -p 2222:2222 cowrie/cowrie:latest 
2023-04-14T08:52:29+0000 [-] Python Version 3.9.2 (default, Feb 28 2021, 17:03:44) [GCC 10.2.1 20210110]
2023-04-14T08:52:29+0000 [-] Twisted Version 22.10.0
2023-04-14T08:52:29+0000 [-] Cowrie Version 2.5.0
2023-04-14T08:52:29+0000 [-] Loaded output engine: jsonlog
2023-04-14T08:52:29+0000 [twisted.scripts._twistd_unix.UnixAppLogger#info] twistd 22.10.0 (/cowrie/cowrie-env/bin/python3 3.9.2) starting up.
2023-04-14T08:52:29+0000 [twisted.scripts._twistd_unix.UnixAppLogger#info] reactor class: twisted.internet.epollreactor.EPollReactor.
2023-04-14T08:52:29+0000 [-] CowrieSSHFactory starting on 2222
2023-04-14T08:52:29+0000 [cowrie.ssh.factory.CowrieSSHFactory#info] Starting factory <cowrie.ssh.factory.CowrieSSHFactory object at 0x7f8dde08bc40>
2023-04-14T08:52:30+0000 [-] Ready to accept SSH connections
2023-04-14T08:52:33+0000 [cowrie.ssh.factory.CowrieSSHFactory] No moduli, no diffie-hellman-group-exchange-sha1
2023-04-14T08:52:33+0000 [cowrie.ssh.factory.CowrieSSHFactory] No moduli, no diffie-hellman-group-exchange-sha256
2023-04-14T08:52:33+0000 [cowrie.ssh.factory.CowrieSSHFactory] New connection: 172.17.0.1:38868 (172.17.0.2:2222) [session: 66c5ec5cda5e]
2023-04-14T08:52:33+0000 [-] Timeout reached in HoneyPotSSHTransport
2023-04-14T08:52:33+0000 [cowrie.ssh.transport.HoneyPotSSHTransport#info] connection lost
2023-04-14T08:52:33+0000 [HoneyPotSSHTransport,0,172.17.0.1] Connection lost after 0 seconds
```