### PR TITLE
Remove unused dependencies from configuration files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,17 +29,14 @@ classifiers=[
 
 dependencies = [
         "attrs==25.3.0",
-        "bcrypt==4.3.0",
         "cryptography==45.0.4",
         "hyperlink==21.0.0",
         "idna==3.10",
-        "packaging==25.0",
-        "pyasn1_modules==0.4.2",
         "requests==2.32.4",
         "service_identity==24.2.0",
         "tftpy==0.8.6",
         "treq==25.5.0",
-        "twisted==25.5.0",
+        "twisted[conch]==25.5.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,10 @@
 attrs==25.3.0
-bcrypt==4.3.0
 cryptography==45.0.4
 hyperlink==21.0.0
 idna==3.10
-packaging==25.0
-pyasn1_modules==0.4.2
 requests==2.32.4
 service_identity==24.2.0
 tftpy==0.8.6
 treq==25.5.0
-twisted==25.5.0
+twisted[conch]==25.5.0
 urllib3==2.5.0


### PR DESCRIPTION
As part of our ongoing research on Python dependency management, we identified a potential improvement in your project’s approach.

Specifically, the dependency `packaging` is listed in `requirements.txt` and `pyproject.toml`, but doesn’t appear to be used anywhere in the codebase. Additionally, `pyasn1_modules` is a transitive dependency of `service-identity` and does not need to be listed explicitly. Finally, `bcrypt` was introduced in #1087 to fix #1085, but it is only needed as part of Twisted's optional `conch` functionality. Installing `twisted[conch]` instead is cleaner and ensures that all required dependencies are pulled in properly without having to manage `bcrypt` directly.

By streamlining these declarations, your dependency list more accurately reflects what the project actually uses. This can improve maintainability and reduce the risk of dependency conflicts over time.

Hope this is helpful!