### PR TITLE
LLM Anthropic support + Configurable context prompt

### DIFF
--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -415,11 +415,16 @@ log_raw = false
 # (default: false)
 #debug = false
 
-# System prompt template sent to the LLM to establish its persona.
+# System prompt template for interactive SSH sessions.
 # Supports variables: {hostname}, {username}, {ip}, {ip6}, {client_ip}, {cwd}
 # Note: hostname, username and cwd are always appended automatically.
 # (default: built-in Linux shell simulation prompt)
 #system_prompt = You are simulating a Linux server at {ip} ({ip6}) accessed via SSH. Respond as if you were the shell on this system. Your response should be the output that would be displayed after executing the command. Keep responses realistic, including appropriate error messages for invalid commands. For file paths, maintain consistent state with previous commands.
+
+# System prompt template for non-interactive exec commands (e.g. ssh host 'cmd').
+# Same variables supported. Defaults to a tighter prompt that suppresses
+# conversational output and asks for raw command output only.
+#system_prompt_exec = You are simulating a Linux server. Respond with ONLY the raw output of the command, no commentary.
 
 
 # ============================================================================

--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -415,6 +415,12 @@ log_raw = false
 # (default: false)
 #debug = false
 
+# System prompt template sent to the LLM to establish its persona.
+# Supports variables: {hostname}, {username}, {ip}, {ip6}, {client_ip}, {cwd}
+# Note: hostname, username and cwd are always appended automatically.
+# (default: built-in Linux shell simulation prompt)
+#system_prompt = You are simulating a Linux server at {ip} ({ip6}) accessed via SSH. Respond as if you were the shell on this system. Your response should be the output that would be displayed after executing the command. Keep responses realistic, including appropriate error messages for invalid commands. For file paths, maintain consistent state with previous commands.
+
 
 # ============================================================================
 # Shell Options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers=[
 dependencies = [
         "attrs==25.4.0",
         "bcrypt==5.0.0",
-        "cryptography==46.0.5",
+        "cryptography==46.0.6",
         "hyperlink==21.0.0",
         "idna==3.11",
         "packaging==26.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers=[
 ]
 
 dependencies = [
-        "attrs==25.4.0",
+        "attrs==26.1.0",
         "bcrypt==5.0.0",
         "cryptography==46.0.6",
         "hyperlink==21.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dev = [
 "pyupgrade==3.21.2",
 "pyyaml==6.0.3",
 "readthedocs-sphinx-search==0.3.2",
-"ruff==0.15.6",
+"ruff==0.15.7",
 "setuptools==82.0.1",
 "sphinx-copybutton==0.5.2",
 "sphinx_rtd_theme==3.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 attrs==25.4.0
 bcrypt==5.0.0
-cryptography==46.0.5
+cryptography==46.0.6
 hyperlink==21.0.0
 idna==3.11
 packaging==26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-attrs==25.4.0
+attrs==26.1.0
 bcrypt==5.0.0
 cryptography==46.0.6
 hyperlink==21.0.0

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -207,7 +207,7 @@ class LLMClient:
             log.msg(f"LLM response: {json.dumps(response_json, indent=2)}")
 
         if "choices" in response_json and len(response_json["choices"]) > 0:
-            content: str = response_json["choices"][0]["message"]["content"]
+            content = response_json["choices"][0]["message"]["content"]
             return content
 
         log.err(f"Unexpected LLM response format: {response}")

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -4,13 +4,16 @@
 from __future__ import annotations
 
 import json
+import os
+import urllib.parse
 from typing import TYPE_CHECKING, Any
 
 from twisted.internet import defer, protocol, reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
+from twisted.internet.endpoints import HostnameEndpoint
 from twisted.python import failure as tw_failure
 from twisted.python import log
-from twisted.web.client import Agent, HTTPConnectionPool, _HTTP11ClientFactory
+from twisted.web.client import Agent, HTTPConnectionPool, ProxyAgent, _HTTP11ClientFactory
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer, IResponse
 from zope.interface import implementer
@@ -87,7 +90,14 @@ class LLMClient:
         self.temperature = CowrieConfig.getfloat("llm", "temperature", fallback=0.7)
         self.debug = CowrieConfig.getboolean("llm", "debug", fallback=False)
 
-        self.agent = Agent(reactor, pool=self._conn_pool)
+        proxy_url = os.environ.get("https_proxy") or os.environ.get("http_proxy")
+        if proxy_url:
+            parsed = urllib.parse.urlparse(proxy_url)
+            proxy_endpoint = HostnameEndpoint(reactor, parsed.hostname, parsed.port or 8080)
+            self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)
+            log.msg(f"LLM using proxy: {parsed.hostname}:{parsed.port}")
+        else:
+            self.agent = Agent(reactor, pool=self._conn_pool)
 
         if not self.api_key:
             log.msg("WARNING: No LLM API key configured in [llm] section")

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import os
 import urllib.parse
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from twisted.internet import defer, protocol, reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
@@ -101,14 +101,15 @@ class LLMClient:
             or os.environ.get("http_proxy")
             or os.environ.get("HTTP_PROXY")
         )
