### PR TITLE
Quick fix for the "No module named cowrie" issue

### DIFF
--- a/bin/createfs
+++ b/bin/createfs
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+import sys
+sys.path.append(r"..")
+sys.path.append(r"src")
+
 from cowrie.scripts import createfs
 
 if __name__ == "__main__":

--- a/bin/fsctl
+++ b/bin/fsctl
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+import sys
+sys.path.append(r"..")
+sys.path.append(r"src")
+
 from cowrie.scripts import fsctl
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hey! since I used the quick fix before opening [an issue](https://github.com/cowrie/cowrie/issues/2034) I worked towards more elegant solutions (that wouldn't require copy pastying the src folder).

In my new fix, I added this: 

```
import sys
sys.path.append(r"..")
sys.path.append(r"src")
```
in the `createfs` and `fsctl`, following the python documentation about [imports](https://docs.python.org/3/reference/simple_stmts.html#the-import-statement)  and it works like a charm.

I'm creating this PR so to solve the issue, if it looks good to you.