### PR TITLE
fix: skip stdin-log save when exec session sent no input

### DIFF
--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -142,24 +142,25 @@ class LoggingServerProtocol(insults.ServerProtocol):
         """
         if self.stdinlogOpen:
             try:
-                with open(self.stdinlogFile, "rb") as f:
-                    shasum = hashlib.sha256(f.read()).hexdigest()
-                    shasumfile = os.path.join(self.downloadPath, shasum)
-                    if os.path.exists(shasumfile):
-                        os.remove(self.stdinlogFile)
-                        duplicate = True
-                    else:
-                        os.rename(self.stdinlogFile, shasumfile)
-                        duplicate = False
+                if os.path.exists(self.stdinlogFile):
+                    with open(self.stdinlogFile, "rb") as f:
+                        shasum = hashlib.sha256(f.read()).hexdigest()
+                        shasumfile = os.path.join(self.downloadPath, shasum)
+                        if os.path.exists(shasumfile):
+                            os.remove(self.stdinlogFile)
+                            duplicate = True
+                        else:
+                            os.rename(self.stdinlogFile, shasumfile)
+                            duplicate = False
 
-                log.msg(
-                    eventid="cowrie.session.file_download",
-                    format="Saved stdin contents with SHA-256 %(shasum)s to %(outfile)s",
-                    duplicate=duplicate,
-                    outfile=shasumfile,
-                    shasum=shasum,
-                    destfile="",
-                )
+                    log.msg(
+                        eventid="cowrie.session.file_download",
+                        format="Saved stdin contents with SHA-256 %(shasum)s to %(outfile)s",
+                        duplicate=duplicate,
+                        outfile=shasumfile,
+                        shasum=shasum,
+                        destfile="",
+                    )
             except OSError:
                 pass
             finally:

--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -161,8 +161,8 @@ class LoggingServerProtocol(insults.ServerProtocol):
                         shasum=shasum,
                         destfile="",
                     )
-            except OSError:
-                pass
+            except OSError as e:
+                log.msg(f"Failed to save stdin contents: {e}")
             finally:
                 self.stdinlogOpen = False
 

--- a/src/cowrie/test/test_insults.py
+++ b/src/cowrie/test/test_insults.py
@@ -12,6 +12,8 @@ import tempfile
 import unittest
 from unittest import mock
 
+from twisted.python import log
+
 from cowrie.insults.insults import LoggingServerProtocol
 
 
@@ -83,3 +85,34 @@ class ConnectionLostStdinTestCase(unittest.TestCase):
             self.assertNotIn(lsp.stdinlogFile, opened)
             self.assertFalse(lsp.stdinlogOpen)
             self.assertFalse(os.path.exists(lsp.stdinlogFile))
+
+    def test_failure_saving_existing_stdin_log_is_logged(self) -> None:
+        """A genuine I/O failure on an existing stdin log must not be silent.
+
+        The missing-file case is now skipped, so any OSError that reaches the
+        handler is unexpected and must be logged rather than swallowed.
+        """
+        with tempfile.TemporaryDirectory() as downloadPath:
+            lsp = make_protocol("e")
+            lsp.stdinlogOpen = True
+            lsp.stdinlogFile = os.path.join(downloadPath, "stdin.log")
+            lsp.downloadPath = downloadPath
+            lsp.redirFiles = None
+            lsp.terminalProtocol = None
+            with open(lsp.stdinlogFile, "wb") as f:
+                f.write(b"id\n")
+
+            def failing_open(*args, **kwargs):  # type: ignore[no-untyped-def]
+                raise OSError
+
+            events: list[dict] = []
+            log.addObserver(events.append)
+            try:
+                with mock.patch("builtins.open", failing_open):
+                    lsp.connectionLost()
+            finally:
+                log.removeObserver(events.append)
+
+            messages = [log.textFromEventDict(e) or "" for e in events]
+            self.assertTrue(any("Failed to save stdin contents" in m for m in messages))
+            self.assertFalse(lsp.stdinlogOpen)

--- a/src/cowrie/test/test_insults.py
+++ b/src/cowrie/test/test_insults.py
@@ -69,13 +69,13 @@ class ConnectionLostStdinTestCase(unittest.TestCase):
             lsp.stdinlogOpen = True
             lsp.stdinlogFile = os.path.join(downloadPath, "never-written-stdin.log")
             lsp.downloadPath = downloadPath
-            lsp.redirFiles = None
+            lsp.redirFiles = set()
             lsp.terminalProtocol = None
 
             opened: list[str] = []
             real_open = open
 
-            def tracking_open(path, *args, **kwargs):  # type: ignore[no-untyped-def]
+            def tracking_open(path, *args, **kwargs):
                 opened.append(path)
                 return real_open(path, *args, **kwargs)
 
@@ -97,12 +97,12 @@ class ConnectionLostStdinTestCase(unittest.TestCase):
             lsp.stdinlogOpen = True
             lsp.stdinlogFile = os.path.join(downloadPath, "stdin.log")
             lsp.downloadPath = downloadPath
-            lsp.redirFiles = None
+            lsp.redirFiles = set()
             lsp.terminalProtocol = None
             with open(lsp.stdinlogFile, "wb") as f:
                 f.write(b"id\n")
 
-            def failing_open(*args, **kwargs):  # type: ignore[no-untyped-def]
+            def failing_open(*args, **kwargs):
                 raise OSError
 
             events: list[dict] = []

--- a/src/cowrie/test/test_insults.py
+++ b/src/cowrie/test/test_insults.py
@@ -7,7 +7,10 @@
 
 from __future__ import annotations
 
+import os
+import tempfile
 import unittest
+from unittest import mock
 
 from cowrie.insults.insults import LoggingServerProtocol
 
@@ -46,3 +49,37 @@ class WriteLineEndingTestCase(unittest.TestCase):
         lsp = make_protocol("i")
         lsp.write(b"Linux server01 5.10.0 armv7l\n")
         self.assertEqual(lsp.transport.written, b"Linux server01 5.10.0 armv7l\r\n")
+
+
+class ConnectionLostStdinTestCase(unittest.TestCase):
+    """Tests for stdin-log cleanup in LoggingServerProtocol.connectionLost()."""
+
+    def test_no_stdin_data_does_not_open_missing_file(self) -> None:
+        """An exec session that received no stdin has no log file to hash.
+
+        connectionMade() sets stdinlogOpen unconditionally for exec channels,
+        but the file is only created once dataReceived() writes to it. A session
+        that closes without sending stdin must not attempt to open the missing
+        file just to have the open fail.
+        """
+        with tempfile.TemporaryDirectory() as downloadPath:
+            lsp = make_protocol("e")
+            lsp.stdinlogOpen = True
+            lsp.stdinlogFile = os.path.join(downloadPath, "never-written-stdin.log")
+            lsp.downloadPath = downloadPath
+            lsp.redirFiles = None
+            lsp.terminalProtocol = None
+
+            opened: list[str] = []
+            real_open = open
+
+            def tracking_open(path, *args, **kwargs):  # type: ignore[no-untyped-def]
+                opened.append(path)
+                return real_open(path, *args, **kwargs)
+
+            with mock.patch("builtins.open", tracking_open):
+                lsp.connectionLost()
+
+            self.assertNotIn(lsp.stdinlogFile, opened)
+            self.assertFalse(lsp.stdinlogOpen)
+            self.assertFalse(os.path.exists(lsp.stdinlogFile))


### PR DESCRIPTION
## Summary

Fixes #40185.

Every SSH exec-channel session that closes without ever sending stdin data raised a `FileNotFoundError` inside `LoggingServerProtocol.connectionLost()`, silently swallowed by the bare `except OSError: pass`. Invisible under normal operation, but the reporter observed 696 occurrences in a single ~2h capture window.

## Root cause

`connectionMade()` sets `stdinlogOpen = True` for every exec channel, but `stdinlogFile` is only created the first time `dataReceived()` writes to it. A session that closes without sending stdin (banner grabs, no-op probes, any command that doesn't read input) leaves the file nonexistent, so `connectionLost()` opened a missing path and raised.

## Fix

Guard the hash-and-save block with `os.path.exists()`, matching the `redirFiles` cleanup directly below it. The check sits inside the `try` so the `finally: self.stdinlogOpen = False` still resets the flag when there's nothing to save. Genuine I/O errors on an existing file still reach the `except OSError` branch.

## Test

Adds `ConnectionLostStdinTestCase` in `test_insults.py`. Because the bug is silently caught, a "doesn't raise" test passes even on the buggy code, so the test spies on `open` to assert the missing file is never opened — it fails on the old code and passes after the fix.

`test_insults` and `test_scp_exec` pass; ruff check/format clean.