### PR TITLE
feat: replace the shlex shell parser with a Lark grammar

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
         "cryptography==49.0.0",
         "hyperlink==21.0.0",
         "idna==3.18",
+        "lark==1.3.1",
         "packaging==26.2",
         "pyasn1_modules==0.4.2",
         "service_identity==24.2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ bcrypt==5.0.0
 cryptography==49.0.0
 hyperlink==21.0.0
 idna==3.18
+lark==1.3.1
 packaging==26.2
 pyasn1_modules==0.4.2
 service_identity==24.2.0

--- a/src/cowrie/commands/bash.py
+++ b/src/cowrie/commands/bash.py
@@ -109,6 +109,7 @@ class Command_sh(HoneyPotCommand):
             shell.environ["SHLVL"] = "1"
         self.protocol.cmdstack.append(shell)
         self.protocol.cmdstack.remove(self)
+        shell.showPrompt()
 
 
 commands["/bin/bash"] = Command_sh

--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -135,6 +135,14 @@ timezone = UTC
 # Beware that the path won't be included in your prompt any longer
 # prompt = hello>
 
+# Command-line parser used by the emulated shell.
+# `shlex` (default) uses the historical shlex-based tokeniser.
+# `lark` uses an experimental Lark grammar that parses quoting, redirection,
+# command substitution and subshells from a single grammar. Selecting `lark`
+# requires the optional `lark` dependency to be installed.
+# (default: shlex)
+# parser = shlex
+
 
 # ============================================================================
 # Network Specific Options

--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -135,14 +135,6 @@ timezone = UTC
 # Beware that the path won't be included in your prompt any longer
 # prompt = hello>
 
-# Command-line parser used by the emulated shell.
-# `shlex` (default) uses the historical shlex-based tokeniser.
-# `lark` uses an experimental Lark grammar that parses quoting, redirection,
-# command substitution and subshells from a single grammar. Selecting `lark`
-# requires the optional `lark` dependency to be installed.
-# (default: shlex)
-# parser = shlex
-
 
 # ============================================================================
 # Network Specific Options

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -67,7 +67,7 @@ start: _WS? _line? _WS?
 _line: _run (_WS? _op _WS? _run)*
 _run: (_content (_WS _content)*)?
 _content: subshell | word | _COMMENT
-_op: SEP | PIPE | AMP | REDIR
+_op: SEP | PIPE | AMP | IO_REDIR | REDIR
 
 subshell: LPAR start RPAR
 
@@ -105,6 +105,11 @@ ESC: /\\./
 SEP.2: "&&" | "||" | ";"
 PIPE: "|"
 AMP: "&"
+// A redirection with a file descriptor directly attached to it ("2>", "2>&",
+// "1>>"): one high-priority token so the digit is a file descriptor, not an
+// argument. A digit separated by whitespace ("2 >") stays an ordinary word,
+// which is how bash tells the two apart.
+IO_REDIR.5: /\d+(?:>>|>&|>|<)/
 REDIR.2: />>|>&|&>|>|</
 
 LPAR: "("

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -39,7 +39,7 @@ from lark.exceptions import LarkError
 _GRAMMAR = r"""
 start: _WS? (_unit (_WS? _unit)*)? _WS?
 
-_unit: SEP | PIPE | AMP | REDIR | subshell | word
+_unit: SEP | PIPE | AMP | REDIR | _COMMENT | subshell | word
 
 subshell: LPAR start RPAR
 
@@ -81,6 +81,11 @@ RPAR: ")"
 BARE_DOLLAR: "$"
 LITERAL: /[^ \t\r\n|&;<>()$`'"\\]+/
 
+// A "#" starts a comment only at a word boundary (higher priority than the
+// LITERAL that would otherwise begin a word with "#"); a "#" inside a word
+// such as "a#b" stays part of the LITERAL.
+_COMMENT.2: /#[^\r\n]*/
+
 _WS: /[ \t\r\n]+/
 """
 
@@ -91,11 +96,6 @@ _parser = Lark(
     lexer="dynamic",
     propagate_positions=True,
 )
-
-# Sentinel returned by word evaluation when an unquoted bare reference to an
-# unset/empty variable should drop the whole word (like ``echo $unset`` which
-# yields no argument at all in a real shell).
-_DROP = object()
 
 
 class ShellContext(Protocol):
@@ -199,7 +199,7 @@ class BashParser:
         )
         if subshell_idx is not None:
             if subshell_idx == 0:
-                return Subshell(source=self._subshell_source(line, units[0]))
+                return Subshell(source=self._group_source(line, units[0]))
             return SyntaxError_(token=self._error_token(line, units[subshell_idx]))
 
         tokens: list[str] = []
@@ -209,15 +209,21 @@ class BashParser:
                 tokens.append(unit.value)
                 continue
             value = self._eval_word(line, unit)
-            if value is not _DROP:
-                tokens.append(value)  # type: ignore[arg-type]
+            if value is not None:
+                tokens.append(value)
         if not tokens:
             return None
         return Command(tokens=tokens)
 
     # -- word evaluation ----------------------------------------------------
 
-    def _eval_word(self, line: str, word: Tree) -> str | object:
+    def _eval_word(self, line: str, word: Tree) -> str | None:
+        """Evaluate a word to its final string, or None if it should be dropped.
+
+        A word is dropped when it is exactly an unquoted reference to an unset
+        or empty variable, like ``echo $unset`` which yields no argument at all
+        in a real shell.
+        """
         atoms = word.children
 
         # Whole-word bare reference: ``$x`` / ``${x}`` as the entire,
@@ -232,7 +238,7 @@ class BashParser:
                     return only.children[0].value  # verbatim, e.g. $@
                 value = self.context.get_variable(name)
                 if not value:
-                    return _DROP
+                    return None
                 return value
 
         parts: list[str] = []
@@ -256,7 +262,7 @@ class BashParser:
         if atom.data == "dollar_var" or atom.data == "dollar_brace":
             return self._expand_embedded(atom)
         if atom.data == "cmdsub":
-            return self.context.command_substitution(self._inner_source(line, atom))
+            return self.context.command_substitution(self._group_source(line, atom))
         if atom.data == "backtick":
             return self.context.command_substitution(self._backtick_source(line, atom))
         return ""
