### PR TITLE
fix: persist shell variables and separate exported environment

### DIFF
--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -1085,14 +1085,52 @@ class Command_set(HoneyPotCommand):
 commands["set"] = Command_set
 
 
+class Command_export(HoneyPotCommand):
+    """
+    Mark shell variables for export so they appear in the environment of
+    child processes. With no operands, list the exported variables.
+    """
+
+    def call(self) -> None:
+        args = [a for a in self.args if a != "-p"]
+        if not args:
+            for name in sorted(self.exported):
+                self.write(f'declare -x {name}="{self.environ.get(name, "")}"\n')
+            return
+        for arg in args:
+            if "=" in arg:
+                key, val = arg.split("=", 1)
+                self.environ[key] = val
+                self.exported.add(key)
+            else:
+                self.exported.add(arg)
+
+
+commands["export"] = Command_export
+
+
+class Command_unset(HoneyPotCommand):
+    """
+    Remove variables from both the shell and the exported environment.
+    """
+
+    def call(self) -> None:
+        for arg in self.args:
+            if arg.startswith("-"):
+                continue
+            self.environ.pop(arg, None)
+            self.exported.discard(arg)
+
+
+commands["unset"] = Command_unset
+
+
 class Command_nop(HoneyPotCommand):
     def call(self) -> None:
         pass
 
 
 commands["umask"] = Command_nop
-commands["unset"] = Command_nop
-commands["export"] = Command_nop
 commands["alias"] = Command_nop
 commands["jobs"] = Command_nop
 commands["kill"] = Command_nop

--- a/src/cowrie/commands/busybox.py
+++ b/src/cowrie/commands/busybox.py
@@ -78,7 +78,9 @@ class Command_busybox(HoneyPotCommand):
 
         line = " ".join(self.args)
         cmd = self.args[0]
