### PR TITLE
fix: send bare LF on PTY-less exec channels

### DIFF
--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -98,10 +98,7 @@ class LoggingServerProtocol(insults.ServerProtocol):
             # Exec channel: no PTY was allocated, so write raw bytes without
             # the \n -> \r\n translation that insults.ServerProtocol.write()
             # performs (which is only appropriate for PTY sessions).
-            if data:
-                if not isinstance(data, bytes):
-                    data = data.encode("utf-8")
-                self.transport.write(data)
+            self.transport.write(data)
         else:
             insults.ServerProtocol.write(self, data)
 

--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -94,7 +94,16 @@ class LoggingServerProtocol(insults.ServerProtocol):
             )
             self.ttylogSize += len(data)
 
-        insults.ServerProtocol.write(self, data)
+        if self.type == "e":
+            # Exec channel: no PTY was allocated, so write raw bytes without
+            # the \n -> \r\n translation that insults.ServerProtocol.write()
+            # performs (which is only appropriate for PTY sessions).
+            if data:
+                if not isinstance(data, bytes):
+                    data = data.encode("utf-8")
+                self.transport.write(data)
+        else:
+            insults.ServerProtocol.write(self, data)
 
     def dataReceived(self, data: bytes) -> None:
         """

--- a/src/cowrie/test/test_insults.py
+++ b/src/cowrie/test/test_insults.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for cowrie/insults/insults.py output handling.
+# ABOUTME: Verifies line-ending behaviour differs between exec and interactive channels.
+
+from __future__ import annotations
+
+import unittest
+
+from cowrie.insults.insults import LoggingServerProtocol
+
+
+class FakeTransport:
+    """Minimal transport capturing bytes written to it."""
+
+    def __init__(self) -> None:
+        self.written: bytes = b""
+
+    def write(self, data: bytes) -> None:
+        self.written += data
+
+
+def make_protocol(channel_type: str) -> LoggingServerProtocol:
+    lsp = LoggingServerProtocol.__new__(LoggingServerProtocol)
+    lsp.type = channel_type
+    lsp.bytesSent = 0
+    lsp.ttylogEnabled = False
+    lsp.ttylogOpen = False
+    lsp.transport = FakeTransport()
+    return lsp
+
+
+class WriteLineEndingTestCase(unittest.TestCase):
+    """Tests for LoggingServerProtocol.write() line-ending handling."""
+
+    def test_exec_channel_keeps_bare_newline(self) -> None:
+        """Exec channels have no PTY, so \\n must not be rewritten to \\r\\n."""
+        lsp = make_protocol("e")
+        lsp.write(b"Linux server01 5.10.0 armv7l\n")
+        self.assertEqual(lsp.transport.written, b"Linux server01 5.10.0 armv7l\n")
+
+    def test_interactive_channel_translates_newline(self) -> None:
+        """Interactive PTY sessions still rewrite \\n to \\r\\n."""
+        lsp = make_protocol("i")
+        lsp.write(b"Linux server01 5.10.0 armv7l\n")
+        self.assertEqual(lsp.transport.written, b"Linux server01 5.10.0 armv7l\r\n")


### PR DESCRIPTION
## Summary

Over a PTY-less SSH exec channel (`ssh host 'cmd'`, no `pty-req`), Cowrie sent `\r\n` line endings where a real Linux host sends bare `\n`.

`LoggingServerProtocol.write()` delegated unconditionally to `insults.ServerProtocol.write()`, which rewrites `\n` to `\r\n`. That translation is correct for interactive PTY sessions (where a real system's tty layer applies `ONLCR`) but wrong for PTY-less exec channels, where there is no tty layer.

The fix bypasses Twisted's translation and writes raw bytes when `self.type == "e"` (exec channel), keeping the `\r\n` behaviour for interactive sessions.

## Test plan

- Added `src/cowrie/test/test_insults.py`:
  - exec channel (`type == "e"`) keeps bare `\n`
  - interactive channel (`type == "i"`) still translates `\n` to `\r\n`
- Followed TDD: exec test failed before the fix, both pass after. No new failures in the wider suite.

Fixes #40166