### PR TITLE
fix: remove orphaned temp file on failed wget/curl download

### DIFF
--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -450,6 +450,10 @@ class Command_curl(HoneyPotCommand):
         """
         handle any exceptions
         """
+        # Close the artifact so a failed download leaves no orphaned temp file.
+        # Artifact.close() removes the empty temp file backing the download.
+        if getattr(self, "artifact", None) is not None:
+            self.artifact.close()
 
         self.protocol.logDispatch(
             eventid="cowrie.session.file_download.failed",

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -572,6 +572,11 @@ class Command_wget(HoneyPotCommand):
         """
         handle errors
         """
+        # Close the artifact so a failed download leaves no orphaned temp file.
+        # Artifact.close() removes the empty temp file backing the download.
+        if getattr(self, "artifact", None) is not None:
+            self.artifact.close()
+
         self.protocol.logDispatch(
             eventid="cowrie.session.file_download.failed",
             format="Attempt to download file(s) from URL (%(url)s) failed",

--- a/src/cowrie/core/artifact.py
+++ b/src/cowrie/core/artifact.py
@@ -73,6 +73,8 @@ class Artifact:
     def close(self, keepEmpty: bool = False) -> tuple[str, str] | None:
         size: int = self.fp.tell()
         if size == 0 and not keepEmpty:
+            self.fp.close()
+            self.closed = True
             try:
                 os.remove(self.fp.name)
             except FileNotFoundError:

--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for cowrie/commands/curl.py, focused on artifact lifecycle.
+# ABOUTME: Verifies that a failed download leaves no orphaned temp file behind.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from twisted.internet import error
+from twisted.python.failure import Failure
+
+from cowrie.commands.curl import Command_curl
+from cowrie.core.artifact import Artifact
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class CurlArtifactCleanupTests(unittest.TestCase):
+    """A failed curl download must not leave an orphaned temp file behind."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+        # The fake factory has no logDispatch; error() dispatches a log event.
+        self.proto.logDispatch = lambda **_kw: None  # type: ignore[method-assign]
+
+        self.tmpdir = tempfile.mkdtemp()
+        self._orig_artifact_dir = Artifact.artifactDir
+        Artifact.artifactDir = self.tmpdir
+
+    def tearDown(self) -> None:
+        Artifact.artifactDir = self._orig_artifact_dir
+        self.proto.connectionLost()
+        for name in os.listdir(self.tmpdir):
+            os.remove(os.path.join(self.tmpdir, name))
+        os.rmdir(self.tmpdir)
+
+    def test_failed_download_removes_temp_artifact(self) -> None:
+        # Bypass HoneyPotCommand.__init__: its stdout/stderr wiring needs a
+        # running process protocol (self.protocol.pp), which is irrelevant to
+        # the artifact lifecycle under test here.
+        cmd = Command_curl.__new__(Command_curl)
+        cmd.protocol = self.proto
+        cmd.errorWritefn = lambda _data: None
+        cmd.exit = lambda: None  # type: ignore[method-assign]  # process teardown is unrelated here
+        cmd.url = b"http://no.such.host/file"
+        cmd.host = "no.such.host"
+        cmd.port = 80
+        cmd.artifact = Artifact("curl-download")
+        temp_filename = cmd.artifact.tempFilename
+        self.assertTrue(os.path.exists(temp_filename))
+
+        cmd.error(Failure(error.DNSLookupError()))
+
+        self.assertFalse(
+            os.path.exists(temp_filename),
+            "failed download left an orphaned temp file behind",
+        )
+        self.assertEqual(os.listdir(self.tmpdir), [])

--- a/src/cowrie/test/test_wget.py
+++ b/src/cowrie/test/test_wget.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for cowrie/commands/wget.py, focused on artifact lifecycle.
+# ABOUTME: Verifies that a failed download leaves no orphaned temp file behind.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from twisted.internet import error
+from twisted.python.failure import Failure
+
+from cowrie.commands.wget import Command_wget
+from cowrie.core.artifact import Artifact
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class WgetArtifactCleanupTests(unittest.TestCase):
+    """A failed wget download must not leave an orphaned temp file behind."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+        # The fake factory has no logDispatch; error() dispatches a log event.
+        self.proto.logDispatch = lambda **_kw: None  # type: ignore[method-assign]
+
+        self.tmpdir = tempfile.mkdtemp()
+        self._orig_artifact_dir = Artifact.artifactDir
+        Artifact.artifactDir = self.tmpdir
+
+    def tearDown(self) -> None:
+        Artifact.artifactDir = self._orig_artifact_dir
+        self.proto.connectionLost()
+        for name in os.listdir(self.tmpdir):
+            os.remove(os.path.join(self.tmpdir, name))
+        os.rmdir(self.tmpdir)
+
+    def test_failed_download_removes_temp_artifact(self) -> None:
+        # Bypass HoneyPotCommand.__init__: its stdout/stderr wiring needs a
+        # running process protocol (self.protocol.pp), which is irrelevant to
+        # the artifact lifecycle under test here.
+        cmd = Command_wget.__new__(Command_wget)
+        cmd.protocol = self.proto
+        cmd.errorWritefn = lambda _data: None
+        cmd.exit = lambda: None  # type: ignore[method-assign]  # process teardown is unrelated here
+        cmd.url = b"http://no.such.host/file"
+        cmd.host = "no.such.host"
+        cmd.port = 80
+        cmd.artifact = Artifact("wget-download")
+        temp_filename = cmd.artifact.tempFilename
+        self.assertTrue(os.path.exists(temp_filename))
+
+        cmd.error(Failure(error.DNSLookupError()))
+
+        self.assertFalse(
+            os.path.exists(temp_filename),
+            "failed download left an orphaned temp file behind",
+        )
+        self.assertEqual(os.listdir(self.tmpdir), [])


### PR DESCRIPTION
## Summary

Fixes #40193.

`Command_wget.start()` creates the download `Artifact` before attempting the transfer, but `error()` never closed it. Every failed `wget` download (DNS failure, refused connection, timeout, FTP error) left an empty `tempfile.NamedTemporaryFile`-named orphan in the download directory, forever.

`Command_curl` has the identical defect — the issue assumed curl was already fixed, but `Command_curl.error()` on current `main` does not close its artifact either. Both are fixed here.

## Changes

- **`artifact.py`**: `Artifact.close()`'s empty-artifact branch removed the on-disk temp file but never closed the underlying `NamedTemporaryFile`, leaking the file descriptor until GC (surfaced as a `ResourceWarning`). It now closes the handle.
- **`wget.py` / `curl.py`**: close the artifact at the top of `error()`. `Artifact.close()` removes the empty temp file backing the download; on a partial download it stores the captured bytes under their shasum instead of leaking an orphan.

## Tests

- `test_wget.py` / `test_curl.py`: assert a failed download (DNS lookup error) leaves no file behind in the download directory. Both fail before the fix, pass after.

## Verification

- Full suite: 415 tests pass.
- `mypy` (project config): clean on changed files and full `src` (239 files).
- `ruff check` / `ruff format --check`: clean.
- No `ResourceWarning` under `-W error::ResourceWarning`.