### PR TITLE
Removed DAEMONIZE steps.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -198,19 +198,11 @@ Running using Supervisord (OPTIONAL)
 On Debian, put the below in /etc/supervisor/conf.d/cowrie.conf::
 
     [program:cowrie]
-    command=/home/cowrie/cowrie/bin/cowrie start
+    command=/home/cowrie/cowrie/bin/cowrie start -n
     directory=/home/cowrie/cowrie/
     user=cowrie
     autorestart=true
     redirect_stderr=true
-
-Update the bin/cowrie script, change::
-
-    DAEMONIZE=""
-
-to::
-
-    DAEMONIZE="-n"
 
 Configure Additional Output Plugins (OPTIONAL)
 **********************************************


### PR DESCRIPTION
On Debian, using Supervisord, adding -n to the start command is the correct step.

The bin/cowrie script is no longer meant to be edited and DAEMONIZE no longer works if you edit it.