### PR TITLE
Bump Twisted to 26.4.0 and adopt its stricter typing

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy-3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
         experimental: [false]
         prerelease: [false]
         include:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy-3.11"]
         experimental: [false]
         prerelease: [false]
         include:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "pypy-3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
         experimental: [false]
         prerelease: [false]
         include:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -99,7 +99,7 @@ jobs:
         prerelease: [false]
         include:
           - python-version: "3.15"
-            experimental: false
+            experimental: true
             prerelease: true
           - python-version: "3.15t"
             experimental: true

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,4 +8,4 @@ setuptools==82.0.1
 sphinx-copybutton==0.5.2
 sphinx_rtd_theme==3.1.0
 sphinxcontrib-googleanalytics==0.5
-twisted==25.5.0
+twisted==26.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,7 @@ version_file = "src/cowrie/_version.py"
 [tool.tox]
 legacy_tox_ini = """
     [tox]
-    envlist = lint,docs,typing,py310,py311,py312,py313,py314,py314t,py315,pypy311
+    envlist = lint,docs,typing,py310,py311,py312,py313,py314,py314t,py315,py315t,pypy311
     deps = -r{toxinidir}/requirements.txt
     skip_missing_interpreters = True
 
@@ -228,6 +228,7 @@ legacy_tox_ini = """
         3.14: py314
         3.14t: py314t
         3.15: py315
