### PR TITLE
Fix UnboundLocalError when auth_class is set to an invalid value

### DIFF
--- a/src/cowrie/core/checkers.py
+++ b/src/cowrie/core/checkers.py
@@ -132,6 +132,8 @@ class HoneypotPasswordChecker:
             )
             authname = getattr(modules[authmodule], "UserDB")
 
+        theauth = authname()
+
         if theauth.checklogin(theusername, thepassword, ip):
             log.msg(
                 eventid="cowrie.login.success",

--- a/src/cowrie/core/checkers.py
+++ b/src/cowrie/core/checkers.py
@@ -124,9 +124,13 @@ class HoneypotPasswordChecker:
         if hasattr(modules[authmodule], authclass):
             authname = getattr(modules[authmodule], authclass)
         else:
-            log.msg(f"auth_class: {authclass} not found in {authmodule}")
-
-        theauth = authname()
+            log.msg(
+                eventid="cowrie.error.config",
+                format="auth_class '%(authclass)s' not found in %(authmodule)s, falling back to UserDB",
+                authclass=authclass,
+                authmodule=authmodule,
+            )
+            authname = getattr(modules[authmodule], "UserDB")
 
         if theauth.checklogin(theusername, thepassword, ip):
             log.msg(


### PR DESCRIPTION

Fixes #40079

When `auth_class` is set to a value that doesn't match any known authentication class, `authname` is never assigned in the `else` branch of `checkers.py`, causing `UnboundLocalError` on line 133.

This adds a fallback to `UserDB` with a structured log warning, consistent with the existing behavior for unset `auth_class` values (PR #2192).
