### PR TITLE
Silence Twisted TripleDES deprecation warnings on startup

### DIFF
--- a/src/cowrie/__init__.py
+++ b/src/cowrie/__init__.py
@@ -1,4 +1,16 @@
 import sys
+import warnings
+
+from cryptography.utils import CryptographyDeprecationWarning
+
+# Fixed upstream by twisted/twisted#12453 (not yet in any released Twisted as
+# of 25.5.0). Drop this filter once requirements.txt pins a Twisted release
+# that includes that fix.
+warnings.filterwarnings(
+    "ignore",
+    category=CryptographyDeprecationWarning,
+    module=r"twisted\.conch\.ssh\.transport",
+)
 
 from twisted.python import log
 


### PR DESCRIPTION
Actually kind of old and probably soon fixed upstream but its annoying me...

it filters the `CryptographyDeprecationWarning` emitted by `twisted.conch.ssh.transport` when it imports `TripleDES` from `cryptography.hazmat.primitives.ciphers.algorithms` (moved to `decrepit` and slated for removal in cryptography 48.0).

Fixed upstream in Twisted by [twisted/twisted#12453](https://github.com/twisted/twisted/pull/12453) (merged 2025-05-31), but not present in any released Twisted yet — `25.5.0` (currently pinned) and `26.4.0rc2` both still trip the warning.

Stopgap until the Twisted pin in `requirements.txt` is bumped past a release that includes the fix; the comment in the diff calls that out as the trigger to remove the filter.