### PR TITLE
Proxy support for llm backend

### DIFF
--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -207,7 +207,7 @@ class LLMClient:
             log.msg(f"LLM response: {json.dumps(response_json, indent=2)}")
 
         if "choices" in response_json and len(response_json["choices"]) > 0:
-            content: str = response_json["choices"][0]["message"]["content"]
+            content = response_json["choices"][0]["message"]["content"]
             return content
 
         log.err(f"Unexpected LLM response format: {response}")

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -4,13 +4,16 @@
 from __future__ import annotations
 
 import json
+import os
+import urllib.parse
 from typing import TYPE_CHECKING, Any
 
 from twisted.internet import defer, protocol, reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
+from twisted.internet.endpoints import HostnameEndpoint
 from twisted.python import failure as tw_failure
 from twisted.python import log
-from twisted.web.client import Agent, HTTPConnectionPool, _HTTP11ClientFactory
+from twisted.web.client import Agent, HTTPConnectionPool, ProxyAgent, _HTTP11ClientFactory
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer, IResponse
 from zope.interface import implementer
@@ -87,7 +90,14 @@ class LLMClient:
         self.temperature = CowrieConfig.getfloat("llm", "temperature", fallback=0.7)
         self.debug = CowrieConfig.getboolean("llm", "debug", fallback=False)
 
-        self.agent = Agent(reactor, pool=self._conn_pool)
+        proxy_url = os.environ.get("https_proxy") or os.environ.get("http_proxy")
+        if proxy_url:
+            parsed = urllib.parse.urlparse(proxy_url)
+            proxy_endpoint = HostnameEndpoint(reactor, parsed.hostname, parsed.port or 8080)
+            self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)
+            log.msg(f"LLM using proxy: {parsed.hostname}:{parsed.port}")
+        else:
+            self.agent = Agent(reactor, pool=self._conn_pool)
 
         if not self.api_key:
             log.msg("WARNING: No LLM API key configured in [llm] section")

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import os
 import urllib.parse
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from twisted.internet import defer, protocol, reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
@@ -101,14 +101,15 @@ class LLMClient:
             or os.environ.get("http_proxy")
             or os.environ.get("HTTP_PROXY")
         )
-        self.agent: Union[Agent, ProxyAgent] = Agent(reactor, pool=self._conn_pool)
         if proxy_url:
             parsed = urllib.parse.urlparse(proxy_url)
             proxy_endpoint = HostnameEndpoint(
                 reactor, parsed.hostname or "localhost", parsed.port or 8080
             )
-            self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)
+            self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)  # type: ignore[assignment]
             log.msg(f"LLM using proxy: {parsed.hostname}:{parsed.port}")
+        else:
+            self.agent = Agent(reactor, pool=self._conn_pool)
 
         if not self.api_key:
             log.msg("WARNING: No LLM API key configured in [llm] section")

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -90,13 +90,20 @@ class LLMClient:
         self.temperature = CowrieConfig.getfloat("llm", "temperature", fallback=0.7)
         self.debug = CowrieConfig.getboolean("llm", "debug", fallback=False)
 
-        proxy_url = os.environ.get("https_proxy") or os.environ.get("http_proxy")
+        proxy_url = (
+            os.environ.get("https_proxy")
+            or os.environ.get("HTTPS_PROXY")
+            or os.environ.get("http_proxy")
+            or os.environ.get("HTTP_PROXY")
+        )
+        log.msg(f"LLM proxy env: https_proxy={os.environ.get('https_proxy')} HTTPS_PROXY={os.environ.get('HTTPS_PROXY')}")
         if proxy_url:
             parsed = urllib.parse.urlparse(proxy_url)
             proxy_endpoint = HostnameEndpoint(reactor, parsed.hostname, parsed.port or 8080)
             self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)
             log.msg(f"LLM using proxy: {parsed.hostname}:{parsed.port}")
         else:
+            log.msg("LLM no proxy configured, connecting directly")
             self.agent = Agent(reactor, pool=self._conn_pool)
 
         if not self.api_key:

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -101,7 +101,7 @@ class LLMClient:
             or os.environ.get("http_proxy")
             or os.environ.get("HTTP_PROXY")
         )
