### PR TITLE
fix: count nested subshells in command substitution

### DIFF
--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -267,6 +267,17 @@ class HoneyPotShell:
         closing_count = 0
 
         while opening_count > closing_count:
+            if pos >= len(cmd_expr):
+                # The current lexer token ended before the expression was
+                # closed; pull the next token and keep scanning.
+                if self.lexer:
+                    tokkie = self.lexer.get_token()
+                    if tokkie is None:
+                        break
+                    cmd_expr = cmd_expr + " " + tokkie
+                    continue
+                else:
+                    break
             if cmd_expr[pos] in (")", "`"):
                 closing_count += 1
                 if opening_count == closing_count:
@@ -288,14 +299,12 @@ class HoneyPotShell:
             elif cmd_expr[pos : pos + 2] == "$(":
                 opening_count += 1
                 pos += 2
+            elif cmd_expr[pos] == "(":
+                # A bare ( opens a nested subshell inside $(...); count it so the
+                # first ) does not falsely close the outer $(...).
+                opening_count += 1
+                pos += 1
             else:
-                if opening_count > closing_count and pos == len(cmd_expr) - 1:
-                    if self.lexer:
-                        tokkie = self.lexer.get_token()
-                        if tokkie is None:
-                            break
-                        else:
-                            cmd_expr = cmd_expr + " " + tokkie
                 pos += 1
 
         return result

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -223,3 +223,24 @@ class ShellEchoCommandTests(unittest.TestCase):
         """Test command substitution in middle with multiple commands"""
         self.proto.lineReceived(b"echo before $(echo first; echo second) after")
         self.assertEqual(self.tr.value(), b"before first\nsecond after\n" + PROMPT)
+
+    def test_command_substitution_space_after_paren(self) -> None:
+        """Test command substitution with a space after $( - regression for #40164"""
+        self.proto.lineReceived(b"echo $( echo hello)")
+        self.assertEqual(self.tr.value(), b"hello\n" + PROMPT)
+
+    def test_command_substitution_nested_subshell(self) -> None:
+        """Nested subshell in command substitution must not crash or drop later
+        commands - regression for #40164"""
+        self.proto.lineReceived(b"x=$( (echo hello) ); echo done")
+        output = self.tr.value()
+        self.assertNotIn(b"syntax error", output)
+        self.assertIn(b"done", output)
+
+    def test_command_substitution_nested_subshell_pipe(self) -> None:
+        """Nested subshell piped inside command substitution must not crash or
+        drop later commands - regression for #40164"""
+        self.proto.lineReceived(b"cpus=$( (echo 4) | head -1 ); echo done")
+        output = self.tr.value()
+        self.assertNotIn(b"syntax error", output)
+        self.assertIn(b"done", output)


### PR DESCRIPTION
## Summary

Fixes #40164. `\$(...)` command substitution crashed with `IndexError: string index out of range` whenever the substituted command started with a nested `(...)` subshell, e.g. `\$( (cmd) )` or `\$( (cmd1 | cmd2) | cmd3 )`.

The scanner in `do_command_substitution()` that finds the matching `)` for the outer `\$(` incremented its open-paren counter only for a literal `\$(`, never for a bare `(` opening a nested subshell. So the first `)` (closing the inner subshell) was mistaken for the close of the outer `\$(...)`. The resulting bookkeeping mismatch eventually indexed `cmd_expr[pos]` with `pos >= len(cmd_expr)`.

The `IndexError` was caught by the broad `except Exception` in `HoneyPotShell.lineReceived`, which cleared `self.cmdpending` and printed `-bash: syntax error: unexpected end of file`, silently dropping every remaining `;`-separated statement on the line. This pattern is common in real fingerprinting one-liners (e.g. `cpus=\$( (nproc || grep -c "^processor" /proc/cpuinfo) | head -1)`), so a captured attacker script would lose its entire remaining output on the first such line.

## Changes

- Count a bare `(` the same way `\$(` is counted, so the first `)` no longer falsely closes the outer `\$(...)`.
- Pull the next lexer token from a top-of-loop `pos >= len(cmd_expr)` guard instead of the old `pos == len-1` special case. This also fixes the related crash where a token ends exactly on the `\$(` delimiter (e.g. `echo \$( echo hello)` with a space after `\$(`), and handles `self.lexer is None` cleanly.

As a side effect this also fixes a latent crash in backtick substitution containing a subshell, e.g. `` \`(echo hi)\` ``, which crashed the same way before.

## Tests

Added three regression tests to `test_echo.py` (`space_after_paren`, `nested_subshell`, `nested_subshell_pipe`). Full suite (381 tests) passes.

## Known limitation (pre-existing, out of scope)

For `\$( (cmd) )` without a pipe, the inner subshell's output is written to the terminal rather than captured into the variable (root cause: `do_subshell_execution*` write to the terminal regardless of redirect mode). This PR removes the crash and the dropped-command data loss; the output-capture gap is a separate, pre-existing issue.