### PR TITLE
feat: implement chpasswd command simulation with logging

### DIFF
--- a/src/cowrie/commands/chpasswd.py
+++ b/src/cowrie/commands/chpasswd.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 """
-This module contains the chpasswd commnad
+This module contains the chpasswd command
 """
 
 from __future__ import annotations
@@ -29,9 +29,9 @@ class Command_chpasswd(HoneyPotCommand):
             "  -e, --encrypted               supplied passwords are encrypted",
             "  -h, --help                    display this help message and exit",
             "  -m, --md5                     encrypt the clear text password using",
-            "                                the MD5 algorithm"
-            "  -R, --root CHROOT_DIR         directory to chroot into"
-            "  -s, --sha-rounds              number of SHA rounds for the SHA*"
+            "                                the MD5 algorithm",
+            "  -R, --root CHROOT_DIR         directory to chroot into",
+            "  -s, --sha-rounds              number of SHA rounds for the SHA*",
             "                                crypt algorithms",
         )
         for line in output:
@@ -42,24 +42,24 @@ class Command_chpasswd(HoneyPotCommand):
         try:
             for line in contents.split(b"\n"):
                 if len(line):
-                    _u, p = line.split(b":")
-                    if not len(p):
-                        self.write(f"chpasswd: line {c}: missing new password\n")
+                    if b":" not in line:
+                        self.write(f"chpasswd: line {c}: invalid format\n")
                     else:
-                        username = _u.decode(errors="ignore")
-password = p.decode(errors="ignore")
+                        _u, p = line.split(b":", 1)
 
-# Log the attempt
-log.msg(
-    eventid="cowrie.command.chpasswd",
-    realm="chpasswd",
-    username=username,
-    password=password,
-    format="chpasswd attempt: %(username)s:%(password)s",
-)
+                        if not len(p):
+                            self.write(f"chpasswd: line {c}: missing new password\n")
+                        else:
+                            username = _u.decode(errors="ignore")
 
-# Simulate success (silent like real Linux)
-self.write("")
+                            log.msg(
+                                eventid="cowrie.command.chpasswd",
+                                realm="chpasswd",
+                                username=username,
+                                format="Password change attempt for %(username)s",
+                            )
+
+                            self.write("password updated successfully\n")
                 c += 1
         except Exception:
             self.write(f"chpasswd: line {c}: missing new password\n")
@@ -76,7 +76,6 @@ self.write("")
             self.exit()
             return
 
-        # Parse options
         for o, a in opts:
             if o in "-h":
                 self.help()
@@ -88,9 +87,7 @@ self.write("")
                     self.help()
                     self.exit()
 
-        if not self.input_data:
-            pass
-        else:
+        if self.input_data:
             self.chpasswd_application(self.input_data)
             self.exit()
 

--- a/src/cowrie/commands/chpasswd.py
+++ b/src/cowrie/commands/chpasswd.py
@@ -47,19 +47,28 @@ class Command_chpasswd(HoneyPotCommand):
                     else:
                         _u, p = line.split(b":", 1)
 
-                        if not len(p):
-                            self.write(f"chpasswd: line {c}: missing new password\n")
-                        else:
-                            username = _u.decode(errors="ignore")
+                        if len(line):
+    if b":" not in line:
+        self.write(f"chpasswd: line {c}: invalid format\n")
+    else:
+        parts = line.split(b":", 1)
 
-                            log.msg(
-                                eventid="cowrie.command.chpasswd",
-                                realm="chpasswd",
-                                username=username,
-                                format="Password change attempt for %(username)s",
-                            )
+        if len(parts) != 2:
+            self.write(f"chpasswd: line {c}: invalid format\n")
+        else:
+            _u, p = parts
 
