### PR TITLE
add PostgreSQL output plugin with reconnect support

### DIFF
--- a/docs/sql/README.rst
+++ b/docs/sql/README.rst
@@ -6,7 +6,7 @@ MySQL/PostgreSQL Output Plugin Prerequisites
 
 * Working Cowrie installation
 * Working MySQL installation
-* Working PosterSQL installation
+* Working PostgreSQL installation
 
 MySQL Installation
 ==================
@@ -147,7 +147,7 @@ PostgreSQL does not support TINYINT. If you are porting the MySQL schema, update
 Cowrie Configuration for PostgreSQL
 ===================================
 
-Uncomment and update the following entries in ``etc/cowrie.cfg`` under the Output Plugins section::
+Add the following entries in ``etc/cowrie.cfg`` under the Output Plugins section::
 
     [output_postgresql]
     enabled = true

--- a/docs/sql/README.rst
+++ b/docs/sql/README.rst
@@ -27,14 +27,14 @@ First create an empty database named ``cowrie``::
 
 Create a Cowrie user account for the database and grant all access privileges::
 
-    GRANT ALL ON cowrie.* TO 'cowrie'@'localhost' IDENTIFIED BY 'PASSWORD HERE';
+    CREATE USER 'cowrie'@'localhost' IDENTIFIED BY 'PASSWORD HERE';
 
 **Restricted Privileges:**
 
 Alternatively you can grant the Cowrie account with less privileges. The following command grants the account with the
 bare minimum required for the output logging to function::
 
-    GRANT INSERT, SELECT, UPDATE ON cowrie.* TO 'cowrie'@'localhost' IDENTIFIED BY 'PASSWORD HERE';
+    GRANT INSERT, SELECT, UPDATE ON cowrie.* TO 'cowrie'@'localhost';
 
 Apply the privilege settings and exit mysql::
 

--- a/docs/sql/postgres.sql
+++ b/docs/sql/postgres.sql
@@ -1,0 +1,113 @@
+-- Table: auth
+CREATE TABLE IF NOT EXISTS auth
+(
+    id        SERIAL PRIMARY KEY,
+    session   CHAR(32)     NOT NULL,
+    success   BOOLEAN      NOT NULL,
+    username  VARCHAR(100) NOT NULL,
+    password  VARCHAR(100) NOT NULL,
+    timestamp TIMESTAMP    NOT NULL
+);
+
+-- Table: clients
+CREATE TABLE IF NOT EXISTS clients
+(
+    id      SERIAL PRIMARY KEY,
+    version VARCHAR(50) NOT NULL
+);
+
+-- Table: downloads
+CREATE TABLE IF NOT EXISTS downloads
+(
+    id        SERIAL PRIMARY KEY,
+    session   CHAR(32)  NOT NULL,
+    timestamp TIMESTAMP NOT NULL,
+    url       TEXT      NOT NULL,
+    outfile   TEXT,
+    shasum    VARCHAR(64)
+);
+CREATE INDEX downloads_session_timestamp_idx ON downloads (session, timestamp);
+
+-- Table: input
+CREATE TABLE IF NOT EXISTS input
+(
+    id        SERIAL PRIMARY KEY,
+    session   CHAR(32)  NOT NULL,
+    timestamp TIMESTAMP NOT NULL,
+    realm     VARCHAR(50),
+    success   BOOLEAN,
+    input     TEXT      NOT NULL
+);
+CREATE INDEX input_session_timestamp_realm_idx ON input (session, timestamp, realm);
+
+-- Table: keyfingerprints
+CREATE TABLE IF NOT EXISTS keyfingerprints
+(
+    id          SERIAL PRIMARY KEY,
+    session     CHAR(32)     NOT NULL,
+    username    VARCHAR(100) NOT NULL,
+    fingerprint VARCHAR(100) NOT NULL
+);
+
+-- Table: params
+CREATE TABLE IF NOT EXISTS params
+(
+    id      SERIAL PRIMARY KEY,
+    session CHAR(32)    NOT NULL,
+    arch    VARCHAR(32) NOT NULL
+);
+CREATE INDEX params_arch_index ON params (arch);
+
+-- Table: sensors
+CREATE TABLE IF NOT EXISTS sensors
+(
+    id SERIAL PRIMARY KEY,
+    ip VARCHAR(255) NOT NULL
+);
+
+-- Table: sessions
+CREATE TABLE IF NOT EXISTS sessions
+(
+    id        CHAR(32) PRIMARY KEY,
+    starttime TIMESTAMP   NOT NULL,
+    endtime   TIMESTAMP,
+    sensor    INTEGER     NOT NULL,
+    ip        VARCHAR(61) NOT NULL DEFAULT '',
+    termsize  VARCHAR(7),
+    client    INTEGER
+);
+CREATE INDEX sessions_starttime_sensor_idx ON sessions (starttime, sensor);
+
+-- Table: ipforwards
+CREATE TABLE IF NOT EXISTS ipforwards
+(
+    id        SERIAL PRIMARY KEY,
+    session   CHAR(32)     NOT NULL,
+    timestamp TIMESTAMP    NOT NULL,
+    dst_ip    VARCHAR(255) NOT NULL DEFAULT '',
+    dst_port  INTEGER      NOT NULL,
+    CONSTRAINT ipforwards_ibfk_1 FOREIGN KEY (session) REFERENCES sessions (id)
+);
+CREATE INDEX ipforwards_session_idx ON ipforwards (session);
+
+-- Table: ipforwardsdata
+CREATE TABLE IF NOT EXISTS ipforwardsdata
+(
+    id        SERIAL PRIMARY KEY,
+    session   CHAR(32)     NOT NULL,
+    timestamp TIMESTAMP    NOT NULL,
+    dst_ip    VARCHAR(255) NOT NULL DEFAULT '',
+    dst_port  INTEGER      NOT NULL,
+    data      TEXT         NOT NULL,
+    CONSTRAINT ipforwardsdata_ibfk_1 FOREIGN KEY (session) REFERENCES sessions (id)
+);
+CREATE INDEX ipforwardsdata_session_timestamp_idx ON ipforwardsdata (session, timestamp);
+
+-- Table: ttylog
+CREATE TABLE IF NOT EXISTS ttylog
+(
+    id      SERIAL PRIMARY KEY,
+    session CHAR(32)     NOT NULL,
+    ttylog  VARCHAR(100) NOT NULL,
+    size    INTEGER      NOT NULL
+);

