### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,5 +1,7 @@
 ---
 name: Tox
+permissions:
+  contents: read
 
 on:  # yamllint disable-line rule:truthy
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cowrie/cowrie/security/code-scanning/8](https://github.com/cowrie/cowrie/security/code-scanning/8)

To fix the problem, we need to add a `permissions` block assigning least-privilege permissions for the GITHUB_TOKEN in the `.github/workflows/tox.yml` file. Since the workflow appears to build and test the code but does not need to write to the repository or perform privileged actions, the minimal permission of `contents: read` is most appropriate. This can be applied at the workflow root level, which will cover all jobs unless a job-specific override is required (here, it is not). The change should be made by adding the `permissions:` line immediately after the `name:` line (after line 2), before the `on:` block. No new imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
