### PR TITLE
fix: remove non-subscriptable generic types for Python 3.13 compatibility

### DIFF
--- a/src/backend_pool/nat.py
+++ b/src/backend_pool/nat.py
@@ -28,7 +28,7 @@ class ClientProtocol(protocol.Protocol):
         self.server_protocol.transport.loseConnection()
 
 
-class ClientFactory(protocol.ClientFactory[ClientProtocol]):
+class ClientFactory(protocol.ClientFactory):
     def __init__(self, server_protocol: ServerProtocol) -> None:
         self.server_protocol = server_protocol
 
@@ -74,7 +74,7 @@ class ServerProtocol(protocol.Protocol):
         self.client_protocol.transport.loseConnection()
 
 
-class ServerFactory(protocol.Factory[ServerProtocol]):
+class ServerFactory(protocol.Factory):
     def __init__(self, dst_ip: str, dst_port: int) -> None:
         self.dst_ip: str = dst_ip
         self.dst_port: int = dst_port

--- a/src/backend_pool/pool_server.py
+++ b/src/backend_pool/pool_server.py
@@ -188,7 +188,7 @@ class PoolServer(Protocol):
             self.transport.write(response)
 
 
-class PoolServerFactory(Factory[PoolServer]):
+class PoolServerFactory(Factory):
     """
     Factory for PoolServer
     """


### PR DESCRIPTION
## Summary

Cowrie fails to start on Python 3.13 with `TypeError: type 'ClientFactory' is not subscriptable`. Twisted's plugin discovery imports `backend_pool` unconditionally, so the error prevents the entire cowrie plugin from loading, resulting in `Unknown command: cowrie`.

In Python 3.13, Twisted's `protocol.ClientFactory`, `protocol.Factory` etc. are not generic types and cannot be subscripted.

## Changes

Removed the type parameters from three class definitions:

- `src/backend_pool/nat.py`: `ClientFactory(protocol.ClientFactory[ClientProtocol])` → `ClientFactory(protocol.ClientFactory)`
- `src/backend_pool/nat.py`: `ServerFactory(protocol.Factory[ServerProtocol])` → `ServerFactory(protocol.Factory)`
- `src/backend_pool/pool_server.py`: `PoolServerFactory(Factory[PoolServer])` → `PoolServerFactory(Factory)`

Closes #40121