### PR TITLE
fix: honour output redirection for busybox-dispatched applets

### DIFF
--- a/src/cowrie/commands/busybox.py
+++ b/src/cowrie/commands/busybox.py
@@ -89,13 +89,17 @@ class Command_busybox(HoneyPotCommand):
                 format="Command found: %(input)s",
             )
 
-            # prepare command arguments
+            # prepare command arguments, passing through the redirections the
+            # shell parsed for the outer busybox command so the dispatched
+            # applet's output is redirected the same as a direct invocation
             pp = PipeProtocol(
                 self.protocol,
                 cmdclass,
                 self.protocol.pp.cmdargs[1:],
                 self.input_data,
                 None,
+                redirect=self.protocol.pp.redirect,
+                redirections=self.protocol.pp.redirections,
             )
 
             # insert the command as we do when chaining commands with pipes

--- a/src/cowrie/test/test_fd_redirection.py
+++ b/src/cowrie/test/test_fd_redirection.py
@@ -218,6 +218,25 @@ class ShellFdRedirectionTests(unittest.TestCase):
         self.proto.lineReceived(b"echo outer$(echo inner$(echo deep))")
         self.assertEqual(self.tr.value(), b"outerinnerdeep\n" + PROMPT)
 
+    def test_busybox_applet_redirect_to_file(self) -> None:
+        # A busybox-dispatched applet must honour the redirection from the
+        # original command line instead of leaking output to the terminal.
+        self.proto.lineReceived(b"busybox echo hello > bboutfile")
+        self.assertEqual(self.tr.value(), PROMPT)
+        self.tr.clear()
+        self.proto.lineReceived(b"cat bboutfile")
+        self.assertEqual(self.tr.value(), b"hello\n" + PROMPT)
+
+    def test_busybox_applet_append_accumulates(self) -> None:
+        # Successive `busybox echo ... >> file` commands accumulate into the
+        # same backing file, like the real Mirai payload-building pattern.
+        self.proto.lineReceived(b"busybox echo one >> bbappendfile")
+        self.proto.lineReceived(b"busybox echo two >> bbappendfile")
+        self.assertEqual(self.tr.value(), PROMPT + PROMPT)
+        self.tr.clear()
+        self.proto.lineReceived(b"cat bbappendfile")
+        self.assertEqual(self.tr.value(), b"one\ntwo\n" + PROMPT)
+
     def test_command_substitution_preserves_prefix(self) -> None:
         # Text before $() should be preserved
         self.proto.lineReceived(b"echo prefix$(echo suffix)")


### PR DESCRIPTION
## Summary

A command dispatched through `/bin/busybox <applet> ...` ignored any output redirection (`>`, `>>`) on the original command line. The output went silently to the terminal instead of the redirected file, while the command still reported `cowrie.command.success` — so nothing visibly went wrong.

This is a likely significant contributor to "samples never get captured" reports: `/bin/busybox <applet>` is a very common invocation style in real IoT-botnet shell scripts (most targets only have busybox, not standalone coreutils), and the failure is completely silent from the bot's point of view. The motivating case is a Mirai-family bot building a payload with eight separate `busybox echo -ne "\xNN..." >> kmount` commands followed by `sh kmount` — every write was lost.

## Root cause

`Command_busybox.call()` builds a fresh `PipeProtocol` for the applet it dispatches to but leaves `redirect`/`redirections` at their defaults. With no redirections, `_setup_redirections()` falls through to `targets[1] = (FD_TERMINAL, None)`. The redirections the shell parsed for the line are sitting on `self.protocol.pp.redirections` but were never passed down to the inner protocol that actually produces the applet output.

## Fix

Pass the outer `PipeProtocol`'s `redirect` and `redirections` through to the inner one. The inner `PipeProtocol` re-resolves the target through its own `_setup_redirections()` / `_prepare_output_file()`, which re-derives the current append offset from the virtual filesystem — so multiple separate `busybox echo ... >> file` commands (each its own top-level command) still accumulate into the same backing file.

## Testing

Added two tests to `cowrie/test/test_fd_redirection.py` (TDD, written failing first):

- `test_busybox_applet_redirect_to_file` — `busybox echo hello > file` leaks nothing to the terminal and the content lands in the file.
- `test_busybox_applet_append_accumulates` — successive `busybox echo ... >> file` commands accumulate, matching the real payload-building pattern.

Full suite (408 tests) passes; `ruff check`, `ruff format --check`, and `mypy` are clean for the changed files.

Closes #40183