### PR TITLE
fix: wget saves files to cwd instead of root

### DIFF
--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -251,6 +251,7 @@ class Command_wget(HoneyPotCommand):
             self.outfile = urldata.path.split("/")[-1]
             if not len(self.outfile.strip()) or not urldata.path.count("/"):
                 self.outfile = "index.html"
+            self.outfile = self.fs.resolve_path(self.outfile, self.protocol.cwd)
 
         elif self.outfile != "-":
             self.outfile = self.fs.resolve_path(self.outfile, self.protocol.cwd)


### PR DESCRIPTION
## Summary
- When wget downloads a file without `-O` option, resolve the auto-generated filename against the current working directory

Fixes #2874

## Test plan
- Run `cd /root && wget https://example.com/file.txt` in the honeypot
- Verify file appears in `/root/file.txt` instead of `/file.txt`