### PR TITLE
fix: chmod --help and --version were broken

### DIFF
--- a/src/cowrie/commands/chmod.py
+++ b/src/cowrie/commands/chmod.py
@@ -57,7 +57,7 @@ class Command_chmod(HoneyPotCommand):
             return
 
         # if --help or --version is present, we don't care about the rest
-        for o in opts:
+        for o, _ in opts:
             if o == "--help":
                 self.errorWrite(CHMOD_HELP)
                 return


### PR DESCRIPTION
## Summary
- Fixed `chmod --help` and `chmod --version` which were silently broken

`getopt.gnu_getopt()` returns a list of tuples like `[('--help', '')]`, but the code was comparing the tuple directly to a string:

```python
for o in opts:
    if o == "--help":  # Always False - comparing tuple to string
```

Changed to unpack the tuple properly:

```python
for o, _ in opts:
    if o == "--help":  # Now works
```

Found via pyright `reportUnnecessaryComparison` warning.

## Test plan
- [x] Verified module imports successfully