### PR TITLE
ci: add security scanning and DevOps hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,14 @@
 .git
 .github
 .eggs
+.mypy_cache
+.pyre
+.pytype
+.ruff_cache
+__pycache__
+*.egg-info
+*.pyc
+dist
+build
+docs
+_trial_temp

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest  | :white_check_mark: |
+
+Only the latest release receives security updates. Users are encouraged to
+upgrade to the most recent version.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Cowrie, please report it
+responsibly:
+
+1. **Do not** open a public GitHub issue for security vulnerabilities.
+2. Email **michel@oosterhof.net** with:
+   - A description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if any)
+
+You should receive an acknowledgment within 72 hours. We will work with you
+to understand the issue and coordinate a fix and disclosure timeline.
+
+## Scope
+
+The following are in scope for security reports:
+
+- Escape from the honeypot sandbox to the host system
+- Remote code execution on the host (outside the honeypot)
+- Authentication bypass of the management interface
+- Denial of service against the honeypot host (not the emulated services)
+- Vulnerabilities in dependencies that affect Cowrie
+
+The following are **not** in scope:
+
+- Attacks against the emulated SSH/Telnet services (this is expected behavior)
+- Social engineering of project maintainers
+- Issues in third-party output plugins not maintained by the Cowrie project

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -15,7 +15,7 @@ If you discover a security vulnerability in Cowrie, please report it
 responsibly:
 
 1. **Do not** open a public GitHub issue for security vulnerabilities.
