### PR TITLE
ci: enable PyO3 ABI3 forward compatibility for Python 3.15

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,6 +20,8 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Adds `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` environment variable to the tox workflow
- Allows PyO3-based packages to build on Python 3.15 despite PyO3 0.26.0 only officially supporting up to 3.14

## Context
PyO3 checks the Python version at build time and errors if it's newer than the maximum supported version. The ABI3 forward compatibility flag tells PyO3 to use the stable ABI instead of erroring, which should work for most packages.

## Test plan
- [ ] Verify Python 3.15 CI job passes (or at least gets past the PyO3 version check)