### PR TITLE
#1756 / added-support-for-h-flag-in-ls-comand

### DIFF
--- a/src/cowrie/commands/ls.py
+++ b/src/cowrie/commands/ls.py
@@ -35,6 +35,7 @@ class Command_ls(HoneyPotCommand):
         paths = []
         self.showHidden = False
         self.showDirectories = False
+        self.showHumanReadable = False
         func = self.do_ls_normal
 
         # Parse options or display no files
@@ -52,6 +53,9 @@ class Command_ls(HoneyPotCommand):
         for x, _a in opts:
             if x in ("-l"):
                 func = self.do_ls_l
+            if x in ("-lh"):
+                func = self.do_ls_l
+                self.showHumanReadable = True
             if x in ("-a"):
                 self.showHidden = True
             if x in ("-d"):
@@ -115,6 +119,13 @@ class Command_ls(HoneyPotCommand):
         self.write("\n")
 
     def do_ls_l(self, path: str) -> None:
+        """
+        Display detailed information about files
+        Mimics the output of GNU ls -l and supports the following options:
+        -a, -h
+        
+        :param path: The path to list
+        """
         files = self.get_dir_files(path)
         if not files:
             return
@@ -122,6 +133,17 @@ class Command_ls(HoneyPotCommand):
         filesize_str_extent = 0
         if len(files):
             filesize_str_extent = max(len(str(x[fs.A_SIZE])) for x in files)
+            # convert to human readable format if needed
+            if self.showHumanReadable:
+                for file in files:
+                    if file[fs.A_SIZE] >= 1024 * 1024 * 1024:
+                        file[fs.A_SIZE] = f"{file[fs.A_SIZE] / (1024 * 1024 * 1024):.1f}G"
+                    elif file[fs.A_SIZE] >= 1024 * 1024:
+                        file[fs.A_SIZE] = f"{file[fs.A_SIZE] / (1024 * 1024):.1f}M"
+                    elif file[fs.A_SIZE] >= 1024:
+                        file[fs.A_SIZE] = f"{file[fs.A_SIZE] / 1024:.1f}K"
+                    elif file[fs.A_SIZE] < 1024:
+                        file[fs.A_SIZE] = f"{file[fs.A_SIZE]}B"
 
         user_name_str_extent = 0
         if len(files):


### PR DESCRIPTION
# Summary
Fix #1756 added human-readable format for the file size when a `-h` flag is used with the `ls` command.

## What I did
- Introduced a new flag`showHumanReadable` which defaults to false
- Added a check If the argument with the `ls` command comes as `-lh` then the `showHumanReadable` flag is set to true and `do_ls_l` is called.
- During generating the file sizes a new iteration is added over the file sizes to convert them to Human readable format adding suffixes as B, K, M, and G.

# Testing Strategy
Created the docker build and tried the command as there were no unit tests for this command.