### PR TITLE
fix: deliver SSH session connectionLost exactly once on teardown

### DIFF
--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -137,8 +137,8 @@ class LoggingServerProtocol(insults.ServerProtocol):
 
     def connectionLost(self, reason: failure.Failure = connectionDone) -> None:
         """
-        FIXME: this method is called 4 times on logout....
-        it's called once from Avatar.closed() if disconnected
+        Finalize the session: hash and store any captured stdin, redirected
+        files, and the TTY log, then drop references to the terminal.
         """
         if self.stdinlogOpen:
             try:

--- a/src/cowrie/shell/session.py
+++ b/src/cowrie/shell/session.py
@@ -6,12 +6,41 @@
 from __future__ import annotations
 
 from twisted.conch.interfaces import ISession
-from twisted.conch.ssh import session
+from twisted.internet.protocol import connectionDone
 from twisted.python import log
 from zope.interface import implementer
 
 from cowrie.insults import insults
 from cowrie.shell import protocol
+
+
+class ProtocolTransport:
+    """Adapt a terminal protocol so the SSH session can drive it as its
+    process transport, firing the protocol's connectionLost exactly once.
+
+    The session machinery calls loseConnection more than once per close
+    (from both SSHSession.loseConnection and SSHSession.closed), so the close
+    is guarded to deliver connectionLost a single time.
+    """
+
+    def __init__(self, proto):
+        self.proto = proto
+        self._lost = False
+
+    def dataReceived(self, data: bytes) -> None:
+        self.proto.transport.write(data)
+
+    def write(self, data: bytes) -> None:
+        self.proto.dataReceived(data)
+
+    def writeSequence(self, seq: list[bytes]) -> None:
+        self.write(b"".join(seq))
+
+    def loseConnection(self) -> None:
+        if self._lost:
+            return
+        self._lost = True
+        self.proto.connectionLost(connectionDone)
 
 
 @implementer(ISession)
@@ -58,7 +87,7 @@ class SSHSessionForCowrieUser:
             protocol.HoneyPotInteractiveProtocol, self
         )
         self.protocol.makeConnection(processprotocol)
-        processprotocol.makeConnection(session.wrapProtocol(self.protocol))
+        processprotocol.makeConnection(ProtocolTransport(self.protocol))
 
     def getPty(self, terminal, windowSize, attrs):
         self.environ["TERM"] = terminal.decode("utf-8")
@@ -75,16 +104,15 @@ class SSHSessionForCowrieUser:
             protocol.HoneyPotExecProtocol, self, cmd
         )
         self.protocol.makeConnection(processprotocol)
-        processprotocol.makeConnection(session.wrapProtocol(self.protocol))
+        processprotocol.makeConnection(ProtocolTransport(self.protocol))
 
     def closed(self) -> None:
         """
-        this is reliably called on both logout and disconnect
-        we notify the protocol here we lost the connection
+        Reliably called on both logout and disconnect. The protocol's
+        connectionLost is delivered by the session transport, so here we only
+        drop our reference to it.
         """
-        if self.protocol:
-            self.protocol.connectionLost("disconnected")
-            self.protocol = None
+        self.protocol = None
 
     def eofReceived(self) -> None:
         if self.protocol:

