### PR TITLE
fix: read issue.net banner as UTF-8 with replacement

### DIFF
--- a/src/cowrie/shell/pwd.py
+++ b/src/cowrie/shell/pwd.py
@@ -9,6 +9,7 @@ import configparser
 import importlib.resources
 import sys
 from binascii import crc32
+from pathlib import Path
 from random import randint, seed
 from typing import Any
 
@@ -26,18 +27,17 @@ class Passwd:
     """
 
     try:
-        with open(
-            "{}/etc/passwd".format(CowrieConfig.get("honeypot", "contents_path")),
-            encoding="ascii",
-        ) as f:
-            passwd_contents = f.read().split("\n")
+        passwd_path = Path(
+            "{}/etc/passwd".format(CowrieConfig.get("honeypot", "contents_path"))
+        )
+        passwd_contents = passwd_path.read_text(encoding="ascii").split("\n")
     except configparser.Error:
         log.msg("Loading default /etc/passwd file from pickle file")
         resources_path = importlib.resources.files(data)
-        config_file_path = (
+        fallback_path = (
             resources_path.joinpath("honeyfs").joinpath("etc").joinpath("passwd")
         )
-        passwd_contents = config_file_path.read_text(encoding="utf-8").split("\n")
+        passwd_contents = fallback_path.read_text(encoding="ascii").split("\n")
     except Exception as e:
         log.err(e, "ERROR: Failed to load /etc/passwd")
         sys.exit(2)

--- a/src/cowrie/ssh/userauth.py
+++ b/src/cowrie/ssh/userauth.py
@@ -70,7 +70,9 @@ class HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer):
         except configparser.Error as e:
             log.msg(f"Loading default /etc/issue.net file: {e!r}")
             resources_path = importlib.resources.files(data)
-            fallback_path = resources_path.joinpath("honeyfs", "etc", "issue.net")
+            fallback_path = (
+                resources_path.joinpath("honeyfs").joinpath("etc").joinpath("issue.net")
+            )
             banner = fallback_path.read_bytes().decode("utf-8", errors="replace")
         except OSError as e:
             log.err(e, "ERROR: Failed to load /etc/issue.net")

--- a/src/cowrie/ssh/userauth.py
+++ b/src/cowrie/ssh/userauth.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import configparser
 import importlib.resources
 import struct
+from pathlib import Path
 from typing import Any
 
 from twisted.conch import error
@@ -62,16 +63,15 @@ class HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer):
         self.bannerSent = True
 
         try:
-            with open(
-                f"{CowrieConfig.get('honeypot', 'contents_path')}/etc/issue.net",
-                encoding="ascii",
-            ) as f:
-                banner = f.read()
+            banner_path = Path(
+                f"{CowrieConfig.get('honeypot', 'contents_path')}/etc/issue.net"
+            )
+            banner = banner_path.read_bytes().decode("utf-8", errors="replace")
         except configparser.Error as e:
             log.msg(f"Loading default /etc/issue.net file: {e!r}")
             resources_path = importlib.resources.files(data)
-            banner_path = resources_path.joinpath("honeyfs", "etc", "issue.net")
-            banner = banner_path.read_text(encoding="utf-8")
+            fallback_path = resources_path.joinpath("honeyfs", "etc", "issue.net")
+            banner = fallback_path.read_bytes().decode("utf-8", errors="replace")
         except OSError as e:
             log.err(e, "ERROR: Failed to load /etc/issue.net")
             return

--- a/src/cowrie/telnet/factory.py
+++ b/src/cowrie/telnet/factory.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import configparser
 import importlib.resources
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from twisted.internet import protocol
@@ -58,18 +59,21 @@ class HoneyPotTelnetFactory(protocol.ServerFactory):
     def startFactory(self) -> None:
         """ """
         try:
-            with open(
-                f"{CowrieConfig.get('honeypot', 'contents_path')}/etc/issue.net",
-                mode="rb",
-            ) as f:
-                self.banner = f.read()
+            banner_path = Path(
+                f"{CowrieConfig.get('honeypot', 'contents_path')}/etc/issue.net"
+            )
+            self.banner = (
+                banner_path.read_bytes().decode("utf-8", errors="replace").encode("utf-8")
+            )
         except configparser.Error as e:
             log.msg(f"Loading default /etc/issue.net file: {e!r}")
             resources_path = importlib.resources.files(data)
-            config_file_path = (
+            fallback_path = (
                 resources_path.joinpath("honeyfs").joinpath("etc").joinpath("issue.net")
             )
-            self.banner = config_file_path.read_text(encoding="utf-8").encode()
+            self.banner = (
+                fallback_path.read_bytes().decode("utf-8", errors="replace").encode("utf-8")
+            )
         except OSError as e:
             log.err(e, "ERROR: Failed to load /etc/issue.net")
             self.banner = b""


### PR DESCRIPTION
The banner file was opened with encoding="ascii", causing a UnicodeDecodeError that propagated out of sendBanner() when the operator-supplied issue.net contained non-ASCII bytes. UnicodeDecodeError is not a subclass of configparser.Error or OSError, so neither except clause caught it.

Read as bytes and decode with errors="replace" on both the primary and bundled-fallback paths, and unify both reads on Path.read_bytes() for consistency.