### PR TITLE
fix: update systemd service file to work with virtualenv

### DIFF
--- a/docs/systemd/etc/systemd/system/cowrie.service
+++ b/docs/systemd/etc/systemd/system/cowrie.service
@@ -1,24 +1,21 @@
 [Unit]
-Description=A SSH and Telnet honeypot service
+Description=Cowrie SSH/Telnet Honeypot
 After=network.target
-After=rsyslog.service
-Requires=cowrie.socket
 
 [Service]
+Type=simple
 User=cowrie
 Group=cowrie
-
-Restart=always
+WorkingDirectory=/home/cowrie/cowrie
+Environment="PATH=/home/cowrie/cowrie/cowrie-env/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ExecStart=/home/cowrie/cowrie/cowrie-env/bin/python3 /home/cowrie/cowrie/cowrie-env/bin/twistd \
+    -n \
+    --umask=0022 \
+    --pidfile=/home/cowrie/cowrie/var/run/cowrie.pid \
+    --logger cowrie.python.logfile.logger \
+    cowrie
+Restart=on-failure
 RestartSec=5
-
-Environment=PYTHONPATH=/opt/cowrie/src
-WorkingDirectory=/opt/cowrie
-
-ExecStart=/opt/cowrie-env/bin/python /opt/cowrie-env/bin/twistd --umask 0022 --nodaemon --pidfile= -l - cowrie
-
-StandardOutput=syslog
-StandardError=syslog
-SyslogIdentifier=cowrie
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixes #2799 

The current systemd service file was outdated for current Cowrie installations. This updates it to work correctly with the virtualenv setup.

Changes:
- Remove dependency on cowrie.socket
- Update installation paths from /opt/cowrie to /home/cowrie/cowrie
- Add virtualenv path to environment so twistd is found correctly
- Switch to Type=simple with twistd arguments
- Add proper pidfile path

Tested this on a Rasperry Pi 4

The previous config caused "failed to start" errors that were tedious to debug.
This config should fix the issue