### PR TITLE
recording "last command" for DShield

### DIFF
--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -52,28 +52,48 @@ class Output(cowrie.core.output.Output):
         # session id so concurrent sessions do not stomp each other's state.
         self.session_state = {}
 
+        self._warn_if_legacy_auth_key()
+
+    def _warn_if_legacy_auth_key(self) -> None:
+        """
+        The pre-2026 DShield API took a base64-encoded auth_key and decoded
+        it before computing the HMAC. The current submitapi uses the key as
+        a raw string. Warn loudly if the configured key still looks
+        base64-encoded so an operator notices before submissions are
+        silently rejected.
+        """
+        try:
+            base64.b64decode(self.auth_key, validate=True)
+        except (binascii.Error, ValueError):
+            return
+        if "=" in self.auth_key:
+            log.msg(
+                "dshield: auth_key looks base64-encoded but the current "
+                "DShield submit API expects the raw key. Update your "
+                "config if submissions are rejected."
+            )
+
     def stop(self):
         pass
 
     def _state(self, session: str) -> dict[str, str]:
         state = self.session_state.get(session)
         if state is None:
-            state = {"lastcommand": "", "hassh": "", "banner": ""}
+            state = {"lastcommand": "", "hassh": "", "banner": "", "username": "", "password": "", "src_ip": "", "timestamp": 0}
             self.session_state[session] = state
         return state
 
     def write(self, event):
         eventid = event["eventid"]
         session = event.get("session", "")
