### PR TITLE
Address pyright diagnostics: real bugs and noise reduction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,11 @@ reportOptionalOperand = "information"
 reportPossiblyUnboundVariable = "information"
 reportUnsupportedDunderAll = "information"
 
+# Tests legitimately exercise protected methods of the code under test.
+[[tool.pyright.executionEnvironments]]
+root = "src/cowrie/test"
+reportPrivateUsage = "none"
+
 [tool.ty.environment]
 python-version = "3.10"
 

--- a/src/cowrie/commands/__init__.py
+++ b/src/cowrie/commands/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__all__ = [
+command_modules = [
     "adduser",
     "apt",
     "awk",

--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -25,10 +25,18 @@ commands = {}
 
 # Initialize rate limiter
 curl_rate_limiter = RateLimiter(
-    enabled=CowrieConfig.getboolean("honeypot", "curl_rate_limit_enabled", fallback=True),
-    max_requests=CowrieConfig.getint("honeypot", "curl_rate_limit_requests", fallback=5),
-    window_seconds=CowrieConfig.getint("honeypot", "curl_rate_limit_window", fallback=60),
-    max_keys=CowrieConfig.getint("honeypot", "curl_rate_limit_max_hosts", fallback=1000)
+    enabled=CowrieConfig.getboolean(
+        "honeypot", "curl_rate_limit_enabled", fallback=True
+    ),
+    max_requests=CowrieConfig.getint(
+        "honeypot", "curl_rate_limit_requests", fallback=5
+    ),
+    window_seconds=CowrieConfig.getint(
+        "honeypot", "curl_rate_limit_window", fallback=60
+    ),
+    max_keys=CowrieConfig.getint(
+        "honeypot", "curl_rate_limit_max_hosts", fallback=1000
+    ),
 )
 
 CURL_HELP = """Usage: curl [options...] <url>
@@ -231,10 +239,10 @@ class Command_curl(HoneyPotCommand):
             elif opt[0] == "-I" or opt[0] == "--head":
                 self.head_request = True
 
-        if len(args):
-            if args[0] is not None:
-                url = str(args[0]).strip()
-        else:
+        url = ""
+        if len(args) and args[0] is not None:
+            url = str(args[0]).strip()
+        if not url:
             self.errorWrite(
                 "curl: try 'curl --help' or 'curl --manual' for more information\n"
             )
@@ -261,8 +269,7 @@ class Command_curl(HoneyPotCommand):
 
         if self.outfile:
             self.outfile = self.fs.resolve_path(self.outfile, self.protocol.cwd)
-            if self.outfile:
-                path = os.path.dirname(self.outfile)
+            path = os.path.dirname(self.outfile) if self.outfile else ""
             if not path or not self.fs.exists(path) or not self.fs.isdir(path):
                 self.errorWrite(
                     f"curl: {self.outfile}: Cannot open: No such file or directory\n"
@@ -273,8 +280,7 @@ class Command_curl(HoneyPotCommand):
         self.url = url.encode("ascii")
 
         parsed = parse.urlparse(url)
-        if parsed.scheme:
-            scheme = parsed.scheme
+        scheme = parsed.scheme
         if scheme != "http" and scheme != "https":
             self.errorWrite(
                 f'curl: (1) Protocol "{scheme}" not supported or disabled in libcurl\n'
@@ -292,7 +298,9 @@ class Command_curl(HoneyPotCommand):
 
         # Check rate limit before proceeding
         if not curl_rate_limiter.check(self.host):
-            log.msg(f"curl: rate limit exceeded for host: {self.host}. Simulating connection timeout")
+            log.msg(
+                f"curl: rate limit exceeded for host: {self.host}. Simulating connection timeout"
+            )
 
             # Simulate connection timeout
             self.errorWrite(
@@ -478,6 +486,7 @@ class Command_curl(HoneyPotCommand):
         # error.ConnectingCancelledError,
 
         log.msg(response.printTraceback())
+        errormsg = ""
         if hasattr(response, "getErrorMessage"):  # Exceptions
             errormsg = response.getErrorMessage()
         log.msg(errormsg)

--- a/src/cowrie/commands/find.py
+++ b/src/cowrie/commands/find.py
@@ -82,7 +82,7 @@ class Command_find(HoneyPotCommand):
         self.exit()
 
     def find_recursive(self, path: str, depth: int) -> None:
-        if self.maxdepth is not None and depth > self.maxdepth:
+        if depth > self.maxdepth:
             return
         try:
             if not self.fs.exists(path):

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -66,6 +66,8 @@ class Command_grep(HoneyPotCommand):
             return
 
         self.n = 10
+        optlist: list[tuple[str, str]] = []
+        args = self.args
         if self.args[0] == ">":
             pass
         else:
@@ -278,6 +280,7 @@ class Command_cd(HoneyPotCommand):
             pname = self.protocol.user.avatar.home
         else:
             pname = self.args[0]
+        newpath = ""
         try:
             newpath = self.fs.resolve_path(pname, self.protocol.cwd)
             inode = self.fs.getfile(newpath)

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -17,7 +17,7 @@ from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
 from cowrie.core.network import communication_allowed
 from cowrie.shell.command import HoneyPotCommand
-from cowrie.shell.customparser import CustomParser, OptionNotFound
+from cowrie.shell.customparser import CustomParser, ExitException, OptionNotFound
 
 if TYPE_CHECKING:
     from twisted.internet.interfaces import IDelayedCall
@@ -160,7 +160,9 @@ class TFTPClient(DatagramProtocol):
             # Duplicate packet, re-send ACK
             self.sendACK(block_num)
         else:
-            log.msg(f"TFTP: Out of order block {block_num}, expected {self.current_block + 1}")
+            log.msg(
+                f"TFTP: Out of order block {block_num}, expected {self.current_block + 1}"
+            )
 
     def handleERROR(self, packet: bytes) -> None:
         """Handle ERROR packet"""
@@ -229,9 +231,7 @@ class Command_tftp(HoneyPotCommand):
 
         try:
             args = parser.parse_args(self.args)
-        except (OptionNotFound, TypeError):
-            # CustomParser.error() raises OptionNotFound incorrectly (missing value arg)
-            # Catch both OptionNotFound and TypeError to handle the bug
+        except (OptionNotFound, ExitException):
             self.exit()
             return
 
@@ -274,9 +274,7 @@ class Command_tftp(HoneyPotCommand):
         path = self.fakeoutfile.rsplit("/", 1)[0] if "/" in self.fakeoutfile else "/"
 
         if not self.fs.exists(path) or not self.fs.isdir(path):
-            self.write(
-                f"tftp: {self.file_to_get}: No such file or directory\n"
-            )
+            self.write(f"tftp: {self.file_to_get}: No such file or directory\n")
             self.exit()
             return
 
@@ -365,9 +363,7 @@ class Command_tftp(HoneyPotCommand):
         self.fs.update_realfile(
             self.fs.getfile(self.fakeoutfile), self.artifactFile.shasumFilename
         )
-        self.fs.chown(
-            self.fakeoutfile, self.protocol.user.uid, self.protocol.user.gid
-        )
+        self.fs.chown(self.fakeoutfile, self.protocol.user.uid, self.protocol.user.gid)
 
         self._safe_exit()
 

--- a/src/cowrie/commands/wc.py
+++ b/src/cowrie/commands/wc.py
@@ -93,6 +93,8 @@ class Command_wc(HoneyPotCommand):
             self.exit()
             return
 
+        optlist: list[tuple[str, str]] = []
+        args = self.args
         if self.args[0] == ">":
             pass
         else:

--- a/src/cowrie/core/checkers.py
+++ b/src/cowrie/core/checkers.py
@@ -9,8 +9,6 @@ This module contains ...
 
 from __future__ import annotations
 
-from sys import modules
-
 from twisted.conch import error
 from twisted.conch.ssh import keys
 from twisted.cred.checkers import ICredentialsChecker
@@ -20,7 +18,7 @@ from twisted.internet import defer
 from twisted.python import failure, log
 from zope.interface import implementer
 
-import cowrie.core.auth  # noqa: F401
+from cowrie.core import auth
 from cowrie.core import credentials as conchcredentials
 from cowrie.core.config import CowrieConfig
 
@@ -120,13 +118,12 @@ class HoneypotPasswordChecker:
     def checkUserPass(self, theusername: bytes, thepassword: bytes, ip: str) -> bool:
         # Is the auth_class defined in the config file?
         authclass = CowrieConfig.get("honeypot", "auth_class", fallback="UserDB")
-        authmodule = "cowrie.core.auth"
 
-        # Check if authclass exists in this module
-        if hasattr(modules[authmodule], authclass):
-            authname = getattr(modules[authmodule], authclass)
+        # Check if authclass exists in the auth module
+        if hasattr(auth, authclass):
+            authname = getattr(auth, authclass)
         else:
-            log.msg(f"auth_class: {authclass} not found in {authmodule}")
+            log.msg(f"auth_class: {authclass} not found in cowrie.core.auth")
 
         theauth = authname()
 

--- a/src/cowrie/core/checkers.py
+++ b/src/cowrie/core/checkers.py
@@ -119,11 +119,14 @@ class HoneypotPasswordChecker:
         # Is the auth_class defined in the config file?
         authclass = CowrieConfig.get("honeypot", "auth_class", fallback="UserDB")
 
-        # Check if authclass exists in the auth module
+        # Check if authclass exists in the auth module, fall back to UserDB
         if hasattr(auth, authclass):
             authname = getattr(auth, authclass)
         else:
-            log.msg(f"auth_class: {authclass} not found in cowrie.core.auth")
+            log.msg(
+                f"auth_class: {authclass} not found in cowrie.core.auth, using UserDB"
+            )
+            authname = auth.UserDB
 
         theauth = authname()
 

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -21,7 +21,7 @@ from twisted.web.client import (
     Agent,
     HTTPConnectionPool,
     ProxyAgent,
-    _HTTP11ClientFactory,
+    _HTTP11ClientFactory,  # pyright: ignore[reportPrivateUsage]
 )
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer, IResponse
@@ -70,7 +70,9 @@ class SimpleResponseReceiver(protocol.Protocol):
     def dataReceived(self, data: bytes) -> None:
         self.buf += data
 
-    def connectionLost(self, reason: tw_failure.Failure = protocol.connectionDone) -> None:
+    def connectionLost(
+        self, reason: tw_failure.Failure = protocol.connectionDone
+    ) -> None:
         self.d.callback((self.status_code, self.buf))
 
 
@@ -89,7 +91,7 @@ class LLMClient:
 
     def __init__(self) -> None:
         self._conn_pool = HTTPConnectionPool(reactor)
-        self._conn_pool._factory = QuietHTTP11ClientFactory
+        self._conn_pool._factory = QuietHTTP11ClientFactory  # pyright: ignore[reportPrivateUsage]
 
         self.api_key = CowrieConfig.get("llm", "api_key", fallback="")
         self.model = CowrieConfig.get("llm", "model", fallback="gpt-4o-mini")
@@ -175,9 +177,7 @@ class LLMClient:
         response.deliverBody(SimpleResponseReceiver(response.code, d))
         return d
 
-    def _handle_connection_error(
-        self, err: tw_failure.Failure
-    ) -> tuple[int, bytes]:
+    def _handle_connection_error(self, err: tw_failure.Failure) -> tuple[int, bytes]:
         """Handle connection errors."""
         err.trap(Exception)
         return (500, err.getErrorMessage().encode("utf-8"))
@@ -201,9 +201,7 @@ class LLMClient:
         return d
 
     @inlineCallbacks
-    def get_response(
-        self, prompt: list[str]
-    ) -> Generator[Deferred[Any], Any, str]:
+    def get_response(self, prompt: list[str]) -> Generator[Deferred[Any], Any, str]:
         """
         Get a response from the LLM for the given prompt.
 

--- a/src/cowrie/output/abuseipdb.py
+++ b/src/cowrie/output/abuseipdb.py
@@ -56,7 +56,9 @@ class Output(output.Output):
         self.reporter = Reporter(self.logbook, self.tolerance_attempts)
 
         # We store the LogBook state any time a shutdown occurs. The rest of
-        # our start-up is just for loading and cleaning the previous state
+        # our start-up is just for loading and cleaning the previous state.
+        # Default to the current setting so a missing state needs no resize.
+        tolerated = self.tolerance_attempts
         try:
             with open(self.state_dump, "rb") as f:
                 self.logbook.update(pickle.load(f))

--- a/src/cowrie/output/axiom.py
+++ b/src/cowrie/output/axiom.py
@@ -48,6 +48,7 @@ class Output(cowrie.core.output.Output):
             msg = json.dumps(event, separators=(",", ":")).encode()
         except TypeError:
             log.err("jsonlog: Can't serialize: '" + repr(event) + "'")
+            return
 
         resp = yield treq.post(
             self.url,

--- a/src/cowrie/output/rmq.py
+++ b/src/cowrie/output/rmq.py
@@ -19,6 +19,7 @@ try:
 except ImportError:
     log.err("Missing dependency: pika")
     pika = None
+    AMQPConnectionError = Exception
 
 
 class CustomJSONEncoder(json.JSONEncoder):

--- a/src/cowrie/output/xmpp.py
+++ b/src/cowrie/output/xmpp.py
@@ -71,7 +71,7 @@ class Output(cowrie.core.output.Output):
         user = CowrieConfig.get("output_xmpp", "user")
         password = CowrieConfig.get("output_xmpp", "password")
         muc = CowrieConfig.get("output_xmpp", "muc")
-        resource = "".join([choice(string.ascii_letters) for i in range(8)])
+        resource = "".join([choice(string.ascii_letters) for _ in range(8)])
         jidstr = user + "/" + resource
         application = service.Application("honeypot")
         self.run(application, jidstr, password, JID(None, [muc, server, None]), server)

--- a/src/cowrie/shell/customparser.py
+++ b/src/cowrie/shell/customparser.py
@@ -9,18 +9,18 @@ import argparse
 
 
 class OptionNotFound(Exception):
-    def __init__(self, value):
+    def __init__(self, value: str | None = None) -> None:
         self.value = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self.value)
 
 
 class ExitException(Exception):
-    def __init__(self, value):
+    def __init__(self, value: str | None = None) -> None:
         self.value = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self.value)
 
 
@@ -58,11 +58,11 @@ class CustomParser(argparse.ArgumentParser):
         )
 
     def exit(self, status=0, message=None):