--- a/src/cowrie/test/test_ssh_teardown.py
+++ b/src/cowrie/test/test_ssh_teardown.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests that SSH session teardown calls the protocol's connectionLost once.
+# ABOUTME: Guards against the historic double/quadruple connectionLost on close.
+
+from __future__ import annotations
+
+import unittest
+
+from twisted.conch.ssh.session import SSHSessionProcessProtocol
+
+from cowrie.shell.session import ProtocolTransport, SSHSessionForCowrieUser
+from cowrie.ssh.session import HoneyPotSSHSession
+
+
+class CountingProtocol:
+    """Stand-in for LoggingServerProtocol that counts connectionLost calls."""
+
+    def __init__(self) -> None:
+        self.lost = 0
+
+    def connectionLost(self, reason) -> None:  # type: ignore[no-untyped-def]
+        self.lost += 1
+
+    def dataReceived(self, data) -> None:  # type: ignore[no-untyped-def]
+        pass
+
+
+class ProtocolTransportTestCase(unittest.TestCase):
+    """ProtocolTransport must fire connectionLost at most once."""
+
+    def test_lose_connection_is_idempotent(self) -> None:
+        proto = CountingProtocol()
+        transport = ProtocolTransport(proto)
+        transport.loseConnection()
+        transport.loseConnection()
+        self.assertEqual(proto.lost, 1)
+
+
+class SessionTeardownTestCase(unittest.TestCase):
+    """A full channel close must reach the protocol's connectionLost exactly once."""
+
+    def _wire(self, proto: CountingProtocol) -> HoneyPotSSHSession:
+        """Replicate the wiring SSHSessionForCowrieUser.openShell sets up."""
+        adapter = SSHSessionForCowrieUser.__new__(SSHSessionForCowrieUser)
+        adapter.protocol = proto
+
+        channel = HoneyPotSSHSession.__new__(HoneyPotSSHSession)
+        channel.session = adapter
+        channel.client = SSHSessionProcessProtocol(channel)
+        channel.client.transport = ProtocolTransport(proto)
+        return channel
+
+    def test_channel_close_tears_down_protocol_once(self) -> None:
+        proto = CountingProtocol()
+        channel = self._wire(proto)
+        channel.closed()
+        self.assertEqual(proto.lost, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The session protocol's `connectionLost` ran 2–4 times per SSH session close. This makes it fire exactly once.

## Root cause

For shell/exec sessions the terminal protocol is wired to the channel via Twisted's `session.wrapProtocol`, which returns a `_DummyTransport`. Two independent things then drive teardown:

1. **Twisted itself double-fires.** Both `SSHSession.loseConnection()` and `SSHSession.closed()` call `client.transport.loseConnection()`, and `_DummyTransport.loseConnection()` calls `connectionLost()` on every invocation with no `disconnecting`/`disconnected` guard (real Twisted transports have one). A logout sequence (`loseConnection` then `closed`) therefore reaches the protocol's `connectionLost` twice with zero cowrie involvement.
2. **A redundant cowrie call.** `SSHSessionForCowrieUser.closed()` additionally called `self.protocol.connectionLost("disconnected")` — a third trigger, and it passed the string `"disconnected"` where the chain is typed `failure.Failure`.

A real process-backed session never hits this: `client.transport` is the OS process transport, `loseConnection()` just closes stdin (idempotent), and `connectionLost` fires once when the process actually dies. `_DummyTransport` fuses those two concepts.

## Fix

- Add `ProtocolTransport` (replacing `wrapProtocol`'s `_DummyTransport`) with the same `dataReceived`/`write`/`writeSequence` bridging but an **idempotent** `loseConnection()`. Used in both `openShell` and `execCommand`.
- Drop the redundant `connectionLost` call from `SSHSessionForCowrieUser.closed()`; the session transport is now the single teardown path. The adapter only clears its reference.
- Replace the now-false `FIXME: ... called 4 times on logout` docstring in `LoggingServerProtocol.connectionLost` with an accurate description.

The Twisted-level deficiency (`_DummyTransport` non-idempotency) is fixed at the cowrie boundary rather than by depending on a patched, private Twisted API.

## Scope

- **Telnet is unaffected and was already correct**: it tears down via `TelnetBootstrapProtocol.connectionLost` (guarded `if self.protocol is not None` + `del`) and never drives the `_DummyTransport` path. The shared-base FIXME was SSH-specific.

## Test

New `test_ssh_teardown.py`:
- `ProtocolTransport.loseConnection` is idempotent.
- A full `channel.closed()` reaches the protocol's `connectionLost` exactly once (was 2 before).

Full suite: 404 passed. `ruff check` + `ruff format` clean.