### PR TITLE
fix: look up MISP malware samples by MD5

### DIFF
--- a/src/cowrie/output/misp.py
+++ b/src/cowrie/output/misp.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 from pathlib import Path
 from typing import Any
@@ -19,6 +20,16 @@ try:
     from pymisp import ExpandedPyMISP as PyMISP
 except ImportError:
     from pymisp import PyMISP as PyMISP
+
+
+def file_md5(path: str) -> str:
+    """Return the MD5 hex digest of the file at ``path``.
+
+    MISP stores ``malware-sample`` attribute values as ``filename|md5``, so
+    MD5 is the hash used to correlate samples and register sightings.
+    """
+    with open(path, "rb") as handle:
+        return hashlib.md5(handle.read(), usedforsecurity=False).hexdigest()
 
 
 class Output(cowrie.core.output.Output):
@@ -131,16 +142,16 @@ class Output(cowrie.core.output.Output):
                 }
                 self.session_tracking[session_id]["downloads"].append(download_info)
 
-                # Option 1: Create immediate malware events as in the old script
-                # This gives instant malware upload without waiting for session to end
-                file_sha_attrib = self.find_attribute(
-                    "malware-sample", f"*|{event['shasum']}"
-                )
-                if file_sha_attrib:
-                    if self.debug:
-                        log.msg("MISP: File known, add sighting")
-                    self.add_sighting(event, file_sha_attrib)
-                # Don't create immediate event - let the session event handle it
+                # malware-sample values are filename|md5, so look up by MD5.
+                outfile = event.get("outfile")
+                if outfile and os.path.exists(outfile):
+                    malware_attrib = self.find_attribute(
+                        "malware-sample", file_md5(outfile)
+                    )
+                    if malware_attrib:
+                        if self.debug:
+                            log.msg("MISP: File known, add sighting")
+                        self.add_sighting(event, malware_attrib)
 
             elif event["eventid"] == "cowrie.session.file_upload":
                 # Track file uploads in session data
@@ -457,15 +468,20 @@ class Output(cowrie.core.output.Output):
         if session_data.get("downloads"):
             for download in session_data["downloads"]:
                 # Add the actual malware sample as a separate attribute to the event (not part of an object)
-                if "outfile" in download and download["shasum"] != "unknown":
+                outfile = download.get("outfile")
+                if (
+                    outfile
+                    and download.get("shasum", "unknown") != "unknown"
+                    and os.path.exists(outfile)
+                ):
                     malware_attr = MISPAttribute()
                     malware_attr.type = "malware-sample"
+                    # MISP malware-sample values are filename|md5; match that so
+                    # the attribute correlates with the file_download lookup.
                     malware_attr.value = (
-                        os.path.basename(download["outfile"]) + "|" + download["shasum"]
+                        f"{os.path.basename(outfile)}|{file_md5(outfile)}"
                     )
-                    malware_attr.data = Path(
-                        download["outfile"]
-                    )  # This uploads the actual binary
+                    malware_attr.data = Path(outfile)  # This uploads the actual binary
                     malware_attr.expand = "binary"
                     malware_attr.comment = (
                         f"File downloaded to Cowrie honeypot in session {session_id}"

--- a/src/cowrie/test/test_misp.py
+++ b/src/cowrie/test/test_misp.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for the MISP output plugin's malware-sample handling.
+# ABOUTME: Ensures downloaded files are looked up by MD5 so sightings register.
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+try:
+    from cowrie.output.misp import Output, file_md5
+
+    have_misp = True
+except ImportError:
+    have_misp = False
+
+
+@unittest.skipIf(not have_misp, "pymisp not installed")
+class TestFileMd5(unittest.TestCase):
+    """file_md5 returns the MD5 hex digest of a file's contents."""
+
+    def test_file_md5(self) -> None:
+        data = b"cowrie malware sample\n"
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(data)
+            path = f.name
+        self.addCleanup(os.remove, path)
+        self.assertEqual(file_md5(path), hashlib.md5(data).hexdigest())
+
+
+@unittest.skipIf(not have_misp, "pymisp not installed")
+class TestMispMalwareSample(unittest.TestCase):
+    """A downloaded file must be looked up in MISP by its MD5 hash."""
+
+    def _make_output(self) -> Output:
+        # Bypass start(), which would connect to a live MISP server.
+        output = Output.__new__(Output)
+        output.misp_api = MagicMock()
+        output.session_tracking = {}
+        output.debug = False
+        output.handle_sessions = True
+        output.publish = False
+        return output
+
+    def test_file_download_lookup_uses_md5(self) -> None:
+        data = b"malicious payload"
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(data)
+            outfile = f.name
+        self.addCleanup(os.remove, outfile)
+
+        output = self._make_output()
+        output.misp_api.search.return_value = {"Attribute": []}
+
+        output.write(
+            {
+                "eventid": "cowrie.session.file_download",
+                "session": "abc123",
+                "src_ip": "10.0.0.1",
+                "outfile": outfile,
+                "shasum": "deadbeef",
+            }
+        )
+
+        output.misp_api.search.assert_called_once()
+        kwargs = output.misp_api.search.call_args.kwargs
+        self.assertEqual(kwargs["type_attribute"], "malware-sample")
+        self.assertEqual(kwargs["value"], hashlib.md5(data).hexdigest())
+
+    def test_missing_outfile_skips_lookup(self) -> None:
+        output = self._make_output()
+
+        output.write(
+            {
+                "eventid": "cowrie.session.file_download",
+                "session": "abc123",
+                "src_ip": "10.0.0.1",
+                "outfile": "/nonexistent/path/file",
+                "shasum": "deadbeef",
+            }
+        )
+
+        output.misp_api.search.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #40153.

## Problem

The MISP output plugin never registered sightings for files seen across
multiple sessions. MISP stores `malware-sample` attribute values as
`filename|md5`, but the plugin searched for them by SHA-256
(`find_attribute("malware-sample", "*|{shasum}")`), which can never match
a value whose hash component is an MD5. So `find_attribute` always
returned nothing and `add_sighting` was never called.

## Fix

- Add a small `file_md5` helper in the MISP output module.
- On `cowrie.session.file_download`, look the sample up by its MD5 and add
  a sighting if it already exists.
- When creating the malware-sample attribute, set its value to
  `filename|md5` so the attribute Cowrie creates correlates with the
  lookup above (instead of `filename|sha256`).
- Both paths guard that the file still exists before hashing it.

## Tests

`test_misp.py`:
- `file_md5` returns the expected digest.
- a file_download event triggers a `malware-sample` lookup keyed by the
  file's MD5 (regression guard for #40153).
- a missing outfile skips the lookup.

These are skipped when PyMISP is not installed.

## Note

Supersedes #40182, which fixed the lookup hash but left the created
attribute value as a bare SHA-256, leaving create and lookup
inconsistent.