### PR TITLE
fix: disconnect cleanly on duplicate KEXINIT during key exchange

### DIFF
--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -95,6 +95,13 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         """
         if not self.gotVersion:
             return
+        # A client that sends a second KEXINIT before the first key exchange
+        # completes drives the base sendKexInit into raising a RuntimeError.
+        # Disconnect such a protocol violation cleanly instead.
+        if self._keyExchangeState != self._KEY_EXCHANGE_NONE:
+            log.msg("Duplicate KEXINIT during key exchange, disconnecting")
+            self.transport.loseConnection()
+            return
         transport.SSHServerTransport.sendKexInit(self)
 
     def _unsupportedVersionReceived(self, remoteVersion: bytes) -> None:


### PR DESCRIPTION
## Summary

Fixes #40176.

A client that sends a second KEXINIT before the first key exchange completes drives Twisted's base `ssh_KEXINIT` into its `else` branch, which calls `sendKexInit()` again. The base `sendKexInit()` then raises `RuntimeError` because `_keyExchangeState` is no longer `_KEY_EXCHANGE_NONE`, surfacing as an unhandled error on the dispatch path instead of a clean disconnect.

## Change

Extend Cowrie's `sendKexInit()` override: when called with a key exchange already in progress (`_keyExchangeState != _KEY_EXCHANGE_NONE`), log and drop the connection rather than calling through to the base (which would raise). The normal first-KEXINIT path (state `_KEY_EXCHANGE_NONE`, including rekeys, which also return to `NONE`) is unchanged.

## Verification

- `mypy` (project config): clean on `src/cowrie/ssh/transport.py`.
- `ruff check`: clean.
- Reproduced the original `RuntimeError` with state `_KEY_EXCHANGE_PROGRESSING` before the change; confirmed a clean `loseConnection()` after, and that the normal first-KEXINIT path still calls through to the base and advances state to `_KEY_EXCHANGE_REQUESTED`.