### PR TITLE
fix: emit session and TTY-log duration as integer milliseconds (duration_ms)

### DIFF
--- a/docs/OUTPUT.rst
+++ b/docs/OUTPUT.rst
@@ -175,7 +175,7 @@ TTY Log closed
 
 Attributes:
 
-    * `duration`: duration of session in seconds
+    * `duration_ms`: duration of session in milliseconds
     * `ttylog`: filename of session log that can be replayed with ``bin/playlog``
     * `size`: size in bytes
     * `shasum`: SHA256 checksum of the attacker input only (honeypot generated output is not included)

--- a/docs/OUTPUT.rst
+++ b/docs/OUTPUT.rst
@@ -157,7 +157,7 @@ Session closed
 
 Attributes:
 
-    * duration
+    * `duration_ms`: duration of session in milliseconds
 
 cowrie.session.params
 =====================

--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -221,12 +221,12 @@ class LoggingServerProtocol(insults.ServerProtocol):
 
             log.msg(
                 eventid="cowrie.log.closed",
-                format="Closing TTY Log: %(ttylog)s after %(duration)s seconds",
+                format="Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
                 ttylog=shasumfile,
                 size=self.ttylogSize,
                 shasum=shasum,
                 duplicate=duplicate,
-                duration=f"{time.time() - self.startTime:.1f}",
+                duration_ms=round((time.time() - self.startTime) * 1000),
             )
 
         insults.ServerProtocol.connectionLost(self, reason)

--- a/src/cowrie/output/influx.py
+++ b/src/cowrie/output/influx.py
@@ -167,7 +167,7 @@ class Output(cowrie.core.output.Output):
             )
 
         elif eventid == "cowrie.session.closed":
-            m["fields"].update({"duration": event["duration"]})
+            m["fields"].update({"duration_ms": event["duration_ms"]})
 
         elif eventid == "cowrie.client.version":
             m["fields"].update(

--- a/src/cowrie/output/misp.py
+++ b/src/cowrie/output/misp.py
@@ -103,7 +103,7 @@ class Output(cowrie.core.output.Output):
                     "client_details": {},
                     "event_created": False,
                     "end_time": None,
-                    "duration": None,
+                    "duration_ms": None,
                 }
 
                 # Track client details for SSH sessions
@@ -221,8 +221,10 @@ class Output(cowrie.core.output.Output):
                 # Set end time and calculate duration
                 self.session_tracking[session_id]["end_time"] = timestamp
 
-                if "duration" in event:
-                    self.session_tracking[session_id]["duration"] = event["duration"]
+                if "duration_ms" in event:
+                    self.session_tracking[session_id]["duration_ms"] = event[
+                        "duration_ms"
+                    ]
 
                 # Only create events for sessions with meaningful activity
                 if not self.session_tracking[session_id].get("event_created", False):
@@ -335,10 +337,10 @@ class Output(cowrie.core.output.Output):
                 object_relation="end-time",
             )
 
-        if session_data.get("duration"):
+        if session_data.get("duration_ms"):
             session_object.add_attribute(
                 type="text",
-                value=str(session_data["duration"]),
+                value=str(session_data["duration_ms"]),
                 object_relation="duration",
             )
 
@@ -546,7 +548,7 @@ class Output(cowrie.core.output.Output):
             f"Source IP: {session_data.get('src_ip', 'unknown')}",
             f"Start Time: {session_data.get('start_time', 'unknown')}",
             f"End Time: {session_data.get('end_time', 'unknown')}",
-            f"Duration: {session_data.get('duration', 'unknown')} seconds",
+            f"Duration: {session_data.get('duration_ms', 'unknown')} milliseconds",
             f"Authentication Success: {session_data.get('auth_success', False)}",
             f"Usernames Attempted: {', '.join(session_data.get('usernames', ['none']))}",
             f"Number of Commands: {len(session_data.get('commands', []))}",

--- a/src/cowrie/output/slack.py
+++ b/src/cowrie/output/slack.py
@@ -159,6 +159,7 @@ class Output(cowrie.core.output.Output):
             "type",
             "fingerprint",
             "duration",
+            "duration_ms",
             "outfile",
             "shasum",
             "src_ip",

--- a/src/cowrie/output/slack.py
+++ b/src/cowrie/output/slack.py
@@ -114,7 +114,7 @@ class Output(cowrie.core.output.Output):
             ),
             "cowrie.session.closed": lambda: (
                 ":red_circle: *LOGOUT* :red_circle: Session closed - "
-                + f"Total duration: `{event.get('duration', 'unknown')}` seconds"
+                + f"Total duration: `{event.get('duration_ms', 'unknown')}` milliseconds"
             ),
             "cowrie.command.input": lambda: _format_command(event.get("input", "")),
             "cowrie.session.file_download": lambda: _format_download(event),

