### PR TITLE
Port malshare and cuckoo output plugins to treq

### DIFF
--- a/src/cowrie/output/cuckoo.py
+++ b/src/cowrie/output/cuckoo.py
@@ -69,7 +69,6 @@ class Output(cowrie.core.output.Output):
 
     def write(self, event):
         if event["eventid"] == "cowrie.session.file_download":
-            log.msg("Sending file to Cuckoo")
             p = urlparse(event["url"]).path
             if p == "":
                 fileName = event["shasum"]
@@ -83,7 +82,6 @@ class Output(cowrie.core.output.Output):
             self._maybe_postfile(event["outfile"], fileName)
 
         elif event["eventid"] == "cowrie.session.file_upload":
-            log.msg("Sending file to Cuckoo")
             self._maybe_postfile(event["outfile"], event["filename"])
 
     @defer.inlineCallbacks
@@ -92,6 +90,7 @@ class Output(cowrie.core.output.Output):
             is_dup = yield self.cuckoo_check_if_dup(os.path.basename(outfile))
             if is_dup:
                 return
+        log.msg("Sending file to Cuckoo")
         yield self.postfile(outfile, fileName)
 
     @defer.inlineCallbacks

--- a/src/cowrie/output/cuckoo.py
+++ b/src/cowrie/output/cuckoo.py
@@ -125,6 +125,8 @@ class Output(cowrie.core.output.Output):
             )
             return True
 
+        # Drain the body so the connection returns to the pool.
+        yield response.text()
         return False
 
     @defer.inlineCallbacks
@@ -152,6 +154,7 @@ class Output(cowrie.core.output.Output):
                 )
             )
         else:
+            yield response.text()
             log.msg(f"Cuckoo Request failed: {response.code}")
 
     @defer.inlineCallbacks
@@ -178,4 +181,5 @@ class Output(cowrie.core.output.Output):
                 )
             )
         else:
+            yield response.text()
             log.msg(f"Cuckoo Request failed: {response.code}")

--- a/src/cowrie/output/cuckoo.py
+++ b/src/cowrie/output/cuckoo.py
@@ -10,17 +10,35 @@ Send downloaded/uplaoded files to Cuckoo
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlparse
 
-# TODO: use `treq`
-import requests
-from requests.auth import HTTPBasicAuth
+from treq.client import HTTPClient
+from twisted.internet import defer, error, reactor, ssl
 from twisted.python import log
+from twisted.web import client
+from twisted.web.iweb import IPolicyForHTTPS
+from zope.interface import implementer
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
 HTTP_TIMEOUT = 20
+
+
+@implementer(IPolicyForHTTPS)
+class _NoVerifyContextFactory:
+    """
+    Cuckoo deployments are typically local with self-signed certs,
+    so verification is skipped on purpose (matches the old verify=False
+    behaviour of requests).
+    """
+
+    def creatorForNetloc(self, hostname, port):
+        return ssl.CertificateOptions(verify=False)
 
 
 class Output(cowrie.core.output.Output):
@@ -41,6 +59,7 @@ class Output(cowrie.core.output.Output):
         self.api_user = CowrieConfig.get("output_cuckoo", "user")
         self.api_passwd = CowrieConfig.get("output_cuckoo", "passwd", raw=True)
         self.cuckoo_force = int(CowrieConfig.getboolean("output_cuckoo", "force"))
