### PR TITLE
run extensive tests on 3.11

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ skip_missing_interpreters = True
 
 [gh-actions]
 python =
-    3.10: py310, lint, docs, typing, pypi
-    3.11: py311
+    3.10: py310
+    3.11: py311, lint, docs, typing, pypi
     3.12: py312
     3.13: py313
     3.14: py314


### PR DESCRIPTION
Debian bookworm is on python 3.11, as long as the Docker image is based on bookworm, we'll use this for the extensive tests.