### PR TITLE
Added the command as an argument to onecmd

### DIFF
--- a/src/cowrie/scripts/fsctl.py
+++ b/src/cowrie/scripts/fsctl.py
@@ -757,9 +757,9 @@ class fseditCmd(cmd.Cmd):
 
 
 def run():
-    if len(sys.argv) != 2:
+    if len(sys.argv) < 2 or len(sys.argv) > 3:
         print(
-            "Usage: %s <fs.pickle>"
+            "Usage: %s <fs.pickle> [command]"
             % os.path.basename(
                 sys.argv[0],
             )
@@ -769,7 +769,10 @@ def run():
     pickle_file_name = sys.argv[1].strip()
     print(pickle_file_name)
 
-    fseditCmd(pickle_file_name).cmdloop()
+    if len(sys.argv) == 3:
+        fseditCmd(pickle_file_name).onecmd()
+    else:
+        fseditCmd(pickle_file_name).cmdloop()
 
 
 if __name__ == "__main__":

--- a/src/cowrie/scripts/fsctl.py
+++ b/src/cowrie/scripts/fsctl.py
@@ -770,7 +770,7 @@ def run():
     print(pickle_file_name)
 
     if len(sys.argv) == 3:
-        fseditCmd(pickle_file_name).onecmd()
+        fseditCmd(pickle_file_name).onecmd(sys.argv[2])
     else:
         fseditCmd(pickle_file_name).cmdloop()
 


### PR DESCRIPTION
Needed in order to run the single command from a CLI argument. This was in the original PR #2009.