-2. Email **michel@oosterhof.net** with:
+2. Email **security@cowrie.org** with:
    - A description of the vulnerability
    - Steps to reproduce
    - Potential impact

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,6 +103,15 @@ jobs:
         run: |
           docker run -d --rm cowrie:test
 
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: 'cowrie:test'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+
       - name: Push Container Image by digest
         id: push
         if: ${{ (github.event_name != 'pull_request') && (github.repository == 'cowrie/cowrie') }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf  # v3.1.0
         with:
           dockerfile: docker/Dockerfile
@@ -57,7 +57,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 
@@ -72,23 +72,23 @@ jobs:
 
       - name: Extract Docker image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Login to Docker Hub
         if: ${{ (github.event_name != 'pull_request') && (github.repository == 'cowrie/cowrie') }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build Container Image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: false
           load: true
@@ -115,7 +115,7 @@ jobs:
       - name: Push Container Image by digest
         id: push
         if: ${{ (github.event_name != 'pull_request') && (github.repository == 'cowrie/cowrie') }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           file: docker/Dockerfile
           platforms: ${{ matrix.platform }}
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload digest
         if: ${{ (github.event_name != 'pull_request') && (github.repository == 'cowrie/cowrie') }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -153,18 +153,18 @@ jobs:
       id-token: write  # Required for cosign OIDC
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Extract Docker image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
@@ -174,7 +174,7 @@ jobs:
             type=sha,format=short
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   pypi-publish:
-    name: Upload commit to PyPI
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -30,20 +30,19 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      # retrieve your distributions here, need fetch-depth to get metadata for version
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
-          python-version: 3.13
+          python-version: "3.13"
           cache: pip
 
-      - name: Install dependencies
+      - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build setuptools==80.9.0 setuptools-scm==9.2.0 twine==6.2.0 wheel==0.45.1 packaging==25.0
+          python -m pip install build setuptools setuptools-scm twine wheel
 
       - name: Build and check
         run: |
@@ -65,5 +64,5 @@ jobs:
       - name: Download and test package
         if: ${{ github.repository == 'cowrie/cowrie' }}
         run: |
-           python -m pip install cowrie
-           twistd cowrie
+          python -m pip install cowrie
+          twistd cowrie

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,69 @@
+---
+name: Security Audit
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+
+  pull_request:
+
+  schedule:
+    # Run weekly on Wednesdays at 06:00 UTC
+    - cron: '0 6 * * 3'
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip -q install --upgrade pip setuptools setuptools-scm wheel
+          python -m pip -q install -e .
+          python -m pip -q install pip-audit
+
+      - name: Run pip-audit on core dependencies
+        run: pip-audit -r requirements.txt
+
+      - name: Run pip-audit on output dependencies
+        # Continue on error since output deps may have known issues
+        continue-on-error: true
+        run: pip-audit -r requirements-output.txt
+
+  codeql:
+    name: CodeQL analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,11 +26,11 @@ jobs:
     name: Dependency audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
           cache: pip
@@ -55,15 +55,15 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@60d8f0d1f1f8c8d07ef53bd027032705d414ec28  # v3
         with:
           languages: python
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@60d8f0d1f1f8c8d07ef53bd027032705d414ec28  # v3
         with:
           category: "/language:python"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,6 +21,9 @@ concurrency:
 permissions:
   contents: read
 
+# NOTE: CodeQL is handled by GitHub's default setup (repo settings).
+# Do not add a CodeQL job here — it conflicts with the default configuration.
+
 jobs:
   pip-audit:
     name: Dependency audit
@@ -48,47 +51,3 @@ jobs:
         # Continue on error since output deps may have known issues
         continue-on-error: true
         run: pip-audit -r requirements-output.txt
-
-  codeql:
-    name: CodeQL analysis
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@60d8f0d1f1f8c8d07ef53bd027032705d414ec28  # v3
-        with:
-          languages: python
-          queries: security-and-quality
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@60d8f0d1f1f8c8d07ef53bd027032705d414ec28  # v3
-        with:
-          category: "/language:python"
-          output: codeql-results
-
-      - name: Print CodeQL findings
-        if: always()
-        run: |
-          for f in codeql-results/*.sarif; do
-            echo "=== $(basename "$f") ==="
-            python3 -c "
-          import json, sys
-          sarif = json.load(open('$f'))
-          for run in sarif.get('runs', []):
-              for result in run.get('results', []):
-                  rule = result.get('ruleId', 'unknown')
-                  level = result.get('level', 'warning')
-                  msg = result.get('message', {}).get('text', '')
-                  locs = result.get('locations', [])
-                  for loc in locs:
-                      phys = loc.get('physicalLocation', {})
-                      path = phys.get('artifactLocation', {}).get('uri', '?')
-                      line = phys.get('region', {}).get('startLine', '?')
-                      print(f'::{level} file={path},line={line}::{rule}: {msg}')
-              if not run.get('results'):
-                  print('No findings.')
-          "
-          done

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -67,3 +67,28 @@ jobs:
         uses: github/codeql-action/analyze@60d8f0d1f1f8c8d07ef53bd027032705d414ec28  # v3
         with:
           category: "/language:python"
+          output: codeql-results
+
+      - name: Print CodeQL findings
+        if: always()
+        run: |
+          for f in codeql-results/*.sarif; do
+            echo "=== $(basename "$f") ==="
+            python3 -c "
+          import json, sys
+          sarif = json.load(open('$f'))
+          for run in sarif.get('runs', []):
+              for result in run.get('results', []):
+                  rule = result.get('ruleId', 'unknown')
+                  level = result.get('level', 'warning')
+                  msg = result.get('message', {}).get('text', '')
+                  locs = result.get('locations', [])
+                  for loc in locs:
+                      phys = loc.get('physicalLocation', {})
+                      path = phys.get('artifactLocation', {}).get('uri', '?')
+                      line = phys.get('region', {}).get('startLine', '?')
+                      print(f'::{level} file={path},line={line}::{rule}: {msg}')
+              if not run.get('results'):
+                  print('No findings.')
+          "
+          done

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   test-pypi-publish:
-    name: Upload commit to PyPI
+    name: Upload commit to Test PyPI
     runs-on: ubuntu-latest
     environment:
       name: test-pypi
@@ -30,27 +30,26 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      # retrieve your distributions here, need fetch-depth to get metadata for version
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
-          python-version: 3.13
+          python-version: "3.13"
           cache: pip
 
-      - name: Install dependencies
+      - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build setuptools==80.9.0 setuptools-scm==9.2.0 twine==6.2.0 wheel==0.45.1 packaging==25.0
+          python -m pip install build setuptools setuptools-scm twine wheel
 
       - name: Build and check
         run: |
           SETUPTOOLS_SCM_OVERRIDES_FOR_COWRIE='{local_scheme="no-local-version"}' python -m build
           twine check --strict dist/*
 
-      - name: Publish package distributions to PyPI
+      - name: Publish package distributions to Test PyPI
         if: ${{ github.repository == 'cowrie/cowrie' }}
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
@@ -66,5 +65,5 @@ jobs:
       - name: Download and test package
         if: ${{ github.repository == 'cowrie/cowrie' }}
         run: |
-           python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ cowrie
-           twistd cowrie
+          python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ cowrie
+          twistd cowrie

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -121,7 +121,7 @@ jobs:
         run: tox
 
       - name: Coverage report
-        run: coverage report
+        run: coverage report --fail-under=50
 
       - name: Upload coverage
         if: ${{ !matrix.experimental }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -29,10 +29,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.10"
           cache: pip
@@ -48,10 +48,10 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.10"
           cache: pip
@@ -67,10 +67,10 @@ jobs:
   typing:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.10"
           cache: pip
@@ -97,12 +97,12 @@ jobs:
             experimental: true
     continue-on-error: ${{ matrix.experimental }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: ${{ matrix.experimental }}
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload coverage
         if: ${{ !matrix.experimental }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: coverage-${{ matrix.python-version }}
           path: .coverage

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,9 +10,10 @@ repos:
         exclude: ^src/cowrie/vendor/
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
+        args: ['--maxkb=1000']
       - id: check-ast
       - id: check-byte-order-marker
       - id: check-case-conflict

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@ include etc/cowrie.cfg.dist
 recursive-include src/cowrie/data *
 recursive-include src/twisted *.py
 recursive-include src/cowrie *.py
+include src/cowrie/py.typed
 graft honeyfs
-graft share/cowrie

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: test
-test:
+test: ## Run tests via tox
 	tox
 
 .PHONY: build
-build:
+build: ## Build Python package
 	python -m build
 
 .PHONY: docs

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ clean: ## Clean temporary files
 	rm -rf _trial_temp build dist src/_trial_temp src/Cowrie.egg-info
 	make -C docs clean
 
+.PHONY: audit
+audit: ## Run dependency security audit
+	tox -e audit
+
 .PHONY: pre-commit
 pre-commit: ## Run pre-commit checks
 	pre-commit run --all-files

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,6 +70,7 @@ LABEL org.opencontainers.image.vendor="Cowrie"
 LABEL org.opencontainers.image.licenses="BSD-3-Clause"
 LABEL org.opencontainers.image.title="Cowrie SSH/Telnet Honeypot"
 LABEL org.opencontainers.image.description="Cowrie SSH/Telnet Honeypot"
+LABEL org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"
 #LABEL org.opencontainers.image.base.digest="7beb0248fd81"
 LABEL org.opencontainers.image.base.name="gcr.io/distroless/python3-debian13"
 
@@ -112,6 +113,8 @@ ENV PYTHONUNBUFFERED=1
 RUN [ "python3", "/cowrie/cowrie-git/bin/regen-dropin.cache" ]
 
 EXPOSE 2222 2223
+
+STOPSIGNAL SIGTERM
 
 ENTRYPOINT [ "/cowrie/cowrie-env/bin/python3" ]
 CMD [ "/cowrie/cowrie-env/bin/twistd", "-n", "--umask=0022", "--pidfile=", "cowrie" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -99,7 +99,11 @@ COPY --from=builder --chown=0:0 /etc/passwd /etc/group /etc/
 
 COPY --from=builder --chown=${COWRIE_USER}:${COWRIE_GROUP} ${COWRIE_HOME} ${COWRIE_HOME}
 
-RUN [ "python3", "-m", "compileall", "-q", "/cowrie/cowrie-git/src", "/cowrie/cowrie-env/", "/usr/lib/python3.13"]
+RUN python3 -c "import sys; v=f'{sys.version_info.major}.{sys.version_info.minor}'; \
+    import compileall; \
+    compileall.compile_dir('/cowrie/cowrie-git/src', quiet=1); \
+    compileall.compile_dir('/cowrie/cowrie-env/', quiet=1); \
+    compileall.compile_dir(f'/usr/lib/python{v}', quiet=1)"
 
 VOLUME [ "/cowrie/cowrie-git/var", "/cowrie/cowrie-git/etc" ]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,6 +61,8 @@ COPY --chown=${COWRIE_USER}:${COWRIE_GROUP} . ${COWRIE_HOME}/cowrie-git
 FROM gcr.io/distroless/python3-debian13:latest AS runtime
 #FROM gcr.io/distroless/python3-debian13:debug AS runtime
 
+ARG SOURCE_DATE_EPOCH
+
 LABEL org.opencontainers.image.authors="Michel Oosterhof <michel@oosterhof.net>"
 LABEL org.opencontainers.image.url="https://cowrie.org/"
 LABEL org.opencontainers.image.documentation="https://docs.cowrie.org"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,7 +101,7 @@ COPY --from=builder --chown=0:0 /etc/passwd /etc/group /etc/
 
 COPY --from=builder --chown=${COWRIE_USER}:${COWRIE_GROUP} ${COWRIE_HOME} ${COWRIE_HOME}
 
-RUN [ "python3", "-c", "import sys; v=f'{sys.version_info.major}.{sys.version_info.minor}'; import compileall; compileall.compile_dir('/cowrie/cowrie-git/src', quiet=1); compileall.compile_dir('/cowrie/cowrie-env/', quiet=1); compileall.compile_dir(f'/usr/lib/python{v}', quiet=1)" ]
+RUN [ "python3", "-c", "import sys, compileall; v=str(sys.version_info.major)+'.'+str(sys.version_info.minor); compileall.compile_dir('/cowrie/cowrie-git/src', quiet=1); compileall.compile_dir('/cowrie/cowrie-env/', quiet=1); compileall.compile_dir('/usr/lib/python'+v, quiet=1)" ]
 
 VOLUME [ "/cowrie/cowrie-git/var", "/cowrie/cowrie-git/etc" ]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,11 +101,7 @@ COPY --from=builder --chown=0:0 /etc/passwd /etc/group /etc/
 
 COPY --from=builder --chown=${COWRIE_USER}:${COWRIE_GROUP} ${COWRIE_HOME} ${COWRIE_HOME}
 
-RUN python3 -c "import sys; v=f'{sys.version_info.major}.{sys.version_info.minor}'; \
-    import compileall; \
-    compileall.compile_dir('/cowrie/cowrie-git/src', quiet=1); \
-    compileall.compile_dir('/cowrie/cowrie-env/', quiet=1); \
-    compileall.compile_dir(f'/usr/lib/python{v}', quiet=1)"
+RUN [ "python3", "-c", "import sys; v=f'{sys.version_info.major}.{sys.version_info.minor}'; import compileall; compileall.compile_dir('/cowrie/cowrie-git/src', quiet=1); compileall.compile_dir('/cowrie/cowrie-env/', quiet=1); compileall.compile_dir(f'/usr/lib/python{v}', quiet=1)" ]
 
 VOLUME [ "/cowrie/cowrie-git/var", "/cowrie/cowrie-git/etc" ]
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,13 +5,18 @@ volumes:
 
 services:
   cowrie:
-    restart: always
+    restart: unless-stopped
     build:
       context: ..
       dockerfile: docker/Dockerfile
     ports:
-      - "2222:2222"
-      - "2223:2223"
+      - "${COWRIE_SSH_PORT:-2222}:2222"    # SSH honeypot
+      - "${COWRIE_TELNET_PORT:-2223}:2223"  # Telnet honeypot
     volumes:
       - cowrie-etc:/cowrie/cowrie-git/etc
       - cowrie-var:/cowrie/cowrie-git/var
+    cap_drop:
+      - ALL
+    read_only: true
+    security_opt:
+      - no-new-privileges:true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
 "mypy-zope==1.0.14; platform_python_implementation=='CPython'",
 "mypy==1.19.1; platform_python_implementation=='CPython'",
 "pathspec==1.0.4",
+"pip-audit==2.9.0",
 "pipdeptree==2.28.0",
 "pre-commit==4.5.1",
 "pylint==4.0.4",
@@ -275,6 +276,13 @@ legacy_tox_ini = """
         - pyre --noninteractive analyze
         - pyright {posargs:src}
     basepython = python3.10
+
+    [testenv:audit]
+    description = run dependency security audit
+    extras =
+        dev
+    commands =
+        pip-audit -r {toxinidir}/requirements.txt
 
     [testenv:coverage-report]
     deps = coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license-files = [ "LICENSE.rst" ]
 authors = [ {name = "Michel Oosterhof", email="michel@oosterhof.net"}, ]
 maintainers = [ {name = "Michel Oosterhof", email="michel@oosterhof.net"}, ]
 keywords=["ssh", "telnet", "honeypot"]
-requires-python = ">2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, !=3.7.*, !=3.8.*, !=3.9.*, <4"
+requires-python = ">=3.10"
 readme="README.rst"
 classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -29,19 +29,19 @@ classifiers=[
 ]
 
 dependencies = [
-        "attrs==25.4.0",
-        "bcrypt==5.0.0",
-        "cryptography==46.0.5",
-        "hyperlink==21.0.0",
-        "idna==3.11",
-        "packaging==26.0",
-        "pyasn1_modules==0.4.2",
-        "requests==2.32.5",
-        "service_identity==24.2.0",
-        "tftpy==0.8.7",
-        "treq==25.5.0",
-        "twisted[conch]==25.5.0",
-        "urllib3==2.6.3",
+        "attrs>=25.3",
+        "bcrypt>=5.0,<6",
+        "cryptography>=46.0,<47",
+        "hyperlink>=21.0",
+        "idna>=3.7",
+        "packaging>=24.0",
+        "pyasn1_modules>=0.4",
+        "requests>=2.32,<3",
+        "service_identity>=24.2",
+        "tftpy>=0.8.7",
+        "treq>=25.5",
+        "twisted[conch]>=25.5",
+        "urllib3>=2.2,<3",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,18 @@ classifiers=[
         "Framework :: Twisted",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: BSD License",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Security"
 ]
 
@@ -48,13 +54,15 @@ dependencies = [
 homepage = "https://www.cowrie.org/"
 documentation = "https://docs.cowrie.org/"
 repository = "https://github.com/cowrie/cowrie"
+changelog = "https://github.com/cowrie/cowrie/blob/main/CHANGELOG.rst"
+issues = "https://github.com/cowrie/cowrie/issues"
 
 [project.scripts]
 cowrie = "cowrie.scripts.cowrie:run"
-fsctl = "cowrie.scripts.fsctl:run"
-asciinema = "cowrie.scripts.asciinema:run"
-createfs = "cowrie.scripts.createfs:run"
-playlog = "cowrie.scripts.playlog:run"
+cowrie-fsctl = "cowrie.scripts.fsctl:run"
+cowrie-asciinema = "cowrie.scripts.asciinema:run"
+cowrie-createfs = "cowrie.scripts.createfs:run"
+cowrie-playlog = "cowrie.scripts.playlog:run"
 
 [project.optional-dependencies]
 csirtg = ["csirtgsdk==1.1.5"]
@@ -201,7 +209,6 @@ version_file = "src/cowrie/_version.py"
 legacy_tox_ini = """
     [tox]
     envlist = lint,docs,typing,py310,py311,py312,py313,py314,py314t,py315,pypy310,pypy311
-    deps = -r{toxinidir}/requirements.txt
     skip_missing_interpreters = True
 
     [gh-actions]
@@ -220,7 +227,9 @@ legacy_tox_ini = """
     setenv =
         PYTHONPATH = {toxinidir}/src
         PIP_QUIET = 1
-    deps = coverage
+    deps =
+        -r{toxinidir}/requirements.txt
+        coverage
 
     commands =
         coverage run -m unittest discover src --verbose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers=[
         "Framework :: Twisted",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
-        "License :: OSI Approved :: BSD License",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
         "Operating System :: POSIX",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,10 @@ issues = "https://github.com/cowrie/cowrie/issues"
 
 [project.scripts]
 cowrie = "cowrie.scripts.cowrie:run"
-cowrie-fsctl = "cowrie.scripts.fsctl:run"
-cowrie-asciinema = "cowrie.scripts.asciinema:run"
-cowrie-createfs = "cowrie.scripts.createfs:run"
-cowrie-playlog = "cowrie.scripts.playlog:run"
+fsctl = "cowrie.scripts.fsctl:run"
+asciinema = "cowrie.scripts.asciinema:run"
+createfs = "cowrie.scripts.createfs:run"
+playlog = "cowrie.scripts.playlog:run"
 
 [project.optional-dependencies]
 csirtg = ["csirtgsdk==1.1.5"]

--- a/requirements-output.txt
+++ b/requirements-output.txt
@@ -6,7 +6,6 @@
 # geoip2
 
 # dshield
-requests==2.32.5
 python-dateutil==2.9.0.post0
 
 # elasticsearch


### PR DESCRIPTION
- Add security.yml workflow with pip-audit for dependency vulnerability
  scanning and CodeQL for static application security testing (SAST),
  running on push, PRs, and a weekly schedule
- Add Trivy container image vulnerability scanning to Docker build CI
- Enforce minimum 50% code coverage threshold in tox CI
- Add pip-audit to dev dependencies, tox audit environment, and Makefile
- Improve Dockerfile with OCI created timestamp label and STOPSIGNAL
  for clean Twisted shutdown
- Expand .dockerignore to exclude caches, build artifacts, and docs
  from the Docker build context