-        self.agent: Union[Agent, ProxyAgent] = Agent(reactor, pool=self._conn_pool)
         if proxy_url:
             parsed = urllib.parse.urlparse(proxy_url)
             proxy_endpoint = HostnameEndpoint(
                 reactor, parsed.hostname or "localhost", parsed.port or 8080
             )
-            self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)
+            self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)  # type: ignore[assignment]
             log.msg(f"LLM using proxy: {parsed.hostname}:{parsed.port}")
+        else:
+            self.agent = Agent(reactor, pool=self._conn_pool)
 
         if not self.api_key:
             log.msg("WARNING: No LLM API key configured in [llm] section")

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -111,24 +111,33 @@ class LLMClient:
         )
 
     def _format_request_body(self, prompt: list[str]) -> dict:
-        """Structure the request body for OpenAI chat completions API."""
+        """Structure the request body for the LLM API.
+
+        Anthropic Messages API requires the system prompt as a top-level
+        parameter; OpenAI uses a message with role 'system'.
+        """
+        system_prompt = prompt[0] if prompt else ""
         messages = []
-        for i, message in enumerate(prompt):
-            if i == 0:
-                # First message is our system prompt
-                messages.append({"role": "system", "content": message})
-            elif message.startswith("User:"):
-                content = message[5:].strip()
-                messages.append({"role": "user", "content": content})
+        for message in prompt[1:]:
+            if message.startswith("User:"):
+                messages.append({"role": "user", "content": message[5:].strip()})
             elif message.startswith("System:"):
-                content = message[7:].strip()
-                messages.append({"role": "assistant", "content": content})
+                messages.append({"role": "assistant", "content": message[7:].strip()})
             else:
                 messages.append({"role": "user", "content": message})
 
+        if self.is_anthropic:
+            return {
+                "model": self.model,
+                "system": system_prompt,
+                "messages": messages or [{"role": "user", "content": ""}],
+                "max_tokens": self.max_tokens,
+            }
+
+        # OpenAI-compatible format
         return {
             "model": self.model,
-            "messages": messages,
+            "messages": [{"role": "system", "content": system_prompt}, *messages],
             "max_tokens": self.max_tokens,
             "temperature": self.temperature,
         }

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -90,13 +90,20 @@ class LLMClient:
         self.temperature = CowrieConfig.getfloat("llm", "temperature", fallback=0.7)
         self.debug = CowrieConfig.getboolean("llm", "debug", fallback=False)
 
-        proxy_url = os.environ.get("https_proxy") or os.environ.get("http_proxy")
+        proxy_url = (
+            os.environ.get("https_proxy")
+            or os.environ.get("HTTPS_PROXY")
+            or os.environ.get("http_proxy")
+            or os.environ.get("HTTP_PROXY")
+        )
+        log.msg(f"LLM proxy env: https_proxy={os.environ.get('https_proxy')} HTTPS_PROXY={os.environ.get('HTTPS_PROXY')}")
         if proxy_url:
             parsed = urllib.parse.urlparse(proxy_url)
             proxy_endpoint = HostnameEndpoint(reactor, parsed.hostname, parsed.port or 8080)
             self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)
             log.msg(f"LLM using proxy: {parsed.hostname}:{parsed.port}")
         else:
+            log.msg("LLM no proxy configured, connecting directly")
             self.agent = Agent(reactor, pool=self._conn_pool)
 
         if not self.api_key:

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -101,7 +101,7 @@ class LLMClient:
             or os.environ.get("http_proxy")
             or os.environ.get("HTTP_PROXY")
         )
-        self.agent: Union[Agent, ProxyAgent]
+        self.agent: Union[Agent, ProxyAgent] = Agent(reactor, pool=self._conn_pool)
         if proxy_url:
             parsed = urllib.parse.urlparse(proxy_url)
             proxy_endpoint = HostnameEndpoint(
@@ -109,8 +109,6 @@ class LLMClient:
             )
             self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)
             log.msg(f"LLM using proxy: {parsed.hostname}:{parsed.port}")
-        else:
-            self.agent = Agent(reactor, pool=self._conn_pool)
 
         if not self.api_key:
             log.msg("WARNING: No LLM API key configured in [llm] section")

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import os
 import urllib.parse
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union
 
 from twisted.internet import defer, protocol, reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
@@ -101,7 +101,7 @@ class LLMClient:
             or os.environ.get("http_proxy")
             or os.environ.get("HTTP_PROXY")
         )
