### PR TITLE
fix: pin cosign to v2.4.1 for Docker Hub compatibility

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -167,6 +167,8 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.0.0
+        with:
+          cosign-release: 'v2.4.1'
 
       - name: Sign the images with GitHub OIDC Token
         env:


### PR DESCRIPTION
## Summary

Pin cosign to v2.4.1 to fix Docker image signing verification failures.

**Root cause:** PR #2779 bumped `cosign-installer` from v3.10.0 to v4.0.0, which installs cosign v3.x by default. Cosign v3 stores signatures using OCI 1.1 referrers API, but Docker Hub only supports OCI 1.0.1.

**Result:** Signing appears to succeed but verification fails with "no signatures found".

**Fix:** Pin to cosign v2.4.1 which uses tag-based signature storage.

## Test plan

- [ ] Verify Docker Build and Publish workflow succeeds after merge