### PR TITLE
replace deprecated `datetime.utcnow()` with equivalent

### DIFF
--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -961,7 +961,7 @@ commands["history"] = Command_history
 
 class Command_date(HoneyPotCommand):
     def call(self) -> None:
-        time = datetime.datetime.utcnow()
+        time = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         self.write("{}\n".format(time.strftime("%a %b %d %H:%M:%S UTC %Y")))
 
 

--- a/src/cowrie/commands/finger.py
+++ b/src/cowrie/commands/finger.py
@@ -12,7 +12,7 @@ FINGER_HELP = """Usage:"""
 
 class Command_finger(HoneyPotCommand):
     def call(self):
-        time = datetime.datetime.utcnow()
+        time = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         user_data = []
         # Get all user data and convert to string
         all_users_byte = self.fs.file_contents("/etc/passwd")

--- a/src/cowrie/output/oraclecloud.py
+++ b/src/cowrie/output/oraclecloud.py
@@ -26,7 +26,7 @@ class Output(cowrie.core.output.Output):
     def sendLogs(self, event):
         log_id = self.generate_random_log_id()
         # Initialize service client with default config file
-        current_time = datetime.datetime.utcnow()
+        current_time = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         self.log_ocid = CowrieConfig.get("output_oraclecloud", "log_ocid")
         self.hostname = CowrieConfig.get("honeypot", "hostname")
 


### PR DESCRIPTION
# PR Summary
This PR addresses the `DeprecationWarning` for `datetime.utcnow()` in Python 3.12+ by replacing it with a timezone-aware equivalent followed by `replace(tzinfo=None)`. Unlike other approaches that convert to timezone-aware objects, this ensures backward compatibility for code expecting naive datetime instances.
```python
# Before (deprecated)  
from datetime import datetime  
naive_time = datetime.utcnow()  # Raises warning  

# Common Fix (timezone-aware)  
from datetime import datetime, timezone  
aware_time = datetime.now(timezone.utc)  # Breaks naive-dependent code  

# This PR's Fix (naive but compliant)  
from datetime import datetime, timezone  
compliant_time = datetime.now(timezone.utc).replace(tzinfo=None)  # No warning, backward-compatible  
```
You can find those warnings in the [last CI run](https://github.com/cowrie/cowrie/actions/runs/14374132407/job/40302603777) (step: `Test with tox`):
```python
test_date_command (cowrie.test.test_base_commands.ShellBaseCommandsTests.test_date_command) ... /home/runner/work/cowrie/cowrie/src/cowrie/commands/base.py:964: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```
