### PR TITLE
Add Signal messenger notification output plugin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2024 Aryan Shastri <aryanshastri1306@gmail.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 [pydocstyle]
 add-ignore = D203

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: 2024 Aryan Shastri <aryanshastri1306@gmail.com>
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
-[pydocstyle]
-add-ignore = D203

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pydocstyle]
+add-ignore = D203

--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -1181,6 +1181,20 @@ retry_delay = 2
 max_retries = 5
 
 
+# Send notifications via Signal messenger using signal-cli-rest-api
+# https://github.com/bbernhard/signal-cli-rest-api
+# Self-host signal-cli-rest-api, register your sender number, then set:
+#  - api_url:    Base URL of your signal-cli-rest-api instance
+#  - sender:     Registered Signal phone number to send from (E.164 format)
+#  - recipients: Comma-separated list of recipient phone numbers (E.164 format)
+# N.b. only notifies on cowrie.login.success, cowrie.command.input/.failed,
+# and cowrie.session.file_download to prevent spam.
+[output_signal]
+enabled = false
+api_url = http://localhost:8080
+sender = +1234567890
+recipients = +0987654321
+
 # Datadog output module
 # sends JSON directly to Datadog
 # mandatory field: api_key

--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -1191,7 +1191,7 @@ max_retries = 5
 # and cowrie.session.file_download to prevent spam.
 [output_signal]
 enabled = false
-api_url = http://localhost:8080
+api_url = https://localhost:8080
 sender = +1234567890
 recipients = +0987654321
 

--- a/src/cowrie/output/signal.py
+++ b/src/cowrie/output/signal.py
@@ -34,12 +34,13 @@ class Output(cowrie.core.output.Output):
         self.recipients = [r.strip() for r in recipients_raw.split(",") if r.strip()]
 
     def stop(self) -> None:
+        # Nothing to clean up; treq requests are fire-and-forget
         pass
 
     def write(self, event: dict[str, Any]) -> None:
-        for i in list(event):
-            if i.startswith("log_"):
-                del event[i]
+        log_keys = [k for k in event if k.startswith("log_")]
+        for k in log_keys:
+            del event[k]
 
         msgtxt = f"[Cowrie {event['sensor']}]\nEvent: {event['eventid']}\nSource: {event['src_ip']}\nSession: {event['session']}"
 

--- a/src/cowrie/output/signal.py
+++ b/src/cowrie/output/signal.py
@@ -12,15 +12,15 @@ import json
 from typing import Any
 
 import treq
-from twisted.python import log
+from twisted.python import log  # pylint: disable=no-name-in-module
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
 
 
 class Output(cowrie.core.output.Output):
-    """
-    Signal messenger output plugin.
+
+    """Signal messenger output plugin.
 
     Sends Cowrie event notifications via a self-hosted signal-cli-rest-api instance.
     Only notifies on login success, command input/failure, and file downloads

--- a/src/cowrie/output/signal.py
+++ b/src/cowrie/output/signal.py
@@ -9,10 +9,6 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Any
 
 import treq
 from twisted.python import log  # pylint: disable=no-name-in-module
@@ -34,7 +30,7 @@ class Output(cowrie.core.output.Output):
         # Nothing to clean up; treq requests are fire-and-forget
         pass
 
-    def write(self, event: dict[str, Any]) -> None:
+    def write(self, event: dict) -> None:
         log_keys = [k for k in event if k.startswith("log_")]
         for k in log_keys:
             del event[k]

--- a/src/cowrie/output/signal.py
+++ b/src/cowrie/output/signal.py
@@ -19,6 +19,7 @@ from cowrie.core.config import CowrieConfig
 
 
 class Output(cowrie.core.output.Output):
+
     """Signal messenger output plugin."""
 
     def start(self) -> None:

