### PR TITLE
Introducing Cowrie Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Documentation
 
 The Documentation can be found `here <https://cowrie.readthedocs.io/en/latest/index.html>`_.
 
-You can also `Ask Cowrie Guru <https://gurubase.io/g/cowrie>`_. It is an Cowrie-focused AI to answer your questions.
+You can also `Ask Cowrie Guru <https://gurubase.io/g/cowrie>`_. It is a Cowrie-focused AI to answer your questions.
 
 Slack
 *****************************************

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ Documentation
 ****************************************
 
 The Documentation can be found `here <https://cowrie.readthedocs.io/en/latest/index.html>`_.
+
 You can also `Ask Cowrie Guru <https://gurubase.io/g/cowrie>`_. It is an Cowrie-focused AI to answer your questions.
 
 Slack

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ Documentation
 ****************************************
 
 The Documentation can be found `here <https://cowrie.readthedocs.io/en/latest/index.html>`_.
+You can also `Ask Cowrie Guru <https://gurubase.io/g/cowrie>`_. It is an Cowrie-focused AI to answer your questions.
 
 Slack
 *****************************************


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Cowrie Guru](https://gurubase.io/g/cowrie) to Gurubase. Cowrie Guru uses the data from this repo and data from the [docs](https://cowrie.readthedocs.io/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Cowrie Guru", which highlights that Cowrie now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Cowrie Guru in Gurubase, just let me know that's totally fine.