### PR TITLE
fix: use MD5 for malware-sample attribute lookup

### DIFF
--- a/src/cowrie/core/utils.py
+++ b/src/cowrie/core/utils.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import ipaddress
 from typing import TYPE_CHECKING, BinaryIO
 
@@ -143,3 +144,13 @@ def create_endpoint_services(reactor, parent, listen_endpoints, factory):
         service = internet.StreamServerEndpointService(endpoint, factory)
         # FIXME: Use addService on parent ?
         service.setServiceParent(parent)
+
+
+def calculate_hash(filepath: str, algorithm: str = "md5") -> str:
+    h = hashlib.new(algorithm)
+
+    with open(filepath, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+
+    return h.hexdigest()

--- a/src/cowrie/output/misp.py
+++ b/src/cowrie/output/misp.py
@@ -14,6 +14,7 @@ from twisted.python import log
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
+from cowrie.core.utils import calculate_hash
 
 try:
     from pymisp import ExpandedPyMISP as PyMISP
@@ -131,16 +132,12 @@ class Output(cowrie.core.output.Output):
                 }
                 self.session_tracking[session_id]["downloads"].append(download_info)
 
-                # Option 1: Create immediate malware events as in the old script
-                # This gives instant malware upload without waiting for session to end
-                file_sha_attrib = self.find_attribute(
-                    "malware-sample", f"*|{event['shasum']}"
-                )
+                md5_hash = calculate_hash(event["outfile"])
+                file_sha_attrib = self.find_attribute("malware-sample", md5_hash)
                 if file_sha_attrib:
                     if self.debug:
                         log.msg("MISP: File known, add sighting")
                     self.add_sighting(event, file_sha_attrib)
-                # Don't create immediate event - let the session event handle it
 
             elif event["eventid"] == "cowrie.session.file_upload":
                 # Track file uploads in session data
@@ -460,9 +457,7 @@ class Output(cowrie.core.output.Output):
                 if "outfile" in download and download["shasum"] != "unknown":
                     malware_attr = MISPAttribute()
                     malware_attr.type = "malware-sample"
-                    malware_attr.value = (
-                        os.path.basename(download["outfile"]) + "|" + download["shasum"]
-                    )
+                    malware_attr.value = (download["shasum"])
                     malware_attr.data = Path(
                         download["outfile"]
                     )  # This uploads the actual binary


### PR DESCRIPTION
MISP stores malware-sample attributes in the format filename|md5, causing lookups based on Cowrie's SHA256 hash to miss existing samples.

Add MD5 calculation for downloaded files and use the MD5 value when searching for malware-sample attributes before creating sightings.

Fixes #40153