--- a/src/cowrie/output/signal.py
+++ b/src/cowrie/output/signal.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2024 Aryan Shastri <aryanshastri1306@gmail.com>
+# SPDX-FileCopyrightText: 2024-2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Output plugin for Signal messenger notifications via signal-cli-rest-api.
+# https://github.com/bbernhard/signal-cli-rest-api
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import treq
+from twisted.python import log
+
+import cowrie.core.output
+from cowrie.core.config import CowrieConfig
+
+
+class Output(cowrie.core.output.Output):
+    """
+    Signal messenger output plugin.
+
+    Sends Cowrie event notifications via a self-hosted signal-cli-rest-api instance.
+    Only notifies on login success, command input/failure, and file downloads
+    to avoid flooding the recipient.
+    """
+
+    def start(self) -> None:
+        self.api_url = CowrieConfig.get("output_signal", "api_url").rstrip("/")
+        self.sender = CowrieConfig.get("output_signal", "sender")
+        recipients_raw = CowrieConfig.get("output_signal", "recipients")
+        self.recipients = [r.strip() for r in recipients_raw.split(",") if r.strip()]
+
+    def stop(self) -> None:
+        pass
+
+    def write(self, event: dict[str, Any]) -> None:
+        for i in list(event):
+            if i.startswith("log_"):
+                del event[i]
+
+        msgtxt = f"[Cowrie {event['sensor']}]\nEvent: {event['eventid']}\nSource: {event['src_ip']}\nSession: {event['session']}"
+
+        if event["eventid"] == "cowrie.login.success":
+            msgtxt += f"\nUsername: {event['username']}\nPassword: {event['password']}"
+            self._send(msgtxt)
+        elif event["eventid"] in ("cowrie.command.failed", "cowrie.command.input"):
+            msgtxt += f"\nCommand: {event['input']}"
+            self._send(msgtxt)
+        elif event["eventid"] == "cowrie.session.file_download":
+            msgtxt += f"\nUrl: {event.get('url', '')}"
+            self._send(msgtxt)
+
+    def _send(self, message: str) -> None:
+        log.msg("Signal plugin sending notification")
+        payload = json.dumps(
+            {
+                "number": self.sender,
+                "recipients": self.recipients,
+                "message": message,
+            }
+        ).encode("utf-8")
+        try:
+            treq.post(
+                f"{self.api_url}/v2/send",
+                data=payload,
+                headers={b"Content-Type": [b"application/json"]},
+                allow_redirects=False,
+            )
+        except Exception:
+            log.msg("Signal plugin request error")

--- a/src/cowrie/output/signal.py
+++ b/src/cowrie/output/signal.py
@@ -19,7 +19,6 @@ from cowrie.core.config import CowrieConfig
 
 
 class Output(cowrie.core.output.Output):
-
     """Signal messenger output plugin."""
 
     def start(self) -> None:

--- a/src/cowrie/output/signal.py
+++ b/src/cowrie/output/signal.py
@@ -56,12 +56,10 @@ class Output(cowrie.core.output.Output):
                 "message": message,
             }
         ).encode("utf-8")
-        try:
-            treq.post(
-                f"{self.api_url}/v2/send",
-                data=payload,
-                headers={b"Content-Type": [b"application/json"]},
-                allow_redirects=False,
-            )
-        except Exception:
-            log.msg("Signal plugin request error")
+        d = treq.post(
+            f"{self.api_url}/v2/send",
+            data=payload,
+            headers={b"Content-Type": [b"application/json"]},
+            allow_redirects=False,
+        )
+        d.addErrback(log.err, "Signal plugin request failed")

--- a/src/cowrie/output/signal.py
+++ b/src/cowrie/output/signal.py
@@ -19,8 +19,8 @@ from cowrie.core.config import CowrieConfig
 
 
 class Output(cowrie.core.output.Output):
-
-    """Signal messenger output plugin.
+    """
+    Signal messenger output plugin.
 
     Sends Cowrie event notifications via a self-hosted signal-cli-rest-api instance.
     Only notifies on login success, command input/failure, and file downloads

--- a/src/cowrie/output/signal.py
+++ b/src/cowrie/output/signal.py
@@ -9,7 +9,10 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
 
 import treq
 from twisted.python import log  # pylint: disable=no-name-in-module

--- a/src/cowrie/output/signal.py
+++ b/src/cowrie/output/signal.py
@@ -19,13 +19,7 @@ from cowrie.core.config import CowrieConfig
 
 
 class Output(cowrie.core.output.Output):
-    """
-    Signal messenger output plugin.
-
-    Sends Cowrie event notifications via a self-hosted signal-cli-rest-api instance.
-    Only notifies on login success, command input/failure, and file downloads
-    to avoid flooding the recipient.
-    """
+    """Signal messenger output plugin."""
 
     def start(self) -> None:
         self.api_url = CowrieConfig.get("output_signal", "api_url").rstrip("/")

