### PR TITLE
fix(telnet): prevent recursion when onResult is None

### DIFF
--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -116,13 +116,17 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
                     s.him.onResult.addCallback(self._chainNegotiation, func, option)
                     s.him.onResult.addErrback(self._handleNegotiationError, func, option)
                 else:
-                    self._chainNegotiation(None, func, option)
+                    # Negotiation completed between error and handling - call directly
+                    # without error chaining to avoid infinite recursion
+                    func(option)
             if func in (self.will, self.wont):
                 if s.us.onResult is not None:
                     s.us.onResult.addCallback(self._chainNegotiation, func, option)
                     s.us.onResult.addErrback(self._handleNegotiationError, func, option)
                 else:
-                    self._chainNegotiation(None, func, option)
+                    # Negotiation completed between error and handling - call directly
+                    # without error chaining to avoid infinite recursion
+                    func(option)
         # We only care about AlreadyNegotiating, everything else can be ignored
         # Possible other types include OptionRefused, AlreadyDisabled, AlreadyEnabled, ConnectionDone, ConnectionLost
         elif f.type is AssertionError:


### PR DESCRIPTION
## Summary

Fix infinite recursion in telnet negotiation error handler when `onResult` is `None`.

## Problem

When `AlreadyNegotiating` is raised and `onResult` is `None` (negotiation completed between error and handling), the previous fix called `_chainNegotiation` which adds the error handler again. If the function keeps raising `AlreadyNegotiating`, this creates infinite recursion.

## Solution

When `onResult` is `None`, call `func(option)` directly without error chaining. This breaks the recursion cycle while still attempting the negotiation.

## Test plan

- [x] Existing telnet transport tests pass
- [ ] Manual test with telnet client that triggers rapid negotiation