### PR TITLE
ci: fix duplicate tox runs on Dependabot PRs

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,6 +5,8 @@ permissions:
 
 on:  # yamllint disable-line rule:truthy
   push:
+    branches:
+      - main
 
   pull_request:
 


### PR DESCRIPTION
## Summary
- Limit the `push` trigger in the tox workflow to the `main` branch only
- Dependabot PRs were triggering the workflow twice: once for the branch push and once for the `pull_request` event
- PRs (including Dependabot) are already covered by the `pull_request` trigger, so the unfiltered `push` trigger was redundant

## Test plan
- [ ] Verify next Dependabot PR only triggers one tox workflow run
- [ ] Verify pushes to `main` (direct or via merge) still trigger the tox workflow