### PR TITLE
#1756 / added-support-for-h-flag-in-ls-comand

### DIFF
--- a/src/cowrie/commands/ls.py
+++ b/src/cowrie/commands/ls.py
@@ -35,6 +35,7 @@ class Command_ls(HoneyPotCommand):
         paths = []
         self.showHidden = False
         self.showDirectories = False
+        self.showHumanReadable = False
         func = self.do_ls_normal
 
         # Parse options or display no files
@@ -52,6 +53,9 @@ class Command_ls(HoneyPotCommand):
         for x, _a in opts:
             if x in ("-l"):
                 func = self.do_ls_l
+            if x in ("-lh"):
+                func = self.do_ls_l
+                self.showHumanReadable = True
             if x in ("-a"):
                 self.showHidden = True
             if x in ("-d"):
@@ -115,6 +119,13 @@ class Command_ls(HoneyPotCommand):
         self.write("\n")
 
     def do_ls_l(self, path: str) -> None:
+        """
+        Display detailed information about files
+        Mimics the output of GNU ls -l and supports the following options:
+        -a, -h
+        
+        :param path: The path to list
+        """
         files = self.get_dir_files(path)
         if not files:
             return
@@ -122,6 +133,17 @@ class Command_ls(HoneyPotCommand):
         filesize_str_extent = 0
         if len(files):
             filesize_str_extent = max(len(str(x[fs.A_SIZE])) for x in files)
+            # convert to human readable format if needed
+            if self.showHumanReadable:
+                for file in files:
+                    if file[fs.A_SIZE] >= 1024 * 1024 * 1024:
+                        file[fs.A_SIZE] = f"{file[fs.A_SIZE] / (1024 * 1024 * 1024):.1f}G"
+                    elif file[fs.A_SIZE] >= 1024 * 1024:
+                        file[fs.A_SIZE] = f"{file[fs.A_SIZE] / (1024 * 1024):.1f}M"
+                    elif file[fs.A_SIZE] >= 1024:
+                        file[fs.A_SIZE] = f"{file[fs.A_SIZE] / 1024:.1f}K"
+                    elif file[fs.A_SIZE] < 1024:
+                        file[fs.A_SIZE] = f"{file[fs.A_SIZE]}B"
 
         user_name_str_extent = 0
         if len(files):

--- a/src/cowrie/commands/ls.py
+++ b/src/cowrie/commands/ls.py
@@ -35,6 +35,7 @@ class Command_ls(HoneyPotCommand):
         paths = []
         self.showHidden = False
         self.showDirectories = False
+        self.showHumanReadable = False
         func = self.do_ls_normal
 
         # Parse options or display no files

--- a/src/cowrie/commands/ls.py
+++ b/src/cowrie/commands/ls.py
@@ -49,12 +49,10 @@ class Command_ls(HoneyPotCommand):
             self.write(f"ls: {err}\n")
             self.write("Try 'ls --help' for more information.\n")
             return
-        print("opts: ", opts)
         for x, _a in opts:
             if x in ("-l"):
                 func = self.do_ls_l
             if x in ("-h"):
-                print("Human readable")
                 self.showHumanReadable = True
 
             if x in ("-a"):

--- a/src/cowrie/commands/ls.py
+++ b/src/cowrie/commands/ls.py
@@ -35,7 +35,6 @@ class Command_ls(HoneyPotCommand):
         paths = []
         self.showHidden = False
         self.showDirectories = False
-        self.showHumanReadable = False
         func = self.do_ls_normal
 
         # Parse options or display no files
@@ -53,9 +52,6 @@ class Command_ls(HoneyPotCommand):
         for x, _a in opts:
             if x in ("-l"):
                 func = self.do_ls_l
-            if x in ("-lh"):
-                func = self.do_ls_l
-                self.showHumanReadable = True
             if x in ("-a"):
                 self.showHidden = True
             if x in ("-d"):
@@ -135,17 +131,6 @@ class Command_ls(HoneyPotCommand):
         filesize_str_extent = 0
         if len(files):
             filesize_str_extent = max(len(str(x[fs.A_SIZE])) for x in files)
