### PR TITLE
fix: resolve variable/method shadowing bugs

### DIFF
--- a/src/cowrie/commands/iptables.py
+++ b/src/cowrie/commands/iptables.py
@@ -180,7 +180,7 @@ class Command_iptables(HoneyPotCommand):
             self.flush("" if opts.flush else opts.flush)
             return
         elif opts.list:
-            self.list("" if opts.list else opts.list)
+            self.list_chains("" if opts.list else opts.list)
             return
         elif opts.list_rules:
             self.list_rules("" if opts.list_rules else opts.list_rules)
@@ -375,7 +375,7 @@ Options:
         else:
             self.no_permission()
 
-    def list(self, chain: str) -> None:
+    def list_chains(self, chain: str) -> None:
         """
         List current rules
         """

--- a/src/cowrie/output/xmpp.py
+++ b/src/cowrie/output/xmpp.py
@@ -67,9 +67,9 @@ class Output(cowrie.core.output.Output):
         password = CowrieConfig.get("output_xmpp", "password")
         muc = CowrieConfig.get("output_xmpp", "muc")
         resource = "".join([choice(string.ascii_letters) for i in range(8)])
-        jid = user + "/" + resource
+        jidstr = user + "/" + resource
         application = service.Application("honeypot")
-        self.run(application, jid, password, JID(None, [muc, server, None]), server)
+        self.run(application, jidstr, password, JID(None, [muc, server, None]), server)
 
     def run(self, application, jidstr, password, muc, server):
         self.xmppclient = XMPPClient(JID(jidstr), password)


### PR DESCRIPTION
## Summary
- **xmpp.py**: Renamed local variable `jid` to `jidstr` to avoid shadowing the imported `jid` module. Line 78 was calling `jid.parse()` on a string instead of the module.
- **iptables.py**: Renamed method `list()` to `list_chains()` to avoid shadowing the builtin `list`. Line 391 would have recursed infinitely instead of calling the builtin `list()`.

Found via `ty` type checker output.

## Test plan
- [x] Verified Python syntax is valid
- [x] Verified iptables module imports successfully