### PR TITLE
fix: ignore NUL bytes in interactive shell instead of logging a warning

### DIFF
--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -379,6 +379,7 @@ class HoneyPotInteractiveProtocol(HoneyPotBaseProtocol, recvline.HistoricRecvLin
 
         self.keyHandlers.update(
             {
+                b"\x00": self.handle_NUL,  # NUL (NVT line ending, keepalive padding)
                 b"\x01": self.handle_HOME,  # CTRL-A
                 b"\x02": self.handle_LEFT,  # CTRL-B
                 b"\x03": self.handle_CTRL_C,  # CTRL-C
@@ -447,6 +448,13 @@ class HoneyPotInteractiveProtocol(HoneyPotBaseProtocol, recvline.HistoricRecvLin
                 self.historyLines.append(b"".join(self.lineBuffer))
             self.historyPosition = len(self.historyLines)
         recvline.RecvLine.handle_RETURN(self)
+
+    def handle_NUL(self) -> None:
+        """
+        Ignore NUL bytes. They are routine NVT traffic: telnet clients send
+        CR NUL as the line ending per RFC 854, and some clients send stray NUL
+        bytes as keepalive padding.
+        """
 
     def handle_CTRL_C(self) -> None:
         if self.cmdstack:

--- a/src/cowrie/test/test_protocol_keystroke.py
+++ b/src/cowrie/test/test_protocol_keystroke.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# ABOUTME: Tests for keystroke handling in the interactive shell protocol,
+# ABOUTME: covering control bytes that should not produce log warnings.
+from __future__ import annotations
+
+import os
+import unittest
+
+from twisted.logger import ILogObserver, globalLogPublisher
+from zope.interface import provider
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class KeystrokeTests(unittest.TestCase):
+    """Tests for HoneyPotInteractiveProtocol.keystrokeReceived."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+        self.events: list[dict[str, object]] = []
+
+        @provider(ILogObserver)
+        def record(event: dict[str, object]) -> None:
+            self.events.append(event)
+
+        globalLogPublisher.addObserver(record)
+        self.addCleanup(globalLogPublisher.removeObserver, record)
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def test_nul_byte_logs_no_warning(self) -> None:
+        """A NUL byte is routine NVT traffic and must not be logged."""
+        self.proto.keystrokeReceived(b"\x00", None)
+
+        unhandled = [
+            e
+            for e in self.events
+            if "Received unhandled keyID" in str(e.get("log_format", ""))
+        ]
+        self.assertEqual(unhandled, [])
+
+    def test_nul_byte_does_not_reach_line_buffer(self) -> None:
+        """The NUL handler is a no-op: it leaves no character in the buffer."""
+        self.proto.keystrokeReceived(b"\x00", None)
+        self.assertEqual(self.proto.lineBuffer, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Interactive telnet and SSH PTY sessions logged a warning for every NUL byte that arrived mid-session:

```
[cowrie.shell.protocol.HoneyPotInteractiveTelnetProtocol#warn] Received unhandled keyID: b'\x00'
```

NUL is routine NVT traffic, not an anomaly: telnet clients send `CR NUL` as the standard line ending per RFC 854, and some clients send stray NUL bytes as keepalive padding. In real sessions this adds up to meaningful log noise (often once per `CMD:` line).

## Root cause

`HoneyPotInteractiveProtocol` inherits Twisted's `RecvLine.keystrokeReceived`, which logs `Received unhandled keyID` for any byte that is neither a registered key handler nor a printable character. `connectionMade()` registers handlers for the CTRL sequences it cares about but nothing for `b"\x00"`, and NUL is not printable, so every NUL falls through to the generic warning.

## Fix

Register a no-op `handle_NUL` for `b"\x00"` in the `keyHandlers` dict, using the exact same mechanism already used for every other control character. The byte is consumed silently.

## Testing

Added `cowrie/test/test_protocol_keystroke.py` (TDD, written failing first):

- `test_nul_byte_logs_no_warning` captures log events and asserts no "unhandled keyID" warning is emitted.
- `test_nul_byte_does_not_reach_line_buffer` confirms the handler is a true no-op.

Both tests pass; `test_base_commands` (54 tests) still green; `ruff check`, `ruff format --check`, and `mypy` are clean for the changed files.

Closes #40186