### PR TITLE
fix: restore initial NAWS negotiation for telnet connections

### DIFF
--- a/src/cowrie/telnet/userauth.py
+++ b/src/cowrie/telnet/userauth.py
@@ -55,10 +55,10 @@ class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
     cve_2026_24061_user: str | None = None
 
     def connectionMade(self):
-        # self.transport.negotiationMap[NAWS] = self.telnet_NAWS
-        # Initial option negotation. Want something at least for Mirai
-        # for opt in (NAWS,):
-        #    self.transport.doChain(opt).addErrback(log.err)
+        self.transport.negotiationMap[NAWS] = self.telnet_NAWS
+        # Initial option negotiation. Want something at least for Mirai
+        for opt in (NAWS,):
+            self.transport.doChain(opt).addErrback(log.err)
 
         # Register NEW-ENVIRON subnegotiation handler for CVE-2026-24061 detection
         self.transport.negotiationMap[NEW_ENVIRON] = self.telnet_NEW_ENVIRON

--- a/src/cowrie/test/test_telnet_userauth.py
+++ b/src/cowrie/test/test_telnet_userauth.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for the telnet auth protocol's initial option negotiation,
+# ABOUTME: ensuring DO NAWS is negotiated before the login banner is sent.
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from twisted.conch.telnet import NAWS
+
+from cowrie.telnet.userauth import HoneyPotTelnetAuthProtocol
+
+
+class TestInitialNegotiation(unittest.TestCase):
+    """connectionMade must proactively negotiate NAWS for Mirai-family clients."""
+
+    def setUp(self) -> None:
+        self.protocol = HoneyPotTelnetAuthProtocol(MagicMock())
+        self.transport = MagicMock()
+        self.transport.negotiationMap = {}
+        self.protocol.transport = self.transport
+        self.protocol.factory = MagicMock()
+        self.protocol.factory.banner = b"banner\n"
+
+    def test_naws_negotiated_on_connect(self) -> None:
+        self.protocol.connectionMade()
+        self.transport.doChain.assert_called_once_with(NAWS)
+
+    def test_naws_handler_registered(self) -> None:
+        self.protocol.connectionMade()
+        self.assertEqual(self.transport.negotiationMap[NAWS], self.protocol.telnet_NAWS)
+
+    def test_naws_negotiated_before_banner(self) -> None:
+        self.protocol.connectionMade()
+        call_names = [c[0] for c in self.transport.mock_calls]
+        self.assertIn("doChain", call_names)
+        self.assertIn("write", call_names)
+        self.assertLess(call_names.index("doChain"), call_names.index("write"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`HoneyPotTelnetAuthProtocol.connectionMade()` sent the banner and login prompt cold, with no telnet option negotiation at all. The `DO NAWS` negotiation — documented in the original code as tuned specifically for Mirai-family clients — had been commented out as incidental fallout from the 2019 telnet-proxy refactor (`34f8464`) and was never restored. It has stayed dead through every commit since, including the recent CVE-2026-24061 NEW-ENVIRON work.

This restores the negotiation so `IAC DO NAWS` (`\xff\xfd\x1f`) is the first thing on the wire again, before the banner, matching pre-2019 behavior. The reporter runs a fork that still has this active and reliably receives IoT-botnet samples; a current-`main` deployment does not.

## Changes

Re-enable the NAWS negotiation block in `connectionMade()`:

```python
self.transport.negotiationMap[NAWS] = self.telnet_NAWS
# Initial option negotiation. Want something at least for Mirai
for opt in (NAWS,):
    self.transport.doChain(opt).addErrback(log.err)
```

The NEW-ENVIRON callback registration (CVE-2026-24061 detection) is left in place alongside it — the two do not conflict: one proactively negotiates an option, the other only registers a passive callback for client-initiated NEW-ENVIRON.

## Safety

The reporter noted this should land together with the telnet teardown crash fix, since restoring NAWS adds a second negotiation into the same race. That guard (the `_closing` flag and the `_handleNegotiationError` early-return during `connectionLost`) is **already present** on `CowrieTelnetTransport` in current `main` (commit `2e57be7a`), so the dependency is satisfied.

## Testing

Added `cowrie/test/test_telnet_userauth.py` (TDD, written failing first):

- `test_naws_negotiated_on_connect` — `doChain(NAWS)` is called on connect.
- `test_naws_handler_registered` — the NAWS subnegotiation handler is registered.
- `test_naws_negotiated_before_banner` — the negotiation precedes the banner write.

Full suite (413 tests) passes; `ruff check` and `mypy` clean for the changed files.