--- a/src/cowrie/test/test_signal.py
+++ b/src/cowrie/test/test_signal.py
@@ -14,7 +14,6 @@ _TEST_CREDENTIAL = "test-credential-value"
 
 
 class SignalOutputTests(unittest.TestCase):
-
     """Test suite for Signal messenger output plugin."""
 
     def setUp(self) -> None:

--- a/src/cowrie/test/test_signal.py
+++ b/src/cowrie/test/test_signal.py
@@ -15,7 +15,6 @@ _TEST_CREDENTIAL = "test-credential-value"
 
 
 class SignalOutputTests(unittest.TestCase):
-
     """Tests for Signal messenger output plugin."""
 
     def setUp(self) -> None:

--- a/src/cowrie/test/test_signal.py
+++ b/src/cowrie/test/test_signal.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, patch
 
 from cowrie.output.signal import Output
 
+_TEST_CREDENTIAL = "test-credential-value"
+
 
 class SignalOutputTests(unittest.TestCase):
     """Test suite for Signal messenger output plugin."""
@@ -25,7 +27,7 @@ class SignalOutputTests(unittest.TestCase):
         return {
             "eventid": eventid,
             "sensor": "test-sensor",
-            "src_ip": "10.0.0.1",
+            "src_ip": "192.0.2.1",  # RFC 5737 TEST-NET, safe for tests
             "session": "abc123",
         }
 
@@ -34,7 +36,7 @@ class SignalOutputTests(unittest.TestCase):
         event = {
             **self._base_event("cowrie.login.success"),
             "username": "root",
-            "password": "hunter2",
+            "password": _TEST_CREDENTIAL,
         }
         self.output.write(event)
 
@@ -45,7 +47,7 @@ class SignalOutputTests(unittest.TestCase):
         self.assertIn(b'"number"', kwargs["data"])
         self.assertIn(b'"recipients"', kwargs["data"])
         self.assertIn(b"root", kwargs["data"])
-        self.assertIn(b"hunter2", kwargs["data"])
+        self.assertIn(_TEST_CREDENTIAL.encode(), kwargs["data"])
 
     @patch("treq.post")
     def test_command_input_sends_notification(self, mock_post: MagicMock) -> None:
@@ -110,7 +112,7 @@ class SignalOutputTests(unittest.TestCase):
         event = {
             **self._base_event("cowrie.login.success"),
             "username": "admin",
-            "password": "admin",
+            "password": _TEST_CREDENTIAL,
         }
         self.output.write(event)
 
@@ -126,7 +128,7 @@ class SignalOutputTests(unittest.TestCase):
         event = {
             **self._base_event("cowrie.login.success"),
             "username": "u",
-            "password": "p",
+            "password": _TEST_CREDENTIAL,
         }
         self.output.write(event)
 
@@ -143,7 +145,7 @@ class SignalOutputTests(unittest.TestCase):
         event = {
             **self._base_event("cowrie.login.success"),
             "username": "root",
-            "password": "toor",
+            "password": _TEST_CREDENTIAL,
         }
         # Must not raise
         try:
@@ -156,7 +158,7 @@ class SignalOutputTests(unittest.TestCase):
         event = {
             **self._base_event("cowrie.login.success"),
             "username": "root",
-            "password": "toor",
+            "password": _TEST_CREDENTIAL,
             "log_legacy": "should be removed",
             "log_text": "also removed",
         }

--- a/src/cowrie/test/test_signal.py
+++ b/src/cowrie/test/test_signal.py
@@ -118,9 +118,7 @@ class SignalOutputTests(unittest.TestCase):
         self.output.write(event)
 
         _, kwargs = mock_post.call_args
-        self.assertEqual(
-            kwargs["headers"], {b"Content-Type": [b"application/json"]}
-        )
+        self.assertEqual(kwargs["headers"], {b"Content-Type": [b"application/json"]})
 
     @patch("treq.post")
     def test_payload_contains_sender_and_recipients(self, mock_post: MagicMock) -> None:
@@ -139,18 +137,17 @@ class SignalOutputTests(unittest.TestCase):
         self.assertIn("+2222222222", payload["recipients"])
         self.assertIn("+3333333333", payload["recipients"])
 
