### PR TITLE
Honor txtcmds_path for text commands

### DIFF
--- a/docs/HONEYFS.rst
+++ b/docs/HONEYFS.rst
@@ -41,3 +41,23 @@ Make sure your config picks up custom.pickle, by referencing it in `cowrie.cfg`:
 Or set an environment variable::
 
   $ export COWRIE_SHELL_FILESYSTEM=custom.pickle
+
+Customizing text command output
+*******************************
+
+Some commands in Cowrie are implemented as simple text output files under
+``txtcmds``. Operators can point Cowrie at a custom directory with
+``[honeypot] txtcmds_path``::
+
+  [honeypot]
+  txtcmds_path = /opt/cowrie/txtcmds
+
+The command path below that directory must match the path in the virtual
+filesystem. For example, to customize ``/usr/bin/lscpu`` output, create::
+
+  /opt/cowrie/txtcmds/usr/bin/lscpu
+
+The command still needs an entry in the virtual filesystem pickle, the same
+way files in ``honeyfs`` need matching metadata. If a command is not present
+under ``txtcmds_path``, Cowrie falls back to the bundled ``cowrie.data/txtcmds``
+output.

--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -71,7 +71,9 @@ etc_path = etc
 # The contents of the file will be the output of the command when run inside
 # the honeypot.
 #
-# In addition to this, the file must exist in the virtual filesystem
+# In addition to this, the file must exist in the virtual filesystem.
+# If a command does not exist under txtcmds_path, Cowrie falls back to the
+# bundled cowrie.data/txtcmds command output.
 #
 # (default: txtcmds)
 txtcmds_path = txtcmds

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -10,6 +10,7 @@ import sys
 import time
 import traceback
 from importlib import import_module
+from pathlib import Path
 from typing import ClassVar
 
 from twisted.conch import recvline
@@ -245,8 +246,15 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         if path is None:
             return None
 
+        relpath = path.lstrip("/")
+        txtcmds_path = CowrieConfig.get("honeypot", "txtcmds_path", fallback="")
+        if txtcmds_path:
+            operator_path = Path(txtcmds_path) / relpath
+            if operator_path.is_file():
+                return self.txtcmd(operator_path.read_bytes())
+
         try:
-            binary_data = read_data_bytes("txtcmds", *path.lstrip("/").split("/"))
+            binary_data = read_data_bytes("txtcmds", *relpath.split("/"))
             return self.txtcmd(binary_data)
         except FileNotFoundError:
             pass

--- a/src/cowrie/test/test_txtcmds_path.py
+++ b/src/cowrie/test/test_txtcmds_path.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for operator-provided txtcmds_path command output overrides.
+# ABOUTME: Covers operator txtcmd precedence and bundled txtcmd fallback.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+ENV_TXTCMDS = "COWRIE_HONEYPOT_TXTCMDS_PATH"
+PROMPT = b"root@unitTest:~# "
+
+
+class TxtcmdsPathTests(unittest.TestCase):
+    """[honeypot] txtcmds_path is used before bundled command output."""
+
+    def setUp(self) -> None:
+        self.previous_txtcmds = os.environ.get(ENV_TXTCMDS)
+        self.tmpdir = tempfile.TemporaryDirectory()
+        os.environ[ENV_TXTCMDS] = self.tmpdir.name
+
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+        self.tmpdir.cleanup()
+
+        if self.previous_txtcmds is None:
+            os.environ.pop(ENV_TXTCMDS, None)
+        else:
+            os.environ[ENV_TXTCMDS] = self.previous_txtcmds
+
+    def test_operator_txtcmds_path_overrides_bundled_command(self) -> None:
+        """A command file under txtcmds_path takes precedence over bundled data."""
+        command_path = Path(self.tmpdir.name) / "usr" / "bin" / "lscpu"
+        command_path.parent.mkdir(parents=True)
+        command_path.write_bytes(b"custom cpu output\n")
+
+        self.proto.lineReceived(b"lscpu")
+
+        self.assertEqual(self.tr.value(), b"custom cpu output\n" + PROMPT)
+
+    def test_missing_operator_txtcmd_falls_back_to_bundled_data(self) -> None:
+        """Missing operator command files keep the existing bundled fallback."""
+        self.proto.lineReceived(b"lscpu")
+
+        output = self.tr.value()
+        self.assertIn(b"Architecture", output)
+        self.assertIn(b"CPU", output)
+        self.assertTrue(output.endswith(PROMPT))


### PR DESCRIPTION
## Summary
- Load operator-provided text command output from [honeypot] txtcmds_path before bundled cowrie.data/txtcmds.
- Keep the existing bundled fallback when no operator command file exists.
- Document txtcmds_path usage in HONEYFS docs and clarify cowrie.cfg.dist.
- Add regression tests for override precedence and fallback behavior.

## Tests
- python3 -m py_compile src/cowrie/shell/protocol.py src/cowrie/test/test_txtcmds_path.py
- PYTHONPATH=/tmp/cowrie-test-deps:src python3 -m unittest src.cowrie.test.test_txtcmds_path src.cowrie.test.test_script_execution