### PR TITLE
Fix Proxy mode failing to start 

### DIFF
--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -228,7 +228,7 @@ Makes a Cowrie SSH/Telnet honeypot.
             factory = cowrie.ssh.factory.CowrieSSHFactory(backend, self.pool_handler)
             factory.tac = self  # type: ignore
 
-            if backend == "shell":
+            if backend in ("shell", "proxy"):
                 factory.portal = portal.Portal(cowrie.shell.realm.HoneyPotRealm())
             elif backend == "llm":
                 factory.portal = portal.Portal(cowrie.llm.realm.HoneyPotRealm())
@@ -255,7 +255,7 @@ Makes a Cowrie SSH/Telnet honeypot.
         if self.enableTelnet:
             f = cowrie.telnet.factory.HoneyPotTelnetFactory(backend, self.pool_handler)
             f.tac = self
-            if backend == "shell":
+            if backend in ("shell", "proxy"):
                 f.portal = portal.Portal(cowrie.shell.realm.HoneyPotRealm())
             elif backend == "llm":
                 f.portal = portal.Portal(cowrie.llm.realm.HoneyPotRealm())


### PR DESCRIPTION
This fixes #2824. Proxy mode was not included in the portal creation. 

I've included proxy into the portal creation for `shell` in both SSH and Telnet. 