### PR TITLE
Oracle cloud custom logs plugin

### DIFF
--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -1066,3 +1066,13 @@ api_key = abcdef1234567890fedcba0987654321
 ddsource = cowrie
 ddtags = env:dev
 service = honeypot
+
+[output_oraclecloud]
+enabled = true
+authtype = user_principals
+log_ocid = ocid1.log.oc1.eu-stockholm-1.xxx
+user_ocid = ocid1.user.oc1..xxx
+fingerprint = 77:9c:4xxxxx
+tenancy_ocid = ocid1.tenancy.oc1..xxx
+region = eu-stockholm-1
+keyfile = /hxxome/xx/raspi.pem

--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -1067,12 +1067,21 @@ ddsource = cowrie
 ddtags = env:dev
 service = honeypot
 
+# Oracle Cloud custom logs output module
+# sends JSON directly to Oracle Cloud custom logs
+# mandatory field: authtype, log_ocid
+# optional fields (to be set if user_principals is selected as authtype): user_ocid, fingerprint, tenancy_ocid, region, keyfile
+# For more information on Oracle Cloud custom logs: https://docs.oracle.com/en-us/iaas/Content/Logging/Concepts/custom_logs.htm
+# For more information on Oracle Cloud user principal authentication method: https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five
+# For more information on Oracle Cloud instance principal authentication method: https://blogs.oracle.com/developers/post/accessing-the-oracle-cloud-infrastructure-api-using-instance-principals
 [output_oraclecloud]
 enabled = true
-authtype = user_principals
-log_ocid = ocid1.log.oc1.eu-stockholm-1.xxx
-user_ocid = ocid1.user.oc1..xxx
-fingerprint = 77:9c:4xxxxx
-tenancy_ocid = ocid1.tenancy.oc1..xxx
-region = eu-stockholm-1
-keyfile = /hxxome/xx/raspi.pem
+# authtype must be set either to user_principals or to instance_principals
+authtype = instance_principals
+# following parameters must be set in case user_principals is used. keyfile is the absolute path to your API pem key file.
+#log_ocid = ocid1.log.oc1.eu-stockholm-1.xxx
+#user_ocid = ocid1.user.oc1..xxx
+#fingerprint = 77:9c:4xxxxx
+#tenancy_ocid = ocid1.tenancy.oc1..xxx
+#region = eu-stockholm-1
+#keyfile = /home/xx/key.pem

--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -1075,7 +1075,7 @@ service = honeypot
 # For more information on Oracle Cloud user principal authentication method: https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five
 # For more information on Oracle Cloud instance principal authentication method: https://blogs.oracle.com/developers/post/accessing-the-oracle-cloud-infrastructure-api-using-instance-principals
 [output_oraclecloud]
-enabled = true
+enabled = false
 # authtype must be set either to user_principals or to instance_principals
 authtype = instance_principals
 # following parameters must be set in case user_principals is used. keyfile is the absolute path to your API pem key file.

--- a/requirements-output.txt
+++ b/requirements-output.txt
@@ -38,3 +38,5 @@ pymisp==2.4.176
 # redis
 redis==5.0.1
 
+# Oracle Cloud
+oci==2.115.1

--- a/src/cowrie/output/oraclecloud.py
+++ b/src/cowrie/output/oraclecloud.py
@@ -34,27 +34,36 @@ class Output(cowrie.core.output.Output):
         self.log_ocid = CowrieConfig.get("output_oraclecloud", "log_ocid")
         self.hostname = CowrieConfig.get("honeypot", "hostname")
 