--- a/src/cowrie/ssh/channel.py
+++ b/src/cowrie/ssh/channel.py
@@ -69,10 +69,10 @@ class CowrieSSHChannel(channel.SSHChannel):
     def closed(self) -> None:
         log.msg(
             eventid="cowrie.log.closed",
-            format="Closing TTY Log: %(ttylog)s after %(duration)s seconds",
+            format="Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
             ttylog=self.ttylogFile,
             size=self.bytesReceived + self.bytesWritten,
-            duration=f"{time.time() - self.startTime:.1f}",
+            duration_ms=round((time.time() - self.startTime) * 1000),
         )
         ttylog.ttylog_close(self.ttylogFile, time.time())
         channel.SSHChannel.closed(self)

--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -248,11 +248,11 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         transport.SSHServerTransport.connectionLost(self, reason)
         self.transport.connectionLost(reason)
         self.transport = None
-        duration = f"{time.time() - self.startTime:.1f}"
+        duration_ms = round((time.time() - self.startTime) * 1000)
         log.msg(
             eventid="cowrie.session.closed",
-            format="Connection lost after %(duration)s seconds",
-            duration=duration,
+            format="Connection lost after %(duration_ms)d milliseconds",
+            duration_ms=duration_ms,
         )
 
     def sendDisconnect(self, reason, desc):

--- a/src/cowrie/ssh_proxy/protocols/exec_term.py
+++ b/src/cowrie/ssh_proxy/protocols/exec_term.py
@@ -73,10 +73,10 @@ class ExecTerm(base_protocol.BaseProtocol):
 
             log.msg(
                 eventid="cowrie.log.closed",
-                format="Closing TTY Log: %(ttylog)s after %(duration)d seconds",
+                format="Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
                 ttylog=shasumfile,
                 size=self.ttylogSize,
                 shasum=shasum,
                 duplicate=duplicate,
-                duration=time.time() - self.startTime,
+                duration_ms=round((time.time() - self.startTime) * 1000),
             )

--- a/src/cowrie/ssh_proxy/protocols/term.py
+++ b/src/cowrie/ssh_proxy/protocols/term.py
@@ -59,12 +59,12 @@ class Term(base_protocol.BaseProtocol):
 
             log.msg(
                 eventid="cowrie.log.closed",
-                format="Closing TTY Log: %(ttylog)s after %(duration)d seconds",
+                format="Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
                 ttylog=shasumfile,
                 size=self.ttylogSize,
                 shasum=shasum,
                 duplicate=duplicate,
-                duration=time.time() - self.startTime,
+                duration_ms=round((time.time() - self.startTime) * 1000),
             )
 
     def parse_packet(self, parent: str, data: bytes) -> None:

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -157,7 +157,9 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         # Cache resolved endpoints for connectionLost logging
         self.backend_local_ip = backend_host.host
         self.backend_local_port = backend_host.port
