### PR TITLE
Ensure that Cowrie fails if the output plugin cannot be loaded.

### DIFF
--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -184,6 +184,7 @@ Makes a Cowrie SSH/Telnet honeypot.
             except Exception:
                 log.err()
                 log.msg(f"Failed to load output engine: {engine}")
+                sys.exit(1)
 
         self.topService = service.MultiService()
         application = service.Application("cowrie")


### PR DESCRIPTION
As mentioned in #1972 this PR suggests a solution to ensure that cowrie exits when unknown plugin issues arise, as the plugin's proper operation is crucial. 