### PR TITLE
Add CVE-2026-24061 exploit detection for telnet NEW-ENVIRON option

### DIFF
--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -153,7 +153,7 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
             option_byte=option_byte,
         )
         # Call parent implementation
-        return TelnetTransport.telnet_WILL(self, option)
+        TelnetTransport.telnet_WILL(self, option)
 
     def telnet_WONT(self, option: bytes) -> None:
         """
@@ -168,7 +168,7 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
             option_name=option_name,
             option_byte=option_byte,
         )
-        return TelnetTransport.telnet_WONT(self, option)
+        TelnetTransport.telnet_WONT(self, option)
 
     def telnet_DO(self, option: bytes) -> None:
         """
@@ -183,7 +183,7 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
             option_name=option_name,
             option_byte=option_byte,
         )
-        return TelnetTransport.telnet_DO(self, option)
+        TelnetTransport.telnet_DO(self, option)
 
     def telnet_DONT(self, option: bytes) -> None:
         """
@@ -198,4 +198,4 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
             option_name=option_name,
             option_byte=option_byte,
         )
-        return TelnetTransport.telnet_DONT(self, option)
+        TelnetTransport.telnet_DONT(self, option)

--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -18,6 +18,24 @@ from twisted.python import failure, log
 
 from cowrie.core.config import CowrieConfig
 
+# Telnet option names for logging (RFC 854, RFC 855, RFC 1572, etc.)
+TELNET_OPTIONS: dict[int, str] = {
+    0: "BINARY",
+    1: "ECHO",
+    3: "SGA",
+    5: "STATUS",
+    6: "TIMING-MARK",
+    24: "TERMINAL-TYPE",
+    31: "NAWS",
+    32: "TERMINAL-SPEED",
+    33: "REMOTE-FLOW-CONTROL",
+    34: "LINEMODE",
+    35: "X-DISPLAY-LOCATION",
+    36: "ENVIRON",
+    39: "NEW-ENVIRON",
+    255: "EXOPL",
+}
+
 
 class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
     """
@@ -112,3 +130,72 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
 
     def _chainNegotiation(self, res, func, option):
         return func(option).addErrback(self._handleNegotiationError, func, option)
+
+    def _get_option_name(self, option: bytes) -> str:
+        """Get human-readable name for a telnet option byte."""
+        if option:
+            option_byte = option[0] if isinstance(option, bytes) else option
+            return TELNET_OPTIONS.get(option_byte, f"UNKNOWN-{option_byte}")
+        return "UNKNOWN"
+
+    def telnet_WILL(self, option: bytes) -> None:
+        """
+        Client indicates willingness to enable an option.
+        Log for security monitoring and CVE detection.
+        """
+        option_name = self._get_option_name(option)
+        option_byte = option[0] if option else 0
+        log.msg(
+            eventid="cowrie.telnet.option",
+            format="Telnet WILL %(option_name)s",
+            command="WILL",
+            option_name=option_name,
+            option_byte=option_byte,
+        )
+        # Call parent implementation
+        return TelnetTransport.telnet_WILL(self, option)
+
+    def telnet_WONT(self, option: bytes) -> None:
+        """
+        Client refuses to enable an option.
+        """
+        option_name = self._get_option_name(option)
+        option_byte = option[0] if option else 0
+        log.msg(
+            eventid="cowrie.telnet.option",
+            format="Telnet WONT %(option_name)s",
+            command="WONT",
+            option_name=option_name,
+            option_byte=option_byte,
+        )
+        return TelnetTransport.telnet_WONT(self, option)
+
+    def telnet_DO(self, option: bytes) -> None:
+        """
+        Client requests that we enable an option.
+        """
+        option_name = self._get_option_name(option)
+        option_byte = option[0] if option else 0
+        log.msg(
+            eventid="cowrie.telnet.option",
+            format="Telnet DO %(option_name)s",
+            command="DO",
+            option_name=option_name,
+            option_byte=option_byte,
+        )
+        return TelnetTransport.telnet_DO(self, option)
+
+    def telnet_DONT(self, option: bytes) -> None:
+        """
+        Client requests that we disable an option.
+        """
+        option_name = self._get_option_name(option)
+        option_byte = option[0] if option else 0
+        log.msg(
+            eventid="cowrie.telnet.option",
+            format="Telnet DONT %(option_name)s",
+            command="DONT",
+            option_name=option_name,
+            option_byte=option_byte,
+        )
+        return TelnetTransport.telnet_DONT(self, option)