--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -830,6 +830,23 @@ password = secret
 port = 3306
 debug = false
 
+
+# PostgresSQL logging module
+# Database structure for this module is supplied in docs/sql/postgres.sql
+#
+# PostgresSQL logging requires extra software: sudo apt-get install libpq-dev
+# PostgresSQL logging requires an extra Python module: pip install psycopg2
+#
+[output_postgresql]
+enabled = false
+host = localhost
+database = cowrie
+username = cowrie
+password = secret
+port = 5432
+debug = false
+
+
 # Rethinkdb output module
 # Rethinkdb output module requires extra Python module: pip install rethinkdb
 

--- a/src/cowrie/output/postgresql.py
+++ b/src/cowrie/output/postgresql.py
@@ -22,11 +22,11 @@ class ReconnectingPostgreSQLConnectionPool(adbapi.ConnectionPool):
         except OperationalError as e:
             # Typical disconnection or restart issues
             transient_errors = (
-                '08003',  # connection_does_not_exist
-                '08006',  # connection_failure
-                '40001',  # serialization_failure
-                '57014',  # query_canceled
-                '53300',  # too_many_connections
+                "08003",  # connection_does_not_exist
+                "08006",  # connection_failure
+                "40001",  # serialization_failure
+                "57014",  # query_canceled
+                "53300",  # too_many_connections
             )
             if e.pgcode not in transient_errors:
                 raise
@@ -69,7 +69,11 @@ class Output(cowrie.core.output.Output):
         log.msg(f"output_postgresql: PostgreSQL Error: {error.value.args!r}")
 
     def simpleQuery(self, sql, args):
-        if sql.startswith("INSERT") or sql.startswith("UPDATE") or sql.startswith("DELETE"):
+        if (
+            sql.startswith("INSERT")
+            or sql.startswith("UPDATE")
+            or sql.startswith("DELETE")
+        ):
             sql += " RETURNING id"
 
         if self.debug:

