### PR TITLE
fix: SSRF protection bypass in ftpget, tftp, and nc commands

### DIFF
--- a/src/cowrie/commands/apt.py
+++ b/src/cowrie/commands/apt.py
@@ -38,18 +38,19 @@ class Command_aptget(HoneyPotCommand):
 
     packages: dict[str, dict[str, Any]]
 
-    def start(self) -> None:
+    @inlineCallbacks
+    def start(self):
+        self.packages = {}
         if len(self.args) == 0:
             self.do_help()
         elif self.args[0] == "-v":
             self.do_version()
         elif self.args[0] == "install":
-            self.do_install()
+            yield self.do_install()
         elif self.args[0] == "moo":
             self.do_moo()
         else:
             self.do_locked()
-        self.packages = {}
 
     def sleep(self, time: float, time2: float | None = None) -> defer.Deferred:
         d: defer.Deferred = defer.Deferred()

--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -7,6 +7,7 @@ import os
 from typing import TYPE_CHECKING
 
 from twisted.internet import defer, reactor
+from twisted.internet.defer import inlineCallbacks
 from twisted.internet.protocol import ClientCreator, Protocol
 from twisted.protocols.ftp import CommandFailed, FTPClient
 from twisted.python import log
@@ -72,7 +73,8 @@ Download a file via FTP
     -P NUM      Port\n\n"""
         )
 
-    def start(self) -> None:
+    @inlineCallbacks
+    def start(self):
         try:
             optlist, args = getopt.getopt(self.args, "cvu:p:P:")
         except getopt.GetoptError:
@@ -125,7 +127,8 @@ Download a file via FTP
             self.exit()
             return
 
-        if not communication_allowed(self.host):
+        allowed = yield communication_allowed(self.host)
+        if not allowed:
             self.exit()
             return
 

--- a/src/cowrie/commands/nc.py
+++ b/src/cowrie/commands/nc.py
@@ -3,6 +3,8 @@ import getopt
 import socket
 import struct
 
+from twisted.internet.defer import inlineCallbacks
+
 from cowrie.core.config import CowrieConfig
 from cowrie.core.network import communication_allowed, is_valid_port
 from cowrie.core.rate_limiter import RateLimiter
@@ -113,6 +115,7 @@ class Command_nc(HoneyPotCommand):
         self.errorWrite("\t\t-z\t\tZero-I/O mode [used for scanning]\n")
         self.errorWrite("\tPort numbers can be individual or ranges: lo-hi [inclusive]\n")
 
+    @inlineCallbacks
     def start(self):
         try:
             _optlist, args = getopt.getopt(
@@ -214,7 +217,7 @@ class Command_nc(HoneyPotCommand):
             self.exit()
             return
 
-        allowed = communication_allowed(host)
+        allowed = yield communication_allowed(host)
         if not allowed:
             log.msg(f"nc: blocked connection attempt to {host} (private/reserved IP range)")
             self.exit()

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -4,7 +4,7 @@ import struct
 from typing import TYPE_CHECKING, Any
 
 from twisted.internet import defer, reactor
-from twisted.internet.defer import CancelledError
+from twisted.internet.defer import CancelledError, inlineCallbacks
 from twisted.internet.protocol import DatagramProtocol
 from twisted.python import log
 
@@ -211,7 +211,8 @@ class Command_tftp(HoneyPotCommand):
     fakeoutfile: str
     udp_port: Any | None = None
 
-    def start(self) -> None:
+    @inlineCallbacks
+    def start(self):
         parser = CustomParser(self)
         parser.prog = "tftp"
         parser.add_argument("hostname", nargs="?", default=None)
@@ -258,7 +259,8 @@ class Command_tftp(HoneyPotCommand):
             self.port = int(port_str)
 
         # Check if communication is allowed
-        if not communication_allowed(self.hostname):
+        allowed = yield communication_allowed(self.hostname)
+        if not allowed:
             self.exit()
             return
 

--- a/src/cowrie/commands/yum.py
+++ b/src/cowrie/commands/yum.py
@@ -45,16 +45,17 @@ class Command_yum(HoneyPotCommand):
 
     packages: dict[str, dict[str, Any]]
 
-    def start(self) -> None:
+    @inlineCallbacks
+    def start(self):
+        self.packages = {}
         if len(self.args) == 0:
-            self.do_help()
+            yield self.do_help()
         elif self.args[0] == "version":
-            self.do_version()
+            yield self.do_version()
         elif self.args[0] == "install":
-            self.do_install()
+            yield self.do_install()
         else:
             self.do_locked()
-        self.packages = {}
 
     def sleep(self, time: float, time2: float | None = None) -> defer.Deferred:
         d: defer.Deferred = defer.Deferred()


### PR DESCRIPTION
## Summary

- Fix critical SSRF protection bypass in `ftpget`, `tftp`, and `nc` commands (GHSA-fvqj-x2cr-pww3)
- Fix related async bugs in `apt` and `yum` commands

## Details

The `communication_allowed()` function in `core/network.py` is decorated with `@inlineCallbacks`, returning a Generator/Deferred rather than a boolean directly. The affected commands were calling this function without `yield`, causing the security check to be completely bypassed:

```python
# Before (VULNERABLE) - Generator is always truthy, so `not <Generator>` is always False
if not communication_allowed(self.host):
    self.exit()
    return

# After (FIXED)
allowed = yield communication_allowed(self.host)
if not allowed:
    self.exit()
    return
```

### Security Impact (GHSA-fvqj-x2cr-pww3)

Attackers could use the honeypot to access:
- Cloud metadata endpoints (169.254.169.254) - AWS/GCP/Azure credential theft
- Internal networks (10.x, 172.16.x, 192.168.x)
- Localhost services (127.0.0.1)

### Additional Fixes

Also fixed the same pattern in `apt.py` and `yum.py` where `@inlineCallbacks` methods (`do_help`, `do_version`, `do_install`) were called without `yield`, causing command execution to halt at the first internal yield.

## Test plan

- [x] All 236 existing tests pass
- [ ] Manual verification that blocked IPs are now properly rejected