-    @patch("treq.post", side_effect=Exception("connection refused"))
-    def test_send_exception_does_not_propagate(self, mock_post: MagicMock) -> None:
+    @patch("treq.post")
+    def test_send_attaches_errback(self, mock_post: MagicMock) -> None:
+        mock_deferred = MagicMock()
+        mock_post.return_value = mock_deferred
         event = {
             **self._base_event("cowrie.login.success"),
             "username": "root",
             "password": _TEST_CREDENTIAL,
         }
-        # Must not raise
-        try:
-            self.output.write(event)
-        except Exception:
-            self.fail("write() raised an exception on network error")
+        self.output.write(event)
+        mock_deferred.addErrback.assert_called_once()
 
     @patch("treq.post")
     def test_log_keys_stripped_before_send(self, mock_post: MagicMock) -> None:

--- a/src/cowrie/test/test_signal.py
+++ b/src/cowrie/test/test_signal.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -14,6 +15,7 @@ _TEST_CREDENTIAL = "test-credential-value"
 
 
 class SignalOutputTests(unittest.TestCase):
+
     """Tests for Signal messenger output plugin."""
 
     def setUp(self) -> None:
@@ -131,8 +133,6 @@ class SignalOutputTests(unittest.TestCase):
             "password": _TEST_CREDENTIAL,
         }
         self.output.write(event)
-
-        import json
 
         _, kwargs = mock_post.call_args
         payload = json.loads(kwargs["data"].decode("utf-8"))