--- a/src/cowrie/telnet/userauth.py
+++ b/src/cowrie/telnet/userauth.py
@@ -24,6 +24,21 @@ from twisted.python import failure, log
 from cowrie.core.config import CowrieConfig
 from cowrie.core.credentials import UsernamePasswordIP
 
+# NEW-ENVIRON telnet option (RFC 1572)
+# Used for environment variable exchange and targeted by CVE-2026-24061
+NEW_ENVIRON = bytes([39])  # 0x27
+
+# NEW-ENVIRON subnegotiation command bytes
+NEW_ENVIRON_IS = 0  # Sender is supplying value
+NEW_ENVIRON_SEND = 1  # Sender requests receiver send value
+NEW_ENVIRON_INFO = 2  # Sender is supplying updated value
+
+# NEW-ENVIRON variable type bytes
+NEW_ENVIRON_VAR = 0  # Well-known variable name follows
+NEW_ENVIRON_VALUE = 1  # Variable value follows
+NEW_ENVIRON_ESC = 2  # Escape byte for literal VAR/VALUE/USERVAR bytes in data
+NEW_ENVIRON_USERVAR = 3  # User-defined variable name follows
+
 
 class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
     """
@@ -40,6 +55,12 @@ class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
         # Initial option negotation. Want something at least for Mirai
         # for opt in (NAWS,):
         #    self.transport.doChain(opt).addErrback(log.err)
+
+        # Register NEW-ENVIRON subnegotiation handler for CVE-2026-24061 detection
+        self.transport.negotiationMap[NEW_ENVIRON] = self.telnet_NEW_ENVIRON
+
+        # Store received environment variables
+        self.environ_received: dict[str, str] = {}
 
         # I need to doubly escape here since my underlying
         # CowrieTelnetTransport hack would remove it and leave just \n
@@ -131,6 +152,117 @@ class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
         else:
             log.msg("Wrong number of NAWS bytes")
 
+    def telnet_NEW_ENVIRON(self, data: list[bytes]) -> None:
+        """
+        Handle NEW-ENVIRON (RFC 1572) subnegotiation.
+
+        Parses environment variables sent by the client and logs them.
+        Also detects CVE-2026-24061 exploit attempts where USER=-f root
+        is used to bypass authentication in vulnerable telnetd implementations.
+
+        Subnegotiation format:
+            IS/SEND/INFO [VAR name VALUE value]* [USERVAR name VALUE value]*
+        """
+        if not data:
+            return
+
+        # Join the data bytes
+        raw_data = b"".join(data)
+        if len(raw_data) < 1:
+            return
+
+        command = raw_data[0]
+
+        # We only care about IS (0) and INFO (2) - client sending values
+        if command not in (NEW_ENVIRON_IS, NEW_ENVIRON_INFO):
+            return
+
+        # Parse the environment variables
+        env_vars = self._parse_new_environ_data(raw_data[1:])
+
+        # Log each environment variable
+        for name, value in env_vars.items():
+            # Store for potential later use
+            self.environ_received[name] = value
+
+            # Log the environment variable (matches SSH cowrie.client.var pattern)
+            log.msg(
+                eventid="cowrie.client.var",
+                format="Telnet NEW-ENVIRON: %(name)s=%(value)s",
+                name=name,
+                value=value,
+            )
+
+            # CVE-2026-24061 detection: USER environment variable with -f flag
+            # This exploit bypasses authentication in GNU inetutils telnetd <= 2.7
+            if name.upper() == "USER" and value.startswith("-f"):
+                log.msg(
+                    eventid="cowrie.telnet.exploit_attempt",
+                    format="CVE-2026-24061 exploit attempt detected: USER=%(value)s",
+                    cve="CVE-2026-24061",
+                    name=name,
+                    value=value,
+                )
+
+    def _parse_new_environ_data(self, data: bytes) -> dict[str, str]:
+        """
+        Parse NEW-ENVIRON subnegotiation data into a dictionary.
+
+        Format: [VAR|USERVAR name VALUE value]* with ESC for escaping.
+        """
+        env_vars: dict[str, str] = {}
+        if not data:
+            return env_vars
+
+        i = 0
+        current_name: list[int] = []
+        current_value: list[int] = []
+        in_value = False
+        escape_next = False
+
+        while i < len(data):
+            byte = data[i]
+
+            if escape_next:
+                # Previous byte was ESC, treat this byte as literal
+                if in_value:
+                    current_value.append(byte)
+                else:
+                    current_name.append(byte)
+                escape_next = False
+            elif byte == NEW_ENVIRON_ESC:
+                # Next byte is escaped
+                escape_next = True
+            elif byte == NEW_ENVIRON_VAR or byte == NEW_ENVIRON_USERVAR:
+                # Save previous variable if any
+                if current_name:
+                    name = bytes(current_name).decode("utf-8", errors="replace")
+                    value = bytes(current_value).decode("utf-8", errors="replace")
+                    env_vars[name] = value
+                # Start new variable
+                current_name = []
+                current_value = []
+                in_value = False
+            elif byte == NEW_ENVIRON_VALUE:
+                # Switch from name to value
+                in_value = True
+            else:
+                # Regular data byte
+                if in_value:
+                    current_value.append(byte)
+                else:
+                    current_name.append(byte)
+
+            i += 1
+
+        # Don't forget the last variable
+        if current_name:
+            name = bytes(current_name).decode("utf-8", errors="replace")
+            value = bytes(current_value).decode("utf-8", errors="replace")
+            env_vars[name] = value
+
+        return env_vars
+
     def enableLocal(self, option: bytes) -> bool:
         if option == ECHO:
             return True
@@ -147,6 +279,10 @@ class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
         elif option == NAWS:
             return True
         elif option == SGA:
+            return True
+        elif option == NEW_ENVIRON:
+            # Accept NEW-ENVIRON to capture environment variables
+            # This enables detection of CVE-2026-24061 exploit attempts
             return True
         else:
             return False

--- a/src/cowrie/test/test_telnet_new_environ.py
+++ b/src/cowrie/test/test_telnet_new_environ.py
@@ -1,0 +1,291 @@
+# Copyright (C) 2026 Anthropic
+"""
+Tests for telnet NEW-ENVIRON option parsing and CVE-2026-24061 detection.
+
+CVE-2026-24061 is a critical authentication bypass in GNU inetutils telnetd
+that exploits the USER environment variable via NEW-ENVIRON telnet option.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from cowrie.telnet.userauth import (
+    NEW_ENVIRON,
+    NEW_ENVIRON_ESC,
+    NEW_ENVIRON_INFO,
+    NEW_ENVIRON_IS,
+    NEW_ENVIRON_USERVAR,
+    NEW_ENVIRON_VALUE,
+    NEW_ENVIRON_VAR,
+    HoneyPotTelnetAuthProtocol,
+)
+from cowrie.telnet.transport import TELNET_OPTIONS, CowrieTelnetTransport
+
+
+class TestNewEnvironParser(unittest.TestCase):
+    """Tests for NEW-ENVIRON subnegotiation parsing."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        # Create protocol with mocked portal
+        mock_portal = MagicMock()
+        self.protocol = HoneyPotTelnetAuthProtocol(mock_portal)
+        self.protocol.environ_received = {}
+
+    def test_parse_single_var(self) -> None:
+        """Test parsing a single VAR name/value pair."""
+        # Format: VAR 'U' 'S' 'E' 'R' VALUE 'r' 'o' 'o' 't'
+        data = bytes([NEW_ENVIRON_VAR]) + b"USER" + bytes([NEW_ENVIRON_VALUE]) + b"root"
+        result = self.protocol._parse_new_environ_data(data)
+        self.assertEqual(result, {"USER": "root"})
+
+    def test_parse_multiple_vars(self) -> None:
+        """Test parsing multiple environment variables."""
+        # VAR USER VALUE root VAR TERM VALUE xterm
+        data = (
+            bytes([NEW_ENVIRON_VAR])
+            + b"USER"
+            + bytes([NEW_ENVIRON_VALUE])
+            + b"root"
+            + bytes([NEW_ENVIRON_VAR])
+            + b"TERM"
+            + bytes([NEW_ENVIRON_VALUE])
+            + b"xterm"
+        )
+        result = self.protocol._parse_new_environ_data(data)
+        self.assertEqual(result, {"USER": "root", "TERM": "xterm"})
+
+    def test_parse_uservar(self) -> None:
+        """Test parsing USERVAR (user-defined variable)."""
+        # USERVAR MYVAR VALUE myvalue
+        data = (
+            bytes([NEW_ENVIRON_USERVAR])
+            + b"MYVAR"
+            + bytes([NEW_ENVIRON_VALUE])
+            + b"myvalue"
+        )
+        result = self.protocol._parse_new_environ_data(data)
+        self.assertEqual(result, {"MYVAR": "myvalue"})
+
+    def test_parse_empty_value(self) -> None:
+        """Test parsing variable with empty value."""
+        # VAR USER VALUE (empty)
+        data = bytes([NEW_ENVIRON_VAR]) + b"USER" + bytes([NEW_ENVIRON_VALUE])
+        result = self.protocol._parse_new_environ_data(data)
+        self.assertEqual(result, {"USER": ""})
+
+    def test_parse_escape_sequence(self) -> None:
+        """Test parsing with escape sequences for literal special bytes."""
+        # VAR TEST VALUE with ESC 0x00 (literal VAR byte) in value
+        data = (
+            bytes([NEW_ENVIRON_VAR])
+            + b"TEST"
+            + bytes([NEW_ENVIRON_VALUE])
+            + b"before"
+            + bytes([NEW_ENVIRON_ESC, NEW_ENVIRON_VAR])  # Escaped VAR byte
+            + b"after"
+        )
+        result = self.protocol._parse_new_environ_data(data)
+        # The VALUE byte (0x00) should be literal in the value
+        self.assertEqual(result["TEST"], "before\x00after")
+
+    def test_parse_empty_data(self) -> None:
+        """Test parsing empty data."""
+        result = self.protocol._parse_new_environ_data(b"")
+        self.assertEqual(result, {})
+
+    def test_parse_cve_2026_24061_payload(self) -> None:
+        """Test parsing the exact CVE-2026-24061 exploit payload."""
+        # VAR USER VALUE -f root
+        data = (
+            bytes([NEW_ENVIRON_VAR])
+            + b"USER"
+            + bytes([NEW_ENVIRON_VALUE])
+            + b"-f root"
+        )
+        result = self.protocol._parse_new_environ_data(data)
+        self.assertEqual(result, {"USER": "-f root"})
+
+    def test_parse_cve_2026_24061_variant_froot(self) -> None:
+        """Test parsing CVE-2026-24061 variant: -froot (no space)."""
+        data = (
+            bytes([NEW_ENVIRON_VAR]) + b"USER" + bytes([NEW_ENVIRON_VALUE]) + b"-froot"
+        )
+        result = self.protocol._parse_new_environ_data(data)
+        self.assertEqual(result, {"USER": "-froot"})
+
+
+class TestCVE2026_24061Detection(unittest.TestCase):
+    """Tests for CVE-2026-24061 exploit detection."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures with mocked transport and logging."""
+        mock_portal = MagicMock()
+        self.protocol = HoneyPotTelnetAuthProtocol(mock_portal)
+        self.protocol.environ_received = {}
+
+        # Mock the transport
+        self.protocol.transport = MagicMock()
+
+    @patch("cowrie.telnet.userauth.log")
+    def test_detect_exploit_f_root(self, mock_log: MagicMock) -> None:
+        """Test detection of USER=-f root exploit."""
+        # Simulate receiving IS VAR USER VALUE -f root
+        data = [
+            bytes([NEW_ENVIRON_IS]),
+            bytes([NEW_ENVIRON_VAR]),
+            *[bytes([c]) for c in b"USER"],
+            bytes([NEW_ENVIRON_VALUE]),
+            *[bytes([c]) for c in b"-f root"],
+        ]
+        self.protocol.telnet_NEW_ENVIRON(data)
+
+        # Check that exploit was detected
+        exploit_logged = False
+        for call in mock_log.msg.call_args_list:
+            if call[1].get("eventid") == "cowrie.telnet.exploit_attempt":
+                exploit_logged = True
+                self.assertEqual(call[1].get("cve"), "CVE-2026-24061")
+                self.assertEqual(call[1].get("value"), "-f root")
+                break
+        self.assertTrue(exploit_logged, "CVE-2026-24061 exploit should be detected")
+
+    @patch("cowrie.telnet.userauth.log")
+    def test_detect_exploit_froot_no_space(self, mock_log: MagicMock) -> None:
+        """Test detection of USER=-froot (no space) variant."""
+        data = [
+            bytes([NEW_ENVIRON_IS]),
+            bytes([NEW_ENVIRON_VAR]),
+            *[bytes([c]) for c in b"USER"],
+            bytes([NEW_ENVIRON_VALUE]),
+            *[bytes([c]) for c in b"-froot"],
+        ]
+        self.protocol.telnet_NEW_ENVIRON(data)
+
+        exploit_logged = False
+        for call in mock_log.msg.call_args_list:
+            if call[1].get("eventid") == "cowrie.telnet.exploit_attempt":
+                exploit_logged = True
+                self.assertEqual(call[1].get("cve"), "CVE-2026-24061")
+                break
+        self.assertTrue(exploit_logged, "CVE-2026-24061 variant should be detected")
+
+    @patch("cowrie.telnet.userauth.log")
+    def test_detect_exploit_lowercase_user(self, mock_log: MagicMock) -> None:
+        """Test detection with lowercase 'user' variable name."""
+        data = [
+            bytes([NEW_ENVIRON_IS]),
+            bytes([NEW_ENVIRON_VAR]),
+            *[bytes([c]) for c in b"user"],
+            bytes([NEW_ENVIRON_VALUE]),
+            *[bytes([c]) for c in b"-f root"],
+        ]
+        self.protocol.telnet_NEW_ENVIRON(data)
+
+        exploit_logged = False
+        for call in mock_log.msg.call_args_list:
+            if call[1].get("eventid") == "cowrie.telnet.exploit_attempt":
+                exploit_logged = True
+                break
+        self.assertTrue(exploit_logged, "Lowercase 'user' should also be detected")
+
+    @patch("cowrie.telnet.userauth.log")
+    def test_no_false_positive_normal_user(self, mock_log: MagicMock) -> None:
+        """Test that normal USER values don't trigger exploit detection."""
+        data = [
+            bytes([NEW_ENVIRON_IS]),
+            bytes([NEW_ENVIRON_VAR]),
+            *[bytes([c]) for c in b"USER"],
+            bytes([NEW_ENVIRON_VALUE]),
+            *[bytes([c]) for c in b"admin"],
+        ]
+        self.protocol.telnet_NEW_ENVIRON(data)
+
+        exploit_logged = False
+        for call in mock_log.msg.call_args_list:
+            if call[1].get("eventid") == "cowrie.telnet.exploit_attempt":
+                exploit_logged = True
+                break
+        self.assertFalse(exploit_logged, "Normal username should not trigger exploit detection")
+
+    @patch("cowrie.telnet.userauth.log")
+    def test_logs_client_var_event(self, mock_log: MagicMock) -> None:
+        """Test that environment variables are logged as cowrie.client.var."""
+        data = [
+            bytes([NEW_ENVIRON_IS]),
+            bytes([NEW_ENVIRON_VAR]),
+            *[bytes([c]) for c in b"TERM"],
+            bytes([NEW_ENVIRON_VALUE]),
+            *[bytes([c]) for c in b"xterm"],
+        ]
+        self.protocol.telnet_NEW_ENVIRON(data)
+
+        var_logged = False
+        for call in mock_log.msg.call_args_list:
+            if call[1].get("eventid") == "cowrie.client.var":
+                var_logged = True
+                self.assertEqual(call[1].get("name"), "TERM")
+                self.assertEqual(call[1].get("value"), "xterm")
+                break
+        self.assertTrue(var_logged, "Environment variable should be logged")
+
+    @patch("cowrie.telnet.userauth.log")
+    def test_ignores_send_command(self, mock_log: MagicMock) -> None:
+        """Test that SEND command (server requesting values) is ignored."""
+        # SEND command - server asking client for values, not client sending
+        data = [
+            bytes([1]),  # SEND = 1
+            bytes([NEW_ENVIRON_VAR]),
+            *[bytes([c]) for c in b"USER"],
+        ]
+        self.protocol.telnet_NEW_ENVIRON(data)
+
+        # Should not log anything since SEND is ignored
+        var_logged = False
+        for call in mock_log.msg.call_args_list:
+            if call[1].get("eventid") == "cowrie.client.var":
+                var_logged = True
+                break
+        self.assertFalse(var_logged, "SEND command should be ignored")
+
+
+class TestTelnetOptionLogging(unittest.TestCase):
+    """Tests for telnet option negotiation logging."""
+
+    def test_telnet_options_lookup(self) -> None:
+        """Test that TELNET_OPTIONS contains expected values."""
+        self.assertEqual(TELNET_OPTIONS[1], "ECHO")
+        self.assertEqual(TELNET_OPTIONS[3], "SGA")
+        self.assertEqual(TELNET_OPTIONS[31], "NAWS")
+        self.assertEqual(TELNET_OPTIONS[39], "NEW-ENVIRON")
+
+    def test_get_option_name_known(self) -> None:
+        """Test _get_option_name for known options."""
+        transport = CowrieTelnetTransport()
+        self.assertEqual(transport._get_option_name(bytes([39])), "NEW-ENVIRON")
+        self.assertEqual(transport._get_option_name(bytes([1])), "ECHO")
+
+    def test_get_option_name_unknown(self) -> None:
+        """Test _get_option_name for unknown options."""
+        transport = CowrieTelnetTransport()
+        self.assertEqual(transport._get_option_name(bytes([99])), "UNKNOWN-99")
+
+
+class TestNewEnvironConstants(unittest.TestCase):
+    """Tests for NEW-ENVIRON protocol constants."""
+
+    def test_new_environ_option_byte(self) -> None:
+        """Test NEW_ENVIRON option is correct (RFC 1572)."""
+        self.assertEqual(NEW_ENVIRON, bytes([39]))
+
+    def test_subnegotiation_commands(self) -> None:
+        """Test subnegotiation command bytes."""
+        self.assertEqual(NEW_ENVIRON_IS, 0)
+        self.assertEqual(NEW_ENVIRON_VALUE, 1)
+        self.assertEqual(NEW_ENVIRON_ESC, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_telnet_new_environ.py
+++ b/src/cowrie/test/test_telnet_new_environ.py
@@ -14,7 +14,6 @@ from unittest.mock import MagicMock, patch
 from cowrie.telnet.userauth import (
     NEW_ENVIRON,
     NEW_ENVIRON_ESC,
-    NEW_ENVIRON_INFO,
     NEW_ENVIRON_IS,
     NEW_ENVIRON_USERVAR,
     NEW_ENVIRON_VALUE,


### PR DESCRIPTION
This adds detection and logging for the CVE-2026-24061 authentication
bypass vulnerability in GNU inetutils telnetd. The exploit uses the
telnet NEW-ENVIRON option (RFC 1572) to send USER=-f root, which
bypasses authentication in vulnerable telnetd implementations.

Changes:
- Add NEW-ENVIRON telnet option handling (option 39/0x27)
- Parse environment variables from subnegotiation data
- Log all environment variables as cowrie.client.var events
- Detect CVE-2026-24061 exploit attempts (USER starting with -f)
- Log exploits as cowrie.telnet.exploit_attempt events
- Add telnet option negotiation logging (WILL/WONT/DO/DONT)
- Log all option negotiations as cowrie.telnet.option events
- Add comprehensive unit tests (19 tests)

New event types:
- cowrie.client.var: Telnet environment variables received
- cowrie.telnet.option: Telnet option negotiation attempts
- cowrie.telnet.exploit_attempt: Known exploit signature detected