### PR TITLE
fix: save scp uploads as file content, not SCP wire framing

### DIFF
--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -97,9 +97,8 @@ class Command_scp(HoneyPotCommand):
         self.drop_tmp_file(data, fname)
 
         if os.path.exists(self.safeoutfile):
-            with open(self.safeoutfile, "rb"):
-                shasum = hashlib.sha256(data).hexdigest()
-                hash_path = os.path.join(self.download_path_uniq, shasum)
+            shasum = hashlib.sha256(data).hexdigest()
+            hash_path = os.path.join(self.download_path_uniq, shasum)
 
             # If we have content already, delete temp file
             if not os.path.exists(hash_path):
@@ -120,9 +119,13 @@ class Command_scp(HoneyPotCommand):
                 destfile=fname,
             )
 
-            # Update the honeyfs to point to downloaded file
-            self.fs.update_realfile(self.fs.getfile(fname), hash_path)
-            self.fs.chown(fname, self.protocol.user.uid, self.protocol.user.gid)
+            # Update the honeyfs to point to downloaded file. The entry is
+            # absent when mkfile could not create it (e.g. the filesystem is at
+            # its new-file quota), in which case there is nothing to point at.
+            f = self.fs.getfile(fname)
+            if f:
+                self.fs.update_realfile(f, hash_path)
+                self.fs.chown(fname, self.protocol.user.uid, self.protocol.user.gid)
 
     def parse_scp_data(self, data: bytes) -> bytes:
         # scp data format:
@@ -159,12 +162,16 @@ class Command_scp(HoneyPotCommand):
                             outfile,
                             self.protocol.user.uid,
                             self.protocol.user.gid,
-                            r.group(2),
-                            r.group(1),
+                            int(r.group(2)),
+                            int(r.group(1), 8),
                         )
                     except fs.FileNotFound:
                         # The outfile locates at a non-existing directory.
                         self.errorWrite(f"-scp: {outfile}: No such file or directory\n")
+                        return b""
+                    except fs.PermissionDenied:
+                        # The outfile locates in a protected path (e.g. /proc).
+                        self.errorWrite(f"-scp: {outfile}: Permission denied\n")
                         return b""
 
                     self.save_file(d, outfile)
@@ -178,22 +185,24 @@ class Command_scp(HoneyPotCommand):
         return data
 
     def eofReceived(self) -> None:
+        terminal = self.protocol.terminal
         if (
-            self.protocol.terminal.stdinlogOpen
-            and self.protocol.terminal.stdinlogFile
-            and os.path.exists(self.protocol.terminal.stdinlogFile)
+            terminal.stdinlogOpen
+            and terminal.stdinlogFile
+            and os.path.exists(terminal.stdinlogFile)
         ):
-            with open(self.protocol.terminal.stdinlogFile, "rb") as f:
+            with open(terminal.stdinlogFile, "rb") as f:
                 data: bytes = f.read()
-                header: bytes = data[: data.find(b"\n")]
-                if re.match(rb"C0[\d]{3} [\d]+ [^\s]+", header):
-                    content = data[data.find(b"\n") + 1 :]
-                else:
-                    content = b""
 
-            if content:
-                with open(self.protocol.terminal.stdinlogFile, "wb") as f:
-                    f.write(content)
+            # Decode the SCP wire protocol into the uploaded file(s), each saved
+            # as content only. The raw stdin log still holds the framing (header,
+            # body and trailing ACK), so remove it to avoid saving it again as a
+            # download.
+            while data:
+                data = self.parse_scp_data(data)
+
+            terminal.stdinlogOpen = False
+            os.remove(terminal.stdinlogFile)
 
         self.exit()
 

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -293,17 +293,25 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
 
         # Mirror ProcessProtocol.transport.closeStdin(): if the command parked
         # waiting for stdin but nothing will ever write to it, signal EOF so it