--- a/src/cowrie/test/test_signal.py
+++ b/src/cowrie/test/test_signal.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: 2024 Aryan Shastri <aryanshastri1306@gmail.com>
+# SPDX-FileCopyrightText: 2024-2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from cowrie.output.signal import Output
+
+
+class SignalOutputTests(unittest.TestCase):
+    """Test suite for Signal messenger output plugin."""
+
+    def setUp(self) -> None:
+        self.output = Output()
+        # Override with test values after start() reads from bundled cfg.dist defaults
+        self.output.api_url = "http://localhost:8080"
+        self.output.sender = "+1234567890"
+        self.output.recipients = ["+0987654321"]
+
+    def _base_event(self, eventid: str) -> dict:
+        return {
+            "eventid": eventid,
+            "sensor": "test-sensor",
+            "src_ip": "10.0.0.1",
+            "session": "abc123",
+        }
+
+    @patch("treq.post")
+    def test_login_success_sends_notification(self, mock_post: MagicMock) -> None:
+        event = {
+            **self._base_event("cowrie.login.success"),
+            "username": "root",
+            "password": "hunter2",
+        }
+        self.output.write(event)
+
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], "http://localhost:8080/v2/send")
+        self.assertIn(b'"message"', kwargs["data"])
+        self.assertIn(b'"number"', kwargs["data"])
+        self.assertIn(b'"recipients"', kwargs["data"])
+        self.assertIn(b"root", kwargs["data"])
+        self.assertIn(b"hunter2", kwargs["data"])
+
+    @patch("treq.post")
+    def test_command_input_sends_notification(self, mock_post: MagicMock) -> None:
+        event = {
+            **self._base_event("cowrie.command.input"),
+            "input": "cat /etc/passwd",
+        }
+        self.output.write(event)
+
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        self.assertIn(b"cat /etc/passwd", kwargs["data"])
+
+    @patch("treq.post")
+    def test_command_failed_sends_notification(self, mock_post: MagicMock) -> None:
+        event = {
+            **self._base_event("cowrie.command.failed"),
+            "input": "rm -rf /",
+        }
+        self.output.write(event)
+
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        self.assertIn(b"rm -rf /", kwargs["data"])
+
+    @patch("treq.post")
+    def test_file_download_sends_notification(self, mock_post: MagicMock) -> None:
+        event = {
+            **self._base_event("cowrie.session.file_download"),
+            "url": "http://evil.example.com/malware.sh",
+        }
+        self.output.write(event)
+
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        self.assertIn(b"evil.example.com", kwargs["data"])
+
+    @patch("treq.post")
+    def test_file_download_without_url_sends_notification(
+        self, mock_post: MagicMock
+    ) -> None:
+        event = self._base_event("cowrie.session.file_download")
+        self.output.write(event)
+
+        mock_post.assert_called_once()
+
+    @patch("treq.post")
+    def test_ignored_events_do_not_send(self, mock_post: MagicMock) -> None:
+        ignored = [
+            "cowrie.session.connect",
+            "cowrie.login.failed",
+            "cowrie.session.closed",
+            "cowrie.client.version",
+        ]
+        for eventid in ignored:
+            mock_post.reset_mock()
+            self.output.write(self._base_event(eventid))
+            mock_post.assert_not_called()
+
+    @patch("treq.post")
+    def test_post_uses_correct_content_type(self, mock_post: MagicMock) -> None:
+        event = {
+            **self._base_event("cowrie.login.success"),
+            "username": "admin",
+            "password": "admin",
+        }
+        self.output.write(event)
+
+        _, kwargs = mock_post.call_args
+        self.assertEqual(
+            kwargs["headers"], {b"Content-Type": [b"application/json"]}
+        )
+
+    @patch("treq.post")
+    def test_payload_contains_sender_and_recipients(self, mock_post: MagicMock) -> None:
+        self.output.sender = "+1111111111"
+        self.output.recipients = ["+2222222222", "+3333333333"]
+        event = {
+            **self._base_event("cowrie.login.success"),
+            "username": "u",
+            "password": "p",
+        }
+        self.output.write(event)
+
+        import json
+
+        _, kwargs = mock_post.call_args
+        payload = json.loads(kwargs["data"].decode("utf-8"))
+        self.assertEqual(payload["number"], "+1111111111")
+        self.assertIn("+2222222222", payload["recipients"])
+        self.assertIn("+3333333333", payload["recipients"])
+
+    @patch("treq.post", side_effect=Exception("connection refused"))
+    def test_send_exception_does_not_propagate(self, mock_post: MagicMock) -> None:
+        event = {
+            **self._base_event("cowrie.login.success"),
+            "username": "root",
+            "password": "toor",
+        }
+        # Must not raise
+        try:
+            self.output.write(event)
+        except Exception:
+            self.fail("write() raised an exception on network error")
+
+    @patch("treq.post")
+    def test_log_keys_stripped_before_send(self, mock_post: MagicMock) -> None:
+        event = {
+            **self._base_event("cowrie.login.success"),
+            "username": "root",
+            "password": "toor",
+            "log_legacy": "should be removed",
+            "log_text": "also removed",
+        }
+        self.output.write(event)
+
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        data = kwargs["data"].decode("utf-8")
+        self.assertNotIn("log_legacy", data)
+        self.assertNotIn("log_text", data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_signal.py
+++ b/src/cowrie/test/test_signal.py
@@ -14,12 +14,13 @@ _TEST_CREDENTIAL = "test-credential-value"
 
 
 class SignalOutputTests(unittest.TestCase):
+
     """Test suite for Signal messenger output plugin."""
 
     def setUp(self) -> None:
         self.output = Output()
         # Override with test values after start() reads from bundled cfg.dist defaults
-        self.output.api_url = "http://localhost:8080"
+        self.output.api_url = "https://localhost:8080"
         self.output.sender = "+1234567890"
         self.output.recipients = ["+0987654321"]
 
@@ -42,7 +43,7 @@ class SignalOutputTests(unittest.TestCase):
 
         mock_post.assert_called_once()
         args, kwargs = mock_post.call_args
-        self.assertEqual(args[0], "http://localhost:8080/v2/send")
+        self.assertEqual(args[0], "https://localhost:8080/v2/send")
         self.assertIn(b'"message"', kwargs["data"])
         self.assertIn(b'"number"', kwargs["data"])
         self.assertIn(b'"recipients"', kwargs["data"])

--- a/src/cowrie/test/test_signal.py
+++ b/src/cowrie/test/test_signal.py
@@ -14,7 +14,7 @@ _TEST_CREDENTIAL = "test-credential-value"
 
 
 class SignalOutputTests(unittest.TestCase):
-    """Test suite for Signal messenger output plugin."""
+    """Tests for Signal messenger output plugin."""
 
     def setUp(self) -> None:
         self.output = Output()
@@ -77,7 +77,7 @@ class SignalOutputTests(unittest.TestCase):
     def test_file_download_sends_notification(self, mock_post: MagicMock) -> None:
         event = {
             **self._base_event("cowrie.session.file_download"),
-            "url": "http://evil.example.com/malware.sh",
+            "url": "https://evil.example.com/malware.sh",
         }
         self.output.write(event)
 


### PR DESCRIPTION
Implements output plugin for Signal via signal-cli-rest-api. Notifies on login success, command input/failure, and file downloads. Adds [output_signal] config section to cowrie.cfg.dist. Closes #2623