### PR TITLE
test: add SSH proxy smoke tests

### DIFF
--- a/src/cowrie/test/test_proxy.py
+++ b/src/cowrie/test/test_proxy.py
@@ -13,9 +13,9 @@ from cowrie.shell.realm import HoneyPotRealm
 from cowrie.ssh.factory import CowrieSSHFactory
 
 from twisted.cred import portal
-from twisted.internet import reactor
+from twisted.internet import defer, reactor
 
-# from cowrie.test.proxy_compare import ProxyTestCommand
+from backend_pool.ssh_exec import execute_ssh
 
 os.environ["COWRIE_HONEYPOT_TTYLOG"] = "false"
 os.environ["COWRIE_OUTPUT_JSONLOG_ENABLED"] = "false"
@@ -26,80 +26,132 @@ def create_ssh_factory(backend):
     factory.portal = portal.Portal(HoneyPotRealm())
     factory.portal.registerChecker(HoneypotPublicKeyChecker())
     factory.portal.registerChecker(HoneypotPasswordChecker())
-    # factory.portal.registerChecker(HoneypotNoneChecker())
 
     return factory
 
 
-# def create_telnet_factory(backend):
-#     factory = HoneyPotTelnetFactory(backend, None)
-#     factory.portal = portal.Portal(HoneyPotRealm())
-#     factory.portal.registerChecker(HoneypotPasswordChecker())
-#
-#     return factory
-
-
-class ProxyTests(unittest.TestCase):
+class ProxySSHSmokeTests(unittest.TestCase):
     """
-    How to test the proxy:
-        - setUp runs a 'shell' backend on 4444; then set up a 'proxy' on port 5555 connected to the 'shell' backend
-        - test_ssh_proxy runs an exec command via a client against both proxy and shell; returns a deferred
-        - the deferred succeeds if the output from both is the same
+    Smoke tests for SSH proxy functionality.
+
+    Tests that the proxy can forward SSH exec commands to the shell backend
+    and return correct output.
     """
 
     HOST = "127.0.0.1"
-
     PORT_BACKEND_SSH = 4444
     PORT_PROXY_SSH = 5555
-    PORT_BACKEND_TELNET = 4445
-    PORT_PROXY_TELNET = 5556
 
-    USERNAME_BACKEND = "root"
-    PASSWORD_BACKEND = "example"
+    USERNAME = "root"
+    PASSWORD = "example"
 
-    USERNAME_PROXY = "root"
-    PASSWORD_PROXY = "example"
-
-    def setUp(self):
-        # ################################################# #
-        # #################### Backend #################### #
-        # ################################################# #
-        # setup SSH backend
-        self.factory_shell_ssh = create_ssh_factory("shell")
-        self.shell_server_ssh = reactor.listenTCP(
-            self.PORT_BACKEND_SSH, self.factory_shell_ssh
-        )
-
-        # ################################################# #
-        # #################### Proxy ###################### #
-        # ################################################# #
-        # setup proxy environment
+    @classmethod
+    def setUpClass(cls):
+        # Setup proxy environment before creating factories
         os.environ["COWRIE_PROXY_BACKEND"] = "simple"
-        os.environ["COWRIE_PROXY_BACKEND_SSH_HOST"] = self.HOST
-        os.environ["COWRIE_PROXY_BACKEND_SSH_PORT"] = str(self.PORT_BACKEND_SSH)
-        os.environ["COWRIE_PROXY_BACKEND_TELNET_HOST"] = self.HOST
-        os.environ["COWRIE_PROXY_BACKEND_TELNET_PORT"] = str(self.PORT_BACKEND_TELNET)
+        os.environ["COWRIE_PROXY_BACKEND_SSH_HOST"] = cls.HOST
+        os.environ["COWRIE_PROXY_BACKEND_SSH_PORT"] = str(cls.PORT_BACKEND_SSH)
 
