### PR TITLE
fix: resolve mypy errors in MISP output plugin and tests

### DIFF
--- a/src/cowrie/output/misp.py
+++ b/src/cowrie/output/misp.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import hashlib
 import os
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pymisp import MISPAttribute, MISPEvent, MISPObject, MISPSighting
 from twisted.python import log
@@ -16,10 +16,13 @@ from twisted.python import log
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
 
-try:
-    from pymisp import ExpandedPyMISP as PyMISP
-except ImportError:
-    from pymisp import PyMISP as PyMISP
+if TYPE_CHECKING:
+    from pymisp import PyMISP
+else:
+    try:
+        from pymisp import ExpandedPyMISP as PyMISP
+    except ImportError:
+        from pymisp import PyMISP
 
 
 def file_md5(path: str) -> str:

--- a/src/cowrie/test/test_misp.py
+++ b/src/cowrie/test/test_misp.py
@@ -38,15 +38,16 @@ class TestFileMd5(unittest.TestCase):
 class TestMispMalwareSample(unittest.TestCase):
     """A downloaded file must be looked up in MISP by its MD5 hash."""
 
-    def _make_output(self) -> Output:
+    def _make_output(self) -> tuple[Output, MagicMock]:
         # Bypass start(), which would connect to a live MISP server.
         output = Output.__new__(Output)
-        output.misp_api = MagicMock()
+        misp_api = MagicMock()
+        output.misp_api = misp_api
         output.session_tracking = {}
         output.debug = False
         output.handle_sessions = True
         output.publish = False
-        return output
+        return output, misp_api
 
     def test_file_download_lookup_uses_md5(self) -> None:
         data = b"malicious payload"
@@ -55,8 +56,8 @@ class TestMispMalwareSample(unittest.TestCase):
             outfile = f.name
         self.addCleanup(os.remove, outfile)
 
-        output = self._make_output()
-        output.misp_api.search.return_value = {"Attribute": []}
+        output, misp_api = self._make_output()
+        misp_api.search.return_value = {"Attribute": []}
 
         output.write(
             {
@@ -68,13 +69,13 @@ class TestMispMalwareSample(unittest.TestCase):
             }
         )
 
-        output.misp_api.search.assert_called_once()
-        kwargs = output.misp_api.search.call_args.kwargs
+        misp_api.search.assert_called_once()
+        kwargs = misp_api.search.call_args.kwargs
         self.assertEqual(kwargs["type_attribute"], "malware-sample")
         self.assertEqual(kwargs["value"], hashlib.md5(data).hexdigest())
 
     def test_missing_outfile_skips_lookup(self) -> None:
-        output = self._make_output()
+        output, misp_api = self._make_output()
 
         output.write(
             {
@@ -86,7 +87,7 @@ class TestMispMalwareSample(unittest.TestCase):
             }
         )
 
-        output.misp_api.search.assert_not_called()
+        misp_api.search.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`mypy src` reported 5 errors, all in the MISP plugin and its tests. This clears them so `mypy src` passes cleanly.

## Changes

**`output/misp.py`** — the conditional import bound `PyMISP` to two different types:

```python
try:
    from pymisp import ExpandedPyMISP as PyMISP
except ImportError:
    from pymisp import PyMISP as PyMISP
```

mypy treated the fallback as an incompatible reassignment of the name. Guarded the type-checker's view with `TYPE_CHECKING` (which sees the modern `PyMISP` — `ExpandedPyMISP` is a deprecated alias of it in the pinned pymisp) while leaving the runtime import fallback untouched.

**`test_misp.py`** — the mock was reached via `output.misp_api`, whose declared type is the real `PyMISP` client, so mypy rejected the mock-only attributes (`return_value`, `assert_called_once`, `call_args`, `assert_not_called`). The helper now returns the `MagicMock` alongside the `Output`, and the tests assert against that reference.

## Testing

`mypy src` now reports no issues (235 files). MISP tests pass; full suite (406 tests) green; `ruff check` and `ruff format --check` clean.