### PR TITLE
Report directory and missing path-like commands with shell-accurate errors

### DIFF
--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -516,9 +516,7 @@ class HoneyPotShell:
                     input=cmd["command"] + " " + " ".join(cmd["rargs"]),
                     format="Command not found: %(input)s",
                 )
-                message = "-bash: {}: command not found\n".format(
-                    cmd["command"]
-                ).encode("utf8")
+                message = self.command_not_found_message(cmd["command"]).encode("utf8")
                 redirects = cmd.get("redirects", [])
                 if redirects:
                     temp_pp = PipeProtocol(
@@ -555,6 +553,19 @@ class HoneyPotShell:
 
         if pp:
             self.protocol.call_command(pp, cmdclass, *cmd_array[0]["rargs"])
+
+    def command_not_found_message(self, cmd: str) -> str:
+        """
+        Build the error a real shell prints when a command cannot be run.
+        A path-like command (one starting with "." or "/") that resolves to an
+        existing directory yields "Is a directory", matching bash's EISDIR; any
+        other unresolved command yields "command not found".
+        """
+        if cmd[:1] in (".", "/"):
+            path = self.protocol.fs.resolve_path(cmd, self.protocol.cwd)
+            if self.protocol.fs.isdir(path):
+                return f"-bash: {cmd}: Is a directory\n"
+        return f"-bash: {cmd}: command not found\n"
 
     def resume(self) -> None:
         if self.interactive:

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -557,14 +557,17 @@ class HoneyPotShell:
     def command_not_found_message(self, cmd: str) -> str:
         """
         Build the error a real shell prints when a command cannot be run.
-        A path-like command (one starting with "." or "/") that resolves to an
-        existing directory yields "Is a directory", matching bash's EISDIR; any
-        other unresolved command yields "command not found".
+        For a path-like command (one starting with "." or "/") match bash's
+        errno-based messages: an existing directory yields "Is a directory"
+        (EISDIR) and a path that does not exist yields "No such file or
+        directory" (ENOENT). Anything else yields "command not found".
         """
         if cmd[:1] in (".", "/"):
             path = self.protocol.fs.resolve_path(cmd, self.protocol.cwd)
             if self.protocol.fs.isdir(path):
                 return f"-bash: {cmd}: Is a directory\n"
+            if not self.protocol.fs.exists(path):
+                return f"-bash: {cmd}: No such file or directory\n"
         return f"-bash: {cmd}: command not found\n"
 
     def resume(self) -> None:

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -112,6 +112,21 @@ class ShellBaseCommandsTests(unittest.TestCase):  # TODO: ps, history
         self.proto.lineReceived(b"php -v\n")
         self.assertEqual(self.tr.value(), Command_php.VERSION.encode() + PROMPT)
 
+    def test_run_directory_as_command(self) -> None:
+        self.proto.lineReceived(b"./\n")
+        self.assertEqual(self.tr.value(), b"-bash: ./: Is a directory\n" + PROMPT)
+
+    def test_run_absolute_directory_as_command(self) -> None:
+        self.proto.lineReceived(b"/etc\n")
+        self.assertEqual(self.tr.value(), b"-bash: /etc: Is a directory\n" + PROMPT)
+
+    def test_run_nonexistent_command(self) -> None:
+        self.proto.lineReceived(b"definitelynotacommand\n")
+        self.assertEqual(
+            self.tr.value(),
+            b"-bash: definitelynotacommand: command not found\n" + PROMPT,
+        )
+
     def test_chattr_command(self) -> None:
         self.proto.lineReceived(b"chattr\n")
         self.assertEqual(

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -127,6 +127,12 @@ class ShellBaseCommandsTests(unittest.TestCase):  # TODO: ps, history
             b"-bash: definitelynotacommand: command not found\n" + PROMPT,
         )
 
+    def test_run_nonexistent_path_command(self) -> None:
+        self.proto.lineReceived(b"./nope\n")
+        self.assertEqual(
+            self.tr.value(), b"-bash: ./nope: No such file or directory\n" + PROMPT
+        )
+
     def test_chattr_command(self) -> None:
         self.proto.lineReceived(b"chattr\n")
         self.assertEqual(


### PR DESCRIPTION
## Summary

Running an existing directory as a command, or a path-like command that does not exist, returned the same `command not found` as any missing command. A real shell distinguishes these via errno, and the difference is a cheap fingerprinting probe that needs no other interaction:

```
$ ./
bash: ./: Is a directory          # cowrie said: command not found
$ ./nope
bash: ./nope: No such file or directory   # cowrie said: command not found
```

Fixes #40189 (the directory case), and folds in the closely-related ENOENT case for path-like commands.

## Root cause

`HoneyPotBaseProtocol.getCommand()` only treats a resolved path as runnable when `fs.isfile()` is true, so a directory (and a nonexistent path) fall through to the same `return None` used for a genuinely missing command. The caller (`HoneyPotShell.runCommand()`) only saw `cmdclass is None` and always printed `command not found`.

## Change

`runCommand()` now builds the not-found message via a small helper, `HoneyPotShell.command_not_found_message()`, scoped to `honeypot.py`. For a path-like command (one starting with `.` or `/`) it mirrors bash's errno-based messages:

- existing directory -> `Is a directory` (EISDIR)
- path that does not exist -> `No such file or directory` (ENOENT)
- anything else, and all non-path-like commands -> `command not found`

Bare names without a slash keep returning `command not found` (a real shell does a PATH search and reports the same). Scoped deliberately to `honeypot.py` rather than changing `getCommand()`'s return signature, since it is also called from `sudo.py` and `busybox.py`.

## Tests

Added regression tests for `./`, `/etc`, `./nope`, and the unchanged bare-name `command not found` case. All pass under `unittest` (the project/CI runner); `ruff check` clean.