### PR TITLE
Refactor sleep command with improved option handling

### DIFF
--- a/src/cowrie/commands/sleep.py
+++ b/src/cowrie/commands/sleep.py
@@ -86,6 +86,12 @@ Written by Jim Meyering and Paul Eggert.
             self.exit()
             return
 
+        # Handle no arguments
+        if not arglist:
+            self.print_usage_error("missing operand")
+            self.exit()
+            return
+
         if len(self.args) == 1:
             m = re.match(r"(\d+)[mhs]?", self.args[0])
             if m:

--- a/src/cowrie/commands/sleep.py
+++ b/src/cowrie/commands/sleep.py
@@ -12,7 +12,7 @@ import getopt
 import re
 
 from cowrie.shell.command import HoneyPotCommand
-from twisted.internet.reactor import callLater  # pylint: disable=no-name-in-module
+from twisted.internet import reactor
 
 commands = {}
 
@@ -110,7 +110,7 @@ Written by Jim Meyering and Paul Eggert.
             _time += int(m.group(1))
 
         self.running = True
-        self.scheduled = callLater(_time, self.done)  # type: ignore[attr-defined]
+        self.scheduled = reactor.callLater(_time, self.done)  # type: ignore[attr-defined]
 
     def handle_CTRL_C(self) -> None:
         if self.running:

--- a/src/cowrie/commands/sleep.py
+++ b/src/cowrie/commands/sleep.py
@@ -7,11 +7,11 @@ This module contains the sleep command
 
 from __future__ import annotations
 
+import getopt
 import re
 
-from twisted.internet import reactor
-
 from cowrie.shell.command import HoneyPotCommand
+from twisted.internet import reactor
 
 commands = {}
 
@@ -23,10 +23,69 @@ class Command_sleep(HoneyPotCommand):
 
     pattern = re.compile(r"(\d+)[mhs]?")
 
+    def print_usage_error(self, error_msg: str = "") -> None:
+        """Print usage error message"""
+        if error_msg:
+            self.errorWrite(f"sleep: {error_msg}\n")
+        self.errorWrite("Try 'sleep --help' for more information.\n")
+
+    def print_help_message(self) -> None:
+        self.write("""
+Usage: sleep NUMBER[SUFFIX]...
+  or:  sleep OPTION
+Pause for NUMBER seconds.  SUFFIX may be 's' for seconds (the default),
+'m' for minutes, 'h' for hours or 'd' for days.  NUMBER need not be an
+integer.  Given two or more arguments, pause for the amount of time
+specified by the sum of their values.
+
+      --help        display this help and exit
+      --version     output version information and exit
+
+GNU coreutils online help: <https://www.gnu.org/software/coreutils/>
+Full documentation <https://www.gnu.org/software/coreutils/sleep>
+""")
+
+    def print_version(self) -> None:
+        self.write("""
+sleep (GNU coreutils) 8.3
+Copyright (C) 2018 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+
+Written by Jim Meyering and Paul Eggert.
+""")
+
     def done(self) -> None:
         self.exit()
 
     def start(self) -> None:
+        try:
+            optlist, arglist = getopt.getopt(self.args, "", ["help", "version"])
+        except getopt.GetoptError as err:
+            # Check if the error was caused by a long option (--option)
+            if f"--{err.opt}" in self.args:
+                message = "unrecognized option"
+            else:
+                # Short options (-o) are not supported
+                message = "invalid option --"
+
+            self.print_usage_error(f"{message} '{err.opt}'")
+            self.exit()
+            return
+
+        # Handle help option first - print help and exit immediately
+        if "--help" in [o[0] for o in optlist]:
+            self.print_help_message()
+            self.exit()
+            return
+
+        # Handle version option then - print version and exit immediately
+        if "--version" in [o[0] for o in optlist]:
+            self.print_version()
+            self.exit()
+            return
+
         if len(self.args) == 1:
             m = re.match(r"(\d+)[mhs]?", self.args[0])
             if m:

--- a/src/cowrie/commands/sleep.py
+++ b/src/cowrie/commands/sleep.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015 Michel Oosterhof <michel@oosterhof.net>
+#               2025 Filippo Lauria <filippo.lauria@iit.cnr.it>
 # All rights reserved.
 
 """
@@ -11,7 +12,7 @@ import getopt
 import re
 
 from cowrie.shell.command import HoneyPotCommand
-from twisted.internet import reactor
+from twisted.internet.reactor import callLater
 
 commands = {}
 
@@ -55,9 +56,6 @@ There is NO WARRANTY, to the extent permitted by law.
 
 Written by Jim Meyering and Paul Eggert.
 """)
-
-    def done(self) -> None:
-        self.exit()
 
     def start(self) -> None:
         try:
@@ -106,7 +104,7 @@ Written by Jim Meyering and Paul Eggert.
             # Ignore time suffix (s/m/h) and accumulate value as seconds
             _time += int(m.group(1))
 
-        self.scheduled = reactor.callLater(_time, self.done)  # type: ignore[attr-defined]
+        self.scheduled = callLater(_time, self.exit)  # type: ignore[attr-defined]
 
 
 commands["/bin/sleep"] = Command_sleep

--- a/src/cowrie/commands/sleep.py
+++ b/src/cowrie/commands/sleep.py
@@ -12,7 +12,7 @@ import getopt
 import re
 
 from cowrie.shell.command import HoneyPotCommand
-from twisted.internet.reactor import callLater
+from twisted.internet.reactor import callLater  # pylint: disable=no-name-in-module
 
 commands = {}
 


### PR DESCRIPTION
Refactored the sleep command:

- Add `--help` and `--version` options with GNU coreutils-style output
- Handle missing operand error case
- Support multiple time arguments (sum of values)
- Simplify code by calling `self.exit` directly instead of wrapper method

This was done while exploring how `reactor.callLater` works, which could potentially be used to implement fake timeout simulations in commands like `wget`, `curl`, `nc`, etc.