### PR TITLE
Update locaksyslog.py

### DIFF
--- a/src/cowrie/output/localsyslog.py
+++ b/src/cowrie/output/localsyslog.py
@@ -57,6 +57,9 @@ class Output(cowrie.core.output.Output):
         if "isError" not in event:
             event["isError"] = False
 
+        if "system" not in event:
+            event["system"] = "cowrie"
+
         if self.format == "cef":
             self.syslog.emit(
                 {


### PR DESCRIPTION
Added a section to add a default system value ("cowrie") if there is no system value present in the event. This aims to fix #2324. It appears that Cowrie's log handler is attempting to access a key called 'system' in the event dictionary, but this key is missing, which was causing wget commands (and likely some others) to hang on the attacker's side when connected to the honeypot.