### PR TITLE
Port dshield to treq, adopt modern submitapi, fix enrichment race

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
         "idna==3.14",
         "packaging==26.2",
         "pyasn1_modules==0.4.2",
-        "requests==2.34.0",
         "service_identity==24.2.0",
         "tftpy==0.8.7",
         "treq==25.5.0",
@@ -63,7 +62,6 @@ playlog = "cowrie.scripts.playlog:run"
 
 [project.optional-dependencies]
 csirtg = ["csirtgsdk==1.1.5"]
-dshield = ["requests"]
 elasticsearch = ["pyes"]
 mysql = ["mysqlclient"]
 mongodb = ["pymongo"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,6 @@ dev = [
 "sphinx_rtd_theme==3.1.0",
 "sphinxcontrib-googleanalytics==0.5",
 "tox==4.33.0",
-"types-python-dateutil==2.9.0.20260124",
 "types-redis==4.6.0.20241004",
 "types-requests==2.32.4.20260107",
 "yamllint==1.37.1",

--- a/requirements-output.txt
+++ b/requirements-output.txt
@@ -10,9 +10,6 @@
 # csirtgsdk==1.1.5
 # geoip2
 
-# dshield
-python-dateutil==2.9.0.post0
-
 # elasticsearch
 elasticsearch==9.1.3
 

--- a/requirements-output.txt
+++ b/requirements-output.txt
@@ -11,7 +11,6 @@
 # geoip2
 
 # dshield
-requests==2.34.0
 python-dateutil==2.9.0.post0
 
 # elasticsearch

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ hyperlink==21.0.0
 idna==3.14
 packaging==26.2
 pyasn1_modules==0.4.2
-requests==2.34.0
 service_identity==24.2.0
 tftpy==0.8.7
 treq==25.5.0

--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
-import re
-import time
+import json
+import os
 
-import dateutil.parser
 import treq
 from twisted.internet import defer, error
 from twisted.python import log
@@ -25,6 +24,10 @@ import cowrie.core.output
 from cowrie.core.config import CowrieConfig
 
 HTTP_TIMEOUT = 10
+VERSION = 20260506
+
+SUBMIT_URL = b"https://www.dshield.org/submitapi/"
+DEBUG_SUBMIT_URL = b"https://www.dshield.org/devsubmitapi/"
 
 
 class Output(cowrie.core.output.Output):
@@ -36,38 +39,54 @@ class Output(cowrie.core.output.Output):
     userid: str
     batch_size: int
     batch: list
+    lastcommand: str
+    hassh: str
+    banner: str
 
     def start(self):
         self.auth_key = CowrieConfig.get("output_dshield", "auth_key")
         self.userid = CowrieConfig.get("output_dshield", "userid")
         self.batch_size = CowrieConfig.getint("output_dshield", "batch_size")
         self.debug = CowrieConfig.getboolean("output_dshield", "debug", fallback=False)
+        self.lastcommand = ""
+        self.hassh = ""
+        self.banner = ""
         self.batch = []  # This is used to store login attempts in batches
 
     def stop(self):
         pass
 
     def write(self, event):
-        if (
-            event["eventid"] == "cowrie.login.success"
-            or event["eventid"] == "cowrie.login.failed"
-        ):
-            date = dateutil.parser.parse(event["timestamp"])
+        eventid = event["eventid"]
+        if eventid in ("cowrie.login.success", "cowrie.login.failed"):
             self.batch.append(
                 {
-                    "date": str(date.date()),
-                    "time": date.time().strftime("%H:%M:%S"),
-                    "timezone": time.strftime("%z"),
+                    "timestamp": int(event["time"]),
                     "source_ip": event["src_ip"],
                     "user": event["username"],
                     "password": event["password"],
+                    "lastcommand": self.lastcommand,
+                    "hassh": self.hassh,
+                    "banner": self.banner,
                 }
             )
+            if self.debug:
+                log.msg(
+                    f"dshield: log appended, batch size {len(self.batch)} max size {self.batch_size}"
+                )
 
             if len(self.batch) >= self.batch_size:
+                if self.debug:
+                    log.msg("dshield: batch size reached, submitting")
                 batch_to_send = self.batch
                 self.submit_entries(batch_to_send)
                 self.batch = []
+        elif eventid == "cowrie.command.input":
+            self.lastcommand = event["input"]
+        elif eventid == "cowrie.client.kex":
+            self.hassh = event["hassh"]
+        elif eventid == "cowrie.client.version":
+            self.banner = event["version"]
 
     def transmission_error(self, batch):
         self.batch.extend(batch)
@@ -77,51 +96,50 @@ class Output(cowrie.core.output.Output):
     @defer.inlineCallbacks
     def submit_entries(self, batch):
         """
-        Large parts of this method are adapted from kippo-pyshield by jkakavas
-        Many thanks to their efforts. https://github.com/jkakavas/kippo-pyshield
+        DShield logs are sent to the https://www.dshield.org/submitapi/ endpoint.
+        For debugging, use https://www.dshield.org/devsubmitapi/.
         """
-        # The nonce is predefined as explained in the original script :
-        # trying to avoid sending the authentication key in the "clear" but
-        # not wanting to deal with a full digest like exchange. Using a
-        # fixed nonce to mix up the limited userid.
-        _nonceb64 = "ElWO1arph+Jifqme6eXD8Uj+QTAmijAWxX1msbJzXDM="
+        url = DEBUG_SUBMIT_URL if self.debug else SUBMIT_URL
+        if self.debug:
+            log.msg(f"dshield: using debug url {url!r}")
 
-        log_output = ""
-        for attempt in batch:
-            log_output += "{}\t{}\t{}\t{}\t{}\t{}\n".format(
-                attempt["date"],
-                attempt["time"],
-                attempt["timezone"],
-                attempt["source_ip"],
-                attempt["user"],
-                attempt["password"],
-            )
+        # Build authentication header
+        nonce = base64.b64encode(os.urandom(8)).decode("ascii")
+        digest = hmac.new(
+            (nonce + str(self.userid)).encode("utf-8"),
+            msg=self.auth_key.encode("utf-8"),
+            digestmod=hashlib.sha256,
+        ).digest()
+        hash64 = base64.b64encode(digest).decode("ascii")
+        auth_header = (
+            f"ISC-HMAC-SHA256 Credentials={hash64} "
+            f"Userid={self.userid} Nonce={nonce}"
+        )
+        if self.debug:
+            log.msg(f"dshield: authentication header {auth_header}")
 
-        nonce = base64.b64decode(_nonceb64)
-        digest = base64.b64encode(
-            hmac.new(
-                nonce + self.userid.encode("ascii"),
-                base64.b64decode(self.auth_key),
-                hashlib.sha256,
-            ).digest()
-        )
-        auth_header = "credentials={} nonce={} userid={}".format(
-            digest.decode("ascii"), _nonceb64, self.userid
-        )
+        payload = {
+            "type": "cowrie",
+            "logs": batch,
+            "authheader": auth_header,
+        }
+
         headers = {
+            b"Content-Type": [b"application/json"],
+            b"User-Agent": [f"Cowrie-{VERSION}".encode("ascii")],
             b"X-ISC-Authorization": [auth_header.encode("ascii")],
-            b"Content-Type": [b"text/plain"],
+            b"X-ISC-LogType": [b"cowrie"],
         }
 
         if self.debug:
-            log.msg(f"dshield: posting: {headers!r}")
-            log.msg(f"dshield: posting: {log_output}")
+            log.msg(f"dshield: posting headers {headers!r}")
+            log.msg(f"dshield: posting payload {payload!r}")
 
         try:
-            response = yield treq.put(
-                url=b"https://secure.dshield.org/api/file/sshlog",
+            response = yield treq.post(
+                url=url,
                 headers=headers,
-                data=log_output.encode("utf8"),
+                data=json.dumps(payload).encode("utf-8"),
                 timeout=HTTP_TIMEOUT,
             )
             body = yield response.text()
@@ -142,43 +160,8 @@ class Output(cowrie.core.output.Output):
             log.msg(f"dshield: status code {response.code}")
             log.msg(f"dshield: response {body}")
 
-        failed = False
         if 200 <= response.code < 300:
-            sha1_regex = re.compile(r"<sha1checksum>([^<]+)<\/sha1checksum>")
-            sha1_match = sha1_regex.search(body)
-            sha1_local = hashlib.sha1()
-            sha1_local.update(log_output.encode("utf8"))
-            if sha1_match is None:
-                log.msg(
-                    f"dshield: ERROR: Could not find sha1checksum in response: {body!r}"
-                )
-                failed = True
-            elif sha1_match.group(1) != sha1_local.hexdigest():
-                log.msg(
-                    f"dshield: ERROR: SHA1 Mismatch {sha1_match.group(1)} {sha1_local.hexdigest()} ."
-                )
-                failed = True
-
-            md5_regex = re.compile(r"<md5checksum>([^<]+)<\/md5checksum>")
-            md5_match = md5_regex.search(body)
-            md5_local = hashlib.md5()
-            md5_local.update(log_output.encode("utf8"))
-            if md5_match is None:
-                log.msg("dshield: ERROR: Could not find md5checksum in response")
-                failed = True
-            elif md5_match.group(1) != md5_local.hexdigest():
-                log.msg(
-                    f"dshield: ERROR: MD5 Mismatch {md5_match.group(1)} {md5_local.hexdigest()} ."
-                )
-                failed = True
-
-            log.msg(
-                f"dshield: SUCCESS: Sent {log_output} bytes worth of data to secure.dshield.org"
-            )
+            log.msg(f"dshield: submit response {body}")
         else:
-            log.msg(f"dshield ERROR: error {response.code}.")
-            log.msg(f"dshield response was {body}")
-            failed = True
-
-        if failed:
+            log.msg(f"dshield: ERROR status {response.code}: {body}")
             self.transmission_error(batch)

--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -40,19 +40,17 @@ class Output(cowrie.core.output.Output):
     userid: str
     batch_size: int
     batch: list
-    lastcommand: str
-    hassh: str
-    banner: str
+    session_state: dict[str, dict[str, str]]
 
     def start(self):
         self.auth_key = CowrieConfig.get("output_dshield", "auth_key")
         self.userid = CowrieConfig.get("output_dshield", "userid")
         self.batch_size = CowrieConfig.getint("output_dshield", "batch_size")
         self.debug = CowrieConfig.getboolean("output_dshield", "debug", fallback=False)
-        self.lastcommand = ""
-        self.hassh = ""
-        self.banner = ""
         self.batch = []  # This is used to store login attempts in batches
+        # Per-session enrichment fields (lastcommand, hassh, banner). Keyed on
+        # session id so concurrent sessions do not stomp each other's state.
+        self.session_state = {}
 
         self._warn_if_legacy_auth_key()
 
@@ -78,18 +76,28 @@ class Output(cowrie.core.output.Output):
     def stop(self):
         pass
 
+    def _state(self, session: str) -> dict[str, str]:
+        state = self.session_state.get(session)
+        if state is None:
+            state = {"lastcommand": "", "hassh": "", "banner": ""}
+            self.session_state[session] = state
+        return state
+
     def write(self, event):
         eventid = event["eventid"]
+        session = event.get("session", "")
+
         if eventid in ("cowrie.login.success", "cowrie.login.failed"):
+            state = self._state(session)
             self.batch.append(
                 {
                     "timestamp": int(event["time"]),
                     "source_ip": event["src_ip"],
                     "user": event["username"],
                     "password": event.get("password", ""),
-                    "lastcommand": self.lastcommand,
-                    "hassh": self.hassh,
-                    "banner": self.banner,
+                    "lastcommand": state["lastcommand"],
+                    "hassh": state["hassh"],
+                    "banner": state["banner"],
                 }
             )
             if self.debug:
@@ -104,11 +112,13 @@ class Output(cowrie.core.output.Output):
                 self.submit_entries(batch_to_send)
                 self.batch = []
         elif eventid == "cowrie.command.input":
-            self.lastcommand = event["input"]
+            self._state(session)["lastcommand"] = event["input"]
         elif eventid == "cowrie.client.kex":
-            self.hassh = event["hassh"]
+            self._state(session)["hassh"] = event["hassh"]
         elif eventid == "cowrie.client.version":
-            self.banner = event["version"]
+            self._state(session)["banner"] = event["version"]
+        elif eventid == "cowrie.session.closed":
+            self.session_state.pop(session, None)
 
     def transmission_error(self, batch):
         self.batch.extend(batch)

--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -17,10 +17,8 @@ import re
 import time
 
 import dateutil.parser
-
-# TODO: use `treq`
-import requests
-from twisted.internet import reactor, threads
+import treq
+from twisted.internet import defer, error
 from twisted.python import log
 
 import cowrie.core.output
@@ -76,6 +74,7 @@ class Output(cowrie.core.output.Output):
         if len(self.batch) > self.batch_size * 2:
             self.batch = self.batch[-self.batch_size :]
 
+    @defer.inlineCallbacks
     def submit_entries(self, batch):
         """
         Large parts of this method are adapted from kippo-pyshield by jkakavas
@@ -88,7 +87,7 @@ class Output(cowrie.core.output.Output):
         _nonceb64 = "ElWO1arph+Jifqme6eXD8Uj+QTAmijAWxX1msbJzXDM="
 
         log_output = ""
-        for attempt in self.batch:
+        for attempt in batch:
             log_output += "{}\t{}\t{}\t{}\t{}\t{}\n".format(
                 attempt["date"],
                 attempt["time"],
@@ -109,68 +108,77 @@ class Output(cowrie.core.output.Output):
         auth_header = "credentials={} nonce={} userid={}".format(
             digest.decode("ascii"), _nonceb64, self.userid
         )
-        headers = {"X-ISC-Authorization": auth_header, "Content-Type": "text/plain"}
+        headers = {
+            b"X-ISC-Authorization": [auth_header.encode("ascii")],
+            b"Content-Type": [b"text/plain"],
+        }
 
         if self.debug:
             log.msg(f"dshield: posting: {headers!r}")
             log.msg(f"dshield: posting: {log_output}")
 
-        req = threads.deferToThread(
-            requests.request,
-            method="PUT",
-            url="https://secure.dshield.org/api/file/sshlog",
-            headers=headers,
-            timeout=HTTP_TIMEOUT,
-            data=log_output,
-        )
+        try:
+            response = yield treq.put(
+                url=b"https://secure.dshield.org/api/file/sshlog",
+                headers=headers,
+                data=log_output.encode("utf8"),
+                timeout=HTTP_TIMEOUT,
+            )
+            body = yield response.text()
+        except (
+            defer.CancelledError,
+            error.ConnectingCancelledError,
+            error.DNSLookupError,
+        ) as e:
+            log.msg(f"dshield: request failed: {e}")
+            self.transmission_error(batch)
+            return
+        except Exception as e:
+            log.msg(f"dshield: request failed: {e}")
+            self.transmission_error(batch)
+            return
 
-        def check_response(resp):
-            failed = False
-            response = resp.content.decode("utf8")
+        if self.debug:
+            log.msg(f"dshield: status code {response.code}")
+            log.msg(f"dshield: response {body}")
 
-            if self.debug:
-                log.msg(f"dshield: status code {resp.status_code}")
-                log.msg(f"dshield: response {resp.content}")
-
-            if resp.ok:
-                sha1_regex = re.compile(r"<sha1checksum>([^<]+)<\/sha1checksum>")
-                sha1_match = sha1_regex.search(response)
-                sha1_local = hashlib.sha1()
-                sha1_local.update(log_output.encode("utf8"))
-                if sha1_match is None:
-                    log.msg(
-                        f"dshield: ERROR: Could not find sha1checksum in response: {response!r}"
-                    )
-                    failed = True
-                elif sha1_match.group(1) != sha1_local.hexdigest():
-                    log.msg(
-                        f"dshield: ERROR: SHA1 Mismatch {sha1_match.group(1)} {sha1_local.hexdigest()} ."
-                    )
-                    failed = True
-
-                md5_regex = re.compile(r"<md5checksum>([^<]+)<\/md5checksum>")
-                md5_match = md5_regex.search(response)
-                md5_local = hashlib.md5()
-                md5_local.update(log_output.encode("utf8"))
-                if md5_match is None:
-                    log.msg("dshield: ERROR: Could not find md5checksum in response")
-                    failed = True
-                elif md5_match.group(1) != md5_local.hexdigest():
-                    log.msg(
-                        f"dshield: ERROR: MD5 Mismatch {md5_match.group(1)} {md5_local.hexdigest()} ."
-                    )
-                    failed = True
-
+        failed = False
+        if 200 <= response.code < 300:
+            sha1_regex = re.compile(r"<sha1checksum>([^<]+)<\/sha1checksum>")
+            sha1_match = sha1_regex.search(body)
+            sha1_local = hashlib.sha1()
+            sha1_local.update(log_output.encode("utf8"))
+            if sha1_match is None:
                 log.msg(
-                    f"dshield: SUCCESS: Sent {log_output} bytes worth of data to secure.dshield.org"
+                    f"dshield: ERROR: Could not find sha1checksum in response: {body!r}"
                 )
-            else:
-                log.msg(f"dshield ERROR: error {resp.status_code}.")
-                log.msg(f"dshield response was {response}")
+                failed = True
+            elif sha1_match.group(1) != sha1_local.hexdigest():
+                log.msg(
+                    f"dshield: ERROR: SHA1 Mismatch {sha1_match.group(1)} {sha1_local.hexdigest()} ."
+                )
                 failed = True
 
-            if failed:
-                # Something went wrong, we need to add them to batch.
-                reactor.callFromThread(self.transmission_error, batch)
+            md5_regex = re.compile(r"<md5checksum>([^<]+)<\/md5checksum>")
+            md5_match = md5_regex.search(body)
+            md5_local = hashlib.md5()
+            md5_local.update(log_output.encode("utf8"))
+            if md5_match is None:
+                log.msg("dshield: ERROR: Could not find md5checksum in response")
+                failed = True
+            elif md5_match.group(1) != md5_local.hexdigest():
+                log.msg(
+                    f"dshield: ERROR: MD5 Mismatch {md5_match.group(1)} {md5_local.hexdigest()} ."
+                )
+                failed = True
 
-        req.addCallback(check_response)
+            log.msg(
+                f"dshield: SUCCESS: Sent {log_output} bytes worth of data to secure.dshield.org"
+            )
+        else:
+            log.msg(f"dshield ERROR: error {response.code}.")
+            log.msg(f"dshield response was {body}")
+            failed = True
+
+        if failed:
+            self.transmission_error(batch)

--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -11,6 +11,7 @@ See https://isc.sans.edu/ssh.html
 from __future__ import annotations
 
 import base64
+import binascii
 import hashlib
 import hmac
 import json
@@ -52,6 +53,27 @@ class Output(cowrie.core.output.Output):
         self.hassh = ""
         self.banner = ""
         self.batch = []  # This is used to store login attempts in batches
+
+        self._warn_if_legacy_auth_key()
+
+    def _warn_if_legacy_auth_key(self) -> None:
+        """
+        The pre-2026 DShield API took a base64-encoded auth_key and decoded
+        it before computing the HMAC. The current submitapi uses the key as
+        a raw string. Warn loudly if the configured key still looks
+        base64-encoded so an operator notices before submissions are
+        silently rejected.
+        """
+        try:
+            base64.b64decode(self.auth_key, validate=True)
+        except (binascii.Error, ValueError):
+            return
+        if "=" in self.auth_key:
+            log.msg(
+                "dshield: auth_key looks base64-encoded but the current "
+                "DShield submit API expects the raw key. Update your "
+                "config if submissions are rejected."
+            )
 
     def stop(self):
         pass

--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -64,7 +64,7 @@ class Output(cowrie.core.output.Output):
                     "timestamp": int(event["time"]),
                     "source_ip": event["src_ip"],
                     "user": event["username"],
-                    "password": event["password"],
+                    "password": event.get("password", ""),
                     "lastcommand": self.lastcommand,
                     "hassh": self.hassh,
                     "banner": self.banner,


### PR DESCRIPTION
## Summary

Ports the dshield output plugin to \`treq\`, incorporates the protocol rewrite from #40100 (modern \`submitapi\`), and fixes three latent bugs.

Closes #40100.

## Commits

**Treq port**
- \`refactor(output): port dshield to treq\` — \`treq.put\` inside an \`inlineCallbacks\` coroutine; drops the \`requests + threads.deferToThread\` roundtrip. Switches \`for attempt in self.batch\` to \`for attempt in batch\` (parameter), which is correct under async semantics.

**Protocol rewrite from #40100**
- \`refactor(output): adopt dshield modern submit API (PR #40100) with treq\` — POST to \`/submitapi/\` (devsubmitapi when debug), JSON body \`{type, logs, authheader}\`, new HMAC scheme (random 8-byte nonce, raw key bytes, \`ISC-HMAC-SHA256 Credentials= Userid= Nonce=\` format), new \`User-Agent\`, \`X-ISC-LogType\` headers. Per-entry schema becomes \`{timestamp, source_ip, user, password, lastcommand, hassh, banner}\`. Drops the SHA1/MD5 response checksum verification.

**Fixes uncovered during review**
- \`fix(output): tolerate missing password in dshield login events\` — \`HoneypotPublicKeyChecker\` and \`HoneypotNoneChecker\` emit login events without a \`password\` field. The previous code (and #40100) raised \`KeyError\` and silently dropped the whole batch. Falls back to an empty string.
- \`feat(output): warn when dshield auth_key looks base64-encoded\` — the new submit API treats \`auth_key\` as a raw string; the pre-2026 API base64-decoded it. Existing users with base64-encoded keys would silently produce bad HMACs and get all submissions rejected. Detect the legacy format and \`log.msg(...)\` a clear warning at start().
- \`fix(output): partition dshield enrichment state by session\` — #40100 stored \`lastcommand\`/\`hassh\`/\`banner\` as instance-wide attributes on the singleton Output. Concurrent sessions stomp each other's state, so a login event for session A picks up whatever session B last set. Switch to a per-session dict keyed on \`event['session']\` and evict on \`cowrie.session.closed\`.

**Cleanup**
- \`build(deps): drop direct requests dependency\` — no cowrie module imports \`requests\` directly anymore (assumes #40118 also lands, but \`treq\` still pulls \`requests\` transitively, so it works in either merge order).
- \`build(deps): drop python-dateutil\` — was only used by the old dshield's TSV timestamp formatting; the new submit API uses \`int(event['time'])\`.

## Migration note

**Users with a base64-encoded \`auth_key\` in their config must re-fetch their key from DShield**, otherwise all submissions will fail. The plugin will log a warning on startup if this is detected.

## Test plan

- [x] \`python -m unittest discover src\` — 294 tests pass
- [x] \`ruff check src\` — clean
- [x] \`mypy --config-file=pyproject.toml src\` — clean
- [ ] End-to-end against \`https://www.dshield.org/devsubmitapi/\` with a real key — relies on @micheloosterhof / operator validation

## Sequencing

#40118 (cuckoo + malshare to treq) is independent. Either PR can land first; the \`drop requests dependency\` commit in this PR doesn't break #40118 because \`treq\` pulls \`requests\` transitively.