-        raise ExitException
+        raise ExitException(message)
 
     def _print_message(self, message, file=None):
         super()._print_message(message, self.protocol)
 
     def error(self, message):
         self.print_usage(self.protocol)
-        raise OptionNotFound
+        raise OptionNotFound(message)

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -128,9 +128,7 @@ class HoneyPotFilesystem:
         # A_REALFILE on matching pickle entries so file_contents reads
         # from disk. When unset (the default), every file is served from
         # the pickle's A_CONTENTS bytes.
-        contents_path = CowrieConfig.get(
-            "honeypot", "contents_path", fallback=""
-        )
+        contents_path = CowrieConfig.get("honeypot", "contents_path", fallback="")
         if contents_path:
             try:
                 self.init_honeyfs(contents_path)
@@ -169,7 +167,7 @@ class HoneyPotFilesystem:
         if path[0] == "/":
             cwdpieces = []
         else:
-            cwdpieces = [x for x in cwd.split("/") if len(x) and x is not None]
+            cwdpieces = [x for x in cwd.split("/") if len(x)]
 
         while 1:
             if not pieces:
@@ -192,7 +190,7 @@ class HoneyPotFilesystem:
         pieces: list[str] = path.rstrip("/").split("/")
         cwdpieces: list[str]
         if len(pieces[0]):