-        # terminates instead of leaking on the cmdstack. Stdin is only left open
-        # for a command reading from a live terminal: an interactive shell that
-        # is not being fed by a pipe.
+        # terminates instead of leaking on the cmdstack. Stdin is left open when
+        # a live source will deliver its own EOF later: an interactive terminal,
+        # or the SSH exec channel feeding the top-level command (e.g. `scp -t`,
+        # whose pushed bytes arrive after the command has started). A piped
+        # command reads buffered output, so it gets EOF here.
         if self.cmdstack and self.cmdstack[-1] is obj:
             parent = self.cmdstack[-2] if len(self.cmdstack) >= 2 else None
-            terminal_stdin = (
+            live_stdin = (
                 not getattr(pp, "stdin_from_pipe", False)
                 and parent is not None
-                and getattr(parent, "interactive", False)
+                and (
+                    getattr(parent, "interactive", False)
+                    or (
+                        isinstance(self, HoneyPotExecProtocol)
+                        and parent is self.cmdstack[0]
+                    )
+                )
             )
-            if not terminal_stdin:
+            if not live_stdin:
                 obj.eofReceived()
 
     def uptime(self):

--- a/src/cowrie/test/test_scp_exec.py
+++ b/src/cowrie/test/test_scp_exec.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from types import SimpleNamespace
+
+from twisted.internet.protocol import connectionDone
+from twisted.python import log
 
 from cowrie.commands import scp
 from cowrie.insults import insults
@@ -28,62 +32,58 @@ scp.Command_scp.download_path = _DOWNLOAD_DIR
 scp.Command_scp.download_path_uniq = _DOWNLOAD_DIR
 
 
-class _Container:
-    """Placeholder object onto which fake transport attributes are attached."""
-
-
-def _make_exec_transport() -> _Container:
+def _make_exec_transport() -> SimpleNamespace:
     """Build the transport.session.conn.transport chain insults expects."""
-    peer = _Container()
-    peer.host = "1.1.1.1"
-    peer.port = 2222
-
-    inner = _Container()
-    inner.sessionno = 1
-    inner.getPeer = lambda: peer
-
-    factory = _Container()
-    factory.starttime = 0
-    factory.logDispatch = lambda **kw: None
-
-    conn_transport = _Container()
-    conn_transport.transportId = "testexec"
-    conn_transport.factory = factory
-    conn_transport.transport = inner
-
-    conn = _Container()
-    conn.transport = conn_transport
-
-    session = _Container()
-    session.id = "chan0"
-    session.conn = conn
-
-    transport = _Container()
-    transport.written = b""
-    transport.session = session
-    transport.write = lambda data: None
-    transport.processEnded = lambda reason=None: None
-    return transport
+    peer = SimpleNamespace(host="1.1.1.1", port=2222)
+    inner = SimpleNamespace(sessionno=1, getPeer=lambda: peer)
+    factory = SimpleNamespace(starttime=0, logDispatch=lambda **kw: None)
+    conn_transport = SimpleNamespace(
+        transportId="testexec", factory=factory, transport=inner
+    )
+    conn = SimpleNamespace(transport=conn_transport)
+    session = SimpleNamespace(id="chan0", conn=conn)
+    return SimpleNamespace(
+        session=session,
+        write=lambda data: None,
+        processEnded=lambda reason=None: None,
+    )
 
 
-def run_exec_scp_push(framed_stdin: bytes) -> list[bytes]:
-    """Drive a full exec-channel `scp -t` push and return saved download contents.
+def run_exec_scp_push(
+    framed_stdin: bytes, chunk_size: int = 0, fs_newcount: int | None = None
+) -> tuple[list[bytes], list[dict]]:
+    """Drive a full exec-channel `scp -t` push.
 
     The SCP-framed bytes are delivered after the command has started, exactly as
-    the SSH channel delivers them, then a channel EOF and connection close.
+    the SSH channel delivers them, then a channel EOF and connection close. A
+    non-zero chunk_size splits the stdin across multiple dataReceived calls, as
+    happens for a large transfer. fs_newcount pre-loads the filesystem's
+    new-file counter to drive it over its quota. Returns the contents of every
+    saved download file and the captured log events.
     """
-    avatar = FakeAvatar(FakeServer())
-    avatar.server.initFileSystem = lambda home: None
+    events: list[dict] = []
+    log.addObserver(events.append)
+    try:
+        avatar = FakeAvatar(FakeServer())
+        avatar.server.initFileSystem = lambda home: None
+        if fs_newcount is not None:
+            avatar.server.fs.newcount = fs_newcount
 
-    lsp = insults.LoggingServerProtocol(
-        protocol.HoneyPotExecProtocol, avatar, b"scp -t /tmp"
-    )
-    lsp.makeConnection(_make_exec_transport())
+        lsp = insults.LoggingServerProtocol(
+            protocol.HoneyPotExecProtocol, avatar, b"scp -t /tmp"
+        )
+        lsp.makeConnection(_make_exec_transport())
 
-    live_stdinlog = lsp.stdinlogFile
-    lsp.dataReceived(framed_stdin)
-    lsp.eofReceived()
-    lsp.connectionLost("done")
+        live_stdinlog = lsp.stdinlogFile
+        if chunk_size:
+            for i in range(0, len(framed_stdin), chunk_size):
+                lsp.dataReceived(framed_stdin[i : i + chunk_size])
+        else:
+            lsp.dataReceived(framed_stdin)
+        lsp.eofReceived()
+        lsp.connectionLost(connectionDone)
+    finally:
+        log.removeObserver(events.append)
 
     saved = []
     for name in os.listdir(_DOWNLOAD_DIR):
@@ -92,7 +92,7 @@ def run_exec_scp_push(framed_stdin: bytes) -> list[bytes]:
             continue
         with open(full, "rb") as f:
             saved.append(f.read())
-    return saved
+    return saved, events
 
 
 class ScpExecPushTests(unittest.TestCase):
@@ -113,7 +113,7 @@ class ScpExecPushTests(unittest.TestCase):
         body = b"\x7fELF\x01\x01\x01" + b"\x00" * 9 + b"PAYLOAD-BODY"
         framed = b"C0755 %d binary\n" % len(body) + body + b"\x00"
 
-        saved = run_exec_scp_push(framed)
+        saved, _events = run_exec_scp_push(framed)
 
         self.assertTrue(saved, "scp push saved no file at all")
         for content in saved:
@@ -121,6 +121,61 @@ class ScpExecPushTests(unittest.TestCase):
                 content.startswith(b"C0"), "SCP header leaked into saved file"
             )
             self.assertIn(body, content)
+
+    def test_exec_scp_push_saves_exact_body(self) -> None:
+        """The saved file is exactly the uploaded bytes: header and trailing
+        ACK byte both removed, declared size honoured."""
+        body = b"\x7fELF\x01\x01\x01" + b"\x00" * 9 + b"PAYLOAD-BODY"
+        framed = b"C0755 %d binary\n" % len(body) + body + b"\x00"
+
+        saved, _events = run_exec_scp_push(framed)
+
+        self.assertEqual(saved, [body])
+
+    def test_exec_scp_push_emits_file_upload(self) -> None:
+        """A decoded scp push is reported as an upload, not a raw stdin
+        download, and the honeyfs is updated to serve the content."""
+        body = b"scp-uploaded-content\n"
+        framed = b"C0644 %d payload\n" % len(body) + body + b"\x00"
+
+        _saved, events = run_exec_scp_push(framed)
+
+        eventids = [e.get("eventid") for e in events]
+        self.assertIn("cowrie.session.file_upload", eventids)
+        self.assertNotIn("cowrie.session.file_download", eventids)
+
+    def test_exec_scp_push_chunked_transfer(self) -> None:
+        """A push split across many dataReceived calls is reassembled and
+        decodes to the exact body, with the declared size honoured across
+        chunk boundaries (the header, body and ACK span several chunks)."""
+        body = (b"\x7fELF" + bytes(range(256))) * 64
+        framed = b"C0644 %d big.bin\n" % len(body) + body + b"\x00"
+
+        saved, _events = run_exec_scp_push(framed, chunk_size=1024)
+
+        self.assertEqual(saved, [body])
+
+    def test_exec_scp_push_into_forbidden_path_does_not_crash(self) -> None:
+        """A crafted filename that traverses into a protected path (/proc) must
+        be refused cleanly, not raise out of the EOF handler."""
+        body = b"x"
+        framed = b"C0644 %d ../../../proc/evil\n" % len(body) + body + b"\x00"
+
+        saved, _events = run_exec_scp_push(framed)
+
+        self.assertEqual(saved, [])
+
+    def test_exec_scp_push_over_fs_quota_does_not_crash(self) -> None:
+        """When the virtual filesystem is at its new-file quota, mkfile cannot
+        create the honeyfs entry. The upload content must still be captured and
+        the honeyfs update skipped, not raise out of the EOF handler."""
+        body = b"quota-test\n"
+        framed = b"C0644 %d quota.bin\n" % len(body) + body + b"\x00"
+
+        saved, events = run_exec_scp_push(framed, fs_newcount=10001)
+
+        self.assertEqual(saved, [body])
+        self.assertIn("cowrie.session.file_upload", [e.get("eventid") for e in events])
 
 
 if __name__ == "__main__":

--- a/src/cowrie/test/test_scp_exec.py
+++ b/src/cowrie/test/test_scp_exec.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for scp file uploads over the SSH exec channel.
+# ABOUTME: Verifies SCP wire framing is decoded so saved files hold only content.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from cowrie.commands import scp
+from cowrie.insults import insults
+from cowrie.shell import protocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+_DOWNLOAD_DIR = tempfile.mkdtemp(prefix="cowrie_scp_exec_")
+
+# Class-level download paths are read from config at import time, so another
+# test module importing these classes first can pin them elsewhere. Force them
+# to this module's scratch directory regardless of import order.
+insults.LoggingServerProtocol.downloadPath = _DOWNLOAD_DIR
+scp.Command_scp.download_path = _DOWNLOAD_DIR
+scp.Command_scp.download_path_uniq = _DOWNLOAD_DIR
+
+
+class _Container:
+    """Placeholder object onto which fake transport attributes are attached."""
+
+
+def _make_exec_transport() -> _Container:
+    """Build the transport.session.conn.transport chain insults expects."""
+    peer = _Container()
+    peer.host = "1.1.1.1"
+    peer.port = 2222
+
+    inner = _Container()
+    inner.sessionno = 1
+    inner.getPeer = lambda: peer
+
+    factory = _Container()
+    factory.starttime = 0
+    factory.logDispatch = lambda **kw: None
+
+    conn_transport = _Container()
+    conn_transport.transportId = "testexec"
+    conn_transport.factory = factory
+    conn_transport.transport = inner
+
+    conn = _Container()
+    conn.transport = conn_transport
+
+    session = _Container()
+    session.id = "chan0"
+    session.conn = conn
+
+    transport = _Container()
+    transport.written = b""
+    transport.session = session
+    transport.write = lambda data: None
+    transport.processEnded = lambda reason=None: None
+    return transport
+
+
+def run_exec_scp_push(framed_stdin: bytes) -> list[bytes]:
+    """Drive a full exec-channel `scp -t` push and return saved download contents.
+
+    The SCP-framed bytes are delivered after the command has started, exactly as
+    the SSH channel delivers them, then a channel EOF and connection close.
+    """
+    avatar = FakeAvatar(FakeServer())
+    avatar.server.initFileSystem = lambda home: None
+
+    lsp = insults.LoggingServerProtocol(
+        protocol.HoneyPotExecProtocol, avatar, b"scp -t /tmp"
+    )
+    lsp.makeConnection(_make_exec_transport())
+
+    live_stdinlog = lsp.stdinlogFile
+    lsp.dataReceived(framed_stdin)
+    lsp.eofReceived()
+    lsp.connectionLost("done")
+
+    saved = []
+    for name in os.listdir(_DOWNLOAD_DIR):
+        full = os.path.join(_DOWNLOAD_DIR, name)
+        if full == live_stdinlog or not os.path.isfile(full):
+            continue
+        with open(full, "rb") as f:
+            saved.append(f.read())
+    return saved
+
+
+class ScpExecPushTests(unittest.TestCase):
+    """An scp push over the exec channel must be saved as just its content."""
+
+    def setUp(self) -> None:
+        for name in os.listdir(_DOWNLOAD_DIR):
+            full = os.path.join(_DOWNLOAD_DIR, name)
+            if os.path.isfile(full):
+                os.remove(full)
+
+    def test_exec_scp_push_strips_header(self) -> None:
+        """The SCP `C<mode> <size> <name>` header must not survive into the save.
+
+        The exec channel delivers stdin after the command starts, so EOF must
+        reach the running scp command rather than firing on an empty stdin log.
+        """
+        body = b"\x7fELF\x01\x01\x01" + b"\x00" * 9 + b"PAYLOAD-BODY"
+        framed = b"C0755 %d binary\n" % len(body) + body + b"\x00"
+
+        saved = run_exec_scp_push(framed)
+
+        self.assertTrue(saved, "scp push saved no file at all")
+        for content in saved:
+            self.assertFalse(
+                content.startswith(b"C0"), "SCP header leaked into saved file"
+            )
+            self.assertIn(body, content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Fixes cowrie/cowrie#40184. A file pushed via `scp host:/path` (which runs `scp -t <path>` on the exec channel) was saved to the downloads directory with the SCP wire framing still attached:

```
000000 43 30 37 35 35 20 31 34 38 35 34 31 36 20 6a 46  >C0755 1485416 jF<
000010 0a 7f 45 4c 46 01 01 01 00 00 00 00 00 00 00 00  >..ELF...........<
```

`C0755 1485416 jF\n` is SCP's own push header; the real ELF starts 17 bytes in, and there's a trailing `\x00` ACK byte appended too.

## Root cause

Two defects, fixed in two commits:

1. **Regression (recent).** `call_command` synthesizes a stdin EOF the instant an exec command starts. For `scp -t`, that fired the scp command's EOF handler *before* the pushed bytes had arrived on the channel, so the SCP framing was never stripped and the raw stdin log (header + body + ACK) was saved as-is.

2. **Pre-existing.** Even when stripping ran, `scp.eofReceived` only removed the header *line* — it left the trailing ACK, ignored the declared byte count, and never emitted `cowrie.session.file_upload` or populated the honeyfs, because the decoder that does all that (`parse_scp_data` → `save_file`) had been left unreferenced.

## Fix

- **`fix: deliver exec stdin EOF from the channel, not at command start`** — the SSH exec channel is a live stdin source that delivers its own EOF when the client closes. Treat it like an interactive terminal and leave stdin open for the top-level exec command, so the real channel EOF drives the command's EOF handler after the bytes arrive. Internal composition (substitution, redirects, pipe tails) still gets a synthesized EOF, so the cmdstack-leak fix (#40165) is preserved.

- **`fix: decode scp uploads to file content, not wire framing`** — decode the captured stdin through `parse_scp_data` on EOF: write only the declared number of body bytes, drop the trailing ACK, emit `cowrie.session.file_upload`, and update the honeyfs so the uploaded path serves its content. Remove the raw stdin log afterwards so the framed bytes are not also saved as a download. Hostile input is refused cleanly instead of escaping the EOF handler: a filename resolving into a protected path (e.g. `/proc` via `../` traversal) and a filesystem at its new-file quota are both handled.

## Behaviour change

Exec scp uploads now report `cowrie.session.file_upload` (with a honeyfs update) instead of a header-stripped `cowrie.session.file_download`. This is semantically correct — scp is an upload — and restores the originally-intended behaviour.

## Scope

Single-file `scp -t <path>` pushes. Recursive transfers (`scp -r`, which use `D`/`E` protocol messages) remain out of scope, as before.

## Tests

New `src/cowrie/test/test_scp_exec.py` drives the real `LoggingServerProtocol` + `HoneyPotExecProtocol` + `Command_scp` end-to-end (stdin arriving after command start, channel EOF, close): header stripped, exact-body save, `file_upload` emitted (and no raw `file_download`), multi-chunk reassembly, and the two hostile-input cases. Full suite (400 tests) green; ruff clean.