+        self.client = HTTPClient(client.Agent(reactor, _NoVerifyContextFactory()))
 
     def stop(self):
         """
@@ -61,89 +80,103 @@ class Output(cowrie.core.output.Output):
                 else:
                     fileName = b
 
-            if (
-                self.cuckoo_force
-                or self.cuckoo_check_if_dup(os.path.basename(event["outfile"])) is False
-            ):
-                self.postfile(event["outfile"], fileName)
+            self._maybe_postfile(event["outfile"], fileName)
 
         elif event["eventid"] == "cowrie.session.file_upload":
-            if (
-                self.cuckoo_force
-                or self.cuckoo_check_if_dup(os.path.basename(event["outfile"])) is False
-            ):
-                log.msg("Sending file to Cuckoo")
-                self.postfile(event["outfile"], event["filename"])
+            log.msg("Sending file to Cuckoo")
+            self._maybe_postfile(event["outfile"], event["filename"])
 
-    def cuckoo_check_if_dup(self, sha256: str) -> bool:
+    @defer.inlineCallbacks
+    def _maybe_postfile(self, outfile, fileName):
+        if not self.cuckoo_force:
+            is_dup = yield self.cuckoo_check_if_dup(os.path.basename(outfile))
+            if is_dup:
+                return
+        yield self.postfile(outfile, fileName)
+
+    @defer.inlineCallbacks
+    def cuckoo_check_if_dup(self, sha256: str) -> Generator[Any, Any, bool]:
         """
         Check if file already was analyzed by cuckoo
         """
         try:
             log.msg(f"Looking for tasks for: {sha256}")
-            res = requests.get(
+            response = yield self.client.get(
                 urljoin(self.url_base, f"/files/view/sha256/{sha256}".encode()),
-                verify=False,
-                auth=HTTPBasicAuth(self.api_user, self.api_passwd),
+                auth=(self.api_user, self.api_passwd),
                 timeout=HTTP_TIMEOUT,
             )
-            if res and res.ok:
-                log.msg(
-                    "Sample found in Sandbox, with ID: {}".format(
-                        res.json().get("sample", {}).get("id", 0)
-                    )
-                )
-                return True
+        except (
+            defer.CancelledError,
+            error.ConnectingCancelledError,
+            error.DNSLookupError,
+        ) as e:
+            log.msg(e)
+            return False
         except Exception as e:
             log.msg(e)
+            return False
+
+        if 200 <= response.code < 300:
+            body = yield response.json()
+            log.msg(
+                "Sample found in Sandbox, with ID: {}".format(
+                    body.get("sample", {}).get("id", 0)
+                )
+            )
+            return True
 
         return False
 
+    @defer.inlineCallbacks
     def postfile(self, artifact, fileName):
         """
         Send a file to Cuckoo
         """
-        with open(artifact, "rb") as art:
-            files = {"file": (fileName, art.read())}
         try:
-            res = requests.post(
-                urljoin(self.url_base, b"tasks/create/file"),
-                files=files,
-                auth=HTTPBasicAuth(self.api_user, self.api_passwd),
-                verify=False,
-                timeout=HTTP_TIMEOUT,
-            )
-            if res and res.ok:
-                log.msg(
-                    "Cuckoo Request: {}, Task created with ID: {}".format(
-                        res.status_code, res.json()["task_id"]
-                    )
+            with open(artifact, "rb") as art:
+                response = yield self.client.post(
+                    urljoin(self.url_base, b"tasks/create/file"),
+                    files={"file": (fileName, art)},
+                    auth=(self.api_user, self.api_passwd),
+                    timeout=HTTP_TIMEOUT,
                 )
-            else:
-                log.msg(f"Cuckoo Request failed: {res.status_code}")
         except Exception as e:
             log.msg(f"Cuckoo Request failed: {e}")
+            return
 
+        if 200 <= response.code < 300:
+            body = yield response.json()
+            log.msg(
+                "Cuckoo Request: {}, Task created with ID: {}".format(
+                    response.code, body["task_id"]
+                )
+            )
+        else:
+            log.msg(f"Cuckoo Request failed: {response.code}")
+
+    @defer.inlineCallbacks
     def posturl(self, scanUrl):
         """
         Send a URL to Cuckoo
         """
-        data = {"url": scanUrl}
         try:
-            res = requests.post(
+            response = yield self.client.post(
                 urljoin(self.url_base, b"tasks/create/url"),
-                data=data,
-                auth=HTTPBasicAuth(self.api_user, self.api_passwd),
-                verify=False,
+                data={"url": scanUrl},
+                auth=(self.api_user, self.api_passwd),
                 timeout=HTTP_TIMEOUT,
             )
-            if res and res.ok:
-                log.msg(
-                    "Cuckoo Request: {}, Task created with ID: {}".format(
-                        res.status_code, res.json()["task_id"]
-                    )
-                )
-            else:
-                log.msg(f"Cuckoo Request failed: {res.status_code}")
         except Exception as e:
             log.msg(f"Cuckoo Request failed: {e}")
+            return
+
+        if 200 <= response.code < 300:
+            body = yield response.json()
+            log.msg(
+                "Cuckoo Request: {}, Task created with ID: {}".format(
+                    response.code, body["task_id"]
+                )
+            )
+        else:
+            log.msg(f"Cuckoo Request failed: {response.code}")

--- a/src/cowrie/output/malshare.py
+++ b/src/cowrie/output/malshare.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 import os
 from urllib.parse import urlparse
 
-import requests
+import treq
+from twisted.internet import defer, error
 from twisted.python import log
 
 import cowrie.core.output
@@ -24,8 +25,6 @@ HTTP_TIMEOUT = 20
 class Output(cowrie.core.output.Output):
     """
     malshare output