-        cmdclass = self.protocol.getCommand(cmd, self.environ["PATH"].split(":"))
+        cmdclass = self.protocol.getCommand(
+            cmd, self.environ.get("PATH", "").split(":")
+        )
         if cmdclass:
             # log found command
             log.msg(

--- a/src/cowrie/commands/env.py
+++ b/src/cowrie/commands/env.py
@@ -32,9 +32,10 @@ For complete documentation, run: info coreutils 'env invocation'
 
 class Command_env(HoneyPotCommand):
     def call(self) -> None:
-        # This only show environ vars, not the shell vars. Need just to mimic real systems
-        for i in self.environ:
-            self.write(f"{i}={self.environ[i]}\n")
+        # env shows only exported variables, not plain shell variables
+        for name in self.environ:
+            if name in self.exported:
+                self.write(f"{name}={self.environ[name]}\n")
 
 
 commands["/usr/bin/env"] = Command_env

--- a/src/cowrie/commands/sudo.py
+++ b/src/cowrie/commands/sudo.py
@@ -94,7 +94,7 @@ class Command_sudo(HoneyPotCommand):
         parsed_arguments = []
         for count in range(0, len(self.args)):
             class_found = self.protocol.getCommand(
-                self.args[count], self.environ["PATH"].split(":")
+                self.args[count], self.environ.get("PATH", "").split(":")
             )
             if class_found:
                 start_value = count
@@ -122,7 +122,9 @@ class Command_sudo(HoneyPotCommand):
 
         if len(parsed_arguments) > 0:
             cmd = parsed_arguments[0]
-            cmdclass = self.protocol.getCommand(cmd, self.environ["PATH"].split(":"))
+            cmdclass = self.protocol.getCommand(
+                cmd, self.environ.get("PATH", "").split(":")
+            )
 
             if cmdclass:
                 command = PipeProtocol(

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -28,6 +28,7 @@ class HoneyPotCommand:
         self.protocol = protocol
         self.args = list(args)
         self.environ = self.protocol.cmdstack[-1].environ
+        self.exported = self.protocol.cmdstack[-1].exported
         self.fs = self.protocol.fs
         self.data: bytes = b""  # output data
         self.input_data: None | (

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -21,9 +21,8 @@ from cowrie.shell import fs
 from cowrie.shell.parser import CommandParser
 from cowrie.shell.pipe import PipeProtocol
 
-# Pre-compiled regexes for environment variable expansion
-_ENV_BRACE_RE = re.compile(r"^\${([_a-zA-Z0-9]+)}$")
-_ENV_SIMPLE_RE = re.compile(r"^\$([_a-zA-Z0-9]+)$")
+# Matches a ${VAR} or $VAR reference anywhere inside a token
+_ENV_VAR_RE = re.compile(r"\$\{([_a-zA-Z0-9]+)\}|\$([_a-zA-Z0-9]+)")
 
 
 class HoneyPotShell:
@@ -34,7 +33,17 @@ class HoneyPotShell:
         self.interactive: bool = interactive
         self.redirect: bool = redirect  # to support output redirection
         self.cmdpending: list[list[str]] = []
-        self.environ: dict[str, str] = copy.copy(protocol.environ)
+        # A nested shell (e.g. a command substitution) inherits the live
+        # environment of whichever shell is currently running; the very first
+        # shell of a session falls back to the login environment, all of which
+        # is exported.
+        if protocol.cmdstack:
+            parent = protocol.cmdstack[-1]
+            self.environ: dict[str, str] = copy.copy(parent.environ)
+            self.exported: set[str] = copy.copy(parent.exported)
+        else:
+            self.environ = copy.copy(protocol.environ)
+            self.exported = set(protocol.environ.keys())
         if hasattr(protocol.user, "windowSize"):
             self.environ["COLUMNS"] = str(protocol.user.windowSize[1])
             self.environ["LINES"] = str(protocol.user.windowSize[0])
@@ -46,6 +55,12 @@ class HoneyPotShell:
 
     def lineReceived(self, line: str) -> None:
         log.msg(eventid="cowrie.command.input", input=line, format="CMD: %(input)s")
+        # posix=True makes the lexer strip quotes as it tokenizes, so by the
+        # time a token reaches variable expansion we can no longer tell whether
+        # a reference was single-quoted ('$1', literal) or double-quoted
+        # ("$1", expanded). expand_variables() works around this by only
+        # expanding variables that are set; a proper lexer/parser that preserves
+        # quoting context per token would let us expand correctly in both cases.
         self.lexer = shlex.shlex(instream=line, punctuation_chars=True, posix=True)
         # Add these special characters that are not in the default lexer
         self.lexer.wordchars += "@%{}=$:+^,()`"
@@ -97,22 +112,19 @@ class HoneyPotShell:
                     continue
                 elif "$(" in tok or "`" in tok:
                     tok = self.do_command_substitution(tok)
-                elif tok.startswith("${"):
-                    envSearch = _ENV_BRACE_RE.search(tok)
-                    if envSearch is not None:
-                        envMatch = envSearch.group(1)
-                        if envMatch in self.environ:
-                            tok = self.environ[envMatch]
-                        else:
+                elif "$" in tok:
+                    whole = _ENV_VAR_RE.fullmatch(tok)
+                    if whole is not None:
+                        # The token is exactly $VAR or ${VAR}. An unset or empty
+                        # variable yields no word, like an unquoted empty
+                        # expansion in a real shell.
+                        name = whole.group(1) or whole.group(2)
+                        value = self.environ.get(name)
+                        if not value:
                             continue
-                elif tok.startswith("$"):
-                    envSearch = _ENV_SIMPLE_RE.search(tok)
-                    if envSearch is not None:
-                        envMatch = envSearch.group(1)
-                        if envMatch in self.environ:
-                            tok = self.environ[envMatch]
-                        else:
-                            continue
+                        tok = value
+                    else:
+                        tok = self.expand_variables(tok)
 
                 tokens.append(tok)
             except Exception as e:
@@ -136,6 +148,30 @@ class HoneyPotShell:
         else:
             # if there's no command, display a prompt again
             self.showPrompt()
+
+    def expand_variables(self, tok: str) -> str:
+        """
+        Replace ${VAR} or $VAR references embedded in a token with their value.
+
+        Only variables that are currently set are expanded; an unknown
+        reference is left verbatim so that field references in quoted awk, sed
+        and perl programs (e.g. $1, $0, $NF) survive, since the lexer has
+        already discarded the single/double quoting that would tell them apart.
+
+        This is a deliberate compromise, not correct shell behaviour: a real
+        shell expands "$1" (double-quoted) but not '$1' (single-quoted). We
+        cannot honour that distinction until the lexer preserves quoting per
+        token. Once a proper lexer/parser is in place, expand every reference
+        according to its quoting and let unset variables expand to empty.
+        """
+
+        def replace(match: re.Match[str]) -> str:
+            name = match.group(1) or match.group(2)
+            if name in self.environ:
+                return self.environ[name]
+            return match.group(0)
+
+        return _ENV_VAR_RE.sub(replace, tok)
 
     def do_subshell_execution_from_lexer(self) -> None:
         """
@@ -377,6 +413,10 @@ class HoneyPotShell:
             break
 
         if not cmd_tokens:
+            # A statement of only assignments (no command) persists those
+            # variables for the rest of the session. They are shell variables,
+            # not exported, so self.exported is left untouched.
+            self.environ = environ
             runOrPrompt()
             return
 

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -471,7 +471,7 @@ class HoneyPotShell:
         lastpp = None
         for index, cmd in reversed(list(enumerate(cmd_array))):
             cmdclass = self.protocol.getCommand(
-                cmd["command"], environ["PATH"].split(":")
+                cmd["command"], environ.get("PATH", "").split(":")
             )
             if cmdclass:
                 log.msg(

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -238,7 +238,9 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
             if not self.fs.exists(path):
                 return None
         else:
-            for i in [f"{self.fs.resolve_path(x, self.cwd)}/{cmd}" for x in paths]:
+            for i in [
+                f"{self.fs.resolve_path(x, self.cwd)}/{cmd}" for x in paths if x
+            ]:
                 if self.fs.exists(i):
                     path = i
                     break

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -137,7 +137,14 @@ class ShellBaseCommandsTests(unittest.TestCase):  # TODO: ps, history
 
     def test_export_command(self) -> None:
         self.proto.lineReceived(b"export\n")
-        self.assertEqual(self.tr.value(), PROMPT)
+        self.assertEqual(
+            self.tr.value(),
+            b'declare -x HOME="/root"\n'
+            b'declare -x LOGNAME="root"\n'
+            b'declare -x PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"\n'
+            b'declare -x TMOUT="1800"\n'
+            b'declare -x USER="root"\n' + PROMPT,
+        )
 
     def test_alias_command(self) -> None:
         self.proto.lineReceived(b"alias\n")

--- a/src/cowrie/test/test_shell_variables.py
+++ b/src/cowrie/test/test_shell_variables.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for shell variable persistence, expansion and export scope.
+# ABOUTME: Covers bare vs exported variables and command-substitution visibility.
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+
+class ShellVariableTests(unittest.TestCase):
+    """Variable assignment, expansion and export-scope behaviour."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def run_line(self, line: bytes) -> bytes:
+        """Send one line, return only the bytes it produced (prompt stripped)."""
+        self.tr.clear()
+        self.proto.lineReceived(line)
+        out = self.tr.value()
+        if out.endswith(PROMPT):
+            out = out[: -len(PROMPT)]
+        return out
+
+    # Cause 1: a bare assignment persists for later commands
+    def test_bare_assignment_persists(self) -> None:
+        self.proto.lineReceived(b"x=hi")
+        self.assertEqual(self.run_line(b"echo $x"), b"hi\n")
+
+    # Cause 2: $VAR expands inside a larger token
+    def test_expand_embedded_in_token(self) -> None:
+        self.proto.lineReceived(b"x=hi")
+        self.assertEqual(self.run_line(b'echo "X:$x"'), b"X:hi\n")
+
+    def test_expand_braced_embedded_in_token(self) -> None:
+        self.proto.lineReceived(b"x=hi")
+        self.assertEqual(self.run_line(b"echo a${x}b"), b"ahib\n")
+
+    # Cause 3: command substitution sees the live shell's variables
+    def test_command_substitution_sees_variable(self) -> None:
+        self.proto.lineReceived(b"x=hi")
+        self.assertEqual(self.run_line(b"echo $(echo $x)"), b"hi\n")
+
+    # An unknown reference embedded in a token is left verbatim, so quoted
+    # awk/sed/perl field references survive (quoting is lost by the lexer)
+    def test_unknown_embedded_left_verbatim(self) -> None:
+        self.assertEqual(self.run_line(b'echo "X:$nope"'), b"X:$nope\n")
+
+    def test_awk_field_reference_survives(self) -> None:
+        self.assertEqual(
+            self.run_line(b'echo "a b" | awk \'{print $1}\''), b"a\n"
+        )
+
+    # A bare unset reference drops the word (no spurious spaces)
+    def test_unset_whole_token_dropped(self) -> None:
+        self.assertEqual(self.run_line(b"echo $nope end"), b"end\n")
+
+    # Regression: inherited environment variables still expand
+    def test_inherited_variable_expands(self) -> None:
+        self.assertEqual(self.run_line(b"echo $LOGNAME"), b"root\n")
+
+    # Two-scope: a bare variable is NOT in the exported environment
+    def test_bare_variable_not_in_env(self) -> None:
+        self.proto.lineReceived(b"x=hi")
+        self.assertNotIn(b"x=hi", self.run_line(b"env"))
+
+    # Two-scope: a bare variable IS visible to `set`
+    def test_bare_variable_in_set(self) -> None:
+        self.proto.lineReceived(b"x=hi")
+        self.assertIn(b"x=hi", self.run_line(b"set"))
+
+    # export VAR=value sets and exports
+    def test_export_assignment_in_env(self) -> None:
+        self.proto.lineReceived(b"export y=bye")
+        self.assertIn(b"y=bye", self.run_line(b"env"))
+
+    # export VAR marks an existing bare variable as exported
+    def test_export_promotes_existing(self) -> None:
+        self.proto.lineReceived(b"x=hi")
+        self.proto.lineReceived(b"export x")
+        self.assertIn(b"x=hi", self.run_line(b"env"))
+
+    # unset removes a variable from both scopes; once unknown its embedded
+    # reference is left verbatim, like any other unset name
+    def test_unset_removes_variable(self) -> None:
+        self.proto.lineReceived(b"export y=bye")
+        self.proto.lineReceived(b"unset y")
+        self.assertNotIn(b"y=bye", self.run_line(b"env"))
+        self.assertEqual(self.run_line(b"echo $y end"), b"end\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_shell_variables.py
+++ b/src/cowrie/test/test_shell_variables.py
@@ -100,6 +100,12 @@ class ShellVariableTests(unittest.TestCase):
         self.proto.lineReceived(b"export x")
         self.assertIn(b"x=hi", self.run_line(b"env"))
 
+    # unset PATH must not crash later command dispatch
+    def test_unset_path_does_not_crash(self) -> None:
+        self.proto.lineReceived(b"unset PATH")
+        self.assertEqual(self.run_line(b"whoami"), b"root\n")
+        self.assertIn(b"command not found", self.run_line(b"definitelynotacommand"))
+
     # unset removes a variable from both scopes; once unknown its embedded
     # reference is left verbatim, like any other unset name
     def test_unset_removes_variable(self) -> None:

--- a/src/cowrie/test/test_shell_variables.py
+++ b/src/cowrie/test/test_shell_variables.py
@@ -37,7 +37,7 @@ class ShellVariableTests(unittest.TestCase):
         """Send one line, return only the bytes it produced (prompt stripped)."""
         self.tr.clear()
         self.proto.lineReceived(line)
-        out = self.tr.value()
+        out: bytes = self.tr.value()
         if out.endswith(PROMPT):
             out = out[: -len(PROMPT)]
         return out


### PR DESCRIPTION
## Summary

Fixes #40167. Shell variable assignments were never visible to later commands, and `$VAR` only expanded when it formed an entire token, so the extremely common idiom `a=$(cmd1); b=$(cmd2); echo "$a $b"` produced empty or literal output. This addresses the three compounding causes from the issue plus the underlying shell-vs-exported-variable distinction.

## Changes

- **Bare assignments persist.** A statement of only `VAR=value` assignments is now kept for the rest of the session. Command-prefix assignments (`VAR=value cmd`) still apply to a single command only, matching real shell semantics.
- **`$VAR`/`${VAR}` expands when embedded in a token** (e.g. `"prefix:$x"`), not just when it is the whole token.
- **Command substitutions inherit the live environment** of the running shell, so a `$(...)` body sees variables set in the calling shell.
- **Shell variables are distinguished from exported ones.** `env` lists only exported variables, `set` lists all, and `export`/`unset` are now implemented instead of being no-ops.

## Deliberate compromise (documented in code)

Cowrie tokenizes with `shlex(posix=True)`, which strips quotes before expansion runs, so by the time a token reaches expansion we cannot tell whether a reference was single-quoted (`'$1'`, literal) or double-quoted (`"$1"`, expanded). To avoid mangling quoted `awk`/`sed`/`perl` field references like `$1`, `$0`, `$NF`, expansion **only substitutes variables that are currently set**; unknown references are left verbatim. The cost is that a genuinely-unset *named* reference stays literal instead of expanding to empty. This trade-off, and the plan to fix it once a proper lexer/parser preserves per-token quoting, is commented at the lexer and in `expand_variables()`.

## Known limitation (not fixed here)

A single line such as `x=hi; echo "$x"` still does not expand, because the whole line is tokenized and expanded before any statement in it runs. Fixing that requires interleaving execution with parsing in `lineReceived`/`runCommand`, a more invasive change left for a follow-up.

## Tests

Adds `test_shell_variables.py` covering persistence, embedded expansion, command-substitution visibility, the export/non-export scope split, and the `awk` field-reference protection. Updates `test_base_commands` for the now-functional `export`. Full suite passes (377 tests).