--- a/src/cowrie/output/postgresql.py
+++ b/src/cowrie/output/postgresql.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from psycopg2 import OperationalError
+from twisted.enterprise import adbapi
+from twisted.internet import defer
+from twisted.python import log
+
+import cowrie.core.output
+from cowrie.core.config import CowrieConfig
+
+
+class ReconnectingPostgreSQLConnectionPool(adbapi.ConnectionPool):
+    """
+    Reconnecting adbapi connection pool for PostgreSQL.
+
+    This handles reconnections on known transient errors like server disconnects or deadlocks.
+    """
+
+    def _runInteraction(self, interaction, *args, **kw):
+        try:
+            return super()._runInteraction(interaction, *args, **kw)
+        except OperationalError as e:
+            # Typical disconnection or restart issues
+            transient_errors = (
+                '08003',  # connection_does_not_exist
+                '08006',  # connection_failure
+                '40001',  # serialization_failure
+                '57014',  # query_canceled
+                '53300',  # too_many_connections
+            )
+            if e.pgcode not in transient_errors:
+                raise
+
+            log.msg(f"output_postgresql: transient error {e!r}, retrying interaction")
+            conn = self.connections.get(self.threadID())
+            self.disconnect(conn)
+            return super()._runInteraction(interaction, *args, **kw)
+
+
+class Output(cowrie.core.output.Output):
+    """
+    PostgreSQL output for Cowrie
+    """
+
+    debug: bool = False
+
+    def start(self):
+        self.debug = CowrieConfig.getboolean("output_postgresql", "debug", fallback=False)
+        port = CowrieConfig.getint("output_postgresql", "port", fallback=5432)
+
+        try:
+            self.db = ReconnectingPostgreSQLConnectionPool(
+                "psycopg2",
+                host=CowrieConfig.get("output_postgresql", "host"),
+                database=CowrieConfig.get("output_postgresql", "database"),
+                user=CowrieConfig.get("output_postgresql", "username"),
+                password=CowrieConfig.get("output_postgresql", "password", raw=True),
+                port=port,
+                cp_min=1,
+                cp_max=1,
+            )
+        except Exception as e:
+            log.msg(f"output_mysql: Error {e.args[0]}: {e.args[1]}")
+
+    def stop(self):
+        self.db.close()
+
+    def sqlerror(self, error):
+        log.msg(f"output_postgresql: PostgreSQL Error: {error.value.args!r}")
+
+    def simpleQuery(self, sql, args):
+        if sql.startswith("INSERT") or sql.startswith("UPDATE") or sql.startswith("DELETE"):
+            sql += " RETURNING id"
+
+        if self.debug:
+            log.msg(f"output_postgresql: PostgreSQL query: {sql} {args!r}")
+
+        d = self.db.runQuery(sql, args)
+        d.addErrback(self.sqlerror)
+
+    @defer.inlineCallbacks
+    def write(self, event):
+        if event["eventid"] == "cowrie.session.connect":
+            if self.debug:
+                log.msg(
+                    f"output_postgresql: SELECT id FROM sensors WHERE ip = '{self.sensor}'"
+                )
+            r = yield self.db.runQuery(
+                "SELECT id FROM sensors WHERE ip = %s",
+                (self.sensor,),
+            )
+            if r:
+                sensorid = r[0][0]
+            else:
+                if self.debug:
+                    log.msg(
+                        f"output_postgresql: INSERT INTO sensors (ip) VALUES ('{self.sensor}')"
+                    )
+                yield self.db.runQuery(
+                    "INSERT INTO sensors (ip) VALUES (%s) ",
+                    (self.sensor,),
+                )
+
+                r = yield self.db.runQuery("SELECT LASTVAL()")
+                sensorid = int(r[0][0])
+            self.simpleQuery(
+                "INSERT INTO sessions (id, starttime, sensor, ip) "
+                "VALUES (%s, TO_TIMESTAMP(%s), %s, %s)",
+                (event["session"], event["time"], sensorid, event["src_ip"]),
+            )
+
+        elif event["eventid"] == "cowrie.login.success":
+            self.simpleQuery(
+                "INSERT INTO auth (session, success, username, password, timestamp) "
+                "VALUES (%s, %s, %s, %s, TO_TIMESTAMP(%s)) ",
+                (
+                    event["session"],
+                    True,
+                    event["username"],
+                    event["password"],
+                    event["time"],
+                ),
+            )
+
+        elif event["eventid"] == "cowrie.login.failed":
+            self.simpleQuery(
+                "INSERT INTO auth (session, success, username, password, timestamp) "
+                "VALUES (%s, %s, %s, %s, TO_TIMESTAMP(%s))",
+                (
+                    event["session"],
+                    False,
+                    event["username"],
+                    event["password"],
+                    event["time"],
+                ),
+            )
+
+        elif event["eventid"] == "cowrie.session.params":
+            self.simpleQuery(
+                "INSERT INTO params (session, arch) VALUES (%s, %s)",
+                (event["session"], event["arch"]),
+            )
+
+        elif event["eventid"] == "cowrie.command.input":
+            self.simpleQuery(
+                "INSERT INTO input (session, timestamp, success, input) "
+                "VALUES (%s, TO_TIMESTAMP(%s), %s , %s)",
+                (event["session"], event["time"], True, event["input"]),
+            )
+
+        elif event["eventid"] == "cowrie.command.failed":
+            self.simpleQuery(
+                "INSERT INTO input (session, timestamp, success, input) "
+                "VALUES (%s, TO_TIMESTAMP(%s), %s , %s)",
+                (event["session"], event["time"], False, event["input"]),
+            )
+
+        elif event["eventid"] == "cowrie.session.file_download":
+            self.simpleQuery(
+                "INSERT INTO downloads (session, timestamp, url, outfile, shasum) "
+                "VALUES (%s, TO_TIMESTAMP(%s), %s, %s, %s)",
+                (
+                    event["session"],
+                    event["time"],
+                    event.get("url", ""),
+                    event["outfile"],
+                    event["shasum"],
+                ),
+            )
+
+        elif event["eventid"] == "cowrie.session.file_download.failed":
+            self.simpleQuery(
+                "INSERT INTO downloads (session, timestamp, url, outfile, shasum) "
+                "VALUES (%s, TO_TIMESTAMP(%s), %s, %s, %s)",
+                (event["session"], event["time"], event.get("url", ""), None, None),
+            )
+
+        elif event["eventid"] == "cowrie.session.file_upload":
+            self.simpleQuery(
+                "INSERT INTO downloads (session, timestamp, url, outfile, shasum) "
+                "VALUES (%s, TO_TIMESTAMP(%s), %s, %s, %s)",
+                (
+                    event["session"],
+                    event["time"],
+                    "",
+                    event["outfile"],
+                    event["shasum"],
+                ),
+            )
+
+        elif event["eventid"] == "cowrie.session.input":
+            self.simpleQuery(
+                "INSERT INTO input (session, timestamp, realm, input) "
+                "VALUES (%s, TO_TIMESTAMP(%s), %s , %s)",
+                (event["session"], event["time"], event["realm"], event["input"]),
+            )
+
+        elif event["eventid"] == "cowrie.client.version":
+            r = yield self.db.runQuery(
+                "SELECT id FROM clients WHERE version = %s",
+                (event["version"],),
+            )
+
+            if r:
+                clientid = int(r[0][0])
+            else:
+                yield self.db.runQuery(
+                    "INSERT INTO clients (version) VALUES (%s)",
+                    (event["version"],),
+                )
+
+                r = yield self.db.runQuery("SELECT LASTVAL()")
+                clientid = int(r[0][0])
+            self.simpleQuery(
+                "UPDATE sessions SET client = %s WHERE id = %s",
+                (clientid, event["session"]),
+            )
+
+        elif event["eventid"] == "cowrie.client.size":
+            self.simpleQuery(
+                "UPDATE sessions SET termsize = %s WHERE id = %s",
+                ("{}x{}".format(event["width"], event["height"]), event["session"]),
+            )
+
+        elif event["eventid"] == "cowrie.session.closed":
+            self.simpleQuery(
+                "UPDATE sessions SET endtime = TO_TIMESTAMP(%s) WHERE id = %s",
+                (event["time"], event["session"]),
+            )
+
+        elif event["eventid"] == "cowrie.log.closed":
+            self.simpleQuery(
+                "INSERT INTO ttylog (session, ttylog, size) VALUES (%s, %s, %s)",
+                (event["session"], event["ttylog"], event["size"]),
+            )
+
+        elif event["eventid"] == "cowrie.client.fingerprint":
+            self.simpleQuery(
+                "INSERT INTO keyfingerprints (session, username, fingerprint) "
+                "VALUES (%s, %s, %s)",
+                (event["session"], event["username"], event["fingerprint"]),
+            )
+
+        elif event["eventid"] == "cowrie.direct-tcpip.request":
+            self.simpleQuery(
+                "INSERT INTO ipforwards (session, timestamp, dst_ip, dst_port) "
+                "VALUES (%s, TO_TIMESTAMP(%s), %s, %s)",
+                (event["session"], event["time"], event["dst_ip"], event["dst_port"]),
+            )
+
+        elif event["eventid"] == "cowrie.direct-tcpip.data":
+            self.simpleQuery(
+                "INSERT INTO ipforwardsdata (session, timestamp, dst_ip, dst_port, data) "
+                "VALUES (%s, TO_TIMESTAMP(%s), %s, %s, %s)",
+                (
+                    event["session"],
+                    event["time"],
+                    event["dst_ip"],
+                    event["dst_port"],
+                    event["data"],
+                ),
+            )


### PR DESCRIPTION
This PR adds a PostgreSQL output plugin for Cowrie. It allows event data to be logged directly to a PostgreSQL database using `psycopg2` and Twisted’s `adbapi`. The implementation supports all major Cowrie events and includes automatic reconnection handling for transient database errors.

Additionally, this PR updates the MySQL documentation to remove legacy GRANT ... IDENTIFIED BY syntax, replacing it with separate CREATE USER and GRANT statements. This change ensures compatibility with MySQL versions 8.0+