### PR TITLE
Fix error on fs tab completion for non-existing dirs

### DIFF
--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -563,6 +563,9 @@ class HoneyPotShell:
         except Exception:
             return
 
+        if not self.protocol.fs.exists(r):
+            return
+
         files = []
         for x in self.protocol.fs.get_path(r):
             if clue == "":


### PR DESCRIPTION
Cowrie throws an unhandled error when attempting to tab complete a directory that does not exist.

## Summary of Changes

Adds an additional check to see if the directory exists before returning the file systems objects in that directory.

Changes have been tested locally and no longer cause a disconnect.

Fixes #2834