### PR TITLE
Fix fd redirect tokenization to distinguish adjacent vs spaced digit-redirect pairs

### DIFF
--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -16,7 +16,11 @@ from twisted.python.compat import iterbytes
 
 from cowrie.core.config import CowrieConfig
 from cowrie.shell import fs
-from cowrie.shell.parser import CommandParser
+from cowrie.shell.parser import (
+    REDIRECT_SENTINEL,
+    CommandParser,
+    inject_redirect_sentinels,
+)
 from cowrie.shell.pipe import PipeProtocol
 
 # Pre-compiled regexes for environment variable expansion
@@ -43,10 +47,13 @@ class HoneyPotShell:
         self.showPrompt()
 
     def lineReceived(self, line: str) -> None:
-        log.msg(eventid="cowrie.command.input", input=line, format="CMD: %(input)s")
-        self.lexer = shlex.shlex(instream=line, punctuation_chars=True, posix=True)
+        # Strip any sentinel bytes that may arrive from subshell re-parsing
+        clean_line = line.replace(REDIRECT_SENTINEL, "")
+        log.msg(eventid="cowrie.command.input", input=clean_line, format="CMD: %(input)s")
+        sentinel_line = inject_redirect_sentinels(clean_line)
+        self.lexer = shlex.shlex(instream=sentinel_line, punctuation_chars=True, posix=True)
         # Add these special characters that are not in the default lexer
-        self.lexer.wordchars += "@%{}=$:+^,()`"
+        self.lexer.wordchars += "@%{}=$:+^,()`" + REDIRECT_SENTINEL
 
         tokens: list[str] = []
 
@@ -280,8 +287,9 @@ class HoneyPotShell:
     def _execute_subshell_with_full_output(self, cmd: str) -> str:
         """Execute subshell commands and capture ALL output, not just the last command."""
         # Split commands by separators and execute each one
-        lexer = shlex.shlex(instream=cmd, punctuation_chars=True, posix=True)
-        lexer.wordchars += "@%{}=$:+^,()`"
+        sentinel_cmd = inject_redirect_sentinels(cmd)
+        lexer = shlex.shlex(instream=sentinel_cmd, punctuation_chars=True, posix=True)
+        lexer.wordchars += "@%{}=$:+^,()`" + REDIRECT_SENTINEL
 
         accumulated_output = ""
         current_cmd_tokens: list[str] = []

--- a/src/cowrie/shell/parser.py
+++ b/src/cowrie/shell/parser.py
@@ -9,6 +9,80 @@ from typing import Any
 # Pre-compiled regex for extracting redirection operators
 _REDIR_OP_RE = re.compile(r"^(\d*)(>>|>&|>|<)(.*)$")
 
+# Sentinel byte used to mark adjacent digit-redirect pairs (e.g., 2>/dev/null)
+# so that shlex tokenization preserves the adjacency information.
+REDIRECT_SENTINEL = "\x01"
+
+# Regex to match a single digit immediately followed by a redirect operator
+_ADJACENT_REDIR_RE = re.compile(r"(\d)([<>])")
+
+
+def _find_closing_quote(cmd_string: str, start: int, quote: str) -> int:
+    """Return the index past the closing *quote* character.
+
+    *start* is the index of the opening quote.  Backslash escapes are
+    honoured inside double-quoted strings.  If the closing quote is
+    missing the end of the string is returned.
+    """
+    j = start + 1
+    length = len(cmd_string)
+    while j < length and cmd_string[j] != quote:
+        if cmd_string[j] == "\\" and quote == '"' and j + 1 < length:
+            j += 1  # skip escaped char in double quotes
+        j += 1
+    return j + 1 if j < length else length
+
+
+def inject_redirect_sentinels(cmd_string: str) -> str:
+    """
+    Mark adjacent digit-redirect pairs for the tokenizer.
+
+    Inserts a sentinel byte between a digit [0-9] and an adjacent
+    redirect operator [<>] so that shlex tokenization preserves the
+    adjacency information. Spaced versions (e.g., ``2 >/dev/null``)
+    are not modified.
+
+    Content inside single or double quotes is left untouched so that
+    quoted strings like ``"2>/dev/null"`` are not mistakenly marked
+    as redirections.
+
+    The sentinel must be stripped after tokenization via
+    merge_redirection_tokens().
+
+    Examples:
+        "echo test 2>/dev/null"  -> "echo test 2\\x01>/dev/null"
+        "echo test 2 >/dev/null" -> "echo test 2 >/dev/null"  (unchanged)
+        "cmd 2>&1"               -> "cmd 2\\x01>&1"
+        "cmd 2>>log"             -> "cmd 2\\x01>>log"
+    """
+    # NOTE: The sentinel is an internal tokenization detail. The original
+    # command string (before sentinel injection) must be used for all
+    # logging and event dispatch. See merge_redirection_tokens().
+
+    # Split the string into quoted and unquoted segments, applying the
+    # sentinel substitution only to unquoted portions.
+    result: list[str] = []
+    i = 0
+    length = len(cmd_string)
+    while i < length:
+        ch = cmd_string[i]
+        if ch in ('"', "'"):
+            end = _find_closing_quote(cmd_string, i, ch)
+            result.append(cmd_string[i:end])
+            i = end
+        else:
+            # Collect unquoted text until the next quote
+            j = i
+            while j < length and cmd_string[j] not in ('"', "'"):
+                j += 1
+            result.append(
+                _ADJACENT_REDIR_RE.sub(
+                    r"\1" + REDIRECT_SENTINEL + r"\2", cmd_string[i:j]
+                )
+            )
+            i = j
+    return "".join(result)
+
 
 class CommandParser:
     """
@@ -18,8 +92,14 @@ class CommandParser:
 
     def merge_redirection_tokens(self, tokens: list[str]) -> list[str]:
         """