-
-        if eventid == "cowrie.session.closed":
-            state = self._state(session)
+        state = self._state(session)
+        if eventid == 'cowrie.session.closed':
             self.batch.append(
                 {
                     "timestamp": int(event["time"]),
                     "source_ip": event["src_ip"],
-                    "user": event["username"],
-                    "password": event.get("password", ""),
+                    "user": state["username"],
+                    "password": state["password"],
                     "lastcommand": state["lastcommand"],
                     "hassh": state["hassh"],
                     "banner": state["banner"],
@@ -90,13 +110,23 @@ class Output(cowrie.core.output.Output):
                 batch_to_send = self.batch
                 self.submit_entries(batch_to_send)
                 self.batch = []
-            self.session_state.pop(session, None)
+        elif eventid in ("cowrie.login.success", "cowrie.login.failed"):
+            log.msg("dshield: cowrie.login.success or cowrie.login.failed")
+            self._state(session)["username"] = event.get("username","")
+            self._state(session)["password"] = event.get("password","")
+            log.msg(f'dshield: {state["username"]} {state["password"]}')
+        elif eventid == 'cowrie.direct-tcpip.request':
+            log.msg("dshield: cowrie.direct-tcpip.request")            
+            self._state(session)["lastcommand"] = event.get("message","")
         elif eventid == "cowrie.command.input":
+            log.msg("dshield: cowrie.command.input")
             self._state(session)["lastcommand"] = event["input"]
         elif eventid == "cowrie.client.kex":
             self._state(session)["hassh"] = event["hassh"]
         elif eventid == "cowrie.client.version":
             self._state(session)["banner"] = event["version"]
+        elif eventid == "cowrie.session.closed":
+            self.session_state.pop(session, None)
 
     def transmission_error(self, batch):
         self.batch.extend(batch)

--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -86,7 +86,7 @@ class Output(cowrie.core.output.Output):
                 "username": "",
                 "password": "",
                 "src_ip": "",
-                "timestamp": 0,
+                "timestamp": "",
             }
             self.session_state[session] = state
         return state
@@ -98,7 +98,7 @@ class Output(cowrie.core.output.Output):
         if eventid == "cowrie.session.closed":
             self.batch.append(
                 {
-                    "timestamp": int(event["time"]),
+                    "timestamp": event["time"],
                     "source_ip": event["src_ip"],
                     "user": state["username"],
                     "password": state["password"],

--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -79,7 +79,15 @@ class Output(cowrie.core.output.Output):
     def _state(self, session: str) -> dict[str, str]:
         state = self.session_state.get(session)
         if state is None:
-            state = {"lastcommand": "", "hassh": "", "banner": "", "username": "", "password": "", "src_ip": "", "timestamp": 0}
+            state = {
+                "lastcommand": "",
+                "hassh": "",
+                "banner": "",
+                "username": "",
+                "password": "",
+                "src_ip": "",
+                "timestamp": 0,
+            }
             self.session_state[session] = state
         return state
 
@@ -87,7 +95,7 @@ class Output(cowrie.core.output.Output):
         eventid = event["eventid"]
         session = event.get("session", "")
         state = self._state(session)
-        if eventid == 'cowrie.session.closed':
+        if eventid == "cowrie.session.closed":
             self.batch.append(
                 {
                     "timestamp": int(event["time"]),
@@ -112,12 +120,12 @@ class Output(cowrie.core.output.Output):
                 self.batch = []
         elif eventid in ("cowrie.login.success", "cowrie.login.failed"):
             log.msg("dshield: cowrie.login.success or cowrie.login.failed")
-            self._state(session)["username"] = event.get("username","")
-            self._state(session)["password"] = event.get("password","")
-            log.msg(f'dshield: {state["username"]} {state["password"]}')
-        elif eventid == 'cowrie.direct-tcpip.request':
-            log.msg("dshield: cowrie.direct-tcpip.request")            
-            self._state(session)["lastcommand"] = event.get("message","")
+            self._state(session)["username"] = event.get("username", "")
+            self._state(session)["password"] = event.get("password", "")
+            log.msg(f"dshield: {state['username']} {state['password']}")
+        elif eventid == "cowrie.direct-tcpip.request":
+            log.msg("dshield: cowrie.direct-tcpip.request")
+            self._state(session)["lastcommand"] = event.get("message", "")
         elif eventid == "cowrie.command.input":
             log.msg("dshield: cowrie.command.input")
             self._state(session)["lastcommand"] = event["input"]
@@ -152,8 +160,7 @@ class Output(cowrie.core.output.Output):
         ).digest()
         hash64 = base64.b64encode(digest).decode("ascii")
         auth_header = (
-            f"ISC-HMAC-SHA256 Credentials={hash64} "
-            f"Userid={self.userid} Nonce={nonce}"
+            f"ISC-HMAC-SHA256 Credentials={hash64} Userid={self.userid} Nonce={nonce}"
         )
         if self.debug:
             log.msg(f"dshield: authentication header {auth_header}")

--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -133,8 +133,6 @@ class Output(cowrie.core.output.Output):
             self._state(session)["hassh"] = event["hassh"]
         elif eventid == "cowrie.client.version":
             self._state(session)["banner"] = event["version"]
-        elif eventid == "cowrie.session.closed":
-            self.session_state.pop(session, None)
 
     def transmission_error(self, batch):
         self.batch.extend(batch)

--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -52,27 +52,6 @@ class Output(cowrie.core.output.Output):
         # session id so concurrent sessions do not stomp each other's state.
         self.session_state = {}
 
-        self._warn_if_legacy_auth_key()
-
-    def _warn_if_legacy_auth_key(self) -> None:
-        """
-        The pre-2026 DShield API took a base64-encoded auth_key and decoded
-        it before computing the HMAC. The current submitapi uses the key as
-        a raw string. Warn loudly if the configured key still looks
-        base64-encoded so an operator notices before submissions are
-        silently rejected.
-        """
-        try:
-            base64.b64decode(self.auth_key, validate=True)
-        except (binascii.Error, ValueError):
-            return
-        if "=" in self.auth_key:
-            log.msg(
-                "dshield: auth_key looks base64-encoded but the current "
-                "DShield submit API expects the raw key. Update your "
-                "config if submissions are rejected."
-            )
-
     def stop(self):
         pass
 
@@ -87,7 +66,7 @@ class Output(cowrie.core.output.Output):
         eventid = event["eventid"]
         session = event.get("session", "")
 
-        if eventid in ("cowrie.login.success", "cowrie.login.failed"):
+        if eventid == "cowrie.session.closed":
             state = self._state(session)
             self.batch.append(
                 {
@@ -111,14 +90,13 @@ class Output(cowrie.core.output.Output):
                 batch_to_send = self.batch
                 self.submit_entries(batch_to_send)
                 self.batch = []
+            self.session_state.pop(session, None)
         elif eventid == "cowrie.command.input":
             self._state(session)["lastcommand"] = event["input"]
         elif eventid == "cowrie.client.kex":
             self._state(session)["hassh"] = event["hassh"]
         elif eventid == "cowrie.client.version":
             self._state(session)["banner"] = event["version"]
-        elif eventid == "cowrie.session.closed":
-            self.session_state.pop(session, None)
 
     def transmission_error(self, batch):
         self.batch.extend(batch)


### PR DESCRIPTION
This update to the DShield output plugin will include the last command issued by the attacker (if present) in the logs. I also removed the base64 api key check, as they should work now.

checked with "ruff" prior to submission.

 