### PR TITLE
Implement loopback address check in ping command

### DIFF
--- a/src/cowrie/commands/ping.py
+++ b/src/cowrie/commands/ping.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import getopt
 import hashlib
+import ipaddress
 import random
 import re
 import socket
@@ -38,6 +39,12 @@ class Command_ping(HoneyPotCommand):
             return False
         else:
             return True
+
+    def is_loopback(self, address: str) -> bool:
+        try:
+            return ipaddress.ip_address(address).is_loopback
+        except ValueError:
+            return False
 
     def start(self) -> None:
         self.host = ""
@@ -93,9 +100,16 @@ class Command_ping(HoneyPotCommand):
         self.count = 0
 
     def showreply(self) -> None:
-        ms = 40 + random.random() * 10
+        if self.is_loopback(self.ip):
+            ms = random.uniform(0, 0.5)
+            ttl = 64
+            time_str = f"{ms:.3f}"
+        else:
+            ms = 40 + random.uniform(0, 10)
+            ttl = 50
+            time_str = f"{ms:.1f}"
         self.write(
-            f"64 bytes from {self.host} ({self.ip}): icmp_seq={self.count + 1} ttl=50 time={ms:.1f} ms\n"
+            f"64 bytes from {self.host} ({self.ip}): icmp_seq={self.count + 1} ttl={ttl} time={time_str} ms\n"
         )
         self.count += 1
         if self.count == self.max:
@@ -112,7 +126,10 @@ class Command_ping(HoneyPotCommand):
         self.write(
             f"{self.count} packets transmitted, {self.count} received, 0% packet loss, time 907ms\n"
         )
-        self.write("rtt min/avg/max/mdev = 48.264/50.352/52.441/2.100 ms\n")
+        if self.is_loopback(self.ip):
+            self.write("rtt min/avg/max/mdev = 0.031/0.045/0.062/0.012 ms\n")
+        else:
+            self.write("rtt min/avg/max/mdev = 48.264/50.352/52.441/2.100 ms\n")
 
     def handle_CTRL_C(self) -> None:
         if self.running is False:


### PR DESCRIPTION
Current implementation applies the same network latency profile to loopback (127.0.0.1) traffic as to external interfaces (~50ms RTT). This is not representative of real kernel networking behavior, where loopback traffic typically exhibits sub-millisecond latency.

This discrepancy introduces a detectable behavioral artifact that can be used to distinguish an emulated environment from a real host via simple timing comparison between loopback and outbound ICMP responses.

This change adjusts loopback handling to reflect realistic local interface semantics:
- loopback RTT reduced to sub-millisecond range
- TTL behaviour aligned with typical local interface expectations

## Security relevance

In real systems, loopback interfaces exhibit near-zero latency relative to external network paths. The current uniform latency model allows trivial differentiation:
- external host RTT: ~50ms
- loopback RTT: same magnitude under current emulation

This divergence can be used as a lightweight fingerprinting heuristic by automated scanners or interactive threat actors.

## This PR fixes it

```
root@notahoneypot:~# ping google.com
PING google.com (29.89.32.244) 56(84) bytes of data.
64 bytes from google.com (29.89.32.244): icmp_seq=1 ttl=50 time=49.5 ms
64 bytes from google.com (29.89.32.244): icmp_seq=2 ttl=50 time=48.3 ms
64 bytes from google.com (29.89.32.244): icmp_seq=3 ttl=50 time=42.5 ms
64 bytes from google.com (29.89.32.244): icmp_seq=4 ttl=50 time=43.9 ms
^C
--- google.com ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 907ms
rtt min/avg/max/mdev = 48.264/50.352/52.441/2.100 ms
root@notahoneypot:~# ping 127.0.0.1
PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
64 bytes from 127.0.0.1 (127.0.0.1): icmp_seq=1 ttl=64 time=0.383 ms
64 bytes from 127.0.0.1 (127.0.0.1): icmp_seq=2 ttl=64 time=0.137 ms
64 bytes from 127.0.0.1 (127.0.0.1): icmp_seq=3 ttl=64 time=0.413 ms
64 bytes from 127.0.0.1 (127.0.0.1): icmp_seq=4 ttl=64 time=0.050 ms
^C
--- 127.0.0.1 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 907ms
rtt min/avg/max/mdev = 0.031/0.045/0.062/0.012 ms
root@notahoneypot:~# 
```

## Effect of change

After patch:

- loopback latency is no longer artificially aligned with WAN latency
- local interface behavior is consistent with expected kernel-level characteristics
- reduces trivial timing-based environment classification