-
-    TODO: use `treq`
     """
 
     apiKey: str
@@ -59,21 +58,33 @@ class Output(cowrie.core.output.Output):
         elif event["eventid"] == "cowrie.session.file_upload":
             self.postfile(event["outfile"], event["filename"])
 
+    @defer.inlineCallbacks
     def postfile(self, artifact, fileName):
         """
         Send a file to MalShare
         """
+        url = (
+            f"https://malshare.com/api.php?api_key={self.apiKey}&action=upload"
+        ).encode()
         try:
-            res = requests.post(
-                "https://malshare.com/api.php?api_key="
-                + self.apiKey
-                + "&action=upload",
-                files={"upload": open(artifact, "rb")},
-                timeout=HTTP_TIMEOUT,
-            )
-            if res and res.ok:
-                log.msg("Submitted to MalShare")
-            else:
-                log.msg(f"MalShare Request failed: {res.status_code}")
+            with open(artifact, "rb") as upload:
+                response = yield treq.post(
+                    url=url,
+                    files={"upload": (fileName, upload)},
+                    timeout=HTTP_TIMEOUT,
+                )
+        except (
+            defer.CancelledError,
+            error.ConnectingCancelledError,
+            error.DNSLookupError,
+        ) as e:
+            log.msg(f"MalShare Request failed: {e}")
+            return
         except Exception as e:
             log.msg(f"MalShare Request failed: {e}")
+            return
+
+        if 200 <= response.code < 300:
+            log.msg("Submitted to MalShare")
+        else:
+            log.msg(f"MalShare Request failed: {response.code}")

--- a/src/cowrie/output/malshare.py
+++ b/src/cowrie/output/malshare.py
@@ -84,6 +84,9 @@ class Output(cowrie.core.output.Output):
             log.msg(f"MalShare Request failed: {e}")
             return
 
+        # Drain the body so the connection returns to the pool.
+        yield response.text()
+
         if 200 <= response.code < 300:
             log.msg("Submitted to MalShare")
         else:


### PR DESCRIPTION
## Summary

Ports the malshare and cuckoo output plugins from synchronous \`requests\` (wrapped in \`threads.deferToThread\`) to \`treq\` so the HTTP calls live on the reactor instead of a thread pool. Both modules already carried \`TODO: use treq\` comments.

## Commits

- \`refactor(output): port malshare to treq\` — \`treq.post\` inside an \`inlineCallbacks\` coroutine; fixes a pre-existing leak where the file handle for \`files=\` was never closed.
- \`refactor(output): port cuckoo to treq\` — per-output \`HTTPClient\` wrapping a Twisted \`Agent\` with a no-verify TLS policy to preserve the previous \`verify=False\` semantics for local self-signed Cuckoo deployments. \`HTTPBasicAuth\` becomes the \`(user, password)\` tuple treq's \`auth=\` accepts. The dedup-then-upload path becomes one \`inlineCallbacks\` chain.
- \`fix(output): only log 'Sending file to Cuckoo' when we actually send\` — the original code logged in \`file_download\` before the dedup check and in \`file_upload\` after it. Unified behind \`_maybe_postfile\` so the message fires only when an upload happens.
- \`fix(output): drain response bodies in cuckoo and malshare\` — treq returns connections to the pool only after the body is consumed. Adds \`yield response.text()\` on every untraversed branch, matching the pattern in \`greynoise.py\`.

## Out of scope

- \`dshield.py\` is on a separate branch / PR because it also integrates the protocol rewrite from #40100.
- Dropping \`requests\` from \`requirements.txt\` and \`pyproject.toml\` will happen in the dshield PR (once all three modules are migrated). treq still pulls \`requests\` transitively, so nothing breaks in either order.

## Test plan

- [x] \`python -m unittest discover src\` — 294 tests pass
- [x] \`ruff check src\` — clean
- [x] \`mypy --config-file=pyproject.toml src\` — clean
- [ ] Real-world end-to-end against a live Cuckoo / malshare endpoint (will rely on existing operators in CI / manual)