@@ -274,7 +280,7 @@ class BashParser:
                 parts.append(self._expand_embedded(part))
             elif part.data == "cmdsub":
                 parts.append(
-                    self.context.command_substitution(self._inner_source(line, part))
+                    self.context.command_substitution(self._group_source(line, part))
                 )
             elif part.data == "backtick":
                 parts.append(
@@ -317,8 +323,8 @@ class BashParser:
 
     # -- source slicing for substitution / subshells ------------------------
 
-    def _inner_source(self, line: str, node: Tree) -> str:
-        """Raw source inside ``$(...)`` (the inner ``start`` tree)."""
+    def _group_source(self, line: str, node: Tree) -> str:
+        """Raw source of the inner ``start`` tree of a ``$(...)`` or ``(...)``."""
         for child in node.children:
             if isinstance(child, Tree) and child.data == "start":
                 if child.meta.empty:
@@ -329,17 +335,8 @@ class BashParser:
     def _backtick_source(self, line: str, node: Tree) -> str:
         if node.meta.empty:
             return ""
-        # Strip the surrounding backticks from the matched span.
-        raw = line[node.meta.start_pos : node.meta.end_pos]
-        return raw.strip("`")
-
-    def _subshell_source(self, line: str, node: Tree) -> str:
-        for child in node.children:
-            if isinstance(child, Tree) and child.data == "start":
-                if child.meta.empty:
-                    return ""
-                return line[child.meta.start_pos : child.meta.end_pos]
-        return ""
+        # Drop the surrounding backtick delimiters from the matched span.
+        return line[node.meta.start_pos + 1 : node.meta.end_pos - 1]
 
     def _error_token(self, line: str, subshell: Tree) -> str:
         """Reconstruct bash's reported token for a misplaced ``(``.

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -110,7 +110,7 @@ AMP: "&"
 // argument. A digit separated by whitespace ("2 >") stays an ordinary word,
 // which is how bash tells the two apart.
 IO_REDIR.5: /\d+(?:>>|>&|>|<)/
-REDIR.2: />>|>&|&>|>|</
+REDIR.2: />>|>&|&>>|&>|>|</
 
 LPAR: "("
 RPAR: ")"

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -37,8 +37,8 @@ Known deviations from standard bash (none are emulated yet):
 * ``{ ...; }`` command grouping and reserved words (``for``/``if``/``while``
   ...) are parsed as ordinary commands, so the shell does not run loops or
   conditionals.
-* An unset variable reference embedded in a larger word is left verbatim
-  rather than expanding to empty (see ``_expand_embedded``).
+* The special parameters ``$@`` / ``$#`` / ``$*`` (and friends other than
+  ``$?``, which is ``0``) are passed through literally rather than expanded.
 
 Input the grammar cannot parse at all (e.g. an unterminated quote) surfaces as
 a syntax error, exactly as the previous implementation degraded on input it
@@ -337,18 +337,10 @@ class BashParser:
         """Expand a ``$VAR`` reference that is embedded in a larger word.
 
         A set variable expands to its value (empty included); an unset
-        reference is left verbatim so quoted awk/sed field references survive.
-        This is a deliberate compromise, not bash behaviour.
-
-        TODO: the Lark grammar records the quoting context that would let us do
-        this correctly. bash expands an
-        unset reference to the empty string when it is unquoted or
-        double-quoted ("$nope" -> "") and only leaves it literal inside single
-        quotes ('$nope' -> "$nope"). Single quotes are already handled (they
-        never reach here), so the remaining work is to pass whether the
-        reference was double-quoted and expand unset double-quoted references
-        to "" instead of verbatim. Doing so changes observable behaviour, so it
-        needs its own test updates (see test_shell_variables).
+        reference expands to the empty string, as bash does for an unquoted or
+        double-quoted reference. A single-quoted reference is kept literal by
+        the grammar (it never reaches here), so quoted awk/sed field references
+        still survive.
         """
         name, special = self._var_name(node)
         if special == "?":
@@ -357,7 +349,7 @@ class BashParser:
             return self._leaf_value(node)
         value = self.context.get_variable(name)
         if value is None:
-            return self._leaf_value(node)  # verbatim, e.g. "$nope"
+            return ""
         return value
 
     def _leaf_value(self, node: Tree) -> str:

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -19,10 +19,31 @@ operators — are emitted as their own string tokens so the existing
 The grammar deliberately models only the subset of bash that Cowrie already
 emulates: lists separated by ``;`` / ``&&`` / ``||``, pipelines, simple
 redirections, single/double quoting, ``$VAR`` / ``${VAR}`` expansion, command
-substitution (``$(...)`` and backticks) and subshells (``(...)``). Constructs
-outside that subset (here-docs, arithmetic expansion, process substitution)
-are intentionally unsupported and surface as a syntax error, exactly as the
-previous implementation degraded on input it could not handle.
+substitution (``$(...)`` and backticks) and subshells (``(...)``).
+
+Known deviations from standard bash (most are shared with the old shlex path
+and predate this parser; none are emulated yet):
+
+* ``&&`` / ``||`` do not short-circuit -- they are split like ``;`` and every
+  command runs regardless of exit status. ``$?`` is always ``0``.
+* A trailing ``&`` is treated as a literal argument, not a background job.
+* No word expansions beyond ``$VAR`` / ``${VAR}``: tilde (``~``), brace
+  (``{a,b}`` / ``{1..3}``), arithmetic (``$((...))``), the parameter
+  expansion operators (``${x:-y}``, ``${#x}``, ``${x/a/b}`` ...), and ANSI-C
+  quoting (``$'...'``) are all passed through literally.
+* Pathname expansion (globbing of ``*`` / ``?`` / ``[...]``) is left to the
+  individual command implementations, not done by the parser.
+* Here-documents (``<<EOF``) and here-strings (``<<<``) are not supported; the
+  operators are tokenised as plain ``<`` redirections.
+* ``{ ...; }`` command grouping and reserved words (``for``/``if``/``while``
+  ...) are parsed as ordinary commands, so the shell does not run loops or
+  conditionals.
+* An unset variable reference embedded in a larger word is left verbatim
+  rather than expanding to empty (see ``_expand_embedded``).
+
+Input the grammar cannot parse at all (e.g. an unterminated quote) surfaces as
+a syntax error, exactly as the previous implementation degraded on input it
+could not handle.
 """
 
 from __future__ import annotations
@@ -124,7 +145,12 @@ class Subshell:
 
 @dataclass
 class SyntaxError_:
-    """A bash-style syntax error to report verbatim."""
+    """A bash-style syntax error to report verbatim.
+
+    TODO: the trailing underscore avoids shadowing the builtin SyntaxError.
+    Consider renaming to ParseError for clarity (touches honeypot.py and the
+    tests).
+    """
 
     token: str
 
@@ -189,6 +215,11 @@ class BashParser:
         # and writes straight to the terminal; anything piped after it is
         # ignored, matching the shlex path. A subshell anywhere else is a
         # syntax error reported on the "(" token, as bash does.
+        # TODO: support a subshell as a real pipeline stage, e.g.
+        # `(echo a) | wc -c`. We currently run the subshell and discard the
+        # rest of the pipeline (parity with the shlex path) instead of feeding
+        # its output into the pipe. bash also allows a subshell in the middle
+        # or end of a pipeline (`x | (cmd)`), which we reject as a syntax error.
         subshell_idx = next(
             (
                 i
@@ -301,6 +332,16 @@ class BashParser:
         A set variable expands to its value (empty included); an unset
         reference is left verbatim so quoted awk/sed field references survive,
         matching the previous implementation's deliberate compromise.
+
+        TODO: this is not how bash behaves and the Lark grammar now records the
+        quoting context that would let us do it correctly. bash expands an
+        unset reference to the empty string when it is unquoted or
+        double-quoted ("$nope" -> "") and only leaves it literal inside single
+        quotes ('$nope' -> "$nope"). Single quotes are already handled (they
+        never reach here), so the remaining work is to pass whether the
+        reference was double-quoted and expand unset double-quoted references
+        to "" instead of verbatim. Doing so changes observable behaviour, so it
+        needs its own test updates (see test_shell_variables).
         """
         name, special = self._var_name(node)
         if special == "?":

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -6,8 +6,8 @@
 # ABOUTME: of statements (token lists, subshells, syntax errors) for the shell.
 
 """
-A small Lark grammar and evaluator that replaces the ``shlex`` based
-tokenisation and the hand-rolled command-substitution / subshell scanning in
+A small Lark grammar and evaluator that tokenises a command line and resolves
+its quoting, redirection, command substitution and subshells for the shell in
 ``honeypot.py``.
 
 The parser produces a flat list of :class:`Statement` objects. Words are fully
@@ -21,8 +21,7 @@ emulates: lists separated by ``;`` / ``&&`` / ``||``, pipelines, simple
 redirections, single/double quoting, ``$VAR`` / ``${VAR}`` expansion, command
 substitution (``$(...)`` and backticks) and subshells (``(...)``).
 
-Known deviations from standard bash (most are shared with the old shlex path
-and predate this parser; none are emulated yet):
+Known deviations from standard bash (none are emulated yet):
 
 * ``&&`` / ``||`` do not short-circuit -- they are split like ``;`` and every
   command runs regardless of exit status. ``$?`` is always ``0``.
@@ -84,9 +83,13 @@ SQ: /'[^']*'/
 dollar_brace: "${" BRACE_NAME "}"
 BRACE_NAME: /[_a-zA-Z0-9]+/
 
+// Higher priority than the bare BARE_DOLLAR so a "$" that begins a variable
+// reference is lexed as one "$VAR" token even when it directly follows literal
+// text in the same word ("got=$x", "$PATH:/x"), rather than splitting into a
+// bare "$" plus a "VAR" literal.
 dollar_var: DOLLAR_NAME | DOLLAR_SPECIAL
-DOLLAR_NAME: /\$[_a-zA-Z0-9]+/
-DOLLAR_SPECIAL: /\$[?@$#!*]/
+DOLLAR_NAME.2: /\$[_a-zA-Z0-9]+/
+DOLLAR_SPECIAL.2: /\$[?@$#!*]/
 
 ESC: /\\./
 
@@ -138,7 +141,11 @@ class Command:
 
 @dataclass
 class Subshell:
-    """A ``(...)`` group whose raw inner source is run as its own shell."""
+    """A ``(...)`` group; its raw inner source is parsed and run in sequence.
+
+    Cowrie does not emulate a subshell's isolated environment, so the caller
+    runs the inner commands in order with the surrounding line.
+    """
 
     source: str
 
@@ -212,14 +219,14 @@ class BashParser:
         self, line: str, units: list[Tree | Token]
     ) -> Statement | None:
         # A subshell is valid only at the start of a statement. There it runs
-        # and writes straight to the terminal; anything piped after it is
-        # ignored, matching the shlex path. A subshell anywhere else is a
-        # syntax error reported on the "(" token, as bash does.
+        # in sequence with the surrounding line; anything piped after it is
+        # ignored. A subshell anywhere else is a syntax error reported on the
+        # "(" token, as bash does.
         # TODO: support a subshell as a real pipeline stage, e.g.
         # `(echo a) | wc -c`. We currently run the subshell and discard the
-        # rest of the pipeline (parity with the shlex path) instead of feeding
-        # its output into the pipe. bash also allows a subshell in the middle
-        # or end of a pipeline (`x | (cmd)`), which we reject as a syntax error.
+        # rest of the pipeline instead of feeding its output into the pipe.
+        # bash also allows a subshell in the middle or end of a pipeline
+        # (`x | (cmd)`), which we reject as a syntax error.
         subshell_idx = next(
             (
                 i
@@ -330,11 +337,11 @@ class BashParser:
         """Expand a ``$VAR`` reference that is embedded in a larger word.
 
         A set variable expands to its value (empty included); an unset
-        reference is left verbatim so quoted awk/sed field references survive,
-        matching the previous implementation's deliberate compromise.
+        reference is left verbatim so quoted awk/sed field references survive.
+        This is a deliberate compromise, not bash behaviour.
 
-        TODO: this is not how bash behaves and the Lark grammar now records the
-        quoting context that would let us do it correctly. bash expands an
+        TODO: the Lark grammar records the quoting context that would let us do
+        this correctly. bash expands an
         unset reference to the empty string when it is unquoted or
         double-quoted ("$nope" -> "") and only leaves it literal inside single
         quotes ('$nope' -> "$nope"). Single quotes are already handled (they

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -236,9 +236,11 @@ class BashParser:
             None,
         )
         if subshell_idx is not None:
+            subshell = units[subshell_idx]
+            assert isinstance(subshell, Tree)
             if subshell_idx == 0:
-                return Subshell(source=self._group_source(line, units[0]))
-            return SyntaxError_(token=self._error_token(line, units[subshell_idx]))
+                return Subshell(source=self._group_source(line, subshell))
+            return SyntaxError_(token=self._error_token(line, subshell))
 
         tokens: list[str] = []
         for unit in units:
@@ -273,7 +275,7 @@ class BashParser:
                 if special == "?":
                     return "0"
                 if special is not None:
-                    return only.children[0].value  # verbatim, e.g. $@
+                    return self._leaf_value(only)  # verbatim, e.g. $@
                 value = self.context.get_variable(name)
                 if not value:
                     return None
@@ -286,15 +288,13 @@ class BashParser:
 
     def _eval_atom(self, line: str, atom: Tree | Token) -> str:
         if isinstance(atom, Token):
-            if atom.type == "LITERAL" or atom.type == "BARE_DOLLAR":
-                return atom.value
             if atom.type == "ESC":
                 # Unquoted backslash escape: the backslash is removed.
-                return atom.value[1:]
-            return atom.value
+                return str(atom.value)[1:]
+            return str(atom.value)
 
         if atom.data == "sq":
-            return atom.children[0].value[1:-1]  # strip surrounding quotes
+            return self._leaf_value(atom)[1:-1]  # strip surrounding quotes
         if atom.data == "dq":
             return self._eval_dquoted(line, atom)
         if atom.data == "dollar_var" or atom.data == "dollar_brace":
@@ -354,20 +354,28 @@ class BashParser:
         if special == "?":
             return "0"
         if special is not None:
-            return node.children[0].value
+            return self._leaf_value(node)
         value = self.context.get_variable(name)
         if value is None:
-            return node.children[0].value  # verbatim, e.g. "$nope"
+            return self._leaf_value(node)  # verbatim, e.g. "$nope"
         return value
+
+    def _leaf_value(self, node: Tree) -> str:
+        """Return the string value of a node's single leaf token."""
+        token = node.children[0]
+        assert isinstance(token, Token)
+        return str(token)
 
     def _var_name(self, node: Tree) -> tuple[str, str | None]:
         """Return (name, special) for a dollar_var/dollar_brace node."""
         if node.data == "dollar_brace":
-            return node.children[0].value, None
+            return self._leaf_value(node), None
         tok = node.children[0]
+        assert isinstance(tok, Token)
+        text = str(tok)
         if tok.type == "DOLLAR_SPECIAL":
-            return tok.value, tok.value[1:]
-        return tok.value[1:], None  # DOLLAR_NAME: strip leading $
+            return text, text[1:]
+        return text[1:], None  # DOLLAR_NAME: strip leading $
 
     # -- source slicing for substitution / subshells ------------------------
 

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -57,9 +57,17 @@ from lark.exceptions import LarkError
 # separator, so it is matched explicitly rather than ignored: adjacent atoms
 # with no whitespace between them form a single word ("a"$x'b' -> one word).
 _GRAMMAR = r"""
-start: _WS? (_unit (_WS? _unit)*)? _WS?
-
-_unit: SEP | PIPE | AMP | REDIR | _COMMENT | subshell | word
+// A line is whitespace-separated content (words and subshells) broken up by the
+// control operators. Whitespace is REQUIRED between two content words, so a run
+// of atoms with no spaces is a single word (a"b"$c -> one word) while operators
+// stay self-delimiting (echo a|b is three tokens). Requiring the space is also
+// what keeps "$(...)" one command-substitution word instead of letting it be
+// re-read as a bare "$" next to a "(...)" subshell.
+start: _WS? _line? _WS?
+_line: _run (_WS? _op _WS? _run)*
+_run: (_content (_WS _content)*)?
+_content: subshell | word | _COMMENT
+_op: SEP | PIPE | AMP | REDIR
 
 subshell: LPAR start RPAR
 

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -255,6 +255,17 @@ class BashParser:
                 return Subshell(statements=self._subshell_statements(line, subshell))
             return SyntaxError_(token=self._error_token(line, subshell))
 
+        # A redirection operator must be followed by a target word. A redirect at
+        # the end of a statement, or directly before another operator, is a bash
+        # syntax error (e.g. `echo >` reports the unexpected token `newline').
+        for i, unit in enumerate(units):
+            if isinstance(unit, Token) and unit.type in ("REDIR", "IO_REDIR"):
+                target = units[i + 1] if i + 1 < len(units) else None
+                if target is None:
+                    return SyntaxError_(token="newline")
+                if isinstance(target, Token):
+                    return SyntaxError_(token=target.value)
+
         tokens: list[str] = []
         for unit in units:
             if isinstance(unit, Token):

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Lark-based bash-subset parser that turns a command line into a list
+# ABOUTME: of statements (token lists, subshells, syntax errors) for the shell.
+
+"""
+A small Lark grammar and evaluator that replaces the ``shlex`` based
+tokenisation and the hand-rolled command-substitution / subshell scanning in
+``honeypot.py``.
+
+The parser produces a flat list of :class:`Statement` objects. Words are fully
+evaluated (variable expansion and command substitution applied), while the
+control operators a real shell cares about — ``|`` and the redirection
+operators — are emitted as their own string tokens so the existing
+``CommandParser`` / ``runCommand`` machinery can consume the result unchanged.
+
+The grammar deliberately models only the subset of bash that Cowrie already
+emulates: lists separated by ``;`` / ``&&`` / ``||``, pipelines, simple
+redirections, single/double quoting, ``$VAR`` / ``${VAR}`` expansion, command
+substitution (``$(...)`` and backticks) and subshells (``(...)``). Constructs
+outside that subset (here-docs, arithmetic expansion, process substitution)
+are intentionally unsupported and surface as a syntax error, exactly as the
+previous implementation degraded on input it could not handle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from lark import Lark, Token, Tree
+from lark.exceptions import LarkError
+
+# Grammar for the supported bash subset. Whitespace is significant as a word
+# separator, so it is matched explicitly rather than ignored: adjacent atoms
+# with no whitespace between them form a single word ("a"$x'b' -> one word).
+_GRAMMAR = r"""
+start: _WS? (_unit (_WS? _unit)*)? _WS?
+
+_unit: SEP | PIPE | AMP | REDIR | subshell | word
+
+subshell: LPAR start RPAR
+
+word: _atom+
+_atom: sq | dq | cmdsub | backtick | dollar_brace | dollar_var | ESC | BARE_DOLLAR | LITERAL
+
+cmdsub: "$(" start ")"
+
+backtick: "`" _bq_atom* "`"
+_bq_atom: dollar_var | dollar_brace | BQ_LITERAL
+BQ_LITERAL: /[^`]+/
+
+dq: "\"" _dq_part* "\""
+_dq_part: cmdsub | backtick | dollar_brace | dollar_var | DQ_ESC | DQ_TEXT
+DQ_TEXT: /[^"$`\\]+/
+DQ_ESC: /\\[\\"$`]/ | /\\/
+
+sq: SQ
+SQ: /'[^']*'/
+
+dollar_brace: "${" BRACE_NAME "}"
+BRACE_NAME: /[_a-zA-Z0-9]+/
+
+dollar_var: DOLLAR_NAME | DOLLAR_SPECIAL
+DOLLAR_NAME: /\$[_a-zA-Z0-9]+/
+DOLLAR_SPECIAL: /\$[?@$#!*]/
+
+ESC: /\\./
+
+// Higher priority than the bare AMP so "&&" and "&>" win maximal munch.
+SEP.2: "&&" | "||" | ";"
+PIPE: "|"
+AMP: "&"
+REDIR.2: />>|>&|&>|>|</
+
+LPAR: "("
+RPAR: ")"
+
+BARE_DOLLAR: "$"
+LITERAL: /[^ \t\r\n|&;<>()$`'"\\]+/
+
+_WS: /[ \t\r\n]+/
+"""
+
+_parser = Lark(
+    _GRAMMAR,
+    start="start",
+    parser="earley",
+    lexer="dynamic",
+    propagate_positions=True,
+)
+
+# Sentinel returned by word evaluation when an unquoted bare reference to an
+# unset/empty variable should drop the whole word (like ``echo $unset`` which
+# yields no argument at all in a real shell).
+_DROP = object()
+
+
+class ShellContext(Protocol):
+    """What the evaluator needs from the live shell to evaluate words."""
+
+    def get_variable(self, name: str) -> str | None:
+        """Return the value of a shell variable, or None if unset."""
+
+    def command_substitution(self, source: str) -> str:
+        """Execute ``source`` and return its captured stdout (newlines stripped)."""
+
+
+@dataclass
+class Command:
+    """A simple command / pipeline: a flat token list with operators kept."""
+
+    tokens: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Subshell:
+    """A ``(...)`` group whose raw inner source is run as its own shell."""
+
+    source: str
+
+
+@dataclass
+class SyntaxError_:
+    """A bash-style syntax error to report verbatim."""
+
+    token: str
+
+
+Statement = Command | Subshell | SyntaxError_
+
+
+class BashParser:
+    """Parse a command line into a list of statements for the shell to run."""
+
+    def __init__(self, context: ShellContext) -> None:
+        self.context = context
+
+    # -- public API ---------------------------------------------------------
+
+    def parse(self, line: str) -> list[Statement]:
+        """
+        Parse ``line`` into ordered statements. Raises nothing for input the
+        grammar rejects: it returns a single :class:`SyntaxError_` with an
+        empty token so the caller can emit the generic message, matching the
+        previous "unexpected end of file" fallback.
+        """
+        try:
+            tree = _parser.parse(line)
+        except LarkError:
+            return [SyntaxError_(token="")]
+        return self._split_statements(line, tree)
+
+    # -- statement splitting ------------------------------------------------
+
+    def _split_statements(self, line: str, tree: Tree) -> list[Statement]:
+        statements: list[Statement] = []
+        units: list[Tree | Token] = []
+
+        def flush() -> bool:
+            """Turn the accumulated units into a statement. Return False to stop."""
+            if not units:
+                return True
+            stmt = self._build_statement(line, units)
+            units.clear()
+            if stmt is None:
+                return True
+            statements.append(stmt)
+            return not isinstance(stmt, SyntaxError_)
+
+        for child in tree.children:
+            if isinstance(child, Token) and child.type == "SEP":
+                if not units and child.value in ("&&", "||"):
+                    statements.append(SyntaxError_(token=child.value))
+                    return statements
+                if not flush():
+                    return statements
+                continue
+            units.append(child)
+        flush()
+        return statements
+
+    def _build_statement(
+        self, line: str, units: list[Tree | Token]
+    ) -> Statement | None:
+        # A subshell is valid only at the start of a statement. There it runs
+        # and writes straight to the terminal; anything piped after it is
+        # ignored, matching the shlex path. A subshell anywhere else is a
+        # syntax error reported on the "(" token, as bash does.
+        subshell_idx = next(
+            (
+                i
+                for i, u in enumerate(units)
+                if isinstance(u, Tree) and u.data == "subshell"
+            ),
+            None,
+        )
+        if subshell_idx is not None:
+            if subshell_idx == 0:
+                return Subshell(source=self._subshell_source(line, units[0]))
+            return SyntaxError_(token=self._error_token(line, units[subshell_idx]))
+
+        tokens: list[str] = []
+        for unit in units:
+            if isinstance(unit, Token):
+                # SEP never reaches here; PIPE / AMP / REDIR pass through.
+                tokens.append(unit.value)
+                continue
+            value = self._eval_word(line, unit)
+            if value is not _DROP:
+                tokens.append(value)  # type: ignore[arg-type]
+        if not tokens:
+            return None
+        return Command(tokens=tokens)
+
+    # -- word evaluation ----------------------------------------------------
+
+    def _eval_word(self, line: str, word: Tree) -> str | object:
+        atoms = word.children
+
+        # Whole-word bare reference: ``$x`` / ``${x}`` as the entire,
+        # unquoted word. An unset or empty value drops the word; ``$?`` is 0.
+        if len(atoms) == 1 and isinstance(atoms[0], Tree):
+            only = atoms[0]
+            if only.data in ("dollar_var", "dollar_brace"):
+                name, special = self._var_name(only)
+                if special == "?":
+                    return "0"
+                if special is not None:
+                    return only.children[0].value  # verbatim, e.g. $@
+                value = self.context.get_variable(name)
+                if not value:
+                    return _DROP
+                return value
+
+        parts: list[str] = []
+        for atom in atoms:
+            parts.append(self._eval_atom(line, atom))
+        return "".join(parts)
+
+    def _eval_atom(self, line: str, atom: Tree | Token) -> str:
+        if isinstance(atom, Token):
+            if atom.type == "LITERAL" or atom.type == "BARE_DOLLAR":
+                return atom.value
+            if atom.type == "ESC":
+                # Unquoted backslash escape: the backslash is removed.
+                return atom.value[1:]
+            return atom.value
+
+        if atom.data == "sq":
+            return atom.children[0].value[1:-1]  # strip surrounding quotes
+        if atom.data == "dq":
+            return self._eval_dquoted(line, atom)
+        if atom.data == "dollar_var" or atom.data == "dollar_brace":
+            return self._expand_embedded(atom)
+        if atom.data == "cmdsub":
+            return self.context.command_substitution(self._inner_source(line, atom))
+        if atom.data == "backtick":
+            return self.context.command_substitution(self._backtick_source(line, atom))
+        return ""
+
+    def _eval_dquoted(self, line: str, dq: Tree) -> str:
+        parts: list[str] = []
+        for part in dq.children:
+            if isinstance(part, Token):
+                if part.type == "DQ_TEXT":
+                    parts.append(part.value)
+                elif part.type == "DQ_ESC":
+                    parts.append(self._unescape_dq(part.value))
+                continue
+            if part.data == "dollar_var" or part.data == "dollar_brace":
+                parts.append(self._expand_embedded(part))
+            elif part.data == "cmdsub":
+                parts.append(
+                    self.context.command_substitution(self._inner_source(line, part))
+                )
+            elif part.data == "backtick":
+                parts.append(
+                    self.context.command_substitution(self._backtick_source(line, part))
+                )
+        return "".join(parts)
+
+    def _unescape_dq(self, text: str) -> str:
+        # Inside double quotes a backslash is literal unless it precedes one of
+        # \ " $ ` ; only then is it removed.
+        if len(text) == 2 and text[1] in '\\"$`':
+            return text[1]
+        return text
+
+    def _expand_embedded(self, node: Tree) -> str:
+        """Expand a ``$VAR`` reference that is embedded in a larger word.
+
+        A set variable expands to its value (empty included); an unset
+        reference is left verbatim so quoted awk/sed field references survive,
+        matching the previous implementation's deliberate compromise.
+        """
+        name, special = self._var_name(node)
+        if special == "?":
+            return "0"
+        if special is not None:
+            return node.children[0].value
+        value = self.context.get_variable(name)
+        if value is None:
+            return node.children[0].value  # verbatim, e.g. "$nope"
+        return value
+
+    def _var_name(self, node: Tree) -> tuple[str, str | None]:
+        """Return (name, special) for a dollar_var/dollar_brace node."""
+        if node.data == "dollar_brace":
+            return node.children[0].value, None
+        tok = node.children[0]
+        if tok.type == "DOLLAR_SPECIAL":
+            return tok.value, tok.value[1:]
+        return tok.value[1:], None  # DOLLAR_NAME: strip leading $
+
+    # -- source slicing for substitution / subshells ------------------------
+
+    def _inner_source(self, line: str, node: Tree) -> str:
+        """Raw source inside ``$(...)`` (the inner ``start`` tree)."""
+        for child in node.children:
+            if isinstance(child, Tree) and child.data == "start":
+                if child.meta.empty:
+                    return ""
+                return line[child.meta.start_pos : child.meta.end_pos]
+        return ""
+
+    def _backtick_source(self, line: str, node: Tree) -> str:
+        if node.meta.empty:
+            return ""
+        # Strip the surrounding backticks from the matched span.
+        raw = line[node.meta.start_pos : node.meta.end_pos]
+        return raw.strip("`")
+
+    def _subshell_source(self, line: str, node: Tree) -> str:
+        for child in node.children:
+            if isinstance(child, Tree) and child.data == "start":
+                if child.meta.empty:
+                    return ""
+                return line[child.meta.start_pos : child.meta.end_pos]
+        return ""
+
+    def _error_token(self, line: str, subshell: Tree) -> str:
+        """Reconstruct bash's reported token for a misplaced ``(``.
+
+        bash points at the ``(`` together with the run of non-space characters
+        that follow it, e.g. ``(echo`` for ``( echo middle )`` written as
+        ``(echo middle)``.
+        """
+        start = subshell.meta.start_pos
+        end = start + 1
+        while end < len(line) and not line[end].isspace() and line[end] != ")":
+            end += 1
+        return line[start:end]

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -141,13 +141,13 @@ class Command:
 
 @dataclass
 class Subshell:
-    """A ``(...)`` group; its raw inner source is parsed and run in sequence.
+    """A ``(...)`` group, holding its already-parsed inner statements.
 
     Cowrie does not emulate a subshell's isolated environment, so the caller
-    runs the inner commands in order with the surrounding line.
+    runs these statements in order with the surrounding line.
     """
 
-    source: str
+    statements: list[Statement] = field(default_factory=list)
 
 
 @dataclass
@@ -239,7 +239,7 @@ class BashParser:
             subshell = units[subshell_idx]
             assert isinstance(subshell, Tree)
             if subshell_idx == 0:
-                return Subshell(source=self._group_source(line, subshell))
+                return Subshell(statements=self._subshell_statements(line, subshell))
             return SyntaxError_(token=self._error_token(line, subshell))
 
         tokens: list[str] = []
@@ -378,6 +378,13 @@ class BashParser:
         return text[1:], None  # DOLLAR_NAME: strip leading $
 
     # -- source slicing for substitution / subshells ------------------------
+
+    def _subshell_statements(self, line: str, subshell: Tree) -> list[Statement]:
+        """Parse the inner ``start`` tree of a ``(...)`` group into statements."""
+        for child in subshell.children:
+            if isinstance(child, Tree) and child.data == "start":
+                return self._split_statements(line, child)
+        return []
 
     def _group_source(self, line: str, node: Tree) -> str:
         """Raw source of the inner ``start`` tree of a ``$(...)`` or ``(...)``."""

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 import copy
 import os
-import re
-import shlex
 from typing import Any
 
 from twisted.internet import error
@@ -18,11 +16,15 @@ from twisted.python.compat import iterbytes
 
 from cowrie.core.config import CowrieConfig
 from cowrie.shell import fs
+from cowrie.shell.bashparse import (
+    BashParser,
+    Command,
+    Statement,
+    Subshell,
+    SyntaxError_,
+)
 from cowrie.shell.parser import CommandParser
 from cowrie.shell.pipe import PipeProtocol
-
-# Matches a ${VAR} or $VAR reference anywhere inside a token
-_ENV_VAR_RE = re.compile(r"\$\{([_a-zA-Z0-9]+)\}|\$([_a-zA-Z0-9]+)")
 
 
 class HoneyPotShell:
@@ -47,18 +49,8 @@ class HoneyPotShell:
         if hasattr(protocol.user, "windowSize"):
             self.environ["COLUMNS"] = str(protocol.user.windowSize[1])
             self.environ["LINES"] = str(protocol.user.windowSize[0])
-        self.lexer: shlex.shlex | None = None
         self.parser = CommandParser()
-        # Selects the command-line parser: the default "shlex" tokeniser or the
-        # Lark grammar in bashparse. Kept configurable while the Lark path is
-        # being validated against the shlex implementation.
-        self.use_lark: bool = (
-            CowrieConfig.get("honeypot", "parser", fallback="shlex") == "lark"
-        )
-        if self.use_lark:
-            from cowrie.shell.bashparse import BashParser
-
-            self.bashparser = BashParser(self)
+        self.bashparser = BashParser(self)
 
         # this is the first prompt after starting
         self.showPrompt()
@@ -70,131 +62,54 @@ class HoneyPotShell:
         return self.environ.get(name)
 
     def command_substitution(self, source: str) -> str:
-        """Run ``source`` as a command substitution and return its stdout."""
-        # TODO: _execute_command_substitution still splits the inner source on
-        # ;/&&/|| with its own shlex lexer (see _execute_subshell_with_full_output)
-        # before re-running each command, which re-enters the Lark path. Once the
-        # Lark parser owns separators end to end, drive substitution from the
-        # parsed statements instead of re-lexing here so the inner parse is pure
-        # Lark too.
-        return self._execute_command_substitution(source)
+        """Run ``source`` as a command substitution and return its captured
+        stdout with trailing newlines stripped.
+
+        The inner source is parsed with the same Lark grammar as a top-level
+        line; each command runs in its own output-capturing subshell and a
+        nested ``(...)`` group recurses.
+        """
+        output = ""
+        for statement in self.bashparser.parse(source):
+            if isinstance(statement, Command):
+                output += self._capture_command(statement.tokens)
+            elif isinstance(statement, Subshell):
+                output += self.command_substitution(statement.source)
+        return output.rstrip("\n")
 
     def lineReceived(self, line: str) -> None:
+        """Parse a command line with the Lark grammar and run the result."""
         log.msg(eventid="cowrie.command.input", input=line, format="CMD: %(input)s")
-        if self.use_lark:
-            self.lineReceivedLark(line)
-            return
-        # posix=True makes the lexer strip quotes as it tokenizes, so by the
-        # time a token reaches variable expansion we can no longer tell whether
-        # a reference was single-quoted ('$1', literal) or double-quoted
-        # ("$1", expanded). expand_variables() works around this by only
-        # expanding variables that are set; a proper lexer/parser that preserves
-        # quoting context per token would let us expand correctly in both cases.
-        self.lexer = shlex.shlex(instream=line, punctuation_chars=True, posix=True)
-        # Add these special characters that are not in the default lexer
-        self.lexer.wordchars += "@%{}=$:+^,()`"
-
-        tokens: list[str] = []
-
-        while True:
-            try:
-                tokkie: str | None = self.lexer.get_token()
-                # log.msg("tok: %s" % (repr(tok)))
-
-                if tokkie is None:  # self.lexer.eof put None for mypy
-                    if tokens:
-                        self.cmdpending.append(tokens)
-                    break
-                else:
-                    tok: str = tokkie
-
-                # For now, treat && and || same as ;, just execute without checking return code
-                if tok == "&&" or tok == "||":
-                    if tokens:
-                        self.cmdpending.append(tokens)
-                        tokens = []
-                        continue
-                    else:
-                        self.protocol.terminal.write(
-                            f"-bash: syntax error near unexpected token `{tok}'\n".encode()
-                        )
-                        break
-                elif tok == ";":
-                    if tokens:
-                        self.cmdpending.append(tokens)
-                        tokens = []
-                    continue
-                elif tok == "$?":
-                    tok = "0"
-                elif tok == "(" or (tok.startswith("(") and not tok.startswith("$(")):
-                    # Parentheses can only appear at the start of a command, not in the middle
-                    if tokens:
-                        # Parentheses in the middle of a command line is a syntax error
-                        self.protocol.terminal.write(
-                            f"-bash: syntax error near unexpected token `{tok}'\n".encode()
-                        )
-                        break
-                    if tok == "(":
-                        self.do_subshell_execution_from_lexer()
-                    else:
-                        self.do_subshell_execution(tok)
-                    continue
-                elif "$(" in tok or "`" in tok:
-                    tok = self.do_command_substitution(tok)
-                elif "$" in tok:
-                    whole = _ENV_VAR_RE.fullmatch(tok)
-                    if whole is not None:
-                        # The token is exactly $VAR or ${VAR}. An unset or empty
-                        # variable yields no word, like an unquoted empty
-                        # expansion in a real shell.
-                        name = whole.group(1) or whole.group(2)
-                        value = self.environ.get(name)
-                        if not value:
-                            continue
-                        tok = value
-                    else:
-                        tok = self.expand_variables(tok)
-
-                tokens.append(tok)
-            except Exception as e:
-                self.protocol.terminal.write(
-                    b"-bash: syntax error: unexpected end of file\n"
-                )
-                # Could run runCommand here, but i'll just clear the list instead
-                log.msg(f"exception: {e}")
-                self.cmdpending = []
-                self.showPrompt()
-                return
+        self._queue_statements(self.bashparser.parse(line))
 
         if self.cmdpending:
-            # Coalesce fd redirection tokens so we don't treat `2` as a command
+            # Coalesce fd redirection tokens so we don't treat `2` as a command.
             self.cmdpending = [
                 self.parser.merge_redirection_tokens(tokens)
                 for tokens in self.cmdpending
             ]
-            # if we have a complete command, go and run it
             self.runCommand()
         else:
-            # if there's no command, display a prompt again
             self.showPrompt()
 
-    def lineReceivedLark(self, line: str) -> None:
-        """
-        Parse a command line with the Lark grammar (bashparse) instead of the
-        shlex lexer. Produces the same self.cmdpending token lists the shlex
-        path builds, so runCommand consumes the result unchanged.
-        """
-        from cowrie.shell.bashparse import Command, Subshell, SyntaxError_
+    def _queue_statements(self, statements: list[Statement]) -> bool:
+        """Append parsed statements to ``cmdpending`` for sequential execution.
 
-        for statement in self.bashparser.parse(line):
+        A subshell's inner statements are flattened into the queue in place so
+        they run in order with the surrounding commands. Cowrie does not
+        emulate a subshell's isolated environment (``cwd`` and friends live on
+        the protocol, not the shell), so flattening matches bash's output
+        ordering without a separate captured-output pass.
+
+        Returns False to stop queueing after a syntax error: commands already
+        queued before the error still run, as in bash.
+        """
+        for statement in statements:
             if isinstance(statement, Command):
                 self.cmdpending.append(statement.tokens)
             elif isinstance(statement, Subshell):
-                # Subshells run immediately and write straight to the terminal,
-                # mirroring the shlex path's do_subshell_execution.
-                self.protocol.terminal.write(
-                    self.run_subshell_command(f"({statement.source})").encode()
-                )
+                if not self._queue_statements(self.bashparser.parse(statement.source)):
+                    return False
             elif isinstance(statement, SyntaxError_):
                 if statement.token:
                     self.protocol.terminal.write(
@@ -204,241 +119,21 @@ class HoneyPotShell:
                     self.protocol.terminal.write(
                         b"-bash: syntax error: unexpected end of file\n"
                     )
-                # Stop after a syntax error; any commands already queued before
-                # it still run, matching the shlex path's behaviour.
-                break
+                return False
+        return True
 
-        if self.cmdpending:
-            self.cmdpending = [
-                self.parser.merge_redirection_tokens(tokens)
-                for tokens in self.cmdpending
-            ]
-            self.runCommand()
-        else:
-            self.showPrompt()
+    def _capture_command(self, tokens: list[str]) -> str:
+        """Run one parsed command in an output-capturing subshell and return
+        its stdout.
 
-    def expand_variables(self, tok: str) -> str:
+        Used for command substitution, where the output becomes a word instead
+        of reaching the terminal. The already-parsed tokens run directly, so no
+        quoting or expansion is repeated.
         """
-        Replace ${VAR} or $VAR references embedded in a token with their value.
-
-        Only variables that are currently set are expanded; an unknown
-        reference is left verbatim so that field references in quoted awk, sed
-        and perl programs (e.g. $1, $0, $NF) survive, since the lexer has
-        already discarded the single/double quoting that would tell them apart.
-
-        This is a deliberate compromise, not correct shell behaviour: a real
-        shell expands "$1" (double-quoted) but not '$1' (single-quoted). We
-        cannot honour that distinction until the lexer preserves quoting per
-        token. Once a proper lexer/parser is in place, expand every reference
-        according to its quoting and let unset variables expand to empty.
-        """
-
-        def replace(match: re.Match[str]) -> str:
-            name = match.group(1) or match.group(2)
-            if name in self.environ:
-                return self.environ[name]
-            return match.group(0)
-
-        return _ENV_VAR_RE.sub(replace, tok)
-
-    def do_subshell_execution_from_lexer(self) -> None:
-        """
-        Execute a subshell command reading tokens from the lexer until matching closing parenthesis.
-        Output goes directly to the terminal.
-        """
-        cmd_tokens = []
-        opening_count = 1
-        closing_count = 0
-
-        while opening_count > closing_count:
-            if self.lexer is None:
-                break
-            tok = self.lexer.get_token()
-            if tok is None:
-                break
-
-            if tok == ")":
-                closing_count += 1
-                if opening_count == closing_count:
-                    break
-                else:
-                    cmd_tokens.append(tok)
-            elif tok == "(":
-                opening_count += 1
-                cmd_tokens.append(tok)
-            else:
-                cmd_tokens.append(tok)
-
-        # execute the command and print to terminal
-        cmd_str = " ".join(cmd_tokens)
-        self.protocol.terminal.write(self.run_subshell_command(f"({cmd_str})").encode())
-
-    def do_subshell_execution(self, start_tok: str) -> None:
-        """
-        Execute a subshell command (command) without output substitution.
-        Output goes directly to the terminal.
-        """
-        if start_tok[0] == "(":
-            cmd_expr = start_tok
-            pos = 1
-            opening_count = 1
-            closing_count = 0
-
-            # parse the remaining tokens to find the matching closing parenthesis
-            while opening_count > closing_count:
-                if cmd_expr[pos] == ")":
-                    closing_count += 1
-                    if opening_count == closing_count:
-                        # execute the command in () and print to terminal
-                        self.protocol.terminal.write(
-                            self.run_subshell_command(cmd_expr[: pos + 1]).encode()
-                        )
-                        break
-                    else:
-                        pos += 1
-                elif cmd_expr[pos] == "(":
-                    opening_count += 1
-                    pos += 1
-                else:
-                    if opening_count > closing_count and pos == len(cmd_expr) - 1:
-                        if self.lexer:
-                            tokkie = self.lexer.get_token()
-                            if tokkie is None:  # self.lexer.eof put None for mypy
-                                break
-                            else:
-                                cmd_expr = cmd_expr + " " + tokkie
-                    pos += 1
-
-    def do_command_substitution(self, start_tok: str) -> str:
-        """
-        Perform command substitution, replacing $(cmd) or `cmd` with output.
-        """
-        result = ""
-        if start_tok[0] == "(":
-            cmd_expr = start_tok
-            pos = 1
-        elif "$(" in start_tok:
-            dollar_pos = start_tok.index("$(")
-            result = start_tok[:dollar_pos]
-            cmd_expr = start_tok[dollar_pos:]
-            pos = 2
-        elif "`" in start_tok:
-            backtick_pos = start_tok.index("`")
-            result = start_tok[:backtick_pos]
-            cmd_expr = start_tok[backtick_pos:]
-            pos = 1
-        else:
-            log.msg(f"failed command substitution: {start_tok}")
-            return start_tok
-
-        opening_count = 1
-        closing_count = 0
-
-        while opening_count > closing_count:
-            if pos >= len(cmd_expr):
-                # The current lexer token ended before the expression was
-                # closed; pull the next token and keep scanning.
-                if self.lexer:
-                    tokkie = self.lexer.get_token()
-                    if tokkie is None:
-                        break
-                    cmd_expr = cmd_expr + " " + tokkie
-                    continue
-                else:
-                    break
-            if cmd_expr[pos] in (")", "`"):
-                closing_count += 1
-                if opening_count == closing_count:
-                    if cmd_expr[0] == "(":
-                        self.protocol.terminal.write(
-                            self.run_subshell_command(cmd_expr[: pos + 1]).encode()
-                        )
-                    else:
-                        result += self.run_subshell_command(cmd_expr[: pos + 1])
-
-                    if pos < len(cmd_expr) - 1:
-                        remainder = cmd_expr[pos + 1 :]
-                        if "$(" in remainder or "`" in remainder:
-                            result = self.do_command_substitution(result + remainder)
-                        else:
-                            result += remainder
-                else:
-                    pos += 1
-            elif cmd_expr[pos : pos + 2] == "$(":
-                opening_count += 1
-                pos += 2
-            elif cmd_expr[pos] == "(":
-                # A bare ( opens a nested subshell inside $(...); count it so the
-                # first ) does not falsely close the outer $(...).
-                opening_count += 1
-                pos += 1
-            else:
-                pos += 1
-
-        return result
-
-    def run_subshell_command(self, cmd_expr: str) -> str:
-        # extract the command from $(...) or `...` or (...) expression
-        if cmd_expr.startswith("$("):
-            cmd = cmd_expr[2:-1]
-        else:
-            cmd = cmd_expr[1:-1]
-
-        # For subshells with multiple commands, we need to capture all output
-        # Create a custom output accumulator
-        if cmd_expr.startswith("("):
-            return self._execute_subshell_with_full_output(cmd)
-        else:
-            # Command substitution - use existing method
-            return self._execute_command_substitution(cmd)
-
-    def _execute_subshell_with_full_output(self, cmd: str) -> str:
-        """Execute subshell commands and capture ALL output, not just the last command."""
-        # Split commands by separators and execute each one
-        lexer = shlex.shlex(instream=cmd, punctuation_chars=True, posix=True)
-        lexer.wordchars += "@%{}=$:+^,()`"
-
-        accumulated_output = ""
-        current_cmd_tokens: list[str] = []
-
-        while True:
-            tok = lexer.get_token()
-            if tok is None:
-                # Process final command
-                if current_cmd_tokens:
-                    cmd_str = " ".join(current_cmd_tokens)
-                    output = self._execute_single_command_with_redirect(cmd_str)
-                    accumulated_output += output
-                break
-            elif tok in (";", "&&", "||"):
-                # Process current command and start new one
-                if current_cmd_tokens:
-                    cmd_str = " ".join(current_cmd_tokens)
-                    output = self._execute_single_command_with_redirect(cmd_str)
-                    accumulated_output += output
-                    current_cmd_tokens = []
-                # Note: We're ignoring && and || conditional logic for now
-            else:
-                current_cmd_tokens.append(tok)
-
-        return accumulated_output
-
-    def _execute_command_substitution(self, cmd: str) -> str:
-        """Execute command substitution - should capture all output."""
-        # Command substitution should also capture all output from multiple commands
-        output = self._execute_subshell_with_full_output(cmd)
-        # trailing newlines are stripped for command substitution
-        return output.rstrip("\n")
-
-    def _execute_single_command_with_redirect(self, cmd: str) -> str:
-        """Execute a single command and return its output."""
-        # instantiate new shell with redirect output
-        self.protocol.cmdstack.append(
-            HoneyPotShell(self.protocol, interactive=False, redirect=True)
-        )
-        # call lineReceived method that indicates that we have some commands to parse
-        self.protocol.cmdstack[-1].lineReceived(cmd)
-        # and remove the shell
+        shell = HoneyPotShell(self.protocol, interactive=False, redirect=True)
+        self.protocol.cmdstack.append(shell)
+        shell.cmdpending.append(self.parser.merge_redirection_tokens(tokens))
+        shell.runCommand()
         res = self.protocol.cmdstack.pop()
 
         try:

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -89,9 +89,7 @@ class HoneyPotShell:
                 self.parser.merge_redirection_tokens(tokens)
                 for tokens in self.cmdpending
             ]
-            self.runCommand()
-        else:
-            self.showPrompt()
+        self._advance()
 
     def _queue_statements(self, statements: list[Statement]) -> bool:
         """Append parsed statements to ``cmdpending`` for sequential execution.
@@ -144,30 +142,35 @@ class HoneyPotShell:
         else:
             return output
 
+    def _finish(self) -> None:
+        """The command queue is drained: do the shell's idle action.
+
+        An interactive shell shows the next prompt. A top-level non-interactive
+        shell (an exec session) ends the process. A nested non-interactive shell
+        (a pipe stage or a command-substitution capture) just returns so its
+        parent can carry on.
+        """
+        if self.interactive:
+            self.showPrompt()
+        elif len(self.protocol.cmdstack) == 1:
+            ret = failure.Failure(error.ProcessDone(status=""))
+            self.protocol.terminal.transport.processEnded(ret)
+
+    def _advance(self) -> None:
+        """Run the next queued command, or finish when the queue is drained."""
+        if self.cmdpending:
+            self.runCommand()
+        else:
+            self._finish()
+
     def runCommand(self):
         pp = None
 
-        def runOrPrompt() -> None:
-            if self.cmdpending:
-                self.runCommand()
-            else:
-                self.showPrompt()
-
         if not self.cmdpending:
-            if self.protocol.pp.next_command is None:  # command dont have pipe(s)
-                if self.interactive:
-                    self.showPrompt()
-                else:
-                    # when commands passed to a shell via PIPE, we spawn a HoneyPotShell in none interactive mode
-                    # if there are another shells on stack (cmdstack), let's just exit our new shell
-                    # else close connection
-                    if len(self.protocol.cmdstack) == 1:
-                        ret = failure.Failure(error.ProcessDone(status=""))
-                        self.protocol.terminal.transport.processEnded(ret)
-                    else:
-                        return
-            else:
-                pass  # command with pipes
+            # Reached after a command completed. Stay quiet mid-pipeline (the
+            # pipe machinery drives the rest); otherwise the queue is drained.
+            if self.protocol.pp.next_command is None:
+                self._finish()
             return
 
         cmdAndArgs = self.cmdpending.pop(0)
@@ -190,7 +193,7 @@ class HoneyPotShell:
             # variables for the rest of the session. They are shell variables,
             # not exported, so self.exported is left untouched.
             self.environ = environ
-            runOrPrompt()
+            self._advance()
             return
 
         pipe_indices = [i for i, x in enumerate(cmd_tokens) if x == "|"]
@@ -218,7 +221,7 @@ class HoneyPotShell:
                     first_ops,
                 )
                 # This triggers _setup_redirections which creates files
-            runOrPrompt()
+            self._advance()
             return
 
         cmd_array.append(
@@ -298,21 +301,11 @@ class HoneyPotShell:
                 else:
                     self.protocol.terminal.write(message)
 
-                # Import here to avoid circular dependency with protocol module
-                from cowrie.shell import protocol
-
-                if (
-                    isinstance(self.protocol, protocol.HoneyPotExecProtocol)
-                    and not self.cmdpending
-                ):
-                    exit_status = failure.Failure(error.ProcessDone(status=""))
-                    self.protocol.terminal.transport.processEnded(exit_status)
-
-                runOrPrompt()
+                self._advance()
                 pp = None  # Got a error. Don't run any piped commands
                 break
         if pp and getattr(pp, "has_redirection_error", False):
-            runOrPrompt()
+            self._advance()
             return
 
         if pp:

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -82,13 +82,6 @@ class HoneyPotShell:
         """Parse a command line with the Lark grammar and run the result."""
         log.msg(eventid="cowrie.command.input", input=line, format="CMD: %(input)s")
         self._queue_statements(self.bashparser.parse(line))
-
-        if self.cmdpending:
-            # Coalesce fd redirection tokens so we don't treat `2` as a command.
-            self.cmdpending = [
-                self.parser.merge_redirection_tokens(tokens)
-                for tokens in self.cmdpending
-            ]
         self._advance()
 
     def _queue_statements(self, statements: list[Statement]) -> bool:
@@ -131,7 +124,7 @@ class HoneyPotShell:
         """
         shell = HoneyPotShell(self.protocol, interactive=False, redirect=True)
         self.protocol.cmdstack.append(shell)
-        shell.cmdpending.append(self.parser.merge_redirection_tokens(tokens))
+        shell.cmdpending.append(tokens)
         shell.runCommand()
         res = self.protocol.cmdstack.pop()
 

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -49,12 +49,35 @@ class HoneyPotShell:
             self.environ["LINES"] = str(protocol.user.windowSize[0])
         self.lexer: shlex.shlex | None = None
         self.parser = CommandParser()
+        # Selects the command-line parser: the default "shlex" tokeniser or the
+        # Lark grammar in bashparse. Kept configurable while the Lark path is
+        # being validated against the shlex implementation.
+        self.use_lark: bool = (
+            CowrieConfig.get("honeypot", "parser", fallback="shlex") == "lark"
+        )
+        if self.use_lark:
+            from cowrie.shell.bashparse import BashParser
+
+            self.bashparser = BashParser(self)
 
         # this is the first prompt after starting
         self.showPrompt()
 
+    # -- bashparse.ShellContext interface -----------------------------------
+
+    def get_variable(self, name: str) -> str | None:
+        """Look up a shell variable for the Lark word evaluator."""
+        return self.environ.get(name)
+
+    def command_substitution(self, source: str) -> str:
+        """Run ``source`` as a command substitution and return its stdout."""
+        return self._execute_command_substitution(source)
+
     def lineReceived(self, line: str) -> None:
         log.msg(eventid="cowrie.command.input", input=line, format="CMD: %(input)s")
+        if self.use_lark:
+            self.lineReceivedLark(line)
+            return
         # posix=True makes the lexer strip quotes as it tokenizes, so by the
         # time a token reaches variable expansion we can no longer tell whether
         # a reference was single-quoted ('$1', literal) or double-quoted
@@ -147,6 +170,47 @@ class HoneyPotShell:
             self.runCommand()
         else:
             # if there's no command, display a prompt again
+            self.showPrompt()
+
+    def lineReceivedLark(self, line: str) -> None:
+        """
+        Parse a command line with the Lark grammar (bashparse) instead of the
+        shlex lexer. Produces the same self.cmdpending token lists the shlex
+        path builds, so runCommand consumes the result unchanged.
+        """
+        from cowrie.shell.bashparse import Command, Subshell, SyntaxError_
+
+        for statement in self.bashparser.parse(line):
+            if isinstance(statement, Command):
+                self.cmdpending.append(statement.tokens)
+            elif isinstance(statement, Subshell):
+                # Subshells run immediately and write straight to the terminal,
+                # mirroring the shlex path's do_subshell_execution.
+                self.protocol.terminal.write(
+                    self.run_subshell_command(f"({statement.source})").encode()
+                )
+            elif isinstance(statement, SyntaxError_):
+                if statement.token:
+                    # NB: the literal "\\n" (backslash-n) mirrors the existing
+                    # shlex path's byte-for-byte output for this message.
+                    self.protocol.terminal.write(
+                        f"-bash: syntax error near unexpected token `{statement.token}'\\n".encode()
+                    )
+                else:
+                    self.protocol.terminal.write(
+                        b"-bash: syntax error: unexpected end of file\n"
+                    )
+                # Stop after a syntax error; any commands already queued before
+                # it still run, matching the shlex path's behaviour.
+                break
+
+        if self.cmdpending:
+            self.cmdpending = [
+                self.parser.merge_redirection_tokens(tokens)
+                for tokens in self.cmdpending
+            ]
+            self.runCommand()
+        else:
             self.showPrompt()
 
     def expand_variables(self, tok: str) -> str:

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -52,9 +52,6 @@ class HoneyPotShell:
         self.parser = CommandParser()
         self.bashparser = BashParser(self)
 
-        # this is the first prompt after starting
-        self.showPrompt()
-
     # -- bashparse.ShellContext interface -----------------------------------
 
     def get_variable(self, name: str) -> str | None:

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -69,13 +69,17 @@ class HoneyPotShell:
         line; each command runs in its own output-capturing subshell and a
         nested ``(...)`` group recurses.
         """
+        return self._capture_statements(self.bashparser.parse(source)).rstrip("\n")
+
+    def _capture_statements(self, statements: list[Statement]) -> str:
+        """Run statements in capture mode, concatenating their stdout."""
         output = ""
-        for statement in self.bashparser.parse(source):
+        for statement in statements:
             if isinstance(statement, Command):
                 output += self._capture_command(statement.tokens)
             elif isinstance(statement, Subshell):
-                output += self.command_substitution(statement.source)
-        return output.rstrip("\n")
+                output += self._capture_statements(statement.statements)
+        return output
 
     def lineReceived(self, line: str) -> None:
         """Parse a command line with the Lark grammar and run the result."""
@@ -108,7 +112,7 @@ class HoneyPotShell:
             if isinstance(statement, Command):
                 self.cmdpending.append(statement.tokens)
             elif isinstance(statement, Subshell):
-                if not self._queue_statements(self.bashparser.parse(statement.source)):
+                if not self._queue_statements(statement.statements):
                     return False
             elif isinstance(statement, SyntaxError_):
                 if statement.token:

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -71,6 +71,12 @@ class HoneyPotShell:
 
     def command_substitution(self, source: str) -> str:
         """Run ``source`` as a command substitution and return its stdout."""
+        # TODO: _execute_command_substitution still splits the inner source on
+        # ;/&&/|| with its own shlex lexer (see _execute_subshell_with_full_output)
+        # before re-running each command, which re-enters the Lark path. Once the
+        # Lark parser owns separators end to end, drive substitution from the
+        # parsed statements instead of re-lexing here so the inner parse is pure
+        # Lark too.
         return self._execute_command_substitution(source)
 
     def lineReceived(self, line: str) -> None:

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -125,7 +125,7 @@ class HoneyPotShell:
                     if tokens:
                         # Parentheses in the middle of a command line is a syntax error
                         self.protocol.terminal.write(
-                            f"-bash: syntax error near unexpected token `{tok}'\\n".encode()
+                            f"-bash: syntax error near unexpected token `{tok}'\n".encode()
                         )
                         break
                     if tok == "(":
@@ -191,10 +191,8 @@ class HoneyPotShell:
                 )
             elif isinstance(statement, SyntaxError_):
                 if statement.token:
-                    # NB: the literal "\\n" (backslash-n) mirrors the existing
-                    # shlex path's byte-for-byte output for this message.
                     self.protocol.terminal.write(
-                        f"-bash: syntax error near unexpected token `{statement.token}'\\n".encode()
+                        f"-bash: syntax error near unexpected token `{statement.token}'\n".encode()
                     )
                 else:
                     self.protocol.terminal.write(

--- a/src/cowrie/shell/parser.py
+++ b/src/cowrie/shell/parser.py
@@ -32,14 +32,22 @@ class CommandParser:
         i = 0
         while i < len(arguments):
             tok = arguments[i]
+            next_token = arguments[i + 1] if (i + 1) < len(arguments) else None
+
+            amp = self._amp_redirect(tok)
+            if amp is not None:
+                consumed = self._apply_amp_redirection(
+                    amp, next_token, ops, cleaned, tok
+                )
+                i += consumed
+                continue
+
             op, fd, inline_target = self._extract_redir_op(tok)
-            consume = 1
 
             if not op and tok in (">", ">>", "<", ">&"):
                 op = tok
 
             if op:
-                next_token = arguments[i + 1] if (i + 1) < len(arguments) else None
                 consumed = self._apply_redirection(
                     op,
                     fd,
@@ -54,9 +62,39 @@ class CommandParser:
                     continue
 
             cleaned.append(tok)
-            i += consume
+            i += 1
 
         return cleaned, ops
+
+    def _amp_redirect(self, token: str) -> tuple[bool, str] | None:
+        """Parse a ``&>`` / ``&>>`` token into (append, inline target).
+
+        Returns None if the token is not an ``&>`` redirection. ``&>`` truncates
+        and ``&>>`` appends; both send stdout and stderr to the target.
+        """
+        if token.startswith("&>>"):
+            return True, token[3:]
+        if token.startswith("&>"):
+            return False, token[2:]
+        return None
+
+    def _apply_amp_redirection(
+        self,
+        amp: tuple[bool, str],
+        next_token: str | None,
+        ops: list[dict[str, Any]],
+        cleaned: list[str],
+        raw_token: str,
+    ) -> int:
+        """Redirect both stdout and stderr (``&>file`` == ``>file 2>&1``)."""
+        append_flag, inline_target = amp
+        target = inline_target or next_token
+        if target is None:
+            cleaned.append(raw_token)
+            return 1
+        ops.append({"type": "file", "fd": 1, "target": target, "append": append_flag})
+        ops.append({"type": "dup", "fd": 2, "target": 1})
+        return 1 if inline_target else 2
 
     def _extract_redir_op(self, token: str) -> tuple[str | None, int | None, str]:
         """Parse a combined redirection token into (op, fd, inline target)."""

--- a/src/cowrie/shell/parser.py
+++ b/src/cowrie/shell/parser.py
@@ -20,47 +20,6 @@ class CommandParser:
     and variable expansion.
     """
 
-    def merge_redirection_tokens(self, tokens: list[str]) -> list[str]:
-        """
-        Combine shlex-split redirection tokens back together.
-        Example: ['2', '>', '/dev/null'] -> ['2>', '/dev/null']
-        """
-        merged: list[str] = []
-        i = 0
-        while i < len(tokens):
-            combined, consumed = self._combine_redir_sequence(tokens, i)
-            if combined:
-                merged.append(combined)
-                i += consumed
-                continue
-            merged.append(tokens[i])
-            i += 1
-        return merged
-
-    def _combine_redir_sequence(
-        self, tokens: list[str], index: int
-    ) -> tuple[str | None, int]:
-        """Glue together fd + operator (+ optional ampersand/target) tokens."""
-        tok = tokens[index]
-        nxt = tokens[index + 1] if index + 1 < len(tokens) else None
-        nxt2 = tokens[index + 2] if index + 2 < len(tokens) else None
-        nxt3 = tokens[index + 3] if index + 3 < len(tokens) else None
-
-        if tok.isdigit() and nxt in (">", ">>", ">&"):
-            combined = f"{tok}{nxt}"
-            if nxt == ">&" and nxt2 not in (None, "|", ";", "&&", "||"):
-                return combined + str(nxt2), 3
-            if nxt in (">", ">>") and nxt2 == "&":
-                if nxt3 not in (None, "|", ";", "&&", "||"):
-                    return combined + "&" + str(nxt3), 4
-                return combined + "&", 3
-            return combined, 2
-
-        if tok in (">", ">>") and nxt == "&":
-            return f"{tok}&", 2
-
-        return None, 1
-
     def parse_redirections(
         self, arguments: list[str]
     ) -> tuple[list[str], list[dict[str, Any]]]:

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -376,6 +376,8 @@ class HoneyPotInteractiveProtocol(HoneyPotBaseProtocol, recvline.HistoricRecvLin
         recvline.HistoricRecvLine.connectionMade(self)
 
         self.cmdstack = [honeypot.HoneyPotShell(self)]
+        # Show the first prompt now that the interactive shell is on the stack.
+        self.cmdstack[0].showPrompt()
 
         self.keyHandlers.update(
             {

--- a/src/cowrie/test/test_awk.py
+++ b/src/cowrie/test/test_awk.py
@@ -35,21 +35,21 @@ class ShellEchoCommandTests(unittest.TestCase):
         self.tr.clear()
 
     def test_awk_command_001(self) -> None:
-        self.proto.lineReceived(b'echo "test test" | awk "{ print $0 }"\n')
+        self.proto.lineReceived(b"echo \"test test\" | awk '{ print $0 }'\n")
         self.assertEqual(self.tr.value(), b"test test\n" + PROMPT)
 
     def test_awk_command_002(self) -> None:
-        self.proto.lineReceived(b'echo "test" | awk "{ print $1 }"\n')
+        self.proto.lineReceived(b"echo \"test\" | awk '{ print $1 }'\n")
         self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
 
     def test_awk_command_003(self) -> None:
-        self.proto.lineReceived(b'echo "test test" | awk "{ print $1 $2 }"\n')
+        self.proto.lineReceived(b"echo \"test test\" | awk '{ print $1 $2 }'\n")
         self.assertEqual(self.tr.value(), b"test test\n" + PROMPT)
 
     def test_awk_command_004(self) -> None:
-        self.proto.lineReceived(b'echo "test test" | awk "{ print $1,$2 }"\n')
+        self.proto.lineReceived(b"echo \"test test\" | awk '{ print $1,$2 }'\n")
         self.assertEqual(self.tr.value(), b"test test\n" + PROMPT)
 
     def test_awk_command_005(self) -> None:
-        self.proto.lineReceived(b'echo "test test" | awk "{ print $1$2 }"\n')
+        self.proto.lineReceived(b"echo \"test test\" | awk '{ print $1$2 }'\n")
         self.assertEqual(self.tr.value(), b"testtest\n" + PROMPT)

--- a/src/cowrie/test/test_bashparse.py
+++ b/src/cowrie/test/test_bashparse.py
@@ -154,6 +154,18 @@ class BashParseRedirectionTests(unittest.TestCase):
     def test_append(self) -> None:
         self.assertEqual(self._tokens("cmd >> log"), ["cmd", ">>", "log"])
 
+    def test_missing_redirect_target_is_syntax_error(self) -> None:
+        # A redirect with no target is a bash syntax error (issue #2920).
+        for line in ("echo test >", "echo test 2>", "cmd >>"):
+            statement = self.parser.parse(line)[0]
+            self.assertIsInstance(statement, SyntaxError_)
+            self.assertEqual(statement.token, "newline")  # type: ignore[union-attr]
+
+    def test_redirect_before_operator_is_syntax_error(self) -> None:
+        statement = self.parser.parse("echo x > | cat")[0]
+        self.assertIsInstance(statement, SyntaxError_)
+        self.assertEqual(statement.token, "|")  # type: ignore[union-attr]
+
 
 class BashParseStatementTests(unittest.TestCase):
     """Statement splitting, substitution and subshells."""

--- a/src/cowrie/test/test_bashparse.py
+++ b/src/cowrie/test/test_bashparse.py
@@ -154,6 +154,10 @@ class BashParseRedirectionTests(unittest.TestCase):
     def test_append(self) -> None:
         self.assertEqual(self._tokens("cmd >> log"), ["cmd", ">>", "log"])
 
+    def test_redirect_both_stdout_stderr(self) -> None:
+        self.assertEqual(self._tokens("cmd &>/dev/null"), ["cmd", "&>", "/dev/null"])
+        self.assertEqual(self._tokens("cmd &>> log"), ["cmd", "&>>", "log"])
+
     def test_missing_redirect_target_is_syntax_error(self) -> None:
         # A redirect with no target is a bash syntax error (issue #2920).
         for line in ("echo test >", "echo test 2>", "cmd >>"):

--- a/src/cowrie/test/test_bashparse.py
+++ b/src/cowrie/test/test_bashparse.py
@@ -105,10 +105,13 @@ class BashParseVariableTests(unittest.TestCase):
     def test_bare_unset_variable_drops_word(self) -> None:
         self.assertEqual(self._tokens("echo $nope end"), ["echo", "end"])
 
-    def test_embedded_unset_variable_kept_verbatim(self) -> None:
-        # Deliberate compromise (see bashparse._expand_embedded): unset
-        # references embedded in a token survive so quoted field references do.
-        self.assertEqual(self._tokens('echo "X:$nope"'), ["echo", "X:$nope"])
+    def test_embedded_unset_variable_expands_empty(self) -> None:
+        # An embedded unset reference expands to empty, like bash. Single-quoted
+        # refs stay literal (handled by the grammar), so awk/sed field idioms
+        # still survive without a verbatim compromise.
+        self.assertEqual(self._tokens('echo "X:$nope"'), ["echo", "X:"])
+        self.assertEqual(self._tokens("echo a$nope"), ["echo", "a"])
+        self.assertEqual(self._tokens("echo a${nope}b"), ["echo", "ab"])
 
     def test_single_quotes_never_expand(self) -> None:
         # Correctness improvement over the shlex path, which loses quoting and

--- a/src/cowrie/test/test_bashparse.py
+++ b/src/cowrie/test/test_bashparse.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Unit tests for the Lark-based bashparse parser.
+# ABOUTME: Covers tokenisation, quoting, redirection, substitution and subshells.
+
+from __future__ import annotations
+
+import unittest
+
+from cowrie.shell.bashparse import (
+    BashParser,
+    Command,
+    Subshell,
+    SyntaxError_,
+)
+
+
+class FakeContext:
+    """Minimal ShellContext: fixed variables and a recording substitution."""
+
+    def __init__(self, env: dict[str, str] | None = None) -> None:
+        self.env = env or {}
+        self.substitutions: list[str] = []
+
+    def get_variable(self, name: str) -> str | None:
+        return self.env.get(name)
+
+    def command_substitution(self, source: str) -> str:
+        self.substitutions.append(source)
+        # Echo back a marker so tests can assert the captured source text.
+        return f"<{source.strip()}>"
+
+
+class BashParseTokenTests(unittest.TestCase):
+    """Tokenisation and quoting behaviour."""
+
+    def setUp(self) -> None:
+        self.ctx = FakeContext({"LOGNAME": "root", "x": "hi"})
+        self.parser = BashParser(self.ctx)
+
+    def _tokens(self, line: str) -> list[str]:
+        statements = self.parser.parse(line)
+        self.assertEqual(len(statements), 1)
+        self.assertIsInstance(statements[0], Command)
+        return statements[0].tokens  # type: ignore[union-attr]
+
+    def test_simple_words(self) -> None:
+        self.assertEqual(self._tokens("echo hello world"), ["echo", "hello", "world"])
+
+    def test_collapses_whitespace(self) -> None:
+        self.assertEqual(self._tokens("echo   a    b"), ["echo", "a", "b"])
+
+    def test_double_quotes_stripped(self) -> None:
+        self.assertEqual(self._tokens('echo "a b"'), ["echo", "a b"])
+
+    def test_adjacent_quotes_concatenate(self) -> None:
+        self.assertEqual(self._tokens('echo "ls""ls"'), ["echo", "lsls"])
+
+    def test_single_quote_inside_double(self) -> None:
+        self.assertEqual(self._tokens("echo \"'ls'\""), ["echo", "'ls'"])
+
+    def test_double_quote_inside_single(self) -> None:
+        self.assertEqual(self._tokens("echo '\"ls\"'"), ["echo", '"ls"'])
+
+    def test_backslash_n_in_double_quotes_kept(self) -> None:
+        # bash does not treat \n specially inside double quotes
+        self.assertEqual(self._tokens('echo "\\n"'), ["echo", "\\n"])
+
+    def test_pipe_is_its_own_token(self) -> None:
+        self.assertEqual(
+            self._tokens("echo a | grep b"), ["echo", "a", "|", "grep", "b"]
+        )
+
+
+class BashParseVariableTests(unittest.TestCase):
+    """Variable expansion, including the single-quote correctness fix."""
+
+    def setUp(self) -> None:
+        self.ctx = FakeContext({"LOGNAME": "root", "x": "hi"})
+        self.parser = BashParser(self.ctx)
+
+    def _tokens(self, line: str) -> list[str]:
+        statement = self.parser.parse(line)[0]
+        assert isinstance(statement, Command)
+        return statement.tokens
+
+    def test_bare_variable_expands(self) -> None:
+        self.assertEqual(self._tokens("echo $LOGNAME"), ["echo", "root"])
+
+    def test_braced_variable_expands(self) -> None:
+        self.assertEqual(self._tokens("echo ${LOGNAME}"), ["echo", "root"])
+
+    def test_embedded_variable_expands(self) -> None:
+        self.assertEqual(self._tokens('echo "X:$x"'), ["echo", "X:hi"])
+        self.assertEqual(self._tokens("echo a${x}b"), ["echo", "ahib"])
+
+    def test_bare_unset_variable_drops_word(self) -> None:
+        self.assertEqual(self._tokens("echo $nope end"), ["echo", "end"])
+
+    def test_embedded_unset_variable_kept_verbatim(self) -> None:
+        # Deliberate compromise (see bashparse._expand_embedded): unset
+        # references embedded in a token survive so quoted field references do.
+        self.assertEqual(self._tokens('echo "X:$nope"'), ["echo", "X:$nope"])
+
+    def test_single_quotes_never_expand(self) -> None:
+        # Correctness improvement over the shlex path, which loses quoting and
+        # would expand a set variable inside single quotes.
+        self.assertEqual(self._tokens("echo '$LOGNAME'"), ["echo", "$LOGNAME"])
+
+    def test_single_quoted_field_reference_survives(self) -> None:
+        self.assertEqual(self._tokens("awk '{print $1}'"), ["awk", "{print $1}"])
+
+    def test_question_mark_status(self) -> None:
+        self.assertEqual(self._tokens("echo $?"), ["echo", "0"])
+
+
+class BashParseRedirectionTests(unittest.TestCase):
+    """Redirection operators are emitted as discrete tokens for runCommand."""
+
+    def setUp(self) -> None:
+        self.parser = BashParser(FakeContext())
+
+    def _tokens(self, line: str) -> list[str]:
+        statement = self.parser.parse(line)[0]
+        assert isinstance(statement, Command)
+        return statement.tokens
+
+    def test_stdout_redirect(self) -> None:
+        self.assertEqual(self._tokens("echo a > f"), ["echo", "a", ">", "f"])
+
+    def test_inline_stderr_redirect(self) -> None:
+        self.assertEqual(
+            self._tokens("cmd 2>/dev/null"), ["cmd", "2", ">", "/dev/null"]
+        )
+
+    def test_fd_dup(self) -> None:
+        self.assertEqual(self._tokens("cmd 2>&1"), ["cmd", "2", ">&", "1"])
+
+    def test_append(self) -> None:
+        self.assertEqual(self._tokens("cmd >> log"), ["cmd", ">>", "log"])
+
+
+class BashParseStatementTests(unittest.TestCase):
+    """Statement splitting, substitution and subshells."""
+
+    def setUp(self) -> None:
+        self.ctx = FakeContext({"x": "hi"})
+        self.parser = BashParser(self.ctx)
+
+    def test_semicolon_splits(self) -> None:
+        statements = self.parser.parse("echo a; echo b")
+        self.assertEqual(
+            [s.tokens for s in statements],  # type: ignore[union-attr]
+            [["echo", "a"], ["echo", "b"]],
+        )
+
+    def test_and_or_split_like_semicolon(self) -> None:
+        statements = self.parser.parse("a && b || c")
+        self.assertEqual(
+            [s.tokens for s in statements],  # type: ignore[union-attr]
+            [["a"], ["b"], ["c"]],
+        )
+
+    def test_command_substitution_captures_source(self) -> None:
+        statements = self.parser.parse("echo $(echo inner)")
+        self.assertEqual(statements[0].tokens, ["echo", "<echo inner>"])  # type: ignore[union-attr]
+        self.assertEqual(self.ctx.substitutions, ["echo inner"])
+
+    def test_backtick_substitution(self) -> None:
+        statements = self.parser.parse("echo `id`")
+        self.assertEqual(statements[0].tokens, ["echo", "<id>"])  # type: ignore[union-attr]
+
+    def test_nested_substitution_source(self) -> None:
+        # The inner $(...) source is handed to the context verbatim; the nested
+        # shell parses it recursively rather than the grammar flattening it.
+        statements = self.parser.parse("echo $(echo $(echo deep))")
+        self.assertEqual(self.ctx.substitutions, ["echo $(echo deep)"])
+        self.assertEqual(statements[0].tokens, ["echo", "<echo $(echo deep)>"])  # type: ignore[union-attr]
+
+    def test_subshell_alone(self) -> None:
+        statements = self.parser.parse("(echo one; echo two)")
+        self.assertEqual(len(statements), 1)
+        self.assertIsInstance(statements[0], Subshell)
+        self.assertEqual(statements[0].source, "echo one; echo two")  # type: ignore[union-attr]
+
+    def test_subshell_after_semicolon(self) -> None:
+        statements = self.parser.parse("echo first; (echo second)")
+        self.assertIsInstance(statements[0], Command)
+        self.assertIsInstance(statements[1], Subshell)
+
+    def test_subshell_in_middle_is_syntax_error(self) -> None:
+        statements = self.parser.parse("echo before (echo middle) after")
+        self.assertIsInstance(statements[0], SyntaxError_)
+        self.assertEqual(statements[0].token, "(echo")  # type: ignore[union-attr]
+
+    def test_leading_andor_is_syntax_error(self) -> None:
+        statements = self.parser.parse("&& echo a")
+        self.assertIsInstance(statements[0], SyntaxError_)
+        self.assertEqual(statements[0].token, "&&")  # type: ignore[union-attr]
+
+    def test_commands_before_error_are_kept(self) -> None:
+        # A syntax error stops parsing but earlier statements still run.
+        statements = self.parser.parse("echo ok ; uname -a (bad) | tr a b")
+        self.assertIsInstance(statements[0], Command)
+        self.assertEqual(statements[0].tokens, ["echo", "ok"])  # type: ignore[union-attr]
+        self.assertIsInstance(statements[1], SyntaxError_)
+
+    def test_empty_line(self) -> None:
+        self.assertEqual(self.parser.parse(""), [])
+
+    def test_only_whitespace(self) -> None:
+        self.assertEqual(self.parser.parse("   \t  "), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_bashparse.py
+++ b/src/cowrie/test/test_bashparse.py
@@ -189,12 +189,23 @@ class BashParseStatementTests(unittest.TestCase):
         statements = self.parser.parse("(echo one; echo two)")
         self.assertEqual(len(statements), 1)
         self.assertIsInstance(statements[0], Subshell)
-        self.assertEqual(statements[0].source, "echo one; echo two")  # type: ignore[union-attr]
+        inner = statements[0].statements  # type: ignore[union-attr]
+        self.assertEqual(
+            [s.tokens for s in inner],  # type: ignore[union-attr]
+            [["echo", "one"], ["echo", "two"]],
+        )
 
     def test_subshell_after_semicolon(self) -> None:
         statements = self.parser.parse("echo first; (echo second)")
         self.assertIsInstance(statements[0], Command)
         self.assertIsInstance(statements[1], Subshell)
+
+    def test_subshell_inner_substitution_runs_in_source_order(self) -> None:
+        # A subshell's inner statements are parsed up front, so a command
+        # substitution inside it is evaluated in source order with the rest of
+        # the line rather than deferred.
+        self.parser.parse("(echo $(a)); echo $(b)")
+        self.assertEqual(self.ctx.substitutions, ["a", "b"])
 
     def test_subshell_in_middle_is_syntax_error(self) -> None:
         statements = self.parser.parse("echo before (echo middle) after")

--- a/src/cowrie/test/test_bashparse.py
+++ b/src/cowrie/test/test_bashparse.py
@@ -214,5 +214,29 @@ class BashParseStatementTests(unittest.TestCase):
         self.assertEqual(self.parser.parse("   \t  "), [])
 
 
+class BashParseCommentTests(unittest.TestCase):
+    """A "#" starts a comment only at a word boundary, like bash."""
+
+    def setUp(self) -> None:
+        self.parser = BashParser(FakeContext())
+
+    def _tokens(self, line: str) -> list[str]:
+        statement = self.parser.parse(line)[0]
+        assert isinstance(statement, Command)
+        return statement.tokens
+
+    def test_trailing_comment_dropped(self) -> None:
+        self.assertEqual(self._tokens("echo foo #comment"), ["echo", "foo"])
+
+    def test_hash_inside_word_kept(self) -> None:
+        self.assertEqual(self._tokens("echo a#b"), ["echo", "a#b"])
+
+    def test_whole_line_comment_yields_nothing(self) -> None:
+        self.assertEqual(self.parser.parse("# just a comment"), [])
+
+    def test_hash_in_quotes_not_a_comment(self) -> None:
+        self.assertEqual(self._tokens('echo "a # b"'), ["echo", "a # b"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/cowrie/test/test_bashparse.py
+++ b/src/cowrie/test/test_bashparse.py
@@ -96,6 +96,12 @@ class BashParseVariableTests(unittest.TestCase):
         self.assertEqual(self._tokens('echo "X:$x"'), ["echo", "X:hi"])
         self.assertEqual(self._tokens("echo a${x}b"), ["echo", "ahib"])
 
+    def test_unquoted_variable_after_literal_expands(self) -> None:
+        # A bare $VAR directly after literal text must still expand, e.g.
+        # PATH=$PATH:/x or url=$x/p.
+        self.assertEqual(self._tokens("echo got=$x"), ["echo", "got=hi"])
+        self.assertEqual(self._tokens("echo $x/p"), ["echo", "hi/p"])
+
     def test_bare_unset_variable_drops_word(self) -> None:
         self.assertEqual(self._tokens("echo $nope end"), ["echo", "end"])
 

--- a/src/cowrie/test/test_bashparse.py
+++ b/src/cowrie/test/test_bashparse.py
@@ -140,12 +140,16 @@ class BashParseRedirectionTests(unittest.TestCase):
         self.assertEqual(self._tokens("echo a > f"), ["echo", "a", ">", "f"])
 
     def test_inline_stderr_redirect(self) -> None:
-        self.assertEqual(
-            self._tokens("cmd 2>/dev/null"), ["cmd", "2", ">", "/dev/null"]
-        )
+        # A file descriptor attached to the operator is one token.
+        self.assertEqual(self._tokens("cmd 2>/dev/null"), ["cmd", "2>", "/dev/null"])
+
+    def test_spaced_fd_is_an_argument(self) -> None:
+        # Whitespace before ">" makes the digit a plain argument, not an fd
+        # (bash: "echo 2 > f" writes "2" to f via stdout). See issue #2917.
+        self.assertEqual(self._tokens("echo 2 > f"), ["echo", "2", ">", "f"])
 
     def test_fd_dup(self) -> None:
-        self.assertEqual(self._tokens("cmd 2>&1"), ["cmd", "2", ">&", "1"])
+        self.assertEqual(self._tokens("cmd 2>&1"), ["cmd", "2>&", "1"])
 
     def test_append(self) -> None:
         self.assertEqual(self._tokens("cmd >> log"), ["cmd", ">>", "log"])

--- a/src/cowrie/test/test_bashparse.py
+++ b/src/cowrie/test/test_bashparse.py
@@ -181,6 +181,17 @@ class BashParseStatementTests(unittest.TestCase):
         statements = self.parser.parse("echo `id`")
         self.assertEqual(statements[0].tokens, ["echo", "<id>"])  # type: ignore[union-attr]
 
+    def test_command_substitution_as_whole_statement(self) -> None:
+        # A command substitution that is the entire statement, or an assignment
+        # value, parses as one command word -- not a misparsed bare "$" next to
+        # a "(...)" subshell (which used to be a syntax error).
+        self.assertEqual(self.parser.parse("$(id)")[0].tokens, ["<id>"])  # type: ignore[union-attr]
+        self.assertEqual(self.parser.parse("x=$(id)")[0].tokens, ["x=<id>"])  # type: ignore[union-attr]
+        self.assertEqual(
+            self.parser.parse("var=$( (echo a; echo b) )")[0].tokens,  # type: ignore[union-attr]
+            ["var=<(echo a; echo b)>"],
+        )
+
     def test_nested_substitution_source(self) -> None:
         # The inner $(...) source is handed to the context verbatim; the nested
         # shell parses it recursively rather than the grammar flattening it.

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -169,7 +169,7 @@ class ShellEchoCommandTests(unittest.TestCase):
         self.proto.lineReceived(b"echo before (echo middle) after")
         self.assertEqual(
             self.tr.value(),
-            b"-bash: syntax error near unexpected token `(echo'\\n" + PROMPT,
+            b"-bash: syntax error near unexpected token `(echo'\n" + PROMPT,
         )
 
     def test_subshell_parentheses_005(self) -> None:

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -115,8 +115,10 @@ class ShellEchoCommandTests(unittest.TestCase):
         self.assertEqual(self.tr.value(), b"test_test_test_test_test\n" + PROMPT)
 
     def test_echo_command_022(self) -> None:
-        self.proto.lineReceived(b"echo test; (echo test)")
-        self.assertEqual(self.tr.value(), b"test\ntest\n" + PROMPT)
+        # A subshell runs in sequence with the surrounding line: the preceding
+        # command's output comes first, like bash (`echo b; (echo a)` -> b, a).
+        self.proto.lineReceived(b"echo b; (echo a)")
+        self.assertEqual(self.tr.value(), b"b\na\n" + PROMPT)
 
     def test_echo_command_023(self) -> None:
         self.proto.lineReceived(b"echo `echo test`")
@@ -186,11 +188,9 @@ class ShellEchoCommandTests(unittest.TestCase):
         self.assertIn(b"syntax error near unexpected token", output)
 
     def test_subshell_parentheses_007(self) -> None:
-        """Test valid subshell after semicolon should work"""
+        """A subshell after a semicolon runs in order, like bash."""
         self.proto.lineReceived(b"echo first; (echo second)")
-        output = self.tr.value()
-        self.assertIn(b"first", output)
-        self.assertIn(b"second", output)
+        self.assertEqual(self.tr.value(), b"first\nsecond\n" + PROMPT)
 
     def test_subshell_parentheses_008(self) -> None:
         """Test subshell with different command separators"""
@@ -213,6 +213,11 @@ class ShellEchoCommandTests(unittest.TestCase):
         self.assertIn(b"one", output)
         self.assertIn(b"two", output)
         self.assertIn(b"three", output)
+
+    def test_subshell_ordering(self) -> None:
+        """A subshell between two commands keeps bash's output order."""
+        self.proto.lineReceived(b"echo a; (echo b; echo c); echo d")
+        self.assertEqual(self.tr.value(), b"a\nb\nc\nd\n" + PROMPT)
 
     def test_command_substitution_multiple_commands(self) -> None:
         """Test command substitution with multiple commands"""

--- a/src/cowrie/test/test_fd_redirection.py
+++ b/src/cowrie/test/test_fd_redirection.py
@@ -40,6 +40,12 @@ class ShellFdRedirectionTests(unittest.TestCase):
         self.proto.lineReceived(b"cat /proc/uptime 2>/dev/null")
         self.assertEqual(self.tr.value(), PROMPT)
 
+    def test_spaced_fd_is_argument(self) -> None:
+        # A space before ">" makes the digit a plain argument, not a file
+        # descriptor: echo writes "hi 2" to the file via stdout (issue #2917).
+        self.proto.lineReceived(b"echo hi 2 > spacedfd; cat spacedfd")
+        self.assertEqual(self.tr.value(), b"hi 2\n" + PROMPT)
+
     def test_redirect_stderr_into_pipe(self) -> None:
         self.proto.lineReceived(b"cat missingfile 2>&1 | grep 'No such file'")
         self.assertEqual(

--- a/src/cowrie/test/test_fd_redirection.py
+++ b/src/cowrie/test/test_fd_redirection.py
@@ -46,6 +46,15 @@ class ShellFdRedirectionTests(unittest.TestCase):
         self.proto.lineReceived(b"echo hi 2 > spacedfd; cat spacedfd")
         self.assertEqual(self.tr.value(), b"hi 2\n" + PROMPT)
 
+    def test_missing_redirect_target_is_syntax_error(self) -> None:
+        # A trailing redirect with no target is a syntax error, not output,
+        # matching bash (issue #2920).
+        self.proto.lineReceived(b"echo test >")
+        self.assertEqual(
+            self.tr.value(),
+            b"-bash: syntax error near unexpected token `newline'\n" + PROMPT,
+        )
+
     def test_redirect_stderr_into_pipe(self) -> None:
         self.proto.lineReceived(b"cat missingfile 2>&1 | grep 'No such file'")
         self.assertEqual(

--- a/src/cowrie/test/test_fd_redirection.py
+++ b/src/cowrie/test/test_fd_redirection.py
@@ -55,6 +55,21 @@ class ShellFdRedirectionTests(unittest.TestCase):
             b"-bash: syntax error near unexpected token `newline'\n" + PROMPT,
         )
 
+    def test_redirect_both_stdout_stderr_to_file(self) -> None:
+        # &>file sends both stdout and stderr to the file (issue #2919): the
+        # error from a failed cat must land in the file, not the terminal.
+        self.proto.lineReceived(b"cat missingfile &> ampfile; cat ampfile")
+        self.assertEqual(
+            self.tr.value(),
+            b"cat: missingfile: No such file or directory\n" + PROMPT,
+        )
+
+    def test_redirect_both_append(self) -> None:
+        self.proto.lineReceived(
+            b"echo one &>> ampappend; echo two &>> ampappend; cat ampappend"
+        )
+        self.assertEqual(self.tr.value(), b"one\ntwo\n" + PROMPT)
+
     def test_redirect_stderr_into_pipe(self) -> None:
         self.proto.lineReceived(b"cat missingfile 2>&1 | grep 'No such file'")
         self.assertEqual(

--- a/src/cowrie/test/test_parser.py
+++ b/src/cowrie/test/test_parser.py
@@ -118,6 +118,29 @@ class ParseRedirectionsTests(unittest.TestCase):
         self.assertEqual(cleaned, ["cmd", ">&file"])
         self.assertEqual(ops, [])
 
+    def test_redirect_both_stdout_stderr(self) -> None:
+        # &>file sends both stdout and stderr to the file (== >file 2>&1)
+        cleaned, ops = self.parser.parse_redirections(["cmd", "&>", "file"])
+        self.assertEqual(cleaned, ["cmd"])
+        self.assertEqual(
+            ops,
+            [
+                {"type": "file", "fd": 1, "target": "file", "append": False},
+                {"type": "dup", "fd": 2, "target": 1},
+            ],
+        )
+
+    def test_redirect_both_append(self) -> None:
+        cleaned, ops = self.parser.parse_redirections(["cmd", "&>>", "file"])
+        self.assertEqual(cleaned, ["cmd"])
+        self.assertEqual(ops[0]["append"], True)
+        self.assertEqual(ops[1], {"type": "dup", "fd": 2, "target": 1})
+
+    def test_redirect_both_inline_target(self) -> None:
+        cleaned, ops = self.parser.parse_redirections(["cmd", "&>file"])
+        self.assertEqual(cleaned, ["cmd"])
+        self.assertEqual(ops[0]["target"], "file")
+
     def test_order_preserved(self) -> None:
         # Redirection order matters for FD duplication
         args = ["cmd", "2>&1", ">", "file"]

--- a/src/cowrie/test/test_parser.py
+++ b/src/cowrie/test/test_parser.py
@@ -3,85 +3,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # ABOUTME: Unit tests for the shell command parser.
-# ABOUTME: Tests token merging, redirection parsing, and edge cases.
+# ABOUTME: Tests redirection parsing of the tokens the grammar produces.
 
 from __future__ import annotations
 
 import unittest
 
 from cowrie.shell.parser import CommandParser
-
-
-class MergeRedirectionTokensTests(unittest.TestCase):
-    """Unit tests for CommandParser.merge_redirection_tokens()"""
-
-    def setUp(self) -> None:
-        self.parser = CommandParser()
-
-    def test_no_redirections(self) -> None:
-        tokens = ["echo", "hello", "world"]
-        result = self.parser.merge_redirection_tokens(tokens)
-        self.assertEqual(result, ["echo", "hello", "world"])
-
-    def test_simple_stdout_redirect(self) -> None:
-        # ['echo', 'test', '>', 'file'] stays as is (no FD prefix)
-        tokens = ["echo", "test", ">", "file"]
-        result = self.parser.merge_redirection_tokens(tokens)
-        self.assertEqual(result, ["echo", "test", ">", "file"])
-
-    def test_stderr_redirect_split(self) -> None:
-        # ['2', '>', '/dev/null'] -> ['2>', '/dev/null']
-        tokens = ["cat", "file", "2", ">", "/dev/null"]
-        result = self.parser.merge_redirection_tokens(tokens)
-        self.assertEqual(result, ["cat", "file", "2>", "/dev/null"])
-
-    def test_stderr_append_split(self) -> None:
-        # ['2', '>>', 'log'] -> ['2>>', 'log']
-        tokens = ["cmd", "2", ">>", "log"]
-        result = self.parser.merge_redirection_tokens(tokens)
-        self.assertEqual(result, ["cmd", "2>>", "log"])
-
-    def test_fd_dup_split(self) -> None:
-        # ['2', '>&', '1'] -> ['2>&1']
-        tokens = ["cmd", "2", ">&", "1"]
-        result = self.parser.merge_redirection_tokens(tokens)
-        self.assertEqual(result, ["cmd", "2>&1"])
-
-    def test_fd_dup_with_ampersand_split(self) -> None:
-        # ['1', '>', '&', '2'] -> ['1>&2']
-        tokens = ["cmd", "1", ">", "&", "2"]
-        result = self.parser.merge_redirection_tokens(tokens)
-        self.assertEqual(result, ["cmd", "1>&2"])
-
-    def test_stdout_stderr_merge(self) -> None:
-        # ['>', '&'] -> ['>&']
-        tokens = ["cmd", ">", "&", "file"]
-        result = self.parser.merge_redirection_tokens(tokens)
-        self.assertEqual(result, ["cmd", ">&", "file"])
-
-    def test_multiple_redirections(self) -> None:
-        # Multiple redirections in one command
-        tokens = ["cat", "2", ">", "/dev/null", "1", ">", "out"]
-        result = self.parser.merge_redirection_tokens(tokens)
-        self.assertEqual(result, ["cat", "2>", "/dev/null", "1>", "out"])
-
-    def test_fd_before_pipe(self) -> None:
-        # FD followed by pipe should not merge
-        tokens = ["cmd", "2", "|", "other"]
-        result = self.parser.merge_redirection_tokens(tokens)
-        self.assertEqual(result, ["cmd", "2", "|", "other"])
-
-    def test_fd_at_end(self) -> None:
-        # FD at end with no operator
-        tokens = ["cmd", "2"]
-        result = self.parser.merge_redirection_tokens(tokens)
-        self.assertEqual(result, ["cmd", "2"])
-
-    def test_complex_fd_chain(self) -> None:
-        # ['3', '>&', '1', '1', '>&', '2', '2', '>&', '3']
-        tokens = ["cmd", "3", ">&", "1", "1", ">&", "2", "2", ">&", "3"]
-        result = self.parser.merge_redirection_tokens(tokens)
-        self.assertEqual(result, ["cmd", "3>&1", "1>&2", "2>&3"])
 
 
 class ParseRedirectionsTests(unittest.TestCase):

--- a/src/cowrie/test/test_pipe_eof.py
+++ b/src/cowrie/test/test_pipe_eof.py
@@ -63,7 +63,7 @@ class PipeEofTests(unittest.TestCase):
                 )
                 self.assertEqual(
                     output,
-                    b"X:$x\n" + PROMPT,
+                    b"X:\n" + PROMPT,
                     f"unexpected output for {tail_cmd!r}: {output!r}",
                 )
 

--- a/src/cowrie/test/test_shell_variables.py
+++ b/src/cowrie/test/test_shell_variables.py
@@ -66,11 +66,12 @@ class ShellVariableTests(unittest.TestCase):
         self.proto.lineReceived(b"x=hi")
         self.assertEqual(self.run_line(b"echo $(echo $x)"), b"hi\n")
 
-    # An unknown reference embedded in a token is left verbatim, so quoted
-    # awk/sed/perl field references survive (quoting is lost by the lexer)
-    def test_unknown_embedded_left_verbatim(self) -> None:
-        self.assertEqual(self.run_line(b'echo "X:$nope"'), b"X:$nope\n")
+    # An unset reference embedded in a token expands to empty, like bash.
+    def test_unknown_embedded_expands_empty(self) -> None:
+        self.assertEqual(self.run_line(b'echo "X:$nope"'), b"X:\n")
 
+    # Single quotes keep the reference literal, so awk/sed/perl field
+    # references still survive (the grammar preserves the quoting).
     def test_awk_field_reference_survives(self) -> None:
         self.assertEqual(self.run_line(b"echo \"a b\" | awk '{print $1}'"), b"a\n")
 
@@ -109,8 +110,8 @@ class ShellVariableTests(unittest.TestCase):
         self.assertEqual(self.run_line(b"whoami"), b"root\n")
         self.assertIn(b"command not found", self.run_line(b"definitelynotacommand"))
 
-    # unset removes a variable from both scopes; once unknown its embedded
-    # reference is left verbatim, like any other unset name
+    # unset removes a variable from both scopes; afterwards a bare reference to
+    # it drops the word, like any other unset name
     def test_unset_removes_variable(self) -> None:
         self.proto.lineReceived(b"export y=bye")
         self.proto.lineReceived(b"unset y")

--- a/src/cowrie/test/test_shell_variables.py
+++ b/src/cowrie/test/test_shell_variables.py
@@ -56,6 +56,11 @@ class ShellVariableTests(unittest.TestCase):
         self.proto.lineReceived(b"x=hi")
         self.assertEqual(self.run_line(b"echo a${x}b"), b"ahib\n")
 
+    # A bare $VAR directly after literal text expands (e.g. PATH=$PATH:/x)
+    def test_expand_unquoted_after_literal(self) -> None:
+        self.proto.lineReceived(b"x=hi")
+        self.assertEqual(self.run_line(b"echo got=$x"), b"got=hi\n")
+
     # Cause 3: command substitution sees the live shell's variables
     def test_command_substitution_sees_variable(self) -> None:
         self.proto.lineReceived(b"x=hi")
@@ -67,9 +72,7 @@ class ShellVariableTests(unittest.TestCase):
         self.assertEqual(self.run_line(b'echo "X:$nope"'), b"X:$nope\n")
 
     def test_awk_field_reference_survives(self) -> None:
-        self.assertEqual(
-            self.run_line(b'echo "a b" | awk \'{print $1}\''), b"a\n"
-        )
+        self.assertEqual(self.run_line(b"echo \"a b\" | awk '{print $1}'"), b"a\n")
 
     # A bare unset reference drops the word (no spurious spaces)
     def test_unset_whole_token_dropped(self) -> None:


### PR DESCRIPTION
Replaces the shlex-based tokeniser and the hand-rolled paren/redirection
scanning in the emulated shell with a single Lark grammar in
`cowrie/shell/bashparse.py`, then uses the per-word quoting and whitespace
context the grammar preserves to fix a batch of bash-fidelity bugs.

## Parser
- Lark is now the only shell parser; the shlex path and the `[honeypot] parser`
  config flag are removed.
- Subshells are parsed once into statements (no re-parse from the executor);
  command substitution and subshell inner source are parsed with the same
  grammar.
- The shell's prompt/termination logic is unified into a single idle step, and
  the opening prompt is emitted explicitly instead of as a constructor side
  effect.

## Bash-fidelity fixes
- An embedded unset variable now expands to empty like bash; single-quoted
  references stay literal (awk/sed field idioms still survive).
- A command substitution that is a whole statement (`x=$(id)`, `$(cmd)`,
  `var=$( (...) )`) parses correctly instead of erroring (#40180).
- `2>file` vs `2 >file` are distinguished by whitespace: a file descriptor
  glued to the operator is a redirect, a digit with a space is an argument
  (#2917).
- A redirect with no target is a syntax error, matching bash (#2920).
- `&>` and `&>>` redirect both stdout and stderr to a file (#2919).
- Also resolves the shlex-era nested `$( (...) )` corruption (#40197) and the
  subshell-pipe crash (#2601).

The full test suite passes (`coverage run -m unittest discover src`); the
parser, redirection, and shell-variable behaviours have unit and integration
coverage, and the modules are clean under mypy and ruff.

Fixes #2917
Fixes #2919
Fixes #2920
Fixes #40180
Fixes #40197
Fixes #2601