-        self.agent: Agent | ProxyAgent
+        self.agent: Union[Agent, ProxyAgent]
         if proxy_url:
             parsed = urllib.parse.urlparse(proxy_url)
             proxy_endpoint = HostnameEndpoint(

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -193,8 +193,14 @@ class LLMClient:
         if self.debug:
             log.msg(f"LLM response: {json.dumps(response_json, indent=2)}")
 
+        # OpenAI-compatible format
         if "choices" in response_json and len(response_json["choices"]) > 0:
             content: str = response_json["choices"][0]["message"]["content"]
+            return content
+
+        # Anthropic Messages API format
+        if "content" in response_json and len(response_json["content"]) > 0:
+            content = response_json["content"][0].get("text", "")
             return content
 
         log.err(f"Unexpected LLM response format: {response}")

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -13,7 +13,12 @@ from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.internet.endpoints import HostnameEndpoint
 from twisted.python import failure as tw_failure
 from twisted.python import log
-from twisted.web.client import Agent, HTTPConnectionPool, ProxyAgent, _HTTP11ClientFactory
+from twisted.web.client import (
+    Agent,
+    HTTPConnectionPool,
+    ProxyAgent,
+    _HTTP11ClientFactory,
+)
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer, IResponse
 from zope.interface import implementer

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -96,14 +96,12 @@ class LLMClient:
             or os.environ.get("http_proxy")
             or os.environ.get("HTTP_PROXY")
         )
-        log.msg(f"LLM proxy env: https_proxy={os.environ.get('https_proxy')} HTTPS_PROXY={os.environ.get('HTTPS_PROXY')}")
         if proxy_url:
             parsed = urllib.parse.urlparse(proxy_url)
             proxy_endpoint = HostnameEndpoint(reactor, parsed.hostname, parsed.port or 8080)
             self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)
             log.msg(f"LLM using proxy: {parsed.hostname}:{parsed.port}")
         else:
-            log.msg("LLM no proxy configured, connecting directly")
             self.agent = Agent(reactor, pool=self._conn_pool)
 
         if not self.api_key:

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -101,9 +101,12 @@ class LLMClient:
             or os.environ.get("http_proxy")
             or os.environ.get("HTTP_PROXY")
         )
+        self.agent: Agent | ProxyAgent
         if proxy_url:
             parsed = urllib.parse.urlparse(proxy_url)
-            proxy_endpoint = HostnameEndpoint(reactor, parsed.hostname, parsed.port or 8080)
+            proxy_endpoint = HostnameEndpoint(
+                reactor, parsed.hostname or "localhost", parsed.port or 8080
+            )
             self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)
             log.msg(f"LLM using proxy: {parsed.hostname}:{parsed.port}")
         else:

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -204,7 +204,7 @@ class LLMClient:
 
         # OpenAI-compatible format
         if "choices" in response_json and len(response_json["choices"]) > 0:
-            content: str = response_json["choices"][0]["message"]["content"]
+            content = response_json["choices"][0]["message"]["content"]
             return content
 
         # Anthropic Messages API format

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -88,12 +88,21 @@ class LLMClient:
         self.debug = CowrieConfig.getboolean("llm", "debug", fallback=False)
 
         self.agent = Agent(reactor, pool=self._conn_pool)
+        self.is_anthropic = "anthropic.com" in self.host
 
         if not self.api_key:
             log.msg("WARNING: No LLM API key configured in [llm] section")
 
     def _build_headers(self) -> Headers:
         """Build HTTP headers with authentication."""