-        self.backend_ip = backend_peer.host     # Sets backend_ip to its IP if backend_ip was a hostname
+        self.backend_ip = (
+            backend_peer.host
+        )  # Sets backend_ip to its IP if backend_ip was a hostname
         self.backend_port = backend_peer.port
 
         log.msg(
@@ -404,11 +406,11 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             self.pool_interface.transport.loseConnection()
 
         if self.startTime is not None:  # startTime is not set when auth fails
-            duration = time.time() - self.startTime
+            duration_ms = round((time.time() - self.startTime) * 1000)
             log.msg(
                 eventid="cowrie.session.closed",
-                format="Connection lost after %(duration)d seconds",
-                duration=duration,
+                format="Connection lost after %(duration_ms)d milliseconds",
+                duration_ms=duration_ms,
             )
 
     def sendDisconnect(self, reason, desc):

--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -92,11 +92,11 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         """
         self.setTimeout(None)
         TelnetTransport.connectionLost(self, reason)
-        duration = time.time() - self.startTime
+        duration_ms = round((time.time() - self.startTime) * 1000)
         log.msg(
             eventid="cowrie.session.closed",
-            format="Connection lost after %(duration)d seconds",
-            duration=duration,
+            format="Connection lost after %(duration_ms)d milliseconds",
+            duration_ms=duration_ms,
         )
 
     def willChain(self, option):
@@ -117,7 +117,9 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
             if func in (self.do, self.dont):
                 if s.him.onResult is not None:
                     s.him.onResult.addCallback(self._chainNegotiation, func, option)
-                    s.him.onResult.addErrback(self._handleNegotiationError, func, option)
+                    s.him.onResult.addErrback(
+                        self._handleNegotiationError, func, option
+                    )
                 else:
                     # Negotiation completed between error and handling - call directly
                     # without error chaining to avoid infinite recursion

--- a/src/cowrie/telnet_proxy/handler.py
+++ b/src/cowrie/telnet_proxy/handler.py
@@ -130,12 +130,12 @@ class TelnetHandler:
 
             log.msg(
                 eventid="cowrie.log.closed",
-                format="Closing TTY Log: %(ttylog)s after %(duration)d seconds",
+                format="Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
                 ttylog=shasumfile,
                 size=self.ttylogSize,
                 shasum=shasum,
                 duplicate=duplicate,
-                duration=time.time() - self.startTime,
+                duration_ms=round((time.time() - self.startTime) * 1000),
             )
 
     def sendBackend(self, data: bytes) -> None:

--- a/src/cowrie/telnet_proxy/server_transport.py
+++ b/src/cowrie/telnet_proxy/server_transport.py
@@ -230,11 +230,11 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
             self.pool_interface.transport.loseConnection()
 
         if self.startTime is not None:  # startTime is not set when auth fails
-            duration = time.time() - self.startTime
+            duration_ms = round((time.time() - self.startTime) * 1000)
             log.msg(
                 eventid="cowrie.session.closed",
-                format="Connection lost after %(duration)d seconds",
-                duration=duration,
+                format="Connection lost after %(duration_ms)d milliseconds",
+                duration_ms=duration_ms,
             )
 
     def packet_buffer(self, payload):

--- a/src/cowrie/test/test_session_duration.py
+++ b/src/cowrie/test/test_session_duration.py
@@ -34,7 +34,7 @@ class TestSessionDuration(unittest.TestCase):
         t.startTime = time.time() - 5
 
         with (
-            patch.object(ssh_transport.log, "msg") as mock_msg,
+            patch("cowrie.ssh.transport.log.msg") as mock_msg,
             patch.object(ssh_transport.HoneyPotSSHTransport, "setTimeout"),
             patch("twisted.conch.ssh.transport.SSHServerTransport.connectionLost"),
         ):
@@ -51,7 +51,7 @@ class TestSessionDuration(unittest.TestCase):
         t.startTime = time.time() - 5
 
         with (
-            patch.object(telnet_transport.log, "msg") as mock_msg,
+            patch("cowrie.telnet.transport.log.msg") as mock_msg,
             patch.object(telnet_transport.CowrieTelnetTransport, "setTimeout"),
             patch("twisted.conch.telnet.TelnetTransport.connectionLost"),
         ):
@@ -69,8 +69,8 @@ class TestSessionDuration(unittest.TestCase):
         ch.startTime = time.time() - 5
 
         with (
-            patch.object(ssh_channel.log, "msg") as mock_msg,
-            patch.object(ssh_channel.ttylog, "ttylog_close"),
+            patch("cowrie.ssh.channel.log.msg") as mock_msg,
+            patch("cowrie.ssh.channel.ttylog.ttylog_close"),
             patch("twisted.conch.ssh.channel.SSHChannel.closed"),
         ):
             ch.closed()

--- a/src/cowrie/test/test_session_duration.py
+++ b/src/cowrie/test/test_session_duration.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests that cowrie.session.closed reports duration_ms as an integer.
+# ABOUTME: Guards against type drift between SSH and telnet session events.
+
+from __future__ import annotations
+
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from cowrie.ssh import transport as ssh_transport
+from cowrie.telnet import transport as telnet_transport
+
+
+class TestSessionDuration(unittest.TestCase):
+    """cowrie.session.closed must emit an integer duration_ms field."""
+
+    def _closed_event(self, mock_msg: MagicMock) -> dict[str, object]:
+        for call in mock_msg.call_args_list:
+            if call.kwargs.get("eventid") == "cowrie.session.closed":
+                return dict(call.kwargs)
+        self.fail("no cowrie.session.closed event was emitted")
+
+    def test_ssh_duration_ms_is_int(self) -> None:
+        t = ssh_transport.HoneyPotSSHTransport()
+        t.transport = MagicMock()
+        t.startTime = time.time() - 5
+
+        with (
+            patch.object(ssh_transport.log, "msg") as mock_msg,
+            patch.object(ssh_transport.HoneyPotSSHTransport, "setTimeout"),
+            patch("twisted.conch.ssh.transport.SSHServerTransport.connectionLost"),
+        ):
+            t.connectionLost()
+
+        event = self._closed_event(mock_msg)
+        ms = event["duration_ms"]
+        assert isinstance(ms, int)
+        self.assertNotIn("duration", event)
+        self.assertGreaterEqual(ms, 5000)
+
+    def test_telnet_duration_ms_is_int(self) -> None:
+        t = telnet_transport.CowrieTelnetTransport()
+        t.startTime = time.time() - 5
+
+        with (
+            patch.object(telnet_transport.log, "msg") as mock_msg,
+            patch.object(telnet_transport.CowrieTelnetTransport, "setTimeout"),
+            patch("twisted.conch.telnet.TelnetTransport.connectionLost"),
+        ):
+            t.connectionLost()
+
+        event = self._closed_event(mock_msg)
+        ms = event["duration_ms"]
+        assert isinstance(ms, int)
+        self.assertNotIn("duration", event)
+        self.assertGreaterEqual(ms, 5000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_session_duration.py
+++ b/src/cowrie/test/test_session_duration.py
@@ -11,18 +11,22 @@ import time
 import unittest
 from unittest.mock import MagicMock, patch
 
+from cowrie.ssh import channel as ssh_channel
 from cowrie.ssh import transport as ssh_transport
 from cowrie.telnet import transport as telnet_transport
 
 
 class TestSessionDuration(unittest.TestCase):
-    """cowrie.session.closed must emit an integer duration_ms field."""
+    """Session events must report duration as an integer duration_ms field."""
+
+    def _event(self, mock_msg: MagicMock, eventid: str) -> dict[str, object]:
+        for call in mock_msg.call_args_list:
+            if call.kwargs.get("eventid") == eventid:
+                return dict(call.kwargs)
+        self.fail(f"no {eventid} event was emitted")
 
     def _closed_event(self, mock_msg: MagicMock) -> dict[str, object]:
-        for call in mock_msg.call_args_list:
-            if call.kwargs.get("eventid") == "cowrie.session.closed":
-                return dict(call.kwargs)
-        self.fail("no cowrie.session.closed event was emitted")
+        return self._event(mock_msg, "cowrie.session.closed")
 
     def test_ssh_duration_ms_is_int(self) -> None:
         t = ssh_transport.HoneyPotSSHTransport()
@@ -54,6 +58,24 @@ class TestSessionDuration(unittest.TestCase):
             t.connectionLost()
 
         event = self._closed_event(mock_msg)
+        ms = event["duration_ms"]
+        assert isinstance(ms, int)
+        self.assertNotIn("duration", event)
+        self.assertGreaterEqual(ms, 5000)
+
+    def test_log_closed_duration_ms_is_int(self) -> None:
+        ch = ssh_channel.CowrieSSHChannel()
+        ch.ttylogFile = "/dev/null"
+        ch.startTime = time.time() - 5
+
+        with (
+            patch.object(ssh_channel.log, "msg") as mock_msg,
+            patch.object(ssh_channel.ttylog, "ttylog_close"),
+            patch("twisted.conch.ssh.channel.SSHChannel.closed"),
+        ):
+            ch.closed()
+
+        event = self._event(mock_msg, "cowrie.log.closed")
         ms = event["duration_ms"]
         assert isinstance(ms, int)
         self.assertNotIn("duration", event)


### PR DESCRIPTION
## Problem

Fixes #40156.

The `cowrie.session.closed` event emitted its `duration` field with an
inconsistent type depending on the protocol:

- **SSH**: string (e.g. `"120.0"`)
- **Telnet**: float (e.g. `0.0015184879302978516`)

This breaks strict field-type mapping in downstream systems such as
Elasticsearch/OpenSearch that share an index pattern across both
protocols. The float was also unnecessarily precise. The same
string-vs-float inconsistency existed on the `cowrie.log.closed`
(TTY log) event.

## Change

Rename the field to **`duration_ms`** and emit it as an **integer number
of milliseconds**, consistently across every emit site:

- `cowrie.session.closed` — SSH, telnet, and both proxy transports
- `cowrie.log.closed` — SSH channel, insults, and the SSH/telnet proxy
  TTY loggers

Internal consumers and docs updated to match: `influx`, `misp`, `slack`,
and `docs/OUTPUT.rst`. The SQL outputs (postgresql/mysql/sqlite) do not
store a duration column, so no schema changes are required.

## Compatibility

This is a deliberate breaking change: the field is renamed rather than
silently changing magnitude under the same name, so downstream consumers
fail loud instead of mis-reading milliseconds as seconds. Consumers
should map `duration_ms` as an integer.

## Tests

New `test_session_duration.py` asserts SSH, telnet, and `log.closed`
emit an integer `duration_ms` and no `duration`.