-        # Send the request to service, some parameters are not required, see API
-        # doc for more info
-        put_logs_response = self.loggingingestion_client.put_logs(
-            log_id=self.log_ocid,
-            put_logs_details=oci.loggingingestion.models.PutLogsDetails(
-                specversion="1.0",
-                log_entry_batches=[
-                    oci.loggingingestion.models.LogEntryBatch(
-                        entries=[
-                            oci.loggingingestion.models.LogEntry(
-                                data=logentry,
-                                id=log_id,
-                                time=current_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"))],
-                        source=self.hostname,
-                        type="cowrie")]),
-            timestamp_opc_agent_processing=current_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
-      
+        try:
+            # Send the request to service, some parameters are not required, see API
+            # doc for more info
+            self.loggingingestion_client.put_logs(
+                log_id=self.log_ocid,
+                put_logs_details=oci.loggingingestion.models.PutLogsDetails(
+                    specversion="1.0",
+                    log_entry_batches=[
+                        oci.loggingingestion.models.LogEntryBatch(
+                            entries=[
+                                oci.loggingingestion.models.LogEntry(
+                                    data=logentry,
+                                    id=log_id,
+                                    time=current_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"))],
+                            source=self.hostname,
+                            type="cowrie")]),
+                timestamp_opc_agent_processing=current_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
+        except oci.exceptions.ServiceError as ex:
+            print(
+                f"Oracle Cloud plugin Error: {ex.message}\n" +
+                f"Oracle Cloud plugin Status Code: {ex.status}\n"
+            )
+        except Exception as ex:
+            print(f"Oracle Cloud plugin Error: {ex}")
+            raise
+            
 
     def start(self):
         """
-        Initialize pymisp module and ObjectWrapper (Abstract event and object creation)
+        Initialize Oracle Cloud LoggingClient with user or instance principal authentication
         """
 
         authtype=CowrieConfig.get("output_oraclecloud", "authtype")

--- a/src/cowrie/output/oraclecloud.py
+++ b/src/cowrie/output/oraclecloud.py
@@ -29,9 +29,7 @@ class Output(cowrie.core.output.Output):
 
     def sendLogs(self, logentry):
         log_id = self.generate_random_log_id()
-        # Initialize service client with default config file
-        current_time = datetime.datetime.utcnow()
-        formatted_time = current_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ")        
+        # Initialize service client with default config file       
         current_time = datetime.datetime.utcnow()
         self.log_ocid = CowrieConfig.get("output_oraclecloud", "log_ocid")
 

--- a/src/cowrie/output/oraclecloud.py
+++ b/src/cowrie/output/oraclecloud.py
@@ -32,6 +32,7 @@ class Output(cowrie.core.output.Output):
         # Initialize service client with default config file       
         current_time = datetime.datetime.utcnow()
         self.log_ocid = CowrieConfig.get("output_oraclecloud", "log_ocid")
+        self.hostname = CowrieConfig.get("honeypot", "hostname")
 
         # Send the request to service, some parameters are not required, see API
         # doc for more info
@@ -46,12 +47,10 @@ class Output(cowrie.core.output.Output):
                                 data=logentry,
                                 id=log_id,
                                 time=current_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"))],
-                        source="EXAMPLE-source-Value",
+                        source=self.hostname,
                         type="cowrie")]),
             timestamp_opc_agent_processing=current_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
-
-        # Get the data from response
-        print(put_logs_response.headers)         
+      
 
     def start(self):
         """

--- a/src/cowrie/output/oraclecloud.py
+++ b/src/cowrie/output/oraclecloud.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+import json
+from configparser import NoOptionError
+
+import oci
+import random
+import string
+import time
+import oci
+from oci import auth
+from datetime import datetime
+
+import cowrie.core.output
+from cowrie.core.config import CowrieConfig
+
+
+class Output(cowrie.core.output.Output):
+    """
+    Oracle Cloud output
+    """
+
+
+    def generate_random_log_id():
+        random.seed(time.time())
+        charset = string.ascii_letters + string.digits
+        random_log_id = ''.join(random.choice(charset) for _ in range(32))
+        return "cowrielog-" + random_log_id
+
+
+    def sendLogs(self, logentry):
+        log_id = self.generate_random_log_id()
+        # Initialize service client with default config file
+        current_time = datetime.datetime.utcnow()
+        self.log_ocid = CowrieConfig.get("output_oraclecloud", "log_ocid")
+
+        # Send the request to service, some parameters are not required, see API
+        # doc for more info
+        put_logs_response = self.loggingingestion_client.put_logs(
+            log_id=self.log_ocid,
+            put_logs_details=oci.loggingingestion.models.PutLogsDetails(
+                specversion="1.0",
+                log_entry_batches=[
+                    oci.loggingingestion.models.LogEntryBatch(
+                        entries=[
+                            oci.loggingingestion.models.LogEntry(
+                                data=json.dumps(logentry),
+                                id=log_id,
+                                time=current_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"))],
+                        source="EXAMPLE-source-Value",
+                        type="cowrie")]),
+            timestamp_opc_agent_processing=current_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
+
+        # Get the data from response
+        print(put_logs_response.headers)         
+
+    def start(self):
+        """
+        Initialize pymisp module and ObjectWrapper (Abstract event and object creation)
+        """
+
+        authtype=CowrieConfig.get("output_oraclecloud", "authtype")
+     
+        if authtype == "instance_principals":
+            signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+
+            # In the base case, configuration does not need to be provided as the region and tenancy are obtained from the InstancePrincipalsSecurityTokenSigner
+            # identity_client = oci.identity.IdentityClient(config={}, signer=signer)
+            self.loggingingestion_client = oci.loggingingestion.LoggingClient(config={}, signer=signer)                     
+
+        if authtype == "user_principals":
+            tenancy_ocid=CowrieConfig.get("output_oraclecloud", "tenancy_ocid")
+            user_ocid=CowrieConfig.get("output_oraclecloud", "user_ocid")
+            region=CowrieConfig.get("output_oraclecloud", "region")
+            fingerprint=CowrieConfig.get("output_oraclecloud", "fingerprint")
+            priv_key=CowrieConfig.get("output_oraclecloud", "priv_key", raw=True)
+
+            config_with_key_content = {
+                "user": user_ocid,
+                "key_content": priv_key,
+                "fingerprint": fingerprint,
+                "tenancy": tenancy_ocid,
+                "region": region
+            }
+            oci.config.validate_config(config_with_key_content)
+            self.loggingingestion_client = oci.loggingingestion.LoggingClient(config_with_key_content)
+
+
+    def stop(self):
+        pass
+
+    def write(self, logentry):
+        """
+        Push to Oracle Cloud put_logs
+        """
+        # Add the entry to redis
+        for i in list(logentry.keys()):
+            # Remove twisted 15 legacy keys
+            if i.startswith("log_"):
+                del logentry[i]
+        self.sendLogs(json.dumps(logentry))

--- a/src/cowrie/output/oraclecloud.py
+++ b/src/cowrie/output/oraclecloud.py
@@ -8,7 +8,7 @@ import string
 import time
 import oci
 from oci import auth
-from datetime import datetime
+import datetime
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -30,6 +30,8 @@ class Output(cowrie.core.output.Output):
     def sendLogs(self, logentry):
         log_id = self.generate_random_log_id()
         # Initialize service client with default config file
+        current_time = datetime.datetime.utcnow()
+        formatted_time = current_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ")        
         current_time = datetime.datetime.utcnow()
         self.log_ocid = CowrieConfig.get("output_oraclecloud", "log_ocid")
 

--- a/src/cowrie/output/oraclecloud.py
+++ b/src/cowrie/output/oraclecloud.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
-import json
-from configparser import NoOptionError
 
-import oci
+import datetime
+import json
 import secrets
 import string
+
 import oci
-from oci import auth
-import datetime
+
+from twisted.python import log
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -17,13 +17,10 @@ class Output(cowrie.core.output.Output):
     """
     Oracle Cloud output
     """
-
-
     def generate_random_log_id(self):
         charset = string.ascii_letters + string.digits
-        random_log_id = ''.join(secrets.choice(charset) for _ in range(32))
+        random_log_id = "".join(secrets.choice(charset) for _ in range(32))
         return f"cowrielog-{random_log_id}"
-
 
     def sendLogs(self, logentry):
         log_id = self.generate_random_log_id()
@@ -50,20 +47,18 @@ class Output(cowrie.core.output.Output):
                             type="cowrie")]),
                 timestamp_opc_agent_processing=current_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
         except oci.exceptions.ServiceError as ex:
-            print(
+            log.err(
                 f"Oracle Cloud plugin Error: {ex.message}\n" +
                 f"Oracle Cloud plugin Status Code: {ex.status}\n"
             )
         except Exception as ex:
-            print(f"Oracle Cloud plugin Error: {ex}")
+            log.err(f"Oracle Cloud plugin Error: {ex}")
             raise
             
-
     def start(self):
         """
         Initialize Oracle Cloud LoggingClient with user or instance principal authentication
         """
-
         authtype=CowrieConfig.get("output_oraclecloud", "authtype")
      
         if authtype == "instance_principals":

--- a/src/cowrie/output/oraclecloud.py
+++ b/src/cowrie/output/oraclecloud.py
@@ -43,7 +43,7 @@ class Output(cowrie.core.output.Output):
                     oci.loggingingestion.models.LogEntryBatch(
                         entries=[
                             oci.loggingingestion.models.LogEntry(
-                                data=json.dumps(logentry),
+                                data=logentry,
                                 id=log_id,
                                 time=current_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"))],
                         source="EXAMPLE-source-Value",

--- a/src/cowrie/output/oraclecloud.py
+++ b/src/cowrie/output/oraclecloud.py
@@ -3,9 +3,8 @@ import json
 from configparser import NoOptionError
 
 import oci
-import random
+import secrets
 import string
-import time
 import oci
 from oci import auth
 import datetime
@@ -21,10 +20,9 @@ class Output(cowrie.core.output.Output):
 
 
     def generate_random_log_id(self):
-        random.seed(time.time())
         charset = string.ascii_letters + string.digits
-        random_log_id = ''.join(random.choice(charset) for _ in range(32))
-        return "cowrielog-" + random_log_id
+        random_log_id = ''.join(secrets.choice(charset) for _ in range(32))
+        return f"cowrielog-{random_log_id}"
 
 
     def sendLogs(self, logentry):

--- a/src/cowrie/output/oraclecloud.py
+++ b/src/cowrie/output/oraclecloud.py
@@ -66,23 +66,24 @@ class Output(cowrie.core.output.Output):
             # identity_client = oci.identity.IdentityClient(config={}, signer=signer)
             self.loggingingestion_client = oci.loggingingestion.LoggingClient(config={}, signer=signer)                     
 
-        if authtype == "user_principals":
+        elif authtype == "user_principals":
             tenancy_ocid=CowrieConfig.get("output_oraclecloud", "tenancy_ocid")
             user_ocid=CowrieConfig.get("output_oraclecloud", "user_ocid")
             region=CowrieConfig.get("output_oraclecloud", "region")
             fingerprint=CowrieConfig.get("output_oraclecloud", "fingerprint")
-            priv_key=CowrieConfig.get("output_oraclecloud", "priv_key", raw=True)
+            keyfile=CowrieConfig.get("output_oraclecloud", "keyfile")
 
             config_with_key_content = {
                 "user": user_ocid,
-                "key_content": priv_key,
+                "key_file": keyfile,
                 "fingerprint": fingerprint,
                 "tenancy": tenancy_ocid,
                 "region": region
             }
             oci.config.validate_config(config_with_key_content)
             self.loggingingestion_client = oci.loggingingestion.LoggingClient(config_with_key_content)
-
+        else:
+            raise ValueError("Invalid authentication type")
 
     def stop(self):
         pass

--- a/src/cowrie/output/oraclecloud.py
+++ b/src/cowrie/output/oraclecloud.py
@@ -20,7 +20,7 @@ class Output(cowrie.core.output.Output):
     """
 
 
-    def generate_random_log_id():
+    def generate_random_log_id(self):
         random.seed(time.time())
         charset = string.ascii_letters + string.digits
         random_log_id = ''.join(random.choice(charset) for _ in range(32))


### PR DESCRIPTION
This PR introduces the output plugin to send logs to Oracle Cloud custom logs service. The plugin supports both instance and user principals authentication methods. 
Issue here: https://github.com/cowrie/cowrie/issues/1996