-        Combine shlex-split redirection tokens back together.
-        Example: ['2', '>', '/dev/null'] -> ['2>', '/dev/null']
+        Combine sentinel-marked fd redirect tokens that shlex split apart.
+
+        Only merges a digit token with a following redirect operator when the
+        digit token ends with the sentinel (meaning they were adjacent in the
+        original input). Tokens without the sentinel (the spaced case) are
+        left as-is: the digit remains a regular command argument.
+
+        All sentinel bytes are stripped from the returned tokens.
         """
         merged: list[str] = []
         i = 0
@@ -31,26 +111,33 @@ class CommandParser:
                 continue
             merged.append(tokens[i])
             i += 1
-        return merged
+        # Defensively strip any remaining sentinel bytes
+        return [t.replace(REDIRECT_SENTINEL, "") for t in merged]
 
     def _combine_redir_sequence(
         self, tokens: list[str], index: int
     ) -> tuple[str | None, int]:
-        """Glue together fd + operator (+ optional ampersand/target) tokens."""
+        """Glue together sentinel-marked fd + operator (+ optional ampersand/target) tokens."""
         tok = tokens[index]
         nxt = tokens[index + 1] if index + 1 < len(tokens) else None
         nxt2 = tokens[index + 2] if index + 2 < len(tokens) else None
         nxt3 = tokens[index + 3] if index + 3 < len(tokens) else None
 
-        if tok.isdigit() and nxt in (">", ">>", ">&"):
-            combined = f"{tok}{nxt}"
-            if nxt == ">&" and nxt2 not in (None, "|", ";", "&&", "||"):
-                return combined + str(nxt2), 3
-            if nxt in (">", ">>") and nxt2 == "&":
-                if nxt3 not in (None, "|", ";", "&&", "||"):
-                    return combined + "&" + str(nxt3), 4
-                return combined + "&", 3
-            return combined, 2
+        # Only merge digit + redirect when the sentinel is present,
+        # meaning they were adjacent in the original input.
+        if tok.endswith(REDIRECT_SENTINEL) and nxt in (">", ">>", ">&", "<", "<<"):
+            fd = tok.rstrip(REDIRECT_SENTINEL)
+            if fd.isdigit():
+                combined = f"{fd}{nxt}"
+                if nxt == ">&" and nxt2 not in (None, "|", ";", "&&", "||"):
+                    return combined + str(nxt2), 3
+                if nxt in (">", ">>") and nxt2 == "&":
+                    if nxt3 not in (None, "|", ";", "&&", "||"):
+                        return combined + "&" + str(nxt3), 4
+                    return combined + "&", 3
+                if nxt in ("<", "<<"):
+                    return combined, 2
+                return combined, 2
 
         if tok in (">", ">>") and nxt == "&":
             return f"{tok}&", 2
@@ -96,11 +183,23 @@ class CommandParser:
         return cleaned, ops
 
     def _extract_redir_op(self, token: str) -> tuple[str | None, int | None, str]:
-        """Parse a combined redirection token into (op, fd, inline target)."""
+        """Parse a combined redirection token into (op, fd, inline target).
+
+        For file-redirect operators (``>``, ``>>``, ``<``), an embedded
+        target means the token came from a quoted string — shlex with
+        ``punctuation_chars=True`` always splits unquoted redirect
+        operators into separate tokens.  Return no-match so the token
+        is kept as a plain argument.
+
+        The ``>&`` operator legitimately carries an inline fd number
+        (e.g. ``2>&1``) after the merge step, so it is not rejected.
+        """
         match = _REDIR_OP_RE.match(token)
         if not match:
             return None, None, ""
         fd_text, op, inline_target = match.groups()
+        if inline_target and op in (">", ">>", "<"):
+            return None, None, ""
         fd = int(fd_text) if fd_text else None
         return op, fd, inline_target
 

--- a/src/cowrie/test/test_fd_redirection.py
+++ b/src/cowrie/test/test_fd_redirection.py
@@ -252,3 +252,63 @@ class ShellFdRedirectionTests(unittest.TestCase):
         # Multiple commands with different redirects
         self.proto.lineReceived(b"echo first > f1; echo second > f2; cat f1; cat f2")
         self.assertEqual(self.tr.value(), b"first\nsecond\n" + PROMPT)
+
+    def test_adjacent_fd_redirect_echo(self) -> None:
+        # Adjacent 2>/dev/null: fd redirect, '2' is NOT an arg
+        self.proto.lineReceived(b"echo test 2>/dev/null")
+        self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
+
+    def test_spaced_fd_redirect_echo(self) -> None:
+        # Spaced 2 >/dev/null: '2' IS an arg, stdout redirect to file.
+        # Redirect to a file and cat it to prove '2' ended up in echo's args.
+        self.proto.lineReceived(b"echo test 2 > spaced_redir_out; cat spaced_redir_out")
+        self.assertEqual(self.tr.value(), b"test 2\n" + PROMPT)
+
+    def test_spaced_fd_redirect_uname(self) -> None:
+        # Spaced: uname -a 2 - '2' is passed as an arg, causing "extra operand" error
+        # (No redirect so the error is visible on the terminal)
+        self.proto.lineReceived(b"uname -a 2")
+        self.assertIn(b"extra operand", self.tr.value())
+
+    def test_adjacent_fd_redirect_uname(self) -> None:
+        # Adjacent: uname -a 2>/dev/null should succeed silently
+        self.proto.lineReceived(b"uname -a 2>/dev/null")
+        output = self.tr.value()
+        self.assertNotIn(b"extra operand", output)
+
+    def test_adjacent_fd_redirect_cat(self) -> None:
+        # Adjacent: cat /proc/uptime 2>/dev/null - fd redirect, should work
+        self.proto.lineReceived(b"cat /proc/uptime 2>/dev/null")
+        output = self.tr.value()
+        self.assertNotIn(b"extra operand", output)
+
+    def test_quoted_redirect_is_literal(self) -> None:
+        """Double-quoted "2>/dev/null" should print as literal string."""
+        self.proto.lineReceived(b'echo "2>/dev/null"')
+        self.assertIn(b"2>/dev/null", self.tr.value())
+
+    def test_single_quoted_redirect_is_literal(self) -> None:
+        """Single-quoted '2>/dev/null' should print as literal string."""
+        self.proto.lineReceived(b"echo '2>/dev/null'")
+        self.assertIn(b"2>/dev/null", self.tr.value())
+
+    def test_multiple_adjacent_fd_redirects(self) -> None:
+        """2>/dev/null 1>/dev/null: both fds redirected, nothing on terminal."""
+        self.proto.lineReceived(b"echo test 2>/dev/null 1>/dev/null")
+        output = self.tr.value().replace(PROMPT, b"")
+        # Both stdout and stderr redirected, terminal should be empty
+        self.assertEqual(output.strip(), b"")
+
+    def test_adjacent_append_redirect(self) -> None:
+        """2>>/dev/null: fd 2 append redirect, echo output still visible."""
+        self.proto.lineReceived(b"echo test 2>>/dev/null")
+        self.assertIn(b"test", self.tr.value())
+
+    def test_spaced_append_redirect(self) -> None:
+        """2 >>/dev/null: '2' is arg, stdout append to /dev/null."""
+        # echo test 2 >> /dev/null: output is 'test 2' appended to /dev/null
+        # Terminal shows nothing because stdout is redirected
+        self.proto.lineReceived(b"echo test 2 >>/dev/null")
+        output = self.tr.value().replace(PROMPT, b"")
+        self.assertEqual(output.strip(), b"")
+

--- a/src/cowrie/test/test_parser.py
+++ b/src/cowrie/test/test_parser.py
@@ -1,11 +1,94 @@
 # ABOUTME: Unit tests for the shell command parser.
-# ABOUTME: Tests token merging, redirection parsing, and edge cases.
+# ABOUTME: Tests sentinel injection, token merging, redirection parsing, and edge cases.
 
 from __future__ import annotations
 
+import shlex
 import unittest
 
-from cowrie.shell.parser import CommandParser
+from cowrie.shell.parser import (
+    REDIRECT_SENTINEL,
+    CommandParser,
+    inject_redirect_sentinels,
+)
+
+S = REDIRECT_SENTINEL
+
+
+class InjectRedirectSentinelsTests(unittest.TestCase):
+    """Unit tests for inject_redirect_sentinels()"""
+
+    def test_adjacent_stderr_redirect(self) -> None:
+        self.assertEqual(
+            inject_redirect_sentinels("echo test 2>/dev/null"),
+            f"echo test 2{S}>/dev/null",
+        )
+
+    def test_spaced_stderr_redirect_unchanged(self) -> None:
+        self.assertEqual(
+            inject_redirect_sentinels("echo test 2 >/dev/null"),
+            "echo test 2 >/dev/null",
+        )
+
+    def test_adjacent_append(self) -> None:
+        self.assertEqual(
+            inject_redirect_sentinels("echo test 2>>/var/log/x"),
+            f"echo test 2{S}>>/var/log/x",
+        )
+
+    def test_adjacent_fd_dup(self) -> None:
+        self.assertEqual(
+            inject_redirect_sentinels("cmd 2>&1"),
+            f"cmd 2{S}>&1",
+        )
+
+    def test_adjacent_stdin(self) -> None:
+        self.assertEqual(
+            inject_redirect_sentinels("cmd 0</dev/null"),
+            f"cmd 0{S}</dev/null",
+        )
+
+    def test_no_redirect_operator(self) -> None:
+        self.assertEqual(inject_redirect_sentinels("echo 2 hello"), "echo 2 hello")
+
+    def test_empty_string(self) -> None:
+        self.assertEqual(inject_redirect_sentinels(""), "")
+
+    def test_bare_redirect(self) -> None:
+        self.assertEqual(inject_redirect_sentinels(">"), ">")
+
+    def test_bare_fd_redirect(self) -> None:
+        self.assertEqual(inject_redirect_sentinels("2>"), f"2{S}>")
+
+    def test_multidigit_not_fd(self) -> None:
+        result = inject_redirect_sentinels("echo 123 > file")
+        self.assertEqual(result, "echo 123 > file")
+
+    def test_adjacent_multidigit_number(self) -> None:
+        # 123>file: the regex matches the last digit ('3') adjacent to '>'.
+        # Real bash treats multi-digit numbers as fd numbers too
+        # (e.g., `echo 123>/dev/null` produces no output), so injecting
+        # the sentinel here is correct behavior.
+        result = inject_redirect_sentinels("echo 123>file")
+        self.assertEqual(result, f"echo 123{S}>file")
+
+    def test_leading_zeros_fd(self) -> None:
+        # 02>/dev/null: bash treats this as fd redirect (fd 2 with leading zero)
+        result = inject_redirect_sentinels("echo test 02>/dev/null")
+        self.assertEqual(result, f"echo test 02{S}>/dev/null")
+
+    def test_large_fd_number(self) -> None:
+        # 9999>/dev/null: bash still treats as fd redirect (fails with
+        # "Bad file descriptor" but 9999 is never passed as an argument)
+        result = inject_redirect_sentinels("echo test 9999>/dev/null")
+        self.assertEqual(result, f"echo test 9999{S}>/dev/null")
+
+    def test_multiple_adjacent_redirects(self) -> None:
+        result = inject_redirect_sentinels("echo test 2>/dev/null 1>/dev/null")
+        self.assertEqual(
+            result,
+            f"echo test 2{S}>/dev/null 1{S}>/dev/null",
+        )
 
 
 class MergeRedirectionTokensTests(unittest.TestCase):
@@ -25,60 +108,257 @@ class MergeRedirectionTokensTests(unittest.TestCase):
         result = self.parser.merge_redirection_tokens(tokens)
         self.assertEqual(result, ["echo", "test", ">", "file"])
 
-    def test_stderr_redirect_split(self) -> None:
-        # ['2', '>', '/dev/null'] -> ['2>', '/dev/null']
-        tokens = ["cat", "file", "2", ">", "/dev/null"]
+    def test_sentinel_stderr_redirect(self) -> None:
+        # With sentinel: ['2\x01', '>', '/dev/null'] -> ['2>', '/dev/null']
+        tokens = ["cat", "file", f"2{S}", ">", "/dev/null"]
         result = self.parser.merge_redirection_tokens(tokens)
         self.assertEqual(result, ["cat", "file", "2>", "/dev/null"])
 
-    def test_stderr_append_split(self) -> None:
-        # ['2', '>>', 'log'] -> ['2>>', 'log']
-        tokens = ["cmd", "2", ">>", "log"]
+    def test_spaced_stderr_no_merge(self) -> None:
+        # Without sentinel: ['2', '>', '/dev/null'] stays separate
+        tokens = ["cat", "file", "2", ">", "/dev/null"]
+        result = self.parser.merge_redirection_tokens(tokens)
+        self.assertEqual(result, ["cat", "file", "2", ">", "/dev/null"])
+
+    def test_sentinel_stderr_append(self) -> None:
+        tokens = ["cmd", f"2{S}", ">>", "log"]
         result = self.parser.merge_redirection_tokens(tokens)
         self.assertEqual(result, ["cmd", "2>>", "log"])
 
-    def test_fd_dup_split(self) -> None:
-        # ['2', '>&', '1'] -> ['2>&1']
-        tokens = ["cmd", "2", ">&", "1"]
+    def test_sentinel_fd_dup(self) -> None:
+        tokens = ["cmd", f"2{S}", ">&", "1"]
         result = self.parser.merge_redirection_tokens(tokens)
         self.assertEqual(result, ["cmd", "2>&1"])
 
-    def test_fd_dup_with_ampersand_split(self) -> None:
-        # ['1', '>', '&', '2'] -> ['1>&2']
-        tokens = ["cmd", "1", ">", "&", "2"]
+    def test_sentinel_fd_dup_with_ampersand(self) -> None:
+        tokens = ["cmd", f"1{S}", ">", "&", "2"]
         result = self.parser.merge_redirection_tokens(tokens)
         self.assertEqual(result, ["cmd", "1>&2"])
 
     def test_stdout_stderr_merge(self) -> None:
-        # ['>', '&'] -> ['>&']
+        # ['>', '&'] -> ['>&'] (no digit involved, no sentinel needed)
         tokens = ["cmd", ">", "&", "file"]
         result = self.parser.merge_redirection_tokens(tokens)
         self.assertEqual(result, ["cmd", ">&", "file"])
 
-    def test_multiple_redirections(self) -> None:
-        # Multiple redirections in one command
-        tokens = ["cat", "2", ">", "/dev/null", "1", ">", "out"]
+    def test_sentinel_multiple_redirections(self) -> None:
+        tokens = ["cat", f"2{S}", ">", "/dev/null", f"1{S}", ">", "out"]
         result = self.parser.merge_redirection_tokens(tokens)
         self.assertEqual(result, ["cat", "2>", "/dev/null", "1>", "out"])
 
     def test_fd_before_pipe(self) -> None:
-        # FD followed by pipe should not merge
         tokens = ["cmd", "2", "|", "other"]
         result = self.parser.merge_redirection_tokens(tokens)
         self.assertEqual(result, ["cmd", "2", "|", "other"])
 
     def test_fd_at_end(self) -> None:
-        # FD at end with no operator
         tokens = ["cmd", "2"]
         result = self.parser.merge_redirection_tokens(tokens)
         self.assertEqual(result, ["cmd", "2"])
 
-    def test_complex_fd_chain(self) -> None:
-        # ['3', '>&', '1', '1', '>&', '2', '2', '>&', '3']
-        tokens = ["cmd", "3", ">&", "1", "1", ">&", "2", "2", ">&", "3"]
+    def test_sentinel_complex_fd_chain(self) -> None:
+        tokens = ["cmd", f"3{S}", ">&", "1", f"1{S}", ">&", "2", f"2{S}", ">&", "3"]
         result = self.parser.merge_redirection_tokens(tokens)
         self.assertEqual(result, ["cmd", "3>&1", "1>&2", "2>&3"])
 
+    def test_sentinel_stdin_redirect(self) -> None:
+        tokens = ["echo", f"0{S}", "<", "/dev/null"]
+        result = self.parser.merge_redirection_tokens(tokens)
+        self.assertEqual(result, ["echo", "0<", "/dev/null"])
+
+    def test_empty_list(self) -> None:
+        self.assertEqual(self.parser.merge_redirection_tokens([]), [])
+
+    def test_sentinel_only_at_start(self) -> None:
+        tokens = [f"2{S}", ">", "/dev/null"]
+        result = self.parser.merge_redirection_tokens(tokens)
+        self.assertEqual(result, ["2>", "/dev/null"])
+
+    def test_sentinel_stripped_from_non_redirect(self) -> None:
+        # If a sentinel somehow ends up in a non-redirect token, it gets stripped
+        tokens = [f"foo{S}bar"]
+        result = self.parser.merge_redirection_tokens(tokens)
+        self.assertEqual(result, ["foobar"])
+
+
+class NoSentinelLeakageTests(unittest.TestCase):
+    """Verify sentinel bytes never survive the full pipeline."""
+
+    def setUp(self) -> None:
+        self.parser = CommandParser()
+
+    def _full_pipeline(self, cmd: str) -> list[str]:
+        """Run inject -> shlex -> merge and return tokens."""
+        sentinel_cmd = inject_redirect_sentinels(cmd)
+        lexer = shlex.shlex(instream=sentinel_cmd, punctuation_chars=True, posix=True)
+        lexer.wordchars += f"@%{{}}=$:+^,()`{REDIRECT_SENTINEL}"
+        tokens = list(lexer)
+        return self.parser.merge_redirection_tokens(tokens)
+
+    def test_no_sentinel_in_adjacent_redirect(self) -> None:
+        tokens = self._full_pipeline("echo test 2>/dev/null")
+        for tok in tokens:
+            self.assertNotIn(S, tok, f"Sentinel leaked in token: {tok!r}")
+
+    def test_no_sentinel_in_spaced_redirect(self) -> None:
+        tokens = self._full_pipeline("echo test 2 >/dev/null")
+        for tok in tokens:
+            self.assertNotIn(S, tok, f"Sentinel leaked in token: {tok!r}")
+
+    def test_no_sentinel_in_quoted_string(self) -> None:
+        tokens = self._full_pipeline('echo "2>/dev/null"')
+        for tok in tokens:
+            self.assertNotIn(S, tok, f"Sentinel leaked in token: {tok!r}")
+
+    def test_no_sentinel_in_single_quoted(self) -> None:
+        tokens = self._full_pipeline("echo '2>/dev/null'")
+        for tok in tokens:
+            self.assertNotIn(S, tok, f"Sentinel leaked in token: {tok!r}")
+
+    def test_no_sentinel_in_large_fd(self) -> None:
+        tokens = self._full_pipeline("echo test 9999>/dev/null")
+        for tok in tokens:
+            self.assertNotIn(S, tok, f"Sentinel leaked in token: {tok!r}")
+
+    def test_no_sentinel_in_leading_zero_fd(self) -> None:
+        tokens = self._full_pipeline("echo test 02>/dev/null")
+        for tok in tokens:
+            self.assertNotIn(S, tok, f"Sentinel leaked in token: {tok!r}")
+
+    def test_no_sentinel_in_escaped_redirect(self) -> None:
+        # Backslash-escaped > should not be treated as redirect by shlex
+        # shlex posix mode handles \> as literal >
+        tokens = self._full_pipeline("echo test 2\\>/dev/null")
+        for tok in tokens:
+            self.assertNotIn(S, tok, f"Sentinel leaked in token: {tok!r}")
+
+
+class EndToEndRedirectParsingTests(unittest.TestCase):
+    """
+    End-to-end tests: inject -> shlex -> merge -> parse_redirections.
+
+    The critical distinction: adjacent 2> = fd redirect (2 NOT an arg),
+    spaced 2 > = arg + stdout redirect (2 IS an arg).
+    """
+
+    def setUp(self) -> None:
+        self.parser = CommandParser()
+
+    def _parse(self, cmd: str) -> tuple[list[str], list[dict]]:
+        """Full pipeline from raw command to cleaned args and redirect ops."""
+        sentinel_cmd = inject_redirect_sentinels(cmd)
+        lexer = shlex.shlex(instream=sentinel_cmd, punctuation_chars=True, posix=True)
+        lexer.wordchars += f"@%{{}}=$:+^,()`{REDIRECT_SENTINEL}"
+        tokens = list(lexer)
+        merged = self.parser.merge_redirection_tokens(tokens)
+        return self.parser.parse_redirections(merged)
+
+    def test_adjacent_fd_redirect(self) -> None:
+        """2>/dev/null: fd redirect, 2 is NOT an arg."""
+        cleaned, ops = self._parse("uname -a 2>/dev/null")
+        self.assertEqual(cleaned, ["uname", "-a"])
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["fd"], 2)
+
+    def test_spaced_arg_plus_redirect(self) -> None:
+        """2 >/dev/null: 2 IS an arg, stdout redirect."""
+        cleaned, ops = self._parse("uname -a 2 >/dev/null")
+        self.assertEqual(cleaned, ["uname", "-a", "2"])
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["fd"], 1)
+
+    def test_echo_adjacent(self) -> None:
+        cleaned, _ops = self._parse("echo test 2>/dev/null")
+        self.assertEqual(cleaned, ["echo", "test"])
+
+    def test_echo_spaced(self) -> None:
+        cleaned, _ops = self._parse("echo test 2 >/dev/null")
+        self.assertEqual(cleaned, ["echo", "test", "2"])
+
+    def test_cat_adjacent(self) -> None:
+        cleaned, _ops = self._parse("cat /proc/uptime 2>/dev/null")
+        self.assertEqual(cleaned, ["cat", "/proc/uptime"])
+
+    def test_cat_spaced(self) -> None:
+        cleaned, _ops = self._parse("cat /proc/uptime 2 >/dev/null")
+        self.assertEqual(cleaned, ["cat", "/proc/uptime", "2"])
+
+    def test_fd_dup_adjacent(self) -> None:
+        cleaned, ops = self._parse("echo test 2>&1 >/dev/null")
+        self.assertEqual(cleaned, ["echo", "test"])
+        self.assertEqual(len(ops), 2)
+
+    def test_no_redirects(self) -> None:
+        cleaned, ops = self._parse("echo hello")
+        self.assertEqual(cleaned, ["echo", "hello"])
+        self.assertEqual(ops, [])
+
+    def test_echo_spaced_to_file(self) -> None:
+        """echo 2 > /tmp/file: 2 is arg, stdout redirect."""
+        cleaned, ops = self._parse("echo 2 > /tmp/file")
+        self.assertEqual(cleaned, ["echo", "2"])
+        self.assertEqual(ops[0]["fd"], 1)
+
+    def test_echo_adjacent_to_file(self) -> None:
+        """echo 2>/tmp/file: fd 2 redirect, no args besides echo."""
+        cleaned, ops = self._parse("echo 2>/tmp/file")
+        self.assertEqual(cleaned, ["echo"])
+        self.assertEqual(ops[0]["fd"], 2)
+
+    def test_quoted_redirect_no_sentinel_leak(self) -> None:
+        """Quoted '2>/dev/null' must not contain sentinel bytes after pipeline."""
+        cleaned, _ops = self._parse('echo "2>/dev/null"')
+        for tok in cleaned:
+            self.assertNotIn(S, tok)
+
+    def test_single_quoted_redirect_no_sentinel_leak(self) -> None:
+        cleaned, _ops = self._parse("echo '2>/dev/null'")
+        for tok in cleaned:
+            self.assertNotIn(S, tok)
+
+    def test_stdin_redirect(self) -> None:
+        cleaned, ops = self._parse("cat < /etc/passwd")
+        self.assertEqual(cleaned, ["cat"])
+        self.assertEqual(ops[0]["type"], "stdin")
+
+    def test_adjacent_stdin_redirect(self) -> None:
+        cleaned, ops = self._parse("cmd 0</dev/null")
+        self.assertEqual(cleaned, ["cmd"])
+        self.assertEqual(ops[0]["type"], "stdin")
+        self.assertEqual(ops[0]["fd"], 0)
+
+    def test_leading_zero_fd(self) -> None:
+        """02>/dev/null: leading zero, still fd redirect."""
+        cleaned, _ops = self._parse("echo test 02>/dev/null")
+        self.assertEqual(cleaned, ["echo", "test"])
+
+    def test_multiple_adjacent_redirects(self) -> None:
+        """2>/dev/null 1>/dev/null: both are fd redirects."""
+        cleaned, ops = self._parse("echo test 2>/dev/null 1>/dev/null")
+        self.assertEqual(cleaned, ["echo", "test"])
+        self.assertEqual(len(ops), 2)
+
+    def test_append_adjacent(self) -> None:
+        """2>>/dev/null: fd 2 append redirect."""
+        cleaned, _ops = self._parse("echo test 2>>/dev/null")
+        self.assertEqual(cleaned, ["echo", "test"])
+
+    def test_append_spaced(self) -> None:
+        """2 >>/dev/null: 2 is arg, stdout append redirect."""
+        cleaned, _ops = self._parse("echo test 2 >>/dev/null")
+        self.assertEqual(cleaned, ["echo", "test", "2"])
+
+    def test_quoted_double_not_redirect(self) -> None:
+        """Double-quoted "2>/dev/null" is a literal string, not a redirect."""
+        cleaned, ops = self._parse('echo "2>/dev/null"')
+        self.assertEqual(cleaned, ["echo", "2>/dev/null"])
+        self.assertEqual(ops, [])
+
+    def test_quoted_single_not_redirect(self) -> None:
+        """Single-quoted '2>/dev/null' is a literal string, not a redirect."""
+        cleaned, ops = self._parse("echo '2>/dev/null'")
+        self.assertEqual(cleaned, ["echo", "2>/dev/null"])
+        self.assertEqual(ops, [])
 
 class ParseRedirectionsTests(unittest.TestCase):
     """Unit tests for CommandParser.parse_redirections()"""
@@ -117,7 +397,9 @@ class ParseRedirectionsTests(unittest.TestCase):
         self.assertEqual(ops[0]["target"], "errors")
 
     def test_stderr_to_devnull_inline(self) -> None:
-        args = ["cmd", "2>/dev/null"]
+        # After the merge pipeline, fd redirects are always split:
+        # "2>" is one token, "/dev/null" is the next.
+        args = ["cmd", "2>", "/dev/null"]
         cleaned, ops = self.parser.parse_redirections(args)
         self.assertEqual(cleaned, ["cmd"])
         self.assertEqual(ops[0]["target"], "/dev/null")
@@ -166,8 +448,9 @@ class ParseRedirectionsTests(unittest.TestCase):
         self.assertEqual(ops[0]["fd"], 5)
 
     def test_inline_target(self) -> None:
-        # '>file' without space
-        args = ["echo", ">file"]
+        # After shlex with punctuation_chars=True, '>' is always a
+        # separate token, so the split form is what the pipeline produces.
+        args = ["echo", ">", "file"]
         cleaned, ops = self.parser.parse_redirections(args)
         self.assertEqual(cleaned, ["echo"])
         self.assertEqual(ops[0]["target"], "file")


### PR DESCRIPTION
Fixes #2917

<html><head></head><body><h2>Problem</h2>
<p>Cowrie's <code>shlex</code>-based tokenizer produces identical output for two inputs that real bash treats differently:</p>
<pre><code>uname -a 2&gt;/dev/null     # adjacent: fd redirect, 2 is NOT an argument
uname -a 2 &gt;/dev/null    # spaced: 2 IS an argument, &gt; redirects stdout
</code></pre>
<p>Both produce <code>['uname', '-a', '2', '&gt;', '/dev/null']</code> after shlex. The adjacency information is lost, so Cowrie treats both as fd redirects. The spaced version silently succeeds instead of erroring.</p>
<p>On real bash:</p>
<pre><code>$ uname -a 2 &gt;/dev/null
uname: extra operand '2'
Try 'uname --help' for more information.
</code></pre>
<p>On Cowrie, the same command succeeds with no error. Attackers use this discrepancy to fingerprint honeypots.</p>
<p>The same issue affects quoted strings. <code>echo "2&gt;/dev/null"</code> should print the literal text <code>2&gt;/dev/null</code>, but Cowrie consumes it as a redirect.</p>
<h2>Solution</h2>
<p>A preprocessing pass injects a sentinel byte (<code>\x01</code>) between digits and redirect operators that are adjacent in the original input. The sentinel preserves adjacency information through shlex tokenization.</p>
<p><strong>How it works:</strong></p>
<ol>
<li>
<p>Before shlex: <code>echo test 2&gt;/dev/null</code> becomes <code>echo test 2\x01&gt;/dev/null</code>. The spaced version <code>echo test 2 &gt;/dev/null</code> is unchanged (no adjacency to mark).</p>
</li>
<li>
<p>shlex tokenizes with the sentinel configured as a word character, keeping it attached to the digit.</p>
</li>
<li>
<p>A merge pass checks for the sentinel. Tokens ending with the sentinel are merged with the following redirect operator into fd redirects (<code>['2\x01', '&gt;'] -&gt; ['2&gt;']</code>). Tokens without the sentinel are left as regular arguments.</p>
</li>
<li>
<p>All sentinel bytes are stripped. The sentinel never appears in log output, event data, or ttylog.</p>
</li>
</ol>
<p><strong>Quoted strings</strong> are handled by skipping sentinel injection inside quoted regions, combined with a check in <code>_extract_redir_op</code>: if a redirect-like token has an embedded target (e.g., <code>2&gt;/dev/null</code> as a single token), it came from a quoted string (since shlex with <code>punctuation_chars=True</code> always splits unquoted <code>&gt;</code> into a separate token). These are returned as plain arguments.</p>