### PR TITLE
Add COWRIE_ALLOW_ROOT to opt out to run as root

### DIFF
--- a/src/cowrie/scripts/cowrie.py
+++ b/src/cowrie/scripts/cowrie.py
@@ -101,8 +101,14 @@ def python_version_warning() -> None:
 
 
 def check_root() -> None:
-    """Check if running as root and exit if so."""
-    if os.name == "posix" and os.getuid() == 0:
+    """Check if running as root and exit if so.
+
+    Set COWRIE_ALLOW_ROOT=1 to opt out of the refusal — useful for
+    container deployments where the container itself is the security
+    boundary and dropping privileges via setcap is impractical.
+    """
+    allow_root = os.environ.get("COWRIE_ALLOW_ROOT", "").lower() in ("1", "true", "yes")
+    if os.name == "posix" and os.getuid() == 0 and not allow_root:
         print("ERROR: You must not run cowrie as root!")
         sys.exit(1)
 

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -128,7 +128,14 @@ Makes a Cowrie SSH/Telnet honeypot.
             )
             sys.exit(1)
 
-        if os.name == "posix" and os.getuid() == 0:
+        # COWRIE_ALLOW_ROOT=1 opts out — see check_root() in
+        # cowrie/scripts/cowrie.py for the rationale.
+        allow_root = os.environ.get("COWRIE_ALLOW_ROOT", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        if os.name == "posix" and os.getuid() == 0 and not allow_root:
             print("ERROR: You must not run cowrie as root!")  # noqa: T201
             sys.exit(1)
 


### PR DESCRIPTION
The "_you must not run as root_" refusal is a bit pain for my case.  I run Cowrie in a container on a non trusted host so multiple security boundaries) alongside an capturing sidecar that needs CAP_NET_RAW. Alternatives like setcap to the python interpreter , privilege-drop wrappers, local patches etc are all uglier than just running as UID 0. 

Therefore i suggest a simply flag to opt out, default behaviour is unchanged. 

Happy to add a docs/config knob version instead if you'd prefer that over an env var.