### PR TITLE
Updated Graylog docs to also describe the pipeline feature

### DIFF
--- a/docs/graylog/README.rst
+++ b/docs/graylog/README.rst
@@ -111,12 +111,12 @@ When running Graylog with the Forwarder input, traditional extractors are not av
 
 Paste the following code into the Rule source::
 
-    rule "Parse Cowie message"
+    rule "Parse Cowrie message"
     when
       has_field("message")
     then
       // If you want to keep the original message, uncomment the following line and comment out the next line.
-      //let json_string = regex_replace("\"message\"", to_string($message.message), "\"cowie_message\"");
+      //let json_string = regex_replace("\"message\"", to_string($message.message), "\"cowrie_message\"");
       let json_string = to_string($message.message);
       let json = parse_json(json_string);
       let map = to_map(json);

--- a/docs/graylog/README.rst
+++ b/docs/graylog/README.rst
@@ -98,13 +98,17 @@ Pipeline
 When running Graylog with the Forwarder input, traditional extractors are not available. Instead, you can use a pipeline rule to parse the JSON data.
 
 1. Create a Stream and add the Cowrie logs to it.
+
 **Streams** -> **Create Stream** -> **Title:** Cowrie -> **Description:** Cowrie logs -> **Create Stream**
 
 2. Create a Stream Rule for the Cowrie Stream.
+
 **Streams** -> **Cowrie** -> **Manage Rules** -> **Add Stream Rule** -> **Type:** `match input` **Input:** `Cowrie (GELF HTTP)` -> **Save**
 
 3. Create a Pipeline Rule for the Cowrie Stream.
+
 **System** -> **Pipelines** -> **Manage rules** -> **Create Rule** -> **Use Source Code Editor**
+
 Paste the following code into the Rule source::
 
     rule "Parse Cowie message"
@@ -120,8 +124,11 @@ Paste the following code into the Rule source::
     end
 
 4. Create a Pipeline for the Cowrie Stream.
+
 **System** -> **Pipelines** -> **Manage pipelines** -> **Add new pipeline** -> **Title:** `Parse Cowrie logs` -> **Description:** Cowrie logs -> **Create Pipeline**
+
 Under the **Pipeline connections** section, connect the Cowrie Stream to the Pipeline by clicking the **Edit connections** button and selecting the Cowrie Stream.
+
 Under Pipeline Stages, edit Stage 0 and add the Pipeline Rule to the Stage.
 
 Syslog Configuration (For Syslog Output only)

--- a/docs/graylog/README.rst
+++ b/docs/graylog/README.rst
@@ -97,15 +97,18 @@ Pipeline
 --------
 When running Graylog with the Forwarder input, traditional extractors are not available. Instead, you can use a pipeline rule to parse the JSON data.
 
-1. Create a Stream and add the Cowrie logs to it.
+Create a Stream and add the Cowrie logs to it.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Streams** -> **Create Stream** -> **Title:** Cowrie -> **Description:** Cowrie logs -> **Create Stream**
 
-2. Create a Stream Rule for the Cowrie Stream.
+Create a Stream Rule for the Cowrie Stream.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Streams** -> **Cowrie** -> **Manage Rules** -> **Add Stream Rule** -> **Type:** `match input` **Input:** `Cowrie (GELF HTTP)` -> **Save**
 
-3. Create a Pipeline Rule for the Cowrie Stream.
+Create a Pipeline Rule for the Cowrie Stream.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **System** -> **Pipelines** -> **Manage rules** -> **Create Rule** -> **Use Source Code Editor**
 
@@ -123,7 +126,8 @@ Paste the following code into the Rule source::
       set_fields(map);
     end
 
-4. Create a Pipeline for the Cowrie Stream.
+Create a Pipeline for the Cowrie Stream.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **System** -> **Pipelines** -> **Manage pipelines** -> **Add new pipeline** -> **Title:** `Parse Cowrie logs` -> **Description:** Cowrie logs -> **Create Pipeline**
 


### PR DESCRIPTION
Added instructions for how to setup and use a pipeline.

This can be used as an alternative to the Input extractor for greater control and further parsing of the data.
It is also a requirement when running the Graylog forwarder inputs.