-                            self.write("password updated successfully\n")
+            if not p:
+                self.write(f"chpasswd: line {c}: missing new password\n")
+            else:
+                username = _u.decode(errors="ignore")
+
+                log.msg(
+                    eventid="cowrie.command.chpasswd",
+                    realm="chpasswd",
+                    username=username,
+                    format="Password change attempt for %(username)s",
+                )
                 c += 1
         except Exception:
             self.write(f"chpasswd: line {c}: missing new password\n")

--- a/src/cowrie/commands/chpasswd.py
+++ b/src/cowrie/commands/chpasswd.py
@@ -46,13 +46,20 @@ class Command_chpasswd(HoneyPotCommand):
                     if not len(p):
                         self.write(f"chpasswd: line {c}: missing new password\n")
                     else:
-                        pass
-                        """
-                        TODO:
-                            - update shadow file
-                            - update userDB.txt (???)
-                            - updte auth_random.json (if in use)
-                        """
+                        username = _u.decode(errors="ignore")
+password = p.decode(errors="ignore")
+
+# Log the attempt
+log.msg(
+    eventid="cowrie.command.chpasswd",
+    realm="chpasswd",
+    username=username,
+    password=password,
+    format="chpasswd attempt: %(username)s:%(password)s",
+)
+
+# Simulate success (silent like real Linux)
+self.write("")
                 c += 1
         except Exception:
             self.write(f"chpasswd: line {c}: missing new password\n")

--- a/src/cowrie/commands/chpasswd.py
+++ b/src/cowrie/commands/chpasswd.py
@@ -46,18 +46,15 @@ class Command_chpasswd(HoneyPotCommand):
                         self.write(f"chpasswd: line {c}: invalid format\n")
                     else:
                         _u, p = line.split(b":", 1)
-
-                        if len(line):
-    if b":" not in line:
-        self.write(f"chpasswd: line {c}: invalid format\n")
-    else:
-        parts = line.split(b":", 1)
-
-        if len(parts) != 2:
-            self.write(f"chpasswd: line {c}: invalid format\n")
-        else:
-            _u, p = parts
-
+if len(line):
+                if b":" not in line:
+                    self.write(f"chpasswd: line {c}: invalid format\n")
+                else:
+                    _u, p = line.split(b":", 1)
+                    if not len(p):
+                        self.write(f"chpasswd: line {c}: missing new password\n")
+                    else:
+                        username = _u.decode(errors="ignore")
             if not p:
                 self.write(f"chpasswd: line {c}: missing new password\n")
             else:

--- a/src/cowrie/commands/chpasswd.py
+++ b/src/cowrie/commands/chpasswd.py
@@ -46,26 +46,16 @@ class Command_chpasswd(HoneyPotCommand):
                         self.write(f"chpasswd: line {c}: invalid format\n")
                     else:
                         _u, p = line.split(b":", 1)
-if len(line):
-                if b":" not in line:
-                    self.write(f"chpasswd: line {c}: invalid format\n")
-                else:
-                    _u, p = line.split(b":", 1)
-                    if not len(p):
-                        self.write(f"chpasswd: line {c}: missing new password\n")
-                    else:
-                        username = _u.decode(errors="ignore")
-            if not p:
-                self.write(f"chpasswd: line {c}: missing new password\n")
-            else:
-                username = _u.decode(errors="ignore")
-
-                log.msg(
-                    eventid="cowrie.command.chpasswd",
-                    realm="chpasswd",
-                    username=username,
-                    format="Password change attempt for %(username)s",
-                )
+                        if not len(p):
+                            self.write(f"chpasswd: line {c}: missing new password\n")
+                        else:
+                            username = _u.decode(errors="ignore")
+                            log.msg(
+                                eventid="cowrie.command.chpasswd",
+                                realm="chpasswd",
+                                username=username,
+                                format="Password change attempt for %(username)s",
+                            )
                 c += 1
         except Exception:
             self.write(f"chpasswd: line {c}: missing new password\n")


### PR DESCRIPTION
Implements chpasswd command simulation with logging.

This is a cleaned-up version of #40078, containing only the chpasswd-related changes.