### PR TITLE
fix: playlog now shows output for exec sessions

### DIFF
--- a/src/cowrie/scripts/playlog.py
+++ b/src/cowrie/scripts/playlog.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# ABOUTME: CLI utility to replay TTY log files recorded by Cowrie.
+# ABOUTME: Supports playback speed control, input/output filtering, and colorization.
 #
 # Copyright (C) 2003-2011 Upi Tamminen <desaster@dragonlight.fi>
 #
@@ -40,7 +42,8 @@ def playlog(fd, settings):
 
         if str(tty) == str(currtty) and op == OP_WRITE:
             # the first stream seen is considered 'output'
-            if prefdir == 0:
+            # TYPE_INTERACT is for exec commands, don't use it to set prefdir
+            if prefdir == 0 and direction != TYPE_INTERACT:
                 prefdir = direction
                 # use the other direction
                 if settings["input_only"]:
@@ -51,7 +54,12 @@ def playlog(fd, settings):
                 color = b"\033[36m"
             elif direction == TYPE_INPUT:
                 color = b"\033[33m"
-            if direction == prefdir or settings["both_dirs"]:
+            # TYPE_INTERACT (exec command) is always shown
+            if (
+                direction == prefdir
+                or direction == TYPE_INTERACT
+                or settings["both_dirs"]
+            ):
                 curtime = float(sec) + float(usec) / 1000000
                 if prevtime != 0:
                     sleeptime = curtime - prevtime


### PR DESCRIPTION
## Summary
- Fixes playlog not showing command output for SSH exec sessions
- The exec command itself (TYPE_INTERACT) is now always displayed

## Problem
For SSH exec sessions, the first ttylog entry is `TYPE_INTERACT` (the executed command). The `playlog` utility was using this to set `prefdir` (preferred direction), which meant subsequent `TYPE_OUTPUT` entries didn't match and were skipped.

## Changes
- Don't use `TYPE_INTERACT` to set `prefdir` - only `TYPE_INPUT` or `TYPE_OUTPUT` should determine the preferred stream
- Always show `TYPE_INTERACT` entries (the exec command itself is useful context)

## Test plan
- [x] Run `playlog` on an exec session ttylog - output now displays
- [x] Run `playlog -b` - still works (shows both streams)
- [x] Run `playlog` on interactive session - still works as before

Fixes #2833