### PR TITLE
fix(docs): handle PackageNotFoundError in conf.py and fix RST title l…

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -292,7 +292,7 @@ The post-login banner can be customized by editing ``honeyfs/etc/motd``.
 
 
 Local testing with SSH
-----------------------
+**********************
 
 After starting Cowrie locally, you can test it by connecting via SSH.
 


### PR DESCRIPTION
…evel

The docs build was failing because conf.py tried to get the package version from importlib.metadata, but failed when cowrie wasn't installed. This adds a fallback to read from cowrie._version instead.

Also fixes INSTALL.rst inconsistent title style that was causing Sphinx to fail when building with -W flag.