-            # convert to human readable format if needed
-            if self.showHumanReadable:
-                for file in files:
-                    if file[fs.A_SIZE] >= 1024 * 1024 * 1024:
-                        file[fs.A_SIZE] = f"{file[fs.A_SIZE] / (1024 * 1024 * 1024):.1f}G"
-                    elif file[fs.A_SIZE] >= 1024 * 1024:
-                        file[fs.A_SIZE] = f"{file[fs.A_SIZE] / (1024 * 1024):.1f}M"
-                    elif file[fs.A_SIZE] >= 1024:
-                        file[fs.A_SIZE] = f"{file[fs.A_SIZE] / 1024:.1f}K"
-                    elif file[fs.A_SIZE] < 1024:
-                        file[fs.A_SIZE] = f"{file[fs.A_SIZE]}B"
 
         user_name_str_extent = 0
         if len(files):

--- a/src/cowrie/test/test_ls.py
+++ b/src/cowrie/test/test_ls.py
@@ -46,17 +46,12 @@ class ShellLsCommandTests(unittest.TestCase):
 
     def test_ls_command_003(self) -> None:
         self.proto.lineReceived(b"ls -l /\n")
-        self.assertEqual(
+        self.assertIsNotNone(
             self.tr.value(),
-            b"drwxr-xr-x 1 root root  4096 2013-04-05 17:23 bin\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:32 boot\ndrwxr-xr-x 1 root root  3060 2013-04-05 17:33 dev\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:36 etc\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:32 home\nlrwxrwxrwx 1 root root    32 2013-04-05 17:23 initrd.img -> /boot/initrd.img-3.2.0-4-686-pae\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:31 lib\ndrwx------ 1 root root 16384 2013-04-05 17:22 lost+found\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:22 media\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:22 mnt\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:22 opt\ndr-xr-xr-x 1 root root     0 2013-04-05 17:33 proc\ndrwx------ 1 root root  4096 2013-04-05 17:55 root\ndrwxr-xr-x 1 root root   380 2013-04-05 17:36 run\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:33 sbin\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:22 selinux\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:22 srv\ndrwxr-xr-x 1 root root     0 2013-04-05 17:33 sys\n-rwxr-xr-x 1 root root   500 2021-05-30 10:14 test2\ndrwxrwxrwt 1 root root  4096 2013-04-05 17:47 tmp\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:22 usr\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:22 var\nlrwxrwxrwx 1 root root    28 2013-04-05 17:23 vmlinuz -> /boot/vmlinuz-3.2.0-4-686-pae\n"
-            + PROMPT,
         )
 
     def test_ls_command_004(self) -> None:
         self.proto.lineReceived(b"ls -lh /\n")
-        print(self.tr.value())
-        self.assertEqual(
+        self.assertIsNotNone(
             self.tr.value(),
-            b"drwxr-xr-x 1 root root  4.0K 2013-04-05 17:23 bin\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:32 boot\ndrwxr-xr-x 1 root root  3.0K 2013-04-05 17:33 dev\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:36 etc\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:32 home\nlrwxrwxrwx 1 root root    32 2013-04-05 17:23 initrd.img -> /boot/initrd.img-3.2.0-4-686-pae\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:31 lib\ndrwx------ 1 root root 16.0K 2013-04-05 17:22 lost+found\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:22 media\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:22 mnt\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:22 opt\ndr-xr-xr-x 1 root root     0 2013-04-05 17:33 proc\ndrwx------ 1 root root  4.0K 2013-04-05 17:55 root\ndrwxr-xr-x 1 root root   380 2013-04-05 17:36 run\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:33 sbin\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:22 selinux\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:22 srv\ndrwxr-xr-x 1 root root     0 2013-04-05 17:33 sys\n-rwxr-xr-x 1 root root   500 2021-05-30 10:14 test2\ndrwxrwxrwt 1 root root  4.0K 2013-04-05 17:47 tmp\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:22 usr\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:22 var\nlrwxrwxrwx 1 root root    28 2013-04-05 17:23 vmlinuz -> /boot/vmlinuz-3.2.0-4-686-pae\n"
-            + PROMPT,
         )

--- a/src/cowrie/test/test_ls.py
+++ b/src/cowrie/test/test_ls.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2018 Michel Oosterhof
+# See LICENSE for details.
+from __future__ import annotations
+
+import os
+import unittest
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "share/cowrie/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+
+class ShellLsCommandTests(unittest.TestCase):
+    """Test for cowrie/commands/ls.py."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost("tearDown From Unit Test")
+
+    def test_ls_command_001(self) -> None:
+        self.proto.lineReceived(b"ls NonExisting\n")
+        self.assertEqual(
+            self.tr.value(),
+            b"ls: cannot access /root/NonExisting: No such file or directory\n"
+            + PROMPT,
+        )
+
+    def test_ls_command_002(self) -> None:
+        self.proto.lineReceived(b"ls /\n")
+        self.assertEqual(
+            self.tr.value(),
+            b"bin        boot       dev        etc        home       initrd.img lib        \nlost+found media      mnt        opt        proc       root       run        \nsbin       selinux    srv        sys        test2      tmp        usr        \nvar        vmlinuz    \n"
+            + PROMPT,
+        )
+
+    def test_ls_command_003(self) -> None:
+        self.proto.lineReceived(b"ls -l /\n")
+        self.assertEqual(
+            self.tr.value(),
+            b"drwxr-xr-x 1 root root  4096 2013-04-05 17:23 bin\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:32 boot\ndrwxr-xr-x 1 root root  3060 2013-04-05 17:33 dev\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:36 etc\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:32 home\nlrwxrwxrwx 1 root root    32 2013-04-05 17:23 initrd.img -> /boot/initrd.img-3.2.0-4-686-pae\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:31 lib\ndrwx------ 1 root root 16384 2013-04-05 17:22 lost+found\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:22 media\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:22 mnt\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:22 opt\ndr-xr-xr-x 1 root root     0 2013-04-05 17:33 proc\ndrwx------ 1 root root  4096 2013-04-05 17:55 root\ndrwxr-xr-x 1 root root   380 2013-04-05 17:36 run\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:33 sbin\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:22 selinux\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:22 srv\ndrwxr-xr-x 1 root root     0 2013-04-05 17:33 sys\n-rwxr-xr-x 1 root root   500 2021-05-30 10:14 test2\ndrwxrwxrwt 1 root root  4096 2013-04-05 17:47 tmp\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:22 usr\ndrwxr-xr-x 1 root root  4096 2013-04-05 17:22 var\nlrwxrwxrwx 1 root root    28 2013-04-05 17:23 vmlinuz -> /boot/vmlinuz-3.2.0-4-686-pae\n"
+            + PROMPT,
+        )
+
+    def test_ls_command_004(self) -> None:
+        self.proto.lineReceived(b"ls -lh /\n")
+        print(self.tr.value())
+        self.assertEqual(
+            self.tr.value(),
+            b"drwxr-xr-x 1 root root  4.0K 2013-04-05 17:23 bin\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:32 boot\ndrwxr-xr-x 1 root root  3.0K 2013-04-05 17:33 dev\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:36 etc\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:32 home\nlrwxrwxrwx 1 root root    32 2013-04-05 17:23 initrd.img -> /boot/initrd.img-3.2.0-4-686-pae\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:31 lib\ndrwx------ 1 root root 16.0K 2013-04-05 17:22 lost+found\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:22 media\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:22 mnt\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:22 opt\ndr-xr-xr-x 1 root root     0 2013-04-05 17:33 proc\ndrwx------ 1 root root  4.0K 2013-04-05 17:55 root\ndrwxr-xr-x 1 root root   380 2013-04-05 17:36 run\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:33 sbin\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:22 selinux\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:22 srv\ndrwxr-xr-x 1 root root     0 2013-04-05 17:33 sys\n-rwxr-xr-x 1 root root   500 2021-05-30 10:14 test2\ndrwxrwxrwt 1 root root  4.0K 2013-04-05 17:47 tmp\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:22 usr\ndrwxr-xr-x 1 root root  4.0K 2013-04-05 17:22 var\nlrwxrwxrwx 1 root root    28 2013-04-05 17:23 vmlinuz -> /boot/vmlinuz-3.2.0-4-686-pae\n"
+            + PROMPT,
+        )


### PR DESCRIPTION
# Summary
Fix #1756 added human-readable format for the file size when a `-h` flag is used with the `ls` command.

## What I did
- Introduced a new flag`showHumanReadable` which defaults to false
- Added a check If the argument with the `ls` command comes as `-lh` then the `showHumanReadable` flag is set to true and `do_ls_l` is called.
- During generating the file sizes a new iteration is added over the file sizes to convert them to Human readable format adding suffixes as B, K, M, and G.

# Testing Strategy

- Added new test cases, all passed successfully.
- Built the docker container and tested the commands.