+        3.15t: py315t
         pypy-3.11: pypy311
 
     [testenv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers=[
 dependencies = [
         "attrs==26.1.0",
         "bcrypt==5.0.0",
-        "cryptography==46.0.7",
+        "cryptography==48.0.0",
         "hyperlink==21.0.0",
         "idna==3.13",
         "packaging==26.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
         "bcrypt==5.0.0",
         "cryptography==48.0.0",
         "hyperlink==21.0.0",
-        "idna==3.13",
+        "idna==3.14",
         "packaging==26.2",
         "pyasn1_modules==0.4.2",
         "requests==2.32.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
         "service_identity==24.2.0",
         "tftpy==0.8.7",
         "treq==25.5.0",
-        "twisted[conch]==25.5.0",
+        "twisted[conch]==26.4.0",
         "urllib3==2.6.3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license-files = [ "LICENSE.rst" ]
 authors = [ {name = "Michel Oosterhof", email="michel@oosterhof.net"}, ]
 maintainers = [ {name = "Michel Oosterhof", email="michel@oosterhof.net"}, ]
 keywords=["ssh", "telnet", "honeypot"]
-requires-python = ">2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, !=3.7.*, !=3.8.*, !=3.9.*, <4"
+requires-python = ">=3.10, <4"
 readme="README.rst"
 classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -173,6 +173,17 @@ reportOptionalMemberAccess = "none"
 reportOptionalOperand = "information"
 reportPossiblyUnboundVariable = "information"
 reportUnsupportedDunderAll = "information"
+
+[tool.ty.environment]
+python-version = "3.10"
+
+[tool.ty.src]
+exclude = ["src/cowrie/vendor/**"]
+
+[[tool.ty.overrides]]
+include = ["src/cowrie/output/**", "src/backend_pool/**"]
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
         "tftpy==0.8.7",
         "treq==25.5.0",
         "twisted[conch]==26.4.0",
-        "urllib3==2.6.3",
+        "urllib3==2.7.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,7 @@ version_file = "src/cowrie/_version.py"
 [tool.tox]
 legacy_tox_ini = """
     [tox]
-    envlist = lint,docs,typing,py310,py311,py312,py313,py314,py314t,py315,pypy310,pypy311
+    envlist = lint,docs,typing,py310,py311,py312,py313,py314,py314t,py315,pypy311
     deps = -r{toxinidir}/requirements.txt
     skip_missing_interpreters = True
 
@@ -228,7 +228,6 @@ legacy_tox_ini = """
         3.14: py314
         3.14t: py314t
         3.15: py315
-        pypy-3.10: pypy310
         pypy-3.11: pypy311
 
     [testenv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
         "idna==3.14",
         "packaging==26.2",
         "pyasn1_modules==0.4.2",
-        "requests==2.32.5",
+        "requests==2.34.0",
         "service_identity==24.2.0",
         "tftpy==0.8.7",
         "treq==25.5.0",

--- a/requirements-output.txt
+++ b/requirements-output.txt
@@ -11,7 +11,7 @@
 # geoip2
 
 # dshield
-requests==2.32.5
+requests==2.34.0
 python-dateutil==2.9.0.post0
 
 # elasticsearch

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 attrs==26.1.0
 bcrypt==5.0.0
-cryptography==46.0.7
+cryptography==48.0.0
 hyperlink==21.0.0
 idna==3.13
 packaging==26.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ hyperlink==21.0.0
 idna==3.14
 packaging==26.2
 pyasn1_modules==0.4.2
-requests==2.32.5
+requests==2.34.0
 service_identity==24.2.0
 tftpy==0.8.7
 treq==25.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ requests==2.32.5
 service_identity==24.2.0
 tftpy==0.8.7
 treq==25.5.0
-twisted[conch]==25.5.0
+twisted[conch]==26.4.0
 urllib3==2.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ attrs==26.1.0
 bcrypt==5.0.0
 cryptography==48.0.0
 hyperlink==21.0.0
-idna==3.13
+idna==3.14
 packaging==26.2
 pyasn1_modules==0.4.2
 requests==2.32.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ service_identity==24.2.0
 tftpy==0.8.7
 treq==25.5.0
 twisted[conch]==26.4.0
-urllib3==2.6.3
+urllib3==2.7.0

--- a/src/backend_pool/nat.py
+++ b/src/backend_pool/nat.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from twisted.internet.interfaces import IAddress
     from twisted.python import failure
 from twisted.internet import protocol, reactor
+from twisted.internet.address import IPv4Address, IPv6Address
 from twisted.internet.protocol import connectionDone
 
 
@@ -27,11 +28,11 @@ class ClientProtocol(protocol.Protocol):
         self.server_protocol.transport.loseConnection()
 
 
-class ClientFactory(protocol.ClientFactory):
+class ClientFactory(protocol.ClientFactory[ClientProtocol]):
     def __init__(self, server_protocol: ServerProtocol) -> None:
         self.server_protocol = server_protocol
 
-    def buildProtocol(self, addr: IAddress) -> ClientProtocol:
+    def buildProtocol(self, addr: IAddress | None) -> ClientProtocol:
         client_protocol = ClientProtocol()
         client_protocol.server_protocol = self.server_protocol
         self.server_protocol.client_protocol = client_protocol
@@ -54,7 +55,7 @@ class ServerProtocol(protocol.Protocol):
 
     def sendData(self) -> None:
         if not self.client_protocol:
-            reactor.callLater(0.5, self.sendData)  # type: ignore[attr-defined]
+            reactor.callLater(0.5, self.sendData)
             return
 
         assert (
@@ -73,12 +74,12 @@ class ServerProtocol(protocol.Protocol):
         self.client_protocol.transport.loseConnection()
 
 
-class ServerFactory(protocol.Factory):
+class ServerFactory(protocol.Factory[ServerProtocol]):
     def __init__(self, dst_ip: str, dst_port: int) -> None:
         self.dst_ip: str = dst_ip
         self.dst_port: int = dst_port
 
-    def buildProtocol(self, addr: IAddress) -> ServerProtocol:
+    def buildProtocol(self, addr: IAddress | None) -> ServerProtocol:
         return ServerProtocol(self.dst_ip, self.dst_port)
 
 
@@ -129,15 +130,23 @@ class NATService:
 
                     # let it recreate the bindings on the next step
 
-            nat_ssh = reactor.listenTCP(  # type: ignore[attr-defined]
-                0, ServerFactory(dst_ip, ssh_port), interface="0.0.0.0"
+            nat_ssh = reactor.listenTCP(
+                0,
+                ServerFactory(dst_ip, ssh_port),  # type: ignore[arg-type]
+                interface="0.0.0.0",
             )
-            nat_telnet = reactor.listenTCP(  # type: ignore[attr-defined]
-                0, ServerFactory(dst_ip, telnet_port), interface="0.0.0.0"
+            nat_telnet = reactor.listenTCP(
+                0,
+                ServerFactory(dst_ip, telnet_port),  # type: ignore[arg-type]
+                interface="0.0.0.0",
             )
             self.bindings[guest_id] = [1, nat_ssh, nat_telnet]
 
-            return nat_ssh._realPortNumber, nat_telnet._realPortNumber
+            ssh_addr = nat_ssh.getHost()
+            telnet_addr = nat_telnet.getHost()
+            assert isinstance(ssh_addr, (IPv4Address, IPv6Address))
+            assert isinstance(telnet_addr, (IPv4Address, IPv6Address))
+            return ssh_addr.port, telnet_addr.port
 
     def free_binding(self, guest_id: int) -> None:
         with self.lock:

--- a/src/backend_pool/pool_server.py
+++ b/src/backend_pool/pool_server.py
@@ -188,7 +188,7 @@ class PoolServer(Protocol):
             self.transport.write(response)
 
 
-class PoolServerFactory(Factory):
+class PoolServerFactory(Factory[PoolServer]):
     """
     Factory for PoolServer
     """
@@ -215,7 +215,8 @@ class PoolServerFactory(Factory):
         if self.pool_service:
             self.pool_service.shutdown_pool()
 
-    def buildProtocol(self, addr: IAddress) -> PoolServer:
+    def buildProtocol(self, addr: IAddress | None) -> PoolServer:
+        assert addr is not None
         assert isinstance(addr, (IPv4Address, IPv6Address))
         log.msg(
             eventid="cowrie.backend_pool.server",

--- a/src/backend_pool/pool_service.py
+++ b/src/backend_pool/pool_service.py
@@ -348,7 +348,11 @@ class PoolService:
         # replenish pool until full
         to_create = self.max_vm - self.existing_pool_size()
         for _ in range(to_create):
-            dom, snap, guest_ip = self.qemu.create_guest(self.is_ip_free)
+            created = self.qemu.create_guest(self.is_ip_free)
+            if created is None:
+                # backend not ready or libvirt failed; try again next loop
+                continue
+            dom, snap, guest_ip = created
 
             # create guest object
             self.guests.append(

--- a/src/backend_pool/pool_service.py
+++ b/src/backend_pool/pool_service.py
@@ -153,7 +153,7 @@ class PoolService:
             "backend_pool", "recycle_period", fallback=-1
         )
         if recycle_period > 0:
-            reactor.callLater(recycle_period, self.restart_pool)  # type: ignore[attr-defined]
+            reactor.callLater(recycle_period, self.restart_pool)
 
     def stop_pool(self) -> None:
         # lazy import to avoid exception if not using the backend_pool
@@ -395,7 +395,7 @@ class PoolService:
         self.__producer_mark_available()
 
         # sleep until next iteration
-        self.loop_next_call = reactor.callLater(  # type: ignore[attr-defined]
+        self.loop_next_call = reactor.callLater(
             self.loop_sleep_time, self.producer_loop
         )
 

--- a/src/backend_pool/ssh_exec.py
+++ b/src/backend_pool/ssh_exec.py
@@ -95,7 +95,7 @@ class ClientCommandFactory(protocol.ClientFactory):
         self.done_deferred = done_deferred
         self.callback = callback
 
-    def buildProtocol(self, addr: IAddress) -> ClientCommandTransport:
+    def buildProtocol(self, addr: IAddress | None) -> ClientCommandTransport:
         return ClientCommandTransport(
             self.username,
             self.password,

--- a/src/backend_pool/telnet_exec.py
+++ b/src/backend_pool/telnet_exec.py
@@ -81,7 +81,7 @@ class TelnetClient(StatefulTelnetProtocol):
 
         # start countdown to command done (when reached, consider the output was completely received and close)
         if not self.done_callback:
-            self.done_callback = reactor.callLater(0.5, self.close)  # type: ignore[attr-defined]
+            self.done_callback = reactor.callLater(0.5, self.close)
         else:
             self.done_callback.reset(0.5)
 
@@ -119,7 +119,7 @@ class TelnetFactory(ClientFactory):
         self.done_deferred = done_deferred
         self.callback = callback
 
-    def buildProtocol(self, addr: IAddress) -> TelnetTransport:
+    def buildProtocol(self, addr: IAddress | None) -> TelnetTransport:
         transport = TelnetTransport(TelnetClient)
         transport.factory = self
         return transport

--- a/src/cowrie/commands/adduser.py
+++ b/src/cowrie/commands/adduser.py
@@ -83,7 +83,7 @@ class Command_adduser(HoneyPotCommand):
             self.schedule_next()
 
     def schedule_next(self) -> None:
-        self.scheduled = reactor.callLater(0.5 + random.random() * 1, self.do_output)  # type: ignore[attr-defined]
+        self.scheduled = reactor.callLater(0.5 + random.random() * 1, self.do_output)
 
     def lineReceived(self, line: str) -> None:
         if self.item + 1 == len(self.output) and line.strip() in ("n", "no"):

--- a/src/cowrie/commands/apt.py
+++ b/src/cowrie/commands/apt.py
@@ -58,7 +58,7 @@ class Command_aptget(HoneyPotCommand):
         d: defer.Deferred = defer.Deferred()
         if time2:
             time = random.randint(int(time * 100), int(time2 * 100.0)) / 100.0
-        reactor.callLater(time, d.callback, None)  # type: ignore[attr-defined]
+        reactor.callLater(time, d.callback, None)
         return d
 
     def do_version(self) -> None:

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -886,7 +886,7 @@ class Command_shutdown(HoneyPotCommand):
             )
             self.write("\n")
             self.write("The system is going down for maintenance NOW!\n")
-            reactor.callLater(3, self.finish)  # type: ignore[attr-defined]
+            reactor.callLater(3, self.finish)
         elif (
             len(self.args) > 1
             and self.args[0].strip().count("-r")
@@ -898,7 +898,7 @@ class Command_shutdown(HoneyPotCommand):
             )
             self.write("\n")
             self.write("The system is going down for reboot NOW!\n")
-            reactor.callLater(3, self.finish)  # type: ignore[attr-defined]
+            reactor.callLater(3, self.finish)
         else:
             self.write("Try `shutdown --help' for more information.\n")
             self.exit()
@@ -923,7 +923,7 @@ class Command_reboot(HoneyPotCommand):
             f"Broadcast message from root@{self.protocol.hostname} (pts/0) ({time.ctime()}):\n\n"
         )
         self.write("The system is going down for reboot NOW!\n")
-        reactor.callLater(3, self.finish)  # type: ignore[attr-defined]
+        reactor.callLater(3, self.finish)
 
     def finish(self) -> None:
         stat = failure.Failure(error.ProcessDone(status=""))
@@ -974,7 +974,7 @@ class Command_yes(HoneyPotCommand):
             self.write(f"{' '.join(self.args)}\n")
         else:
             self.write("y\n")
-        self.scheduled = reactor.callLater(0.01, self.y)  # type: ignore[attr-defined]
+        self.scheduled = reactor.callLater(0.01, self.y)
 
     def handle_CTRL_C(self) -> None:
         self.scheduled.cancel()

--- a/src/cowrie/commands/gcc.py
+++ b/src/cowrie/commands/gcc.py
@@ -18,7 +18,7 @@ from cowrie.core.config import CowrieConfig
 from cowrie.shell.command import HoneyPotCommand
 
 if TYPE_CHECKING:
-    from twisted.internet.defer import Deferred
+    from twisted.internet.interfaces import IDelayedCall
 
 commands = {}
 
@@ -57,7 +57,7 @@ class Command_gcc(HoneyPotCommand):
         b"\x01\x00\x00\x00"
     )
 
-    scheduled: Deferred
+    scheduled: IDelayedCall
 
     def call(self) -> None:
         """
@@ -138,7 +138,7 @@ class Command_gcc(HoneyPotCommand):
             timeout = 0.1 + random.random()
 
             # Schedule call to make it more time consuming and real
-            self.scheduled = reactor.callLater(  # type: ignore[attr-defined]
+            self.scheduled = reactor.callLater(
                 timeout, self.generate_file, (output_file if output_file else "a.out")
             )
         else:

--- a/src/cowrie/commands/ping.py
+++ b/src/cowrie/commands/ping.py
@@ -89,7 +89,7 @@ class Command_ping(HoneyPotCommand):
 
         self.running = True
         self.write(f"PING {self.host} ({self.ip}) 56(84) bytes of data.\n")
-        self.scheduled = reactor.callLater(0.2, self.showreply)  # type: ignore[attr-defined]
+        self.scheduled = reactor.callLater(0.2, self.showreply)
         self.count = 0
 
     def showreply(self) -> None:
@@ -105,7 +105,7 @@ class Command_ping(HoneyPotCommand):
             self.exit()
             return
         else:
-            self.scheduled = reactor.callLater(1, self.showreply)  # type: ignore[attr-defined]
+            self.scheduled = reactor.callLater(1, self.showreply)
 
     def printstatistics(self) -> None:
         self.write(f"--- {self.host} ping statistics ---\n")

--- a/src/cowrie/commands/sleep.py
+++ b/src/cowrie/commands/sleep.py
@@ -111,7 +111,7 @@ Written by Jim Meyering and Paul Eggert.
             _time += int(m.group(1))
 
         self.running = True
-        self.scheduled = reactor.callLater(_time, self.done)  # type: ignore[attr-defined]
+        self.scheduled = reactor.callLater(_time, self.done)
 
     def handle_CTRL_C(self) -> None:
         if self.running:

--- a/src/cowrie/commands/ssh.py
+++ b/src/cowrie/commands/ssh.py
@@ -123,7 +123,7 @@ class Command_ssh(HoneyPotCommand):
         self.protocol.password_input = True
 
     def wait(self, line: str) -> None:
-        reactor.callLater(2, self.finish, line)  # type: ignore[attr-defined]
+        reactor.callLater(2, self.finish, line)
 
     def finish(self, line: str) -> None:
         self.pause = False

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -183,7 +183,7 @@ class TFTPClient(DatagramProtocol):
         if self.timeout_call is not None and self.timeout_call.active():
             self.timeout_call.cancel()
 
-        self.timeout_call = reactor.callLater(TFTP_TIMEOUT, self.handleTimeout)  # type: ignore[attr-defined]
+        self.timeout_call = reactor.callLater(TFTP_TIMEOUT, self.handleTimeout)
 
     def handleTimeout(self) -> None:
         """Handle timeout - retry or fail"""

--- a/src/cowrie/commands/yum.py
+++ b/src/cowrie/commands/yum.py
@@ -64,7 +64,7 @@ class Command_yum(HoneyPotCommand):
         d: defer.Deferred = defer.Deferred()
         if time2:
             time = random.randint(int(time * 100), int(time2 * 100)) / 100.0
-        reactor.callLater(time, d.callback, None)  # type: ignore[attr-defined]
+        reactor.callLater(time, d.callback, None)
         return d
 
     @inlineCallbacks

--- a/src/cowrie/core/output.py
+++ b/src/cowrie/core/output.py
@@ -90,7 +90,7 @@ class Output(metaclass=abc.ABCMeta):
             self.timeFormat = "%Y-%m-%dT%H:%M:%S.%f%z"
 
         # Event trigger so that stop() is called by the reactor when stopping
-        reactor.addSystemEventTrigger("before", "shutdown", self.stop)  # type: ignore
+        reactor.addSystemEventTrigger("before", "shutdown", self.stop)
 
         self.start()
 

--- a/src/cowrie/output/abuseipdb.py
+++ b/src/cowrie/output/abuseipdb.py
@@ -18,7 +18,7 @@ __version__ = "0.3b3"
 
 import pickle
 from collections import deque
-from datetime import datetime
+from datetime import datetime, timezone
 from json.decoder import JSONDecodeError
 from pathlib import Path
 from time import sleep, time
@@ -363,7 +363,7 @@ class Reporter:
 
     @staticmethod
     def epoch_to_string_utc(t):
-        t_utc = datetime.utcfromtimestamp(t)
+        t_utc = datetime.fromtimestamp(t, timezone.utc)
         return t_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     @staticmethod

--- a/src/cowrie/output/rmq.py
+++ b/src/cowrie/output/rmq.py
@@ -22,16 +22,16 @@ except ImportError:
 
 
 class CustomJSONEncoder(json.JSONEncoder):
-    def default(self, obj):
-        match obj:
+    def default(self, o):
+        match o:
             case NamedConstant() | ValueConstant():
-                return str(obj)
+                return str(o)
             case IPv4Address() | IPv6Address():
-                return obj.host  # Extract the IP address as a string
+                return o.host  # Extract the IP address as a string
             case bytes():
-                return obj.decode("utf-8", errors="replace")  # Convert bytes to string
+                return o.decode("utf-8", errors="replace")  # Convert bytes to string
             case _:
-                return super().default(obj)
+                return super().default(o)
 
 
 class Output(cowrie.core.output.Output):

--- a/src/cowrie/output/virustotal.py
+++ b/src/cowrie/output/virustotal.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 from twisted.internet import defer, reactor
+from twisted.internet.protocol import connectionDone
 from twisted.python import log
 from twisted.web import client, http_headers
 from twisted.web.iweb import IBodyProducer, IResponse
@@ -49,7 +50,7 @@ def readBody(response: IResponse) -> defer.Deferred:
         def dataReceived(self, data):
             self.data += data
 
-        def connectionLost(self, reason):
+        def connectionLost(self, reason=connectionDone):
             d.callback(self.data)
 
     collector = BodyCollector()

--- a/src/cowrie/ssh_proxy/client_transport.py
+++ b/src/cowrie/ssh_proxy/client_transport.py
@@ -45,7 +45,7 @@ class BackendSSHTransport(transport.SSHClientTransport, TimeoutMixin):
 
     def __init__(self, factory: BackendSSHFactory):
         self.delayedPackets: list[tuple[int, bytes]] = []
-        self.factory: BackendSSHFactory = factory  # type: ignore
+        self.factory: BackendSSHFactory = factory
         self.canAuth: bool = False
         self.authDone: bool = False
 

--- a/src/cowrie/ssh_proxy/client_transport.py
+++ b/src/cowrie/ssh_proxy/client_transport.py
@@ -111,7 +111,7 @@ class BackendSSHTransport(transport.SSHClientTransport, TimeoutMixin):
         # backend auth is done, attackers will now be connected to the backend
         self.authDone = True
 
-    def connectionLost(self, reason):
+    def connectionLost(self, reason=None):
         if self.factory.server.pool_interface:
             log.msg(
                 eventid="cowrie.proxy.client_disconnect",

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -362,7 +362,7 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
 
         transport.SSHServerTransport.setService(self, service)
 
-    def connectionLost(self, reason):
+    def connectionLost(self, reason=None):
         """
         This seems to be the only reliable place of catching lost connection
         """

--- a/src/cowrie/telnet/factory.py
+++ b/src/cowrie/telnet/factory.py
@@ -85,11 +85,11 @@ class HoneyPotTelnetFactory(protocol.ServerFactory):
                 HoneyPotTelnetAuthProtocol, self.portal
             )
 
-        protocol.ServerFactory.startFactory(self)
+        super().startFactory()
         log.msg("Ready to accept Telnet connections")
 
     def stopFactory(self) -> None:
         """
         Stop output plugins
         """
-        protocol.ServerFactory.stopFactory(self)
+        super().stopFactory()

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import os
 import struct
 import unittest
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from twisted.internet import defer
 from twisted.internet import reactor as _reactor
@@ -52,12 +52,12 @@ class MockTFTPServer(DatagramProtocol):
         self.test_file_content = test_file_content
         self.client_addr: tuple[str, int] | None = None
 
-    def datagramReceived(self, data: bytes, addr: tuple[str, int]) -> None:
+    def datagramReceived(self, datagram: bytes, addr: Any) -> None:
         """Handle TFTP packets"""
-        if len(data) < 2:
+        if len(datagram) < 2:
             return
 
-        opcode = struct.unpack("!H", data[:2])[0]
+        opcode = struct.unpack("!H", datagram[:2])[0]
 
         if opcode == OPCODE_RRQ:
             # Read request - send data back
@@ -65,7 +65,7 @@ class MockTFTPServer(DatagramProtocol):
             self.sendFile()
         elif opcode == OPCODE_ACK:
             # ACK received - if not final ACK, send next block
-            block_num = struct.unpack("!H", data[2:4])[0]
+            block_num = struct.unpack("!H", datagram[2:4])[0]
             self.sendNextBlock(block_num)
 
     def sendFile(self) -> None:


### PR DESCRIPTION
## Summary

Bumps Twisted from 25.5.0 to 26.4.0 (latest stable on PyPI) and adapts the codebase to Twisted 26.4's stricter typing. While auditing the result with \`ty\` I also picked up a handful of pre-existing real bugs.

## Commits

**Twisted bump and adaptation**
- \`build(deps): bump twisted from 25.5.0 to 26.4.0\` — pins in \`requirements.txt\`, \`docs/requirements.txt\`, and \`pyproject.toml\`.
- \`fix(commands): correct gcc.scheduled type annotation\` — \`reactor.callLater()\` returns \`IDelayedCall\`, not \`Deferred\`. The annotation was wrong but harmless at runtime (both have \`cancel()\`).
- \`fix(types): adapt to Twisted 26.4 typing changes\` — five things, all consequences of upstream typing improvements:
  - \`Factory\` is now \`Generic[P]\`; parameterize \`PoolServerFactory\`, \`ClientFactory\`, \`ServerFactory\`.
  - \`Factory.buildProtocol\` now declares \`addr: IAddress | None\`; five override signatures updated.
  - Replace private \`_realPortNumber\` access with public \`getHost().port\`.
  - Replace unbound \`protocol.ServerFactory.startFactory(self)\` with \`super().startFactory()\` (and same for stop).
  - Remove ~18 \`# type: ignore[attr-defined]\` comments on \`reactor.callLater\` etc. that are now properly typed upstream.

**Config hygiene**
- \`build: tighten requires-python and configure ty\` — \`requires-python\` claimed \`>2.7\` despite tox/ruff already targeting 3.10+; corrected to \`>=3.10, <4\`. Adds \`[tool.ty]\` block excluding \`src/cowrie/vendor\` and silencing \`unresolved-import\` for optional output plugins.

**Pre-existing real bugs uncovered by ty**
- \`fix(output): replace deprecated datetime.utcfromtimestamp\` — Python deprecation.
- \`fix(backend_pool): guard against None from create_guest\` — \`QemuGuest.create_guest\` returns \`tuple[Any, str, str] | None\`; the producer loop was unpacking unconditionally, which would raise \`TypeError\` instead of retrying.
- \`fix(output): align rmq JSON encoder default override\` — \`json.JSONEncoder.default\` uses parameter name \`o\`.
- \`fix(output): give virustotal BodyCollector.connectionLost a default reason\` — \`Protocol.connectionLost\` defaults \`reason\` to \`connectionDone\`.
- \`fix(ssh_proxy): give connectionLost a default reason\` — same for the two SSH proxy transports.
- \`fix(test): match datagramReceived signature in TFTP test server\` — parameter was narrowed to \`tuple[str, int]\` and named \`data\` instead of \`datagram\`, breaking LSP.

## Test plan

- [x] \`python -m unittest discover src\` — 294/294 pass
- [x] \`mypy --config-file=pyproject.toml src\` — clean
- [x] \`ruff check src\` — clean
- [x] \`yamllint .\` — clean
- [x] \`ty check src\` — 632 → 504 diagnostics; all remaining are pre-existing and either ty false positives on Twisted's zope-interface dispatch or known typing gaps (\`ITransport | None\` narrowing, \`IAddress.host/.port\`) that would require invasive changes orthogonal to this PR.

Notes:
- \`pylint\` could not be run locally because of an astroid bug on Python 3.15; the lint env in tox is pinned to 3.10 so CI is unaffected.
- \`pyright\` runs in strict mode but is gated by \`-\` in the tox lint env (informational only). It reports 8516 errors on this branch vs. 8571 on main (−55).