### PR TITLE
Improve proxy backend logging

### DIFF
--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -163,6 +163,7 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             backend_port=self.backend_port,
             error=reason.getErrorMessage(),
             protocol="ssh",
+            system=f"{self.logPrefix()},{self.transport.sessionno},{self.peer_ip}", # Not sure if there's a better way to do this
         )
         if self.transport:
             self.transport.loseConnection()
@@ -179,6 +180,7 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             local_ip=backend_host.host,
             local_port=backend_host.port,
             protocol="ssh",
+            system=f"{self.logPrefix()},{self.transport.sessionno},{self.peer_ip}", # Not sure if there's a better way to do this
         )
 
         self.startTime = time.time()

--- a/src/cowrie/telnet_proxy/server_transport.py
+++ b/src/cowrie/telnet_proxy/server_transport.py
@@ -120,6 +120,7 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
             backend_port=self.backend_port,
             error=reason.getErrorMessage(),
             protocol="telnet",
+            system=f"{self.logPrefix()},{self.transport.sessionno},{self.peer_ip}", # Not sure if there's a better way to do this
         )
         self.transport.loseConnection()
 
@@ -135,6 +136,7 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
             local_ip=backend_host.host,
             local_port=backend_host.port,
             protocol="telnet",
+            system=f"{self.logPrefix()},{self.transport.sessionno},{self.peer_ip}", # Not sure if there's a better way to do this
         )
 
         self.startTime = time.time()

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -228,7 +228,7 @@ Makes a Cowrie SSH/Telnet honeypot.
             factory = cowrie.ssh.factory.CowrieSSHFactory(backend, self.pool_handler)
             factory.tac = self  # type: ignore
 
-            if backend == "shell":
+            if backend in ("shell", "proxy"):
                 factory.portal = portal.Portal(cowrie.shell.realm.HoneyPotRealm())
             elif backend == "llm":
                 factory.portal = portal.Portal(cowrie.llm.realm.HoneyPotRealm())
@@ -255,7 +255,7 @@ Makes a Cowrie SSH/Telnet honeypot.
         if self.enableTelnet:
             f = cowrie.telnet.factory.HoneyPotTelnetFactory(backend, self.pool_handler)
             f.tac = self
-            if backend == "shell":
+            if backend in ("shell", "proxy"):
                 f.portal = portal.Portal(cowrie.shell.realm.HoneyPotRealm())
             elif backend == "llm":
                 f.portal = portal.Portal(cowrie.llm.realm.HoneyPotRealm())


### PR DESCRIPTION
This pull request adds more verbose and contextual logging for backend connection and disconnection events. The goal is to make it easier to correlate logs between Cowrie and SSH/Telnet backend services.

### Summary of changes
- Added logging context for previously `Uninitialized` messages related to `backend_connection_success` and `backend_connection_error`.
- Updated both Telnet and SSH backends to include the backend host, port, and peer connection details when reporting success or error events.
- Added disconnect logging in `connectionLost` for Telnet and SSH, including backend host/port and the peer's address and port.


### Before
```
cowrie-1     | 2025-12-05T10:28:20+0000 [cowrie.ssh.factory.CowrieSSHFactory] New connection: 172.27.0.1:46960 (172.27.0.3:2222) [session: 820f78570218]
cowrie-1     | 2025-12-05T10:28:20+0000 [cowrie.ssh_proxy.client_transport.BackendSSHFactory#info] Starting factory <cowrie.ssh_proxy.client_transport.BackendSSHFactory object at 0x7f9232b40790>
cowrie-1     | 2025-12-05T10:28:20+0000 [FrontendSSHTransport,0,172.27.0.1] Remote SSH version: SSH-2.0-OpenSSH_10.0p2 Debian-8
cowrie-1     | 2025-12-05T10:28:20+0000 [Uninitialized] Connected to SSH backend at 172.27.0.2          
cowrie-1     | 2025-12-05T10:28:20+0000 [Uninitialized] Connected to honeypot backend       <--- No information on connecting port
...
cowrie-1     | 2025-12-05T10:29:08+0000 [FrontendSSHTransport,0,172.27.0.1] CMD: exit
ssh-backend  | Received disconnect from 172.27.0.3 port 38026:11: disconnected by user
cowrie-1     | 2025-12-05T10:29:08+0000 [FrontendSSHTransport,0,172.27.0.1] remote close
ssh-backend  | Disconnected from user admin 172.27.0.3 port 38026
cowrie-1     | 2025-12-05T10:29:08+0000 [FrontendSSHTransport,0,172.27.0.1] Closing TTY Log: var/lib/cowrie/tty/d6ee3ea7db56918b761587d85907034d85e167d05db734c4aac7e11a425ced55 after 43 seconds
cowrie-1     | 2025-12-05T10:29:08+0000 [FrontendSSHTransport,0,172.27.0.1] Unhandled SSH packet: 1
cowrie-1     | 2025-12-05T10:29:08+0000 [cowrie.ssh_proxy.server_transport.FrontendSSHTransport#info] connection lost
cowrie-1     | 2025-12-05T10:29:08+0000 [FrontendSSHTransport,0,172.27.0.1] Connection lost after 48 seconds
cowrie-1     | 2025-12-05T10:29:08+0000 [BackendSSHTransport,client] Lost connection with the proxy's backend: None:None
cowrie-1     | 2025-12-05T10:29:08+0000 [cowrie.ssh_proxy.client_transport.BackendSSHFactory#info] Stopping factory <cowrie.ssh_proxy.client_transport.BackendSSHFactory object at 0x7f9232b40790
```