+        if self.is_anthropic:
+            return Headers(
+                {
+                    b"Content-Type": [b"application/json"],
+                    b"x-api-key": [self.api_key.encode()],
+                    b"anthropic-version": [b"2023-06-01"],
+                }
+            )
         return Headers(
             {
                 b"Content-Type": [b"application/json"],

--- a/src/cowrie/llm/protocol.py
+++ b/src/cowrie/llm/protocol.py
@@ -125,6 +125,37 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         # Use LLM client to get a response
         self._process_command_with_llm(string)
 
+    def _build_system_context(self, exec_command: str = "") -> str:
+        """
+        Build the system context prompt, using the configured template if present.
+        Supports variables: {hostname}, {username}, {ip}, {ip6}, {client_ip}, {cwd}.
+        """
+        default = (
+            "You are simulating a Linux server that has been accessed via SSH. "
+            "Respond as if you were the shell on this system. "
+            "Your response should be the output that would be displayed after executing the command. "
+            "Keep responses realistic, including appropriate error messages for invalid commands. "
+            "For file paths, maintain consistent state with previous commands."
+        )
+        template = CowrieConfig.get("llm", "system_prompt", fallback=default)
+        context = template.format_map(
+            {
+                "hostname": self.hostname,
+                "username": self.user.username,
+                "ip": getattr(self, "kippoIP", ""),
+                "ip6": getattr(self, "kippoIPv6", ""),
+                "client_ip": getattr(self, "clientIP", ""),
+                "cwd": self.cwd,
+            }
+        )
+        context += (
+            f" The hostname is '{self.hostname}' and username is '{self.user.username}'."
+            f" The current working directory is '{self.cwd}'."
+        )
+        if exec_command:
+            context += f" The command to execute is: {exec_command}"
+        return context
+
     def _process_command_with_llm(self, command: str) -> None:
         """
         Process a command by sending it to the LLM and writing the response
@@ -138,17 +169,7 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         # Add the command to our history
         self.command_history.append(f"User: {command}")
 
-        # Construct an appropriate prompt for the LLM
-        # We'll include system context to help the LLM respond appropriately
-        system_context = (
-            "You are simulating a Linux server that has been accessed via SSH. "
-            "Respond as if you were the shell on this system. "
-            "Your response should be the output that would be displayed after executing the command. "
-            "Keep responses realistic, including appropriate error messages for invalid commands. "
-            "For file paths, maintain consistent state with previous commands. "
-            f"The hostname is '{self.hostname}' and username is '{self.user.username}'. "
-            f"The current working directory is '{self.cwd}'. "
-        )
+        system_context = self._build_system_context()
 
         # Keep only the last 10 commands for context
         prompt = [system_context, *self.command_history[-10:]]
@@ -245,14 +266,7 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
         self.command_history = []
 
         # Construct the prompt
-        system_context = (
-            "You are simulating a Linux server that has been accessed via SSH with a command to execute. "
-            "Respond with ONLY the output that would be displayed after executing this command. "
-            "Keep responses realistic, including appropriate error messages for invalid commands. "
-            f"The hostname is '{self.hostname}' and username is '{self.user.username}'. "
-            f"The current working directory is '{self.cwd}'. "
-            "The command to execute is: " + self.execcmd
-        )
+        system_context = self._build_system_context(exec_command=self.execcmd)
 
         prompt = [system_context]
 

--- a/src/cowrie/llm/protocol.py
+++ b/src/cowrie/llm/protocol.py
@@ -129,15 +129,27 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         """
         Build the system context prompt, using the configured template if present.
         Supports variables: {hostname}, {username}, {ip}, {ip6}, {client_ip}, {cwd}.
+        For exec commands a tighter default is used to suppress conversational output.
         """
-        default = (
-            "You are simulating a Linux server that has been accessed via SSH. "
-            "Respond as if you were the shell on this system. "
-            "Your response should be the output that would be displayed after executing the command. "
-            "Keep responses realistic, including appropriate error messages for invalid commands. "
-            "For file paths, maintain consistent state with previous commands."
-        )
-        template = CowrieConfig.get("llm", "system_prompt", fallback=default)
+        if exec_command:
+            default = (
+                "You are simulating a Linux server that has been accessed via SSH "
+                "with a command to execute. "
+                "Respond with ONLY the output that would be displayed after executing this command. "
+                "Keep responses realistic, including appropriate error messages for invalid commands."
+            )
+            config_key = "system_prompt_exec"
+        else:
+            default = (
+                "You are simulating a Linux server that has been accessed via SSH. "
+                "Respond as if you were the shell on this system. "
+                "Your response should be the output that would be displayed after executing the command. "
+                "Keep responses realistic, including appropriate error messages for invalid commands. "
+                "For file paths, maintain consistent state with previous commands."
+            )
+            config_key = "system_prompt"
+
+        template = CowrieConfig.get("llm", config_key, fallback=default)
         context = template.format_map(
             {
                 "hostname": self.hostname,


### PR DESCRIPTION
   - **Anthropic API support**: auto-detects `anthropic.com` in the configured host and switches to `x-api-key` + `anthropic-version: 2023-06-01` headers; parses the Anthropic Messages API response format (`content[0].text`) alongside the existing OpenAI format (`choices[0].message.content`). Same to the requset itself, system prompt is sent on top-level. 
   -  **Configurable system prompts**: `_build_system_context()` helper reads `system_prompt` (interactive) and `system_prompt_exec` (non-interactive exec) from `[llm]` config,  supporting template variables `{hostname}`, `{username}`, `{ip}`, `{ip6}`, `{client_ip}`, `{cwd}`; interactive and exec paths now share one helper instead of duplicating the    prompt string

   ## Configuration

   ```ini
   [llm]
   host = https://api.anthropic.com
   path = /v1/messages
   api_key = sk-ant-...
   model = claude-haiku-4-5-20251001
  ```

   Optional custom prompt:
   ```ini
   system_prompt = You are a OpenWRT Router at {ip}. Hostname: {hostname}, user: {username}... 
   ```