### PR TITLE
Fix formatting in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,8 @@ Docker versions are available.
 
 * On Docker Hub: https://hub.docker.com/r/cowrie/cowrie
 
-### Configuring Cowrie in Docker
+Configuring Cowrie in Docker
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Cowrie in Docker can be configured using environment variables. The
 variables start with COWRIE_ then have the section name in capitals,


### PR DESCRIPTION
Fixes erroneous use of Markdown in .rst file.

I have earlier filed a pull request with erroneous syntax. I have not noticed the format is reStructuredText and assumed it was Markdown. This pull request fixes the formatting.