### PR TITLE
ci: publish the docker image only from release tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,11 +7,11 @@ name: Docker Build and Publish
 
 on:  # yamllint disable-line rule:truthy
   push:
-    # Publish `main` as Docker `latest` image.
+    # Build and test on `main`, but only publish from release tags below.
     branches:
       - main
 
-    # Publish `v1.2.3` tags as releases.
+    # Publish `v1.2.3` tags as releases (`latest` tracks the newest tag).
     tags:
       - v*
 
@@ -84,7 +84,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        if: ${{ (github.event_name != 'pull_request') && (github.repository == 'cowrie/cowrie') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && (github.repository == 'cowrie/cowrie') }}
         uses: docker/login-action@v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -109,7 +109,7 @@ jobs:
 
       - name: Push Container Image by digest
         id: push
-        if: ${{ (github.event_name != 'pull_request') && (github.repository == 'cowrie/cowrie') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && (github.repository == 'cowrie/cowrie') }}
         uses: docker/build-push-action@v7.2.0
         with:
           file: docker/Dockerfile
@@ -124,14 +124,14 @@ jobs:
           cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
 
       - name: Export digest
-        if: ${{ (github.event_name != 'pull_request') && (github.repository == 'cowrie/cowrie') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && (github.repository == 'cowrie/cowrie') }}
         run: |
           mkdir -p ${{ runner.temp }}/digests
           digest="${{ steps.push.outputs.digest }}"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: ${{ (github.event_name != 'pull_request') && (github.repository == 'cowrie/cowrie') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && (github.repository == 'cowrie/cowrie') }}
         uses: actions/upload-artifact@v7
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
@@ -141,7 +141,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
-    if: ${{ (github.event_name != 'pull_request') && (github.repository == 'cowrie/cowrie') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && (github.repository == 'cowrie/cowrie') }}
     needs:
       - build
     permissions:
@@ -165,7 +165,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=sha,format=short
 
       - name: Login to Docker Hub


### PR DESCRIPTION
The Docker image was pushed (and tagged `latest`) on every push to `main`.
Gate all publish steps on a `v*` release tag instead, so `main` and pull
requests still build and test the image but never publish.

- Docker Hub login, push-by-digest, digest export/upload (build job) and the
  manifest merge/sign job now run only on `refs/tags/v*`.
- `latest` tracks the newest release tag rather than `main` (the merge job no
  longer runs on `main`, so a main-pinned `latest` would otherwise freeze).

PyPI (`pypi.yml`) already publishes only from `v*` tags. `test-pypi.yml` is
left unchanged — it keeps publishing to test.pypi.org from `main` as a
pre-release check of the publish pipeline.