### After
```
cowrie-1     | 2025-12-05T10:34:59+0000 [cowrie.ssh.factory.CowrieSSHFactory] New connection: 172.27.0.1:56158 (172.27.0.3:2222) [session: 82ed52e4d005]
cowrie-1     | 2025-12-05T10:34:59+0000 [cowrie.ssh_proxy.client_transport.BackendSSHFactory#info] Starting factory <cowrie.ssh_proxy.client_transport.BackendSSHFactory object at 0x7fa80ff6a790>
cowrie-1     | 2025-12-05T10:34:59+0000 [FrontendSSHTransport,0,172.27.0.1] Remote SSH version: SSH-2.0-OpenSSH_10.0p2 Debian-8
cowrie-1     | 2025-12-05T10:34:59+0000 [FrontendSSHTransport,0,172.27.0.1] SSH client hassh fingerprint: eeca2460550b9ded084ecf2f70a75356
cowrie-1     | 2025-12-05T10:34:59+0000 [cowrie.ssh_proxy.server_transport.FrontendSSHTransport#debug] kex alg=b'curve25519-sha256' key alg=b'ssh-ed25519'
cowrie-1     | 2025-12-05T10:34:59+0000 [cowrie.ssh_proxy.server_transport.FrontendSSHTransport#debug] outgoing: b'aes128-ctr' b'hmac-sha2-256' b'none'
cowrie-1     | 2025-12-05T10:34:59+0000 [cowrie.ssh_proxy.server_transport.FrontendSSHTransport#debug] incoming: b'aes128-ctr' b'hmac-sha2-256' b'none'
cowrie-1     | 2025-12-05T10:34:59+0000 [Uninitialized] Connected to SSH backend at 172.27.0.2
cowrie-1     | 2025-12-05T10:34:59+0000 [FrontendSSHTransport,0,172.27.0.1] Connected to honeypot backend 172.27.0.2:2222 from 172.27.0.3:51698                     <--- New addition
...
cowrie-1     | 2025-12-05T10:35:02+0000 [FrontendSSHTransport,0,172.27.0.1] CMD: exit
ssh-backend  | Attempt to write login records by non-root user (aborting)
cowrie-1     | 2025-12-05T10:35:02+0000 [BackendSSHTransport,client] Unhandled SSH packet: 96
cowrie-1     | 2025-12-05T10:35:02+0000 [BackendSSHTransport,client] exitCode: 0
cowrie-1     | 2025-12-05T10:35:02+0000 [FrontendSSHTransport,0,172.27.0.1] remote close
ssh-backend  | Received disconnect from 172.27.0.3 port 51698:11: disconnected by user
cowrie-1     | 2025-12-05T10:35:02+0000 [FrontendSSHTransport,0,172.27.0.1] Closing TTY Log: var/lib/cowrie/tty/661fc19e8a98f4d51125cd07fa3ec0cdbecf81cc247b5a26cce905204b0a70bd after 1 seconds
ssh-backend  | Disconnected from user admin 172.27.0.3 port 51698
cowrie-1     | 2025-12-05T10:35:02+0000 [FrontendSSHTransport,0,172.27.0.1] Unhandled SSH packet: 1
cowrie-1     | 2025-12-05T10:35:02+0000 [FrontendSSHTransport,0,172.27.0.1] Disconnected from honeypot backend 172.27.0.2:2222 from 172.27.0.3:51698        <--- New addition
cowrie-1     | 2025-12-05T10:35:02+0000 [cowrie.ssh_proxy.server_transport.FrontendSSHTransport#info] connection lost
cowrie-1     | 2025-12-05T10:35:02+0000 [FrontendSSHTransport,0,172.27.0.1] Connection lost after 3 seconds
cowrie-1     | 2025-12-05T10:35:02+0000 [BackendSSHTransport,client] Lost connection with the proxy's backend: 172.27.0.2:2222
cowrie-1     | 2025-12-05T10:35:02+0000 [cowrie.ssh_proxy.client_transport.BackendSSHFactory#info] Stopping factory <cowrie.ssh_proxy.client_transport.BackendSSHFactory object at 0x7fa80ff6a790>
```