### PR TITLE
test: type test_tftp.py and test_ftpget.py properly for mypy

### DIFF
--- a/src/cowrie/test/test_ftpget.py
+++ b/src/cowrie/test/test_ftpget.py
@@ -1,22 +1,37 @@
 # SPDX-FileCopyrightText: 2018-2025 Michel Oosterhof <michel@oosterhof.net>
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# mypy: disable-error-code="var-annotated,attr-defined,return-value"
 
 from __future__ import annotations
 
 import os
 import tempfile
 import unittest
+from typing import TYPE_CHECKING, cast
 
 from twisted.cred.checkers import InMemoryUsernamePasswordDatabaseDontUse
 from twisted.cred.portal import Portal
-from twisted.internet import defer, reactor
+from twisted.internet import defer
+from twisted.internet import reactor as _reactor
 from twisted.protocols.ftp import FTPFactory, FTPRealm
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
+
+if TYPE_CHECKING:
+    from twisted.internet.address import IPv4Address
+    from twisted.internet.interfaces import (
+        IListeningPort,
+        IReactorTCP,
+        IReactorTime,
+    )
+
+    class _Reactor(IReactorTime, IReactorTCP):
+        pass
+
+
+reactor = cast("_Reactor", _reactor)
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
@@ -42,7 +57,7 @@ class ShellFtpGetCommandTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tr.clear()
 
-    def test_help_command(self) -> None:
+    def test_help_command(self) -> defer.Deferred[None]:
         usage = (
             b"BusyBox v1.20.2 (2016-06-22 15:12:53 EDT) multi-call binary.\n"
             b"\n"
@@ -56,7 +71,7 @@ class ShellFtpGetCommandTests(unittest.TestCase):
             b"    -p PASS     Password\n"
             b"    -P NUM      Port\n\n"
         )
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def do_test():
             self.proto.lineReceived(b"ftpget\n")
@@ -70,9 +85,9 @@ class ShellFtpGetCommandTests(unittest.TestCase):
         reactor.callLater(0, do_test)
         return d
 
-    def test_insufficient_args(self) -> None:
+    def test_insufficient_args(self) -> defer.Deferred[None]:
         """Test ftpget with only one argument shows help"""
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def do_test():
             self.proto.lineReceived(b"ftpget host.com\n")
@@ -87,9 +102,9 @@ class ShellFtpGetCommandTests(unittest.TestCase):
         reactor.callLater(0, do_test)
         return d
 
-    def test_connection_refused(self) -> None:
+    def test_connection_refused(self) -> defer.Deferred[None]:
         """Test ftpget with invalid host shows connection error"""
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def do_test():
             # Use a non-routable IP to guarantee connection failure
@@ -106,9 +121,9 @@ class ShellFtpGetCommandTests(unittest.TestCase):
         reactor.callLater(0, do_test)
         return d
 