-            cwdpieces = [x for x in cwd.split("/") if len(x) and x is not None]
+            cwdpieces = [x for x in cwd.split("/") if len(x)]
             path = path[1:]
         else:
             cwdpieces, pieces = [], pieces[1:]

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -687,6 +687,6 @@ class HoneyPotShell:
                 self.protocol.terminal.write(b"\n")
                 self.showPrompt()
 
-        self.protocol.lineBuffer = [y for x, y in enumerate(iterbytes(newbyt))]
+        self.protocol.lineBuffer = list(iterbytes(newbyt))
         self.protocol.lineBufferIndex = len(self.protocol.lineBuffer)
         self.protocol.terminal.write(newbyt)

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -478,6 +478,7 @@ class HoneyPotShell:
             )
 
         lastpp = None
+        cmdclass = None
         for index, cmd in reversed(list(enumerate(cmd_array))):
             cmdclass = self.protocol.getCommand(
                 cmd["command"], environ.get("PATH", "").split(":")

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -32,7 +32,7 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
     """
 
     commands: ClassVar[dict] = {}
-    for c in cowrie.commands.__all__:
+    for c in cowrie.commands.command_modules:
         try:
             module = import_module(f"cowrie.commands.{c}")
             commands.update(module.commands)
@@ -122,7 +122,9 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         else:
             try:
                 with socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) as s:
-                    s.connect(("2001:4860:4860::8888", 80))  # NOSONAR - probe target to detect host GUA, not a secret
+                    s.connect(
+                        ("2001:4860:4860::8888", 80)
+                    )  # NOSONAR - probe target to detect host GUA, not a secret
                     addr = s.getsockname()[0]
                     # Only use GUA, not link-local
                     self.kippoIPv6 = addr if not addr.lower().startswith("fe80") else ""
@@ -177,9 +179,7 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
                 try:
                     contents = self_cmd.fs.file_contents(path)
                 except Exception:
-                    self_cmd.errorWrite(
-                        f"-bash: {path}: No such file or directory\n"
-                    )
+                    self_cmd.errorWrite(f"-bash: {path}: No such file or directory\n")
                     return
 
                 # Null bytes indicate actual binary — reject like real bash
@@ -210,9 +210,7 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
 
                 self_cmd.protocol._script_depth = depth + 1
                 try:
-                    shell = honeypot.HoneyPotShell(
-                        self_cmd.protocol, interactive=False
-                    )
+                    shell = honeypot.HoneyPotShell(self_cmd.protocol, interactive=False)
                     self_cmd.protocol.cmdstack.append(shell)
                     shell.lineReceived("; ".join(lines))
                     self_cmd.protocol.cmdstack.pop()
@@ -238,9 +236,7 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
             if not self.fs.exists(path):
                 return None
         else:
-            for i in [
-                f"{self.fs.resolve_path(x, self.cwd)}/{cmd}" for x in paths if x
-            ]:
+            for i in [f"{self.fs.resolve_path(x, self.cwd)}/{cmd}" for x in paths if x]:
                 if self.fs.exists(i):
                     path = i
                     break

--- a/src/cowrie/test/fake_transport.py
+++ b/src/cowrie/test/fake_transport.py
@@ -171,7 +171,7 @@ class FakeTransport(proto_helpers.StringTransport):
         self.eraseDisplay()
 
     def eraseDisplay(self):
-        self.lines = [self._emptyLine(self.width) for i in range(self.height)]
+        self.lines = [self._emptyLine(self.width) for _ in range(self.height)]
 
     def _currentFormattingState(self):
         return True
@@ -180,4 +180,4 @@ class FakeTransport(proto_helpers.StringTransport):
         return True
 
     def _emptyLine(self, width):
-        return [(self.void, self._currentFormattingState()) for i in range(width)]
+        return [(self.void, self._currentFormattingState()) for _ in range(width)]

--- a/src/cowrie/test/test_checkers.py
+++ b/src/cowrie/test/test_checkers.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for the SSH password credential checker.
+# ABOUTME: Covers the fallback when auth_class is misconfigured.
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from cowrie.core import auth
+from cowrie.core.checkers import HoneypotPasswordChecker
+from cowrie.core.config import CowrieConfig
+
+
+class TestHoneypotPasswordChecker(unittest.TestCase):
+    """checkUserPass must not crash when auth_class is unknown."""
+
+    def setUp(self) -> None:
+        self._had_option = CowrieConfig.has_option("honeypot", "auth_class")
+        self._old = (
+            CowrieConfig.get("honeypot", "auth_class") if self._had_option else None
+        )
+
+    def tearDown(self) -> None:
+        if self._had_option:
+            CowrieConfig.set("honeypot", "auth_class", self._old)
+        else:
+            CowrieConfig.remove_option("honeypot", "auth_class")
+
+    def test_unknown_auth_class_falls_back_to_userdb(self) -> None:
+        CowrieConfig.set("honeypot", "auth_class", "NoSuchAuthClass")
+        checker = HoneypotPasswordChecker()
+        with patch.object(auth, "UserDB") as mock_userdb:
+            mock_userdb.return_value.checklogin.return_value = False
+            result = checker.checkUserPass(b"root", b"toor", "1.2.3.4")
+        self.assertFalse(result)
+        mock_userdb.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_customparser.py
+++ b/src/cowrie/test/test_customparser.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests that CustomParser raises its termination exceptions correctly.
+# ABOUTME: error() must raise OptionNotFound and exit() must raise ExitException.
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from cowrie.shell.customparser import CustomParser, ExitException, OptionNotFound
+
+
+class TestCustomParser(unittest.TestCase):
+    """CustomParser.error/exit must raise usable exceptions, not TypeError."""
+
+    def _parser(self) -> CustomParser:
+        return CustomParser(MagicMock())
+
+    def test_error_raises_option_not_found_with_message(self) -> None:
+        parser = self._parser()
+        with self.assertRaises(OptionNotFound) as cm:
+            parser.error("bad option")
+        self.assertEqual(cm.exception.value, "bad option")
+
+    def test_exit_raises_exit_exception(self) -> None:
+        parser = self._parser()
+        with self.assertRaises(ExitException):
+            parser.exit()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -19,15 +19,13 @@ from twisted.plugin import IPlugin
 from twisted.python import log, usage
 from zope.interface import implementer, provider
 
-import cowrie.core.checkers
-import cowrie.core.uuid
 import cowrie.llm.realm
 import cowrie.shell.realm
 import cowrie.ssh.factory
 import cowrie.telnet.factory
 from backend_pool.pool_server import PoolServerFactory
 from cowrie import __version__ as __cowrie_version__
-from cowrie import core
+from cowrie.core import checkers, uuid
 from cowrie.core.config import CowrieConfig
 from cowrie.core.utils import create_endpoint_services, get_endpoints_from_section
 from cowrie.pool_interface.handler import PoolHandler
@@ -85,7 +83,7 @@ class CowrieServiceMaker:
             "backend_pool", "pool_only", fallback=False
         )
 
-        self.uuid = core.uuid.get_uuid()
+        self.uuid = uuid.get_uuid()
         CowrieConfig.set("honeypot", "uuid", str(self.uuid))
 
     def makeService(self, options: dict) -> service.Service:
@@ -210,11 +208,11 @@ Makes a Cowrie SSH/Telnet honeypot.
             else:
                 raise ValueError(backend)
 
-            factory.portal.registerChecker(core.checkers.HoneypotPublicKeyChecker())
-            factory.portal.registerChecker(core.checkers.HoneypotPasswordChecker())
+            factory.portal.registerChecker(checkers.HoneypotPublicKeyChecker())
+            factory.portal.registerChecker(checkers.HoneypotPasswordChecker())
 
             if CowrieConfig.getboolean("ssh", "auth_none_enabled", fallback=False):
-                factory.portal.registerChecker(core.checkers.HoneypotNoneChecker())
+                factory.portal.registerChecker(checkers.HoneypotNoneChecker())
 
             if CowrieConfig.has_section("ssh"):
                 listen_endpoints = get_endpoints_from_section(CowrieConfig, "ssh", 2222)
@@ -237,7 +235,7 @@ Makes a Cowrie SSH/Telnet honeypot.
             else:
                 raise ValueError(backend)
 
-            f.portal.registerChecker(core.checkers.HoneypotPasswordChecker())
+            f.portal.registerChecker(checkers.HoneypotPasswordChecker())
 
             listen_endpoints = get_endpoints_from_section(CowrieConfig, "telnet", 2223)
             create_endpoint_services(reactor, self.topService, listen_endpoints, f)


### PR DESCRIPTION
Works through pyright's actionable diagnostic categories, fixing several
real latent bugs found along the way and clearing the noise the rest
represented. The bulk of pyright's remaining output is the untyped-Twisted
cascade, which is out of scope here.

## Real bug fixes (with tests where testable)

- **CustomParser raised the wrong exception** — `exit()`/`error()` did
  `raise ExitException` / `raise OptionNotFound` on the bare classes, but
  both `__init__` require a `value`, so the raise itself threw `TypeError`.
  The tftp command had a workaround catching `TypeError`; that is removed.
  (`test_customparser.py`)
- **Login crashed on a bad `auth_class`** — `checkUserPass` left `authname`
  unbound when the configured class was missing, raising `NameError` on
  every login. Now falls back to `UserDB`. (`test_checkers.py`)
- **Possibly-unbound variables that could `NameError`** — curl
  (url/path/scheme/errormsg), grep/wc (args when first arg is `>`), axiom
  output (skip POST on unserializable event), abuseipdb output (default
  `tolerated` on first run).

## Cleanups

- Remove unused imports; import `auth`/`checkers`/`uuid` directly instead of
  via dynamic/sys.modules indirection so the references are visible.
- Drop dead conditions (`is not None` on values that are never None) and
  unused loop variables.
- Rename `cowrie.commands.__all__` to `command_modules`; it is a registry of
  module names consumed by `protocol.py`, not a public-API declaration.
- Bind a few variables that are provably set but defeat pyright's flow
  analysis.
- Exempt the test tree from `reportPrivateUsage` (tests legitimately call
  protected methods) and mark the LLM client's deliberate use of Twisted's
  private `_HTTP11ClientFactory` with inline ignores.

## Cleared pyright categories

reportUnusedImport, reportUnusedVariable, reportPossiblyUnboundVariable (25),
reportUnsupportedDunderAll (55), reportPrivateUsage (27), and the two
"invalid exception class" reportGeneralTypeIssues all go to zero.

## Notes

- Also deleted two stale, gitignored `.pytype` build caches that pyright was
  scanning (~520 spurious unused-import warnings).
- Separately noticed `cowrie/output/rmq.py` fails to import on modern Twisted
  (`twisted.python.constants` was removed); left for a follow-up.