### PR TITLE
fix(llm): resolve mypy type errors in LLM client

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -90,13 +90,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "pypy-3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy-3.10"]
         experimental: [false]
+        prerelease: [false]
         include:
+          - python-version: "3.15"
+            experimental: false
+            prerelease: true
           - python-version: "3.15t"
             experimental: true
+            prerelease: true
           - python-version: "pypy-3.11"
             experimental: true
+            prerelease: false
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - uses: actions/checkout@v6
@@ -107,7 +113,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: ${{ matrix.experimental }}
+          allow-prereleases: ${{ matrix.prerelease }}
           cache: pip
 
       - name: Install dependencies

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -90,10 +90,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy-3.10", "pypy-3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy-3.10"]
         experimental: [false]
         include:
           - python-version: "3.15"
+            experimental: true
+          - python-version: "pypy-3.11"
             experimental: true
     continue-on-error: ${{ matrix.experimental }}
     steps:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -90,10 +90,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy-3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "pypy-3.10"]
         experimental: [false]
         include:
-          - python-version: "3.15"
+          - python-version: "3.15t"
             experimental: true
           - python-version: "pypy-3.11"
             experimental: true

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -101,12 +101,13 @@ class LLMClient:
             or os.environ.get("http_proxy")
             or os.environ.get("HTTP_PROXY")
         )
+        self.agent: Agent | ProxyAgent
         if proxy_url:
             parsed = urllib.parse.urlparse(proxy_url)
             proxy_endpoint = HostnameEndpoint(
                 reactor, parsed.hostname or "localhost", parsed.port or 8080
             )
-            self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)  # type: ignore[assignment]
+            self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)
             log.msg(f"LLM using proxy: {parsed.hostname}:{parsed.port}")
         else:
             self.agent = Agent(reactor, pool=self._conn_pool)
@@ -207,7 +208,7 @@ class LLMClient:
             log.msg(f"LLM response: {json.dumps(response_json, indent=2)}")
 
         if "choices" in response_json and len(response_json["choices"]) > 0:
-            content = response_json["choices"][0]["message"]["content"]
+            content: str = response_json["choices"][0]["message"]["content"]
             return content
 
         log.err(f"Unexpected LLM response format: {response}")


### PR DESCRIPTION
Add explicit type annotation for self.agent to support both Agent and ProxyAgent, remove stale type: ignore comment, and annotate JSON-derived content variable as str.