-    def test_invalid_directory(self) -> None:
+    def test_invalid_directory(self) -> defer.Deferred[None]:
         """Test ftpget with invalid local directory"""
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def do_test():
             self.proto.lineReceived(
@@ -132,7 +147,7 @@ class ShellFtpGetAsyncTests(unittest.TestCase):
     proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
     tr = FakeTransport("", "31337")
     ftp_port: int
-    ftp_server = None
+    ftp_server: IListeningPort | None = None
     tmpdir: tempfile.TemporaryDirectory
 
     @classmethod
@@ -155,8 +170,9 @@ class ShellFtpGetAsyncTests(unittest.TestCase):
         portal.registerChecker(checker)
 
         factory = FTPFactory(portal)
-        cls.ftp_server = reactor.listenTCP(0, factory, interface="127.0.0.1")
-        cls.ftp_port = cls.ftp_server.getHost().port
+        server = reactor.listenTCP(0, factory, interface="127.0.0.1")
+        cls.ftp_server = server
+        cls.ftp_port = cast("IPv4Address", server.getHost()).port
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -168,12 +184,12 @@ class ShellFtpGetAsyncTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tr.clear()
 
-    def test_successful_download_anonymous(self) -> None:
+    def test_successful_download_anonymous(self) -> defer.Deferred[None]:
         """Test successful FTP download with anonymous login"""
         cmd = f"ftpget 127.0.0.1 -P {self.ftp_port} /tmp/downloaded.txt test.txt\n"
         self.proto.lineReceived(cmd.encode())
 
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def check():
             output = self.tr.value()
@@ -186,12 +202,12 @@ class ShellFtpGetAsyncTests(unittest.TestCase):
         reactor.callLater(1.0, check)
         return d
 
-    def test_successful_download_with_auth(self) -> None:
+    def test_successful_download_with_auth(self) -> defer.Deferred[None]:
         """Test successful FTP download with username/password"""
         cmd = f"ftpget -u testuser -p testpass 127.0.0.1 -P {self.ftp_port} /tmp/downloaded2.txt test.txt\n"
         self.proto.lineReceived(cmd.encode())
 
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def check():
             output = self.tr.value()
@@ -202,12 +218,12 @@ class ShellFtpGetAsyncTests(unittest.TestCase):
         reactor.callLater(1.0, check)
         return d
 
-    def test_verbose_output(self) -> None:
+    def test_verbose_output(self) -> defer.Deferred[None]:
         """Test ftpget -v shows FTP commands"""
         cmd = f"ftpget -v 127.0.0.1 -P {self.ftp_port} /tmp/downloaded3.txt test.txt\n"
         self.proto.lineReceived(cmd.encode())
 
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def check():
             output = self.tr.value()
@@ -219,12 +235,12 @@ class ShellFtpGetAsyncTests(unittest.TestCase):
         reactor.callLater(1.0, check)
         return d
 
-    def test_file_not_found(self) -> None:
+    def test_file_not_found(self) -> defer.Deferred[None]:
         """Test FTP download of non-existent file"""
         cmd = f"ftpget 127.0.0.1 -P {self.ftp_port} /tmp/notfound.txt nonexistent.txt\n"
         self.proto.lineReceived(cmd.encode())
 
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def check():
             output = self.tr.value()
@@ -235,7 +251,7 @@ class ShellFtpGetAsyncTests(unittest.TestCase):
         reactor.callLater(1.0, check)
         return d
 
-    def test_non_blocking_behavior(self) -> None:
+    def test_non_blocking_behavior(self) -> defer.Deferred[None]:
         """Test that FTP download doesn't block the reactor"""
         # Start FTP download
         cmd = f"ftpget 127.0.0.1 -P {self.ftp_port} /tmp/nonblock.txt test.txt\n"
@@ -244,7 +260,7 @@ class ShellFtpGetAsyncTests(unittest.TestCase):
         # Immediately try another command
         self.proto.lineReceived(b"echo test\n")
 
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def check():
             output = self.tr.value()

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 import os
 import struct
 import unittest
+from typing import TYPE_CHECKING, cast
 
-from twisted.internet import defer, reactor
+from twisted.internet import defer
+from twisted.internet import reactor as _reactor
 from twisted.internet.protocol import DatagramProtocol
 
 from cowrie.commands.tftp import (
@@ -21,6 +23,20 @@ from cowrie.commands.tftp import (
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
+
+if TYPE_CHECKING:
+    from twisted.internet.address import IPv4Address
+    from twisted.internet.interfaces import (
+        IListeningPort,
+        IReactorTime,
+        IReactorUDP,
+    )
+
+    class _Reactor(IReactorTime, IReactorUDP):
+        pass
+
+
+reactor = cast("_Reactor", _reactor)
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
@@ -101,9 +117,9 @@ class ShellTftpCommandTests(unittest.TestCase):
             + PROMPT,
         )
 
-    def test_tftp_insufficient_args(self) -> None:
+    def test_tftp_insufficient_args(self) -> defer.Deferred[None]:
         """Test tftp with only hostname shows usage"""
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def do_test():
             self.proto.lineReceived(b"tftp hostname.com\n")
@@ -118,9 +134,9 @@ class ShellTftpCommandTests(unittest.TestCase):
         reactor.callLater(0, do_test)
         return d
 
-    def test_tftp_invalid_directory(self) -> None:
+    def test_tftp_invalid_directory(self) -> defer.Deferred[None]:
         """Test tftp with invalid local directory"""
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def do_test():
             self.proto.lineReceived(b"tftp -c get /nonexistent/file.txt host.com\n")
@@ -142,7 +158,7 @@ class ShellTftpAsyncTests(unittest.TestCase):
     proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
     tr = FakeTransport("", "31337")
     tftp_port: int
-    tftp_server = None
+    tftp_server: IListeningPort | None = None
     test_content = b"Test file from TFTP server\n"
 
     @classmethod
@@ -151,8 +167,11 @@ class ShellTftpAsyncTests(unittest.TestCase):
 
         # Setup mock TFTP server
         server_protocol = MockTFTPServer(cls.test_content)
-        cls.tftp_server = reactor.listenUDP(0, server_protocol, interface="127.0.0.1")
-        cls.tftp_port = cls.tftp_server.getHost().port
+        server = reactor.listenUDP(
+            0, server_protocol, interface="127.0.0.1", maxPacketSize=8192
+        )
+        cls.tftp_server = server
+        cls.tftp_port = cast("IPv4Address", server.getHost()).port
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -163,12 +182,12 @@ class ShellTftpAsyncTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tr.clear()
 
-    def test_successful_download(self) -> None:
+    def test_successful_download(self) -> defer.Deferred[None]:
         """Test successful TFTP download"""
         cmd = f"tftp -c get /tmp/tftp_test.txt 127.0.0.1:{self.tftp_port}\n"
         self.proto.lineReceived(cmd.encode())
 
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def check():
             output = self.tr.value()
@@ -181,12 +200,12 @@ class ShellTftpAsyncTests(unittest.TestCase):
         reactor.callLater(1.0, check)
         return d
 
-    def test_download_with_r_flag(self) -> None:
+    def test_download_with_r_flag(self) -> defer.Deferred[None]:
         """Test TFTP download with -r flag"""
         cmd = f"tftp -r /tmp/tftp_test2.txt -g 127.0.0.1:{self.tftp_port}\n"
         self.proto.lineReceived(cmd.encode())
 
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def check():
             output = self.tr.value()
@@ -197,13 +216,13 @@ class ShellTftpAsyncTests(unittest.TestCase):
         reactor.callLater(1.0, check)
         return d
 
-    def test_connection_refused(self) -> None:
+    def test_connection_refused(self) -> defer.Deferred[None]:
         """Test TFTP with unreachable host"""
         # Use non-routable IP
         cmd = b"tftp -c get /tmp/test.txt 192.0.2.1\n"
         self.proto.lineReceived(cmd)
 
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def check():
             output = self.tr.value()
@@ -215,7 +234,7 @@ class ShellTftpAsyncTests(unittest.TestCase):
         reactor.callLater(6.0, check)
         return d
 
-    def test_non_blocking_behavior(self) -> None:
+    def test_non_blocking_behavior(self) -> defer.Deferred[None]:
         """Test that TFTP download doesn't block the reactor"""
         # Start TFTP download
         cmd = f"tftp -c get /tmp/nonblock.txt 127.0.0.1:{self.tftp_port}\n"
@@ -224,7 +243,7 @@ class ShellTftpAsyncTests(unittest.TestCase):
         # Immediately try another command
         self.proto.lineReceived(b"echo test\n")
 
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def check():
             output = self.tr.value()
@@ -235,20 +254,22 @@ class ShellTftpAsyncTests(unittest.TestCase):
         reactor.callLater(1.0, check)
         return d
 
-    def test_large_file_download(self) -> None:
+    def test_large_file_download(self) -> defer.Deferred[None]:
         """Test TFTP download of file larger than one block"""
         # Create a larger test file (2 blocks)
         large_content = b"X" * (TFTP_BLOCK_SIZE * 2 + 100)
 
         # Create new server with large content
         server_protocol = MockTFTPServer(large_content)
-        large_server = reactor.listenUDP(0, server_protocol, interface="127.0.0.1")
-        large_port = large_server.getHost().port
+        large_server = reactor.listenUDP(
+            0, server_protocol, interface="127.0.0.1", maxPacketSize=8192
+        )
+        large_port = cast("IPv4Address", large_server.getHost()).port
 
         cmd = f"tftp -c get /tmp/large.txt 127.0.0.1:{large_port}\n"
         self.proto.lineReceived(cmd.encode())
 
-        d = defer.Deferred()
+        d: defer.Deferred[None] = defer.Deferred()
 
         def check():
             output = self.tr.value()


### PR DESCRIPTION
## Summary

- Replace the file-level `# mypy: disable-error-code="var-annotated,attr-defined,return-value"` directive in `test_ftpget.py` and the equivalent (previously unsuppressed) errors in `test_tftp.py` with explicit type annotations.
- mypy was reporting 24 errors in `test_tftp.py` from the same patterns silenced in `test_ftpget.py`; both files now pass without suppression.

## Approach

- Cast `reactor` once via a synthetic `_Reactor(IReactorTime, IReactor{TCP,UDP})` interface in a `TYPE_CHECKING` block, so call sites stay clean (no per-call `cast`).
- Annotate `Deferred` instances and async test return types as `defer.Deferred[None]`.
- Type listening-port class attrs as `IListeningPort | None`.
- Cast `getHost()` results to `IPv4Address` to access `.port` (the base `IAddress` doesn't expose it).
- Pass `maxPacketSize=8192` explicitly to `listenUDP` because mypy-zope doesn't propagate interface method defaults.

All changes are type-only; runtime behavior is unchanged (`cast` is a no-op; `maxPacketSize=8192` is the existing default).

## Test plan

- [x] `mypy src` clean (214 source files, no errors)
- [x] `trial cowrie.test.test_tftp cowrie.test.test_ftpget` produces the same pass/fail counts as before this change (no behavioral regression introduced)