-        self.agent: Union[Agent, ProxyAgent]
+        self.agent: Union[Agent, ProxyAgent] = Agent(reactor, pool=self._conn_pool)
         if proxy_url:
             parsed = urllib.parse.urlparse(proxy_url)
             proxy_endpoint = HostnameEndpoint(
@@ -109,8 +109,6 @@ class LLMClient:
             )
             self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)
             log.msg(f"LLM using proxy: {parsed.hostname}:{parsed.port}")
-        else:
-            self.agent = Agent(reactor, pool=self._conn_pool)
 
         if not self.api_key:
             log.msg("WARNING: No LLM API key configured in [llm] section")

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import os
 import urllib.parse
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union
 
 from twisted.internet import defer, protocol, reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
@@ -101,7 +101,7 @@ class LLMClient:
             or os.environ.get("http_proxy")
             or os.environ.get("HTTP_PROXY")
         )
-        self.agent: Agent | ProxyAgent
+        self.agent: Union[Agent, ProxyAgent]
         if proxy_url:
             parsed = urllib.parse.urlparse(proxy_url)
             proxy_endpoint = HostnameEndpoint(

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -13,7 +13,12 @@ from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.internet.endpoints import HostnameEndpoint
 from twisted.python import failure as tw_failure
 from twisted.python import log
-from twisted.web.client import Agent, HTTPConnectionPool, ProxyAgent, _HTTP11ClientFactory
+from twisted.web.client import (
+    Agent,
+    HTTPConnectionPool,
+    ProxyAgent,
+    _HTTP11ClientFactory,
+)
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer, IResponse
 from zope.interface import implementer

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -96,14 +96,12 @@ class LLMClient:
             or os.environ.get("http_proxy")
             or os.environ.get("HTTP_PROXY")
         )
-        log.msg(f"LLM proxy env: https_proxy={os.environ.get('https_proxy')} HTTPS_PROXY={os.environ.get('HTTPS_PROXY')}")
         if proxy_url:
             parsed = urllib.parse.urlparse(proxy_url)
             proxy_endpoint = HostnameEndpoint(reactor, parsed.hostname, parsed.port or 8080)
             self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)
             log.msg(f"LLM using proxy: {parsed.hostname}:{parsed.port}")
         else:
-            log.msg("LLM no proxy configured, connecting directly")
             self.agent = Agent(reactor, pool=self._conn_pool)
 
         if not self.api_key:

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -101,9 +101,12 @@ class LLMClient:
             or os.environ.get("http_proxy")
             or os.environ.get("HTTP_PROXY")
         )
+        self.agent: Agent | ProxyAgent
         if proxy_url:
             parsed = urllib.parse.urlparse(proxy_url)
-            proxy_endpoint = HostnameEndpoint(reactor, parsed.hostname, parsed.port or 8080)
+            proxy_endpoint = HostnameEndpoint(
+                reactor, parsed.hostname or "localhost", parsed.port or 8080
+            )
             self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)
             log.msg(f"LLM using proxy: {parsed.hostname}:{parsed.port}")
         else:


### PR DESCRIPTION
The LLM backend uses `twisted.web.client.Agent` which does not respect standard proxy environment variables (`HTTPS_PROXY`, `HTTP_PROXY` etc.).

This PR  check for proxy environment variables at startup and switch to `twisted.web.client.ProxyAgent` when one is configured. Falls back to the existing `Agent` behaviour when no proxy is set — no behaviour change for users without a proxy.

- `src/cowrie/llm/llm.py`: detect proxy env vars on `LLMClient` init, use `ProxyAgent` via `HostnameEndpoint` when present, log the proxy host/port for visibility

This way the LLM-Backend communication can pulled over a internal http proxy - makes sense if cowrie sits in a isolated network (or aslong api.openai.com) do not support IPv6 ;-) 


PS: have you considered to use `request` for this llm part as it might be much simpler code?