-        # setup SSH proxy
-        self.factory_proxy_ssh = create_ssh_factory("proxy")
-        self.proxy_server_ssh = reactor.listenTCP(
-            self.PORT_PROXY_SSH, self.factory_proxy_ssh
+        # Setup SSH shell backend
+        cls.factory_shell_ssh = create_ssh_factory("shell")
+        cls.shell_server_ssh = reactor.listenTCP(
+            cls.PORT_BACKEND_SSH, cls.factory_shell_ssh
         )
 
-    # def test_ls(self):
-    #     command_tester = ProxyTestCommand('ssh', self.HOST, self.PORT_BACKEND_SSH, self.PORT_PROXY_SSH,
-    #                                       self.USERNAME_BACKEND, self.PASSWORD_BACKEND,
-    #                                       self.USERNAME_PROXY, self.PASSWORD_PROXY)
-    #
-    #     return command_tester.execute_both('ls -halt')
+        # Setup SSH proxy pointing to backend
+        cls.factory_proxy_ssh = create_ssh_factory("proxy")
+        cls.proxy_server_ssh = reactor.listenTCP(
+            cls.PORT_PROXY_SSH, cls.factory_proxy_ssh
+        )
 
-    def tearDown(self):
-        for client in self.factory_proxy_ssh.running:
-            if client.transport:
-                client.transport.loseConnection()
+    @classmethod
+    def tearDownClass(cls):
+        cls.proxy_server_ssh.stopListening()
+        cls.shell_server_ssh.stopListening()
 
-        self.proxy_server_ssh.stopListening()
-        self.shell_server_ssh.stopListening()
+        cls.factory_shell_ssh.stopFactory()
+        cls.factory_proxy_ssh.stopFactory()
 
-        self.factory_shell_ssh.stopFactory()
-        self.factory_proxy_ssh.stopFactory()
+    def test_proxy_whoami(self):
+        """Test that 'whoami' command works through proxy."""
+        d = execute_ssh(
+            self.HOST,
+            self.PORT_PROXY_SSH,
+            self.USERNAME,
+            self.PASSWORD,
+            b"whoami",
+        )
+
+        def check_result(data):
+            self.assertIn(b"root", data)
+
+        d.addCallback(check_result)
+        return d
+
+    def test_proxy_echo(self):
+        """Test that 'echo' command works through proxy."""
+        d = execute_ssh(
+            self.HOST,
+            self.PORT_PROXY_SSH,
+            self.USERNAME,
+            self.PASSWORD,
+            b"echo hello",
+        )
+
+        def check_result(data):
+            self.assertIn(b"hello", data)
+
+        d.addCallback(check_result)
+        return d
+
+    def test_proxy_id(self):
+        """Test that 'id' command works through proxy."""
+        d = execute_ssh(
+            self.HOST,
+            self.PORT_PROXY_SSH,
+            self.USERNAME,
+            self.PASSWORD,
+            b"id",
+        )
+
+        def check_result(data):
+            self.assertIn(b"uid=0(root)", data)
+
+        d.addCallback(check_result)
+        return d
+
+    def test_proxy_matches_backend(self):
+        """Test that proxy output matches direct backend output."""
+        results = {"backend": None, "proxy": None}
+
+        def store_backend(data):
+            results["backend"] = data
+
+        def store_proxy(data):
+            results["proxy"] = data
+
+        d_backend = execute_ssh(
+            self.HOST,
+            self.PORT_BACKEND_SSH,
+            self.USERNAME,
+            self.PASSWORD,
+            b"uname -a",
+        )
+        d_backend.addCallback(store_backend)
+
+        d_proxy = execute_ssh(
+            self.HOST,
+            self.PORT_PROXY_SSH,
+            self.USERNAME,
+            self.PASSWORD,
+            b"uname -a",
+        )
+        d_proxy.addCallback(store_proxy)
+
+        d = defer.DeferredList([d_backend, d_proxy])
+
+        def compare_results(_):
+            self.assertEqual(results["backend"], results["proxy"])
+
+        d.addCallback(compare_results)
+        return d


### PR DESCRIPTION
## Summary
- Add working smoke tests for simple proxy functionality
- Tests verify SSH exec commands work correctly through the proxy
- Replaces commented-out test code with 4 actual tests

## Tests added
| Test | Description |
|------|-------------|
| `test_proxy_whoami` | Verify `whoami` works through proxy |
| `test_proxy_echo` | Verify `echo` command works through proxy |
| `test_proxy_id` | Verify `id` command works through proxy |
| `test_proxy_matches_backend` | Verify proxy output matches direct backend |

## Test plan
- [x] All 181 tests pass locally
- [x] Ruff and mypy clean