### PR TITLE
Real command exit status: $?, && / ||, and exec exit-status

### DIFF
--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -1145,3 +1145,14 @@ commands["chgrp"] = Command_nop
 commands[":"] = Command_nop
 commands["do"] = Command_nop
 commands["done"] = Command_nop
+commands["true"] = Command_nop
+commands["/bin/true"] = Command_nop
+
+
+class Command_false(HoneyPotCommand):
+    def call(self) -> None:
+        self.exit_code = 1
+
+
+commands["false"] = Command_false
+commands["/bin/false"] = Command_false

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -15,11 +15,11 @@ import re
 import time
 from typing import TYPE_CHECKING, Any
 
-from twisted.internet import error, reactor
-from twisted.python import failure, log
+from twisted.internet import reactor
+from twisted.python import log
 
 from cowrie.core import utils
-from cowrie.shell.command import HoneyPotCommand
+from cowrie.shell.command import HoneyPotCommand, process_status
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -904,8 +904,7 @@ class Command_shutdown(HoneyPotCommand):
             self.exit()
 
     def finish(self) -> None:
-        stat = failure.Failure(error.ProcessDone(status=""))
-        self.protocol.terminal.transport.processEnded(stat)
+        self.protocol.terminal.transport.processEnded(process_status(0))
 
 
 commands["/sbin/shutdown"] = Command_shutdown
@@ -926,8 +925,7 @@ class Command_reboot(HoneyPotCommand):
         reactor.callLater(3, self.finish)
 
     def finish(self) -> None:
-        stat = failure.Failure(error.ProcessDone(status=""))
-        self.protocol.terminal.transport.processEnded(stat)
+        self.protocol.terminal.transport.processEnded(process_status(0))
 
 
 commands["/sbin/reboot"] = Command_reboot

--- a/src/cowrie/commands/bash.py
+++ b/src/cowrie/commands/bash.py
@@ -83,10 +83,14 @@ class Command_sh(HoneyPotCommand):
     def execute_commands(self, cmds: str) -> None:
         # self.input_data holds commands passed via PIPE
         # create new HoneyPotShell for our a new 'sh' shell
-        self.protocol.cmdstack.append(HoneyPotShell(self.protocol, interactive=False))
+        shell = HoneyPotShell(self.protocol, interactive=False)
+        self.protocol.cmdstack.append(shell)
 
         # call lineReceived method that indicates that we have some commands to parse
-        self.protocol.cmdstack[-1].lineReceived(cmds)
+        shell.lineReceived(cmds)
+
+        # `bash -c '...'` exits with the status of the last command it ran.
+        self.exit_code = shell.last_exit_code
 
         # remove the shell
         self.protocol.cmdstack.pop()

--- a/src/cowrie/commands/bash.py
+++ b/src/cowrie/commands/bash.py
@@ -11,10 +11,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-from twisted.internet import error
-from twisted.python import failure
-
-from cowrie.shell.command import HoneyPotCommand
+from cowrie.shell.command import HoneyPotCommand, process_status
 from cowrie.shell.fs import FileNotFound
 from cowrie.shell.honeypot import HoneyPotShell
 
@@ -70,7 +67,9 @@ class Command_sh(HoneyPotCommand):
         if lines and _SHEBANG_RE.match(lines[0]):
             lines = lines[1:]
         # Strip comment-only lines and blank lines
-        lines = [line for line in lines if line.strip() and not line.strip().startswith("#")]
+        lines = [
+            line for line in lines if line.strip() and not line.strip().startswith("#")
+        ]
 
         if not lines:
             return
@@ -120,11 +119,20 @@ commands["sh"] = Command_sh
 
 class Command_exit(HoneyPotCommand):
     def call(self) -> None:
+        # `exit [N]` exits with N, or the last command's status ($?) by default.
+        code = getattr(self.protocol.cmdstack[-2], "last_exit_code", 0)
+        if self.args:
+            try:
+                code = int(self.args[0]) & 0xFF
+            except ValueError:
+                self.errorWrite(
+                    f"-bash: exit: {self.args[0]}: numeric argument required\n"
+                )
+                code = 2
         # this removes the second last command, which is the shell
         self.protocol.cmdstack.pop(-2)
         if len(self.protocol.cmdstack) < 2:
-            stat = failure.Failure(error.ProcessDone(status=""))
-            self.protocol.terminal.transport.processEnded(stat)
+            self.protocol.terminal.transport.processEnded(process_status(code))
 
 
 commands["exit"] = Command_exit

--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -295,11 +295,10 @@ class Command_curl(HoneyPotCommand):
         if parsed.hostname:
             self.host = parsed.hostname
         else:
-            self.errorWrite(
-                f'curl: (1) Protocol "{scheme}" not supported or disabled in libcurl\n'
-            )
-            self.exit_code = 1
+            self.errorWrite("curl: (3) URL using bad/illegal format or missing URL\n")
+            self.exit_code = 3
             self.exit()
+            return
         self.port = parsed.port or (443 if scheme == "https" else 80)
 
         # Check rate limit before proceeding

--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -226,6 +226,7 @@ class Command_curl(HoneyPotCommand):
             self.errorWrite(
                 "curl: try 'curl --help' or 'curl --manual' for more information\n"
             )
+            self.exit_code = 2
             self.exit()
             return
 
@@ -246,6 +247,7 @@ class Command_curl(HoneyPotCommand):
             self.errorWrite(
                 "curl: try 'curl --help' or 'curl --manual' for more information\n"
             )
+            self.exit_code = 2
             self.exit()
             return
 
@@ -264,6 +266,7 @@ class Command_curl(HoneyPotCommand):
                     or not urldata.path.count("/")
                 ):
                     self.errorWrite("curl: Remote file name has no length!\n")
+                    self.exit_code = 23
                     self.exit()
                     return
 
@@ -274,6 +277,7 @@ class Command_curl(HoneyPotCommand):
                 self.errorWrite(
                     f"curl: {self.outfile}: Cannot open: No such file or directory\n"
                 )
+                self.exit_code = 23
                 self.exit()
                 return
 
@@ -285,6 +289,7 @@ class Command_curl(HoneyPotCommand):
             self.errorWrite(
                 f'curl: (1) Protocol "{scheme}" not supported or disabled in libcurl\n'
             )
+            self.exit_code = 1
             self.exit()
             return
         if parsed.hostname:
@@ -293,6 +298,7 @@ class Command_curl(HoneyPotCommand):
             self.errorWrite(
                 f'curl: (1) Protocol "{scheme}" not supported or disabled in libcurl\n'
             )
+            self.exit_code = 1
             self.exit()
         self.port = parsed.port or (443 if scheme == "https" else 80)
 
@@ -306,6 +312,7 @@ class Command_curl(HoneyPotCommand):
             self.errorWrite(
                 f"curl: (7) Failed to connect to {self.host} port {self.port}: Operation timed out\n"
             )
+            self.exit_code = 7
             self.exit()
             return
 
@@ -313,6 +320,7 @@ class Command_curl(HoneyPotCommand):
         if not allowed:
             log.msg("Attempt to access blocked network address")
             self.errorWrite(f"curl: (6) Could not resolve host: {self.host}\n")
+            self.exit_code = 6
             self.exit()
             return None
 
@@ -450,6 +458,7 @@ class Command_curl(HoneyPotCommand):
         """
         handle any exceptions
         """
+        self.exit_code = 1
         # Close the artifact so a failed download leaves no orphaned temp file.
         # Artifact.close() removes the empty temp file backing the download.
         if getattr(self, "artifact", None) is not None:

--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -226,8 +226,7 @@ class Command_curl(HoneyPotCommand):
             self.errorWrite(
                 "curl: try 'curl --help' or 'curl --manual' for more information\n"
             )
-            self.exit_code = 2
-            self.exit()
+            self.exit(2)
             return
 
         for opt in optlist:
@@ -247,8 +246,7 @@ class Command_curl(HoneyPotCommand):
             self.errorWrite(
                 "curl: try 'curl --help' or 'curl --manual' for more information\n"
             )
-            self.exit_code = 2
-            self.exit()
+            self.exit(2)
             return
 
         if "://" not in url:
@@ -266,8 +264,7 @@ class Command_curl(HoneyPotCommand):
                     or not urldata.path.count("/")
                 ):
                     self.errorWrite("curl: Remote file name has no length!\n")
-                    self.exit_code = 23
-                    self.exit()
+                    self.exit(23)
                     return
 
         if self.outfile:
@@ -277,8 +274,7 @@ class Command_curl(HoneyPotCommand):
                 self.errorWrite(
                     f"curl: {self.outfile}: Cannot open: No such file or directory\n"
                 )
-                self.exit_code = 23
-                self.exit()
+                self.exit(23)
                 return
 
         self.url = url.encode("ascii")
@@ -289,15 +285,13 @@ class Command_curl(HoneyPotCommand):
             self.errorWrite(
                 f'curl: (1) Protocol "{scheme}" not supported or disabled in libcurl\n'
             )
-            self.exit_code = 1
-            self.exit()
+            self.exit(1)
             return
         if parsed.hostname:
             self.host = parsed.hostname
         else:
             self.errorWrite("curl: (3) URL using bad/illegal format or missing URL\n")
-            self.exit_code = 3
-            self.exit()
+            self.exit(3)
             return
         self.port = parsed.port or (443 if scheme == "https" else 80)
 
@@ -311,16 +305,14 @@ class Command_curl(HoneyPotCommand):
             self.errorWrite(
                 f"curl: (7) Failed to connect to {self.host} port {self.port}: Operation timed out\n"
             )
-            self.exit_code = 7
-            self.exit()
+            self.exit(7)
             return
 
         allowed = yield communication_allowed(self.host)
         if not allowed:
             log.msg("Attempt to access blocked network address")
             self.errorWrite(f"curl: (6) Could not resolve host: {self.host}\n")
-            self.exit_code = 6
-            self.exit()
+            self.exit(6)
             return None
 
         self.artifact = Artifact("curl-download")

--- a/src/cowrie/commands/dd.py
+++ b/src/cowrie/commands/dd.py
@@ -88,9 +88,11 @@ class Command_dd(HoneyPotCommand):
 
     def exit(self, success: bool = True) -> None:
         if success is True:
-            self.write("0+0 records in\n")
-            self.write("0+0 records out\n")
-            self.write("0 bytes transferred in 0.695821 secs (0 bytes/sec)\n")
+            # Real dd writes its transfer statistics to stderr, not stdout, so
+            # they do not pollute a command substitution that captures stdout.
+            self.errorWrite("0+0 records in\n")
+            self.errorWrite("0+0 records out\n")
+            self.errorWrite("0 bytes transferred in 0.695821 secs (0 bytes/sec)\n")
         HoneyPotCommand.exit(self)
 
     def lineReceived(self, line: str) -> None:

--- a/src/cowrie/commands/dd.py
+++ b/src/cowrie/commands/dd.py
@@ -34,7 +34,7 @@ class Command_dd(HoneyPotCommand):
         for arg in self.args:
             if arg.find("=") == -1:
                 self.write(f"unknown operand: {arg}")
-                HoneyPotCommand.exit(self)
+                self.exit(success=False)
             operand, value = arg.split("=")
             if operand not in ("if", "bs", "of", "count"):
                 self.write(f"unknown operand: {operand}")
@@ -93,6 +93,8 @@ class Command_dd(HoneyPotCommand):
             self.errorWrite("0+0 records in\n")
             self.errorWrite("0+0 records out\n")
             self.errorWrite("0 bytes transferred in 0.695821 secs (0 bytes/sec)\n")
+        else:
+            self.exit_code = 1
         HoneyPotCommand.exit(self)
 
     def lineReceived(self, line: str) -> None:

--- a/src/cowrie/commands/dd.py
+++ b/src/cowrie/commands/dd.py
@@ -34,11 +34,11 @@ class Command_dd(HoneyPotCommand):
         for arg in self.args:
             if arg.find("=") == -1:
                 self.write(f"unknown operand: {arg}")
-                self.exit(success=False)
+                self._finish(success=False)
             operand, value = arg.split("=")
             if operand not in ("if", "bs", "of", "count"):
                 self.write(f"unknown operand: {operand}")
-                self.exit(success=False)
+                self._finish(success=False)
             self.ddargs[operand] = value
 
         if self.input_data:
@@ -84,18 +84,18 @@ class Command_dd(HoneyPotCommand):
                         self.errorWrite(f"dd: {iname}: No such file or directory\n")
                         bSuccess = False
 
-                self.exit(success=bSuccess)
+                self._finish(success=bSuccess)
 
-    def exit(self, success: bool = True) -> None:
-        if success is True:
+    def _finish(self, success: bool = True) -> None:
+        if success:
             # Real dd writes its transfer statistics to stderr, not stdout, so
             # they do not pollute a command substitution that captures stdout.
             self.errorWrite("0+0 records in\n")
             self.errorWrite("0+0 records out\n")
             self.errorWrite("0 bytes transferred in 0.695821 secs (0 bytes/sec)\n")
+            self.exit(0)
         else:
-            self.exit_code = 1
-        HoneyPotCommand.exit(self)
+            self.exit(1)
 
     def lineReceived(self, line: str) -> None:
         log.msg(
@@ -106,7 +106,7 @@ class Command_dd(HoneyPotCommand):
         )
 
     def eofReceived(self) -> None:
-        self.exit()
+        self._finish()
 
 
 def parse_size(param: str) -> int:

--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -84,11 +84,13 @@ Download a file via FTP
             optlist, args = getopt.getopt(self.args, "cvu:p:P:")
         except getopt.GetoptError:
             self.help()
+            self.exit_code = 1
             self.exit()
             return
 
         if len(args) < 2:
             self.help()
+            self.exit_code = 1
             self.exit()
             return
 
@@ -129,11 +131,13 @@ Download a file via FTP
             self.errorWrite(
                 f"ftpget: can't open '{self.local_file}': No such file or directory"
             )
+            self.exit_code = 1
             self.exit()
             return
 
         allowed = yield communication_allowed(self.host)
         if not allowed:
+            self.exit_code = 1
             self.exit()
             return
 
@@ -159,6 +163,7 @@ Download a file via FTP
             d.addErrback(self._download_error)
         else:
             self.artifactFile.close()
+            self.exit_code = 1
             self.exit()
 
     def ftp_download_async(self) -> defer.Deferred[None] | None:
@@ -282,6 +287,7 @@ Download a file via FTP
         """
         Called when download fails
         """
+        self.exit_code = 1
         self.artifactFile.close()
 
         error_msg = "Connection error"

--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -84,14 +84,12 @@ Download a file via FTP
             optlist, args = getopt.getopt(self.args, "cvu:p:P:")
         except getopt.GetoptError:
             self.help()
-            self.exit_code = 1
-            self.exit()
+            self.exit(1)
             return
 
         if len(args) < 2:
             self.help()
-            self.exit_code = 1
-            self.exit()
+            self.exit(1)
             return
 
         self.verbose = False
@@ -131,14 +129,12 @@ Download a file via FTP
             self.errorWrite(
                 f"ftpget: can't open '{self.local_file}': No such file or directory"
             )
-            self.exit_code = 1
-            self.exit()
+            self.exit(1)
             return
 
         allowed = yield communication_allowed(self.host)
         if not allowed:
-            self.exit_code = 1
-            self.exit()
+            self.exit(1)
             return
 
         self.url_log = "ftp://"
@@ -163,8 +159,7 @@ Download a file via FTP
             d.addErrback(self._download_error)
         else:
             self.artifactFile.close()
-            self.exit_code = 1
-            self.exit()
+            self.exit(1)
 
     def ftp_download_async(self) -> defer.Deferred[None] | None:
         """

--- a/src/cowrie/commands/su.py
+++ b/src/cowrie/commands/su.py
@@ -165,6 +165,8 @@ class Command_su(HoneyPotCommand):
 
         self.protocol.cmdstack.append(shell)
         shell.lineReceived(command)
+        # `su -c '...'` exits with the status of the command it ran.
+        self.exit_code = shell.last_exit_code
         self.protocol.cmdstack.pop()
         self.exit()
 

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -239,6 +239,7 @@ class Command_tftp(HoneyPotCommand):
             if len(args.c) > 1:
                 self.file_to_get = args.c[1]
                 if args.hostname is None:
+                    self.exit_code = 1
                     self.exit()
                     return
                 self.hostname = args.hostname
@@ -250,10 +251,12 @@ class Command_tftp(HoneyPotCommand):
             self.write(
                 "usage: tftp [-h] [-c C C] [-l L] [-g G] [-p P] [-r R] [hostname]\n"
             )
+            self.exit_code = 1
             self.exit()
             return
 
         if self.hostname is None:
+            self.exit_code = 1
             self.exit()
             return
 
@@ -266,6 +269,7 @@ class Command_tftp(HoneyPotCommand):
         # Check if communication is allowed
         allowed = yield communication_allowed(self.hostname)
         if not allowed:
+            self.exit_code = 1
             self.exit()
             return
 
@@ -275,6 +279,7 @@ class Command_tftp(HoneyPotCommand):
 
         if not self.fs.exists(path) or not self.fs.isdir(path):
             self.write(f"tftp: {self.file_to_get}: No such file or directory\n")
+            self.exit_code = 1
             self.exit()
             return
 
@@ -383,6 +388,7 @@ class Command_tftp(HoneyPotCommand):
             # User cancelled with CTRL-C, exit silently (^C already printed)
             return
 
+        self.exit_code = 1
         error_msg = failure.getErrorMessage()
         url = f"tftp://{self.hostname}:{self.port}/{self.file_to_get.lstrip('/')}"
 
@@ -432,6 +438,7 @@ class Command_tftp(HoneyPotCommand):
                 self.tftp_client.deferred.cancel()
 
         self.write("^C")
+        self.exit_code = 130  # 128 + SIGINT
         self.exit()
 
 

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -239,8 +239,7 @@ class Command_tftp(HoneyPotCommand):
             if len(args.c) > 1:
                 self.file_to_get = args.c[1]
                 if args.hostname is None:
-                    self.exit_code = 1
-                    self.exit()
+                    self.exit(1)
                     return
                 self.hostname = args.hostname
         elif args.r:
@@ -251,13 +250,11 @@ class Command_tftp(HoneyPotCommand):
             self.write(
                 "usage: tftp [-h] [-c C C] [-l L] [-g G] [-p P] [-r R] [hostname]\n"
             )
-            self.exit_code = 1
-            self.exit()
+            self.exit(1)
             return
 
         if self.hostname is None:
-            self.exit_code = 1
-            self.exit()
+            self.exit(1)
             return
 
         # Parse port from hostname if provided
@@ -269,8 +266,7 @@ class Command_tftp(HoneyPotCommand):
         # Check if communication is allowed
         allowed = yield communication_allowed(self.hostname)
         if not allowed:
-            self.exit_code = 1
-            self.exit()
+            self.exit(1)
             return
 
         # Resolve local file path
@@ -279,8 +275,7 @@ class Command_tftp(HoneyPotCommand):
 
         if not self.fs.exists(path) or not self.fs.isdir(path):
             self.write(f"tftp: {self.file_to_get}: No such file or directory\n")
-            self.exit_code = 1
-            self.exit()
+            self.exit(1)
             return
 
         # Initialize artifact
@@ -438,8 +433,7 @@ class Command_tftp(HoneyPotCommand):
                 self.tftp_client.deferred.cancel()
 
         self.write("^C")
-        self.exit_code = 130  # 128 + SIGINT
-        self.exit()
+        self.exit(130)  # 128 + SIGINT
 
 
 commands["/usr/bin/tftp"] = Command_tftp

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -112,6 +112,7 @@ class Command_wget(HoneyPotCommand):
 
     def print_usage_error(self, error_msg: str = "") -> None:
         """Print usage error message"""
+        self.exit_code = 1
         if error_msg:
             self.errorWrite(f"wget: {error_msg}\n")
         self.errorWrite("Usage: wget [OPTION]... [URL]...\n\n")
@@ -230,6 +231,7 @@ class Command_wget(HoneyPotCommand):
             self.errorWrite("failed: Connection timed out.\n")
             self.errorWrite("Retrying.\n\n")
 
+            self.exit_code = 1
             self.exit()
             return
 
@@ -243,6 +245,7 @@ class Command_wget(HoneyPotCommand):
                     f"Resolving {self.host} ({self.host})... failed: Temporary failure in name resolution.\n"
                 )
             self.errorWrite(f"wget: unable to resolve host address ‘{self.host}’\n")
+            self.exit_code = 1
             self.exit()
             return None
 
@@ -261,6 +264,7 @@ class Command_wget(HoneyPotCommand):
                 self.errorWrite(
                     f"wget: {self.outfile}: Cannot open: No such file or directory\n"
                 )
+                self.exit_code = 1
                 self.exit()
                 return
 
@@ -311,6 +315,7 @@ class Command_wget(HoneyPotCommand):
 
         if not remote_path or remote_path.endswith("/"):
             self.errorWrite("wget: unsupported directory target in FTP URL\n")
+            self.exit_code = 1
             self.exit()
             return None
 
@@ -319,6 +324,7 @@ class Command_wget(HoneyPotCommand):
 
         if not self.ftp_remote_file:
             self.errorWrite("wget: missing remote filename in FTP URL\n")
+            self.exit_code = 1
             self.exit()
             return None
 
@@ -436,6 +442,7 @@ class Command_wget(HoneyPotCommand):
 
     def handle_CTRL_C(self) -> None:
         self.write("^C\n")
+        self.exit_code = 130  # 128 + SIGINT
         self.exit()
 
     def success(self, response):
@@ -572,6 +579,7 @@ class Command_wget(HoneyPotCommand):
         """
         handle errors
         """
+        self.exit_code = 1
         # Close the artifact so a failed download leaves no orphaned temp file.
         # Artifact.close() removes the empty temp file backing the download.
         if getattr(self, "artifact", None) is not None:

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -231,8 +231,7 @@ class Command_wget(HoneyPotCommand):
             self.errorWrite("failed: Connection timed out.\n")
             self.errorWrite("Retrying.\n\n")
 
-            self.exit_code = 1
-            self.exit()
+            self.exit(1)
             return
 
         allowed = yield communication_allowed(self.host)
@@ -245,8 +244,7 @@ class Command_wget(HoneyPotCommand):
                     f"Resolving {self.host} ({self.host})... failed: Temporary failure in name resolution.\n"
                 )
             self.errorWrite(f"wget: unable to resolve host address ‘{self.host}’\n")
-            self.exit_code = 1
-            self.exit()
+            self.exit(1)
             return None
 
         self.url = url.encode("utf8")
@@ -264,8 +262,7 @@ class Command_wget(HoneyPotCommand):
                 self.errorWrite(
                     f"wget: {self.outfile}: Cannot open: No such file or directory\n"
                 )
-                self.exit_code = 1
-                self.exit()
+                self.exit(1)
                 return
 
         self.artifact = Artifact("wget-download")
@@ -315,8 +312,7 @@ class Command_wget(HoneyPotCommand):
 
         if not remote_path or remote_path.endswith("/"):
             self.errorWrite("wget: unsupported directory target in FTP URL\n")
-            self.exit_code = 1
-            self.exit()
+            self.exit(1)
             return None
 
         self.ftp_remote_dir = posixpath.dirname(remote_path)
@@ -324,8 +320,7 @@ class Command_wget(HoneyPotCommand):
 
         if not self.ftp_remote_file:
             self.errorWrite("wget: missing remote filename in FTP URL\n")
-            self.exit_code = 1
-            self.exit()
+            self.exit(1)
             return None
 
         self.ftp_client = None
@@ -442,8 +437,7 @@ class Command_wget(HoneyPotCommand):
 
     def handle_CTRL_C(self) -> None:
         self.write("^C\n")
-        self.exit_code = 130  # 128 + SIGINT
-        self.exit()
+        self.exit(130)  # 128 + SIGINT
 
     def success(self, response):
         """

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -10,11 +10,14 @@ A small Lark grammar and evaluator that tokenises a command line and resolves
 its quoting, redirection, command substitution and subshells for the shell in
 ``honeypot.py``.
 
-The parser produces a flat list of :class:`Statement` objects. Words are fully
-evaluated (variable expansion and command substitution applied), while the
-control operators a real shell cares about — ``|`` and the redirection
-operators — are emitted as their own string tokens so the existing
-``CommandParser`` / ``runCommand`` machinery can consume the result unchanged.
+The parser produces a flat list of :class:`Statement` objects carrying the
+joining operator (``;`` / ``&&`` / ``||``) and the still-unevaluated word trees.
+Words are expanded only when a statement is about to run (see
+:meth:`BashParser.evaluate`), so the shell can interleave parsing and execution
+like a real shell. The control operators a real shell cares about — ``|`` and
+the redirection operators — pass through as their own string tokens so the
+existing ``CommandParser`` / ``runCommand`` machinery consumes the result
+unchanged.
 
 The grammar deliberately models only the subset of bash that Cowrie already
 emulates: lists separated by ``;`` / ``&&`` / ``||``, pipelines, simple
@@ -23,8 +26,6 @@ substitution (``$(...)`` and backticks) and subshells (``(...)``).
 
 Known deviations from standard bash (none are emulated yet):
 
-* ``&&`` / ``||`` do not short-circuit -- they are split like ``;`` and every
-  command runs regardless of exit status. ``$?`` is always ``0``.
 * A trailing ``&`` is treated as a literal argument, not a background job.
 * No word expansions beyond ``$VAR`` / ``${VAR}``: tilde (``~``), brace
   (``{a,b}`` / ``{1..3}``), arithmetic (``$((...))``), the parameter
@@ -38,7 +39,7 @@ Known deviations from standard bash (none are emulated yet):
   ...) are parsed as ordinary commands, so the shell does not run loops or
   conditionals.
 * The special parameters ``$@`` / ``$#`` / ``$*`` (and friends other than
-  ``$?``, which is ``0``) are passed through literally rather than expanded.
+  ``$?``) are passed through literally rather than expanded.
 
 Input the grammar cannot parse at all (e.g. an unterminated quote) surfaces as
 a syntax error, exactly as the previous implementation degraded on input it
@@ -140,6 +141,9 @@ class ShellContext(Protocol):
 
     def get_variable(self, name: str) -> str | None:
         """Return the value of a shell variable, or None if unset."""
+
+    def get_status(self) -> str:
+        """Return ``$?`` -- the last command's exit status, as a string."""
 
     def command_substitution(self, source: str) -> str:
         """Execute ``source`` and return its captured stdout (newlines stripped)."""
@@ -326,7 +330,7 @@ class BashParser:
             if only.data in ("dollar_var", "dollar_brace"):
                 name, special = self._var_name(only)
                 if special == "?":
-                    return "0"
+                    return self.context.get_status()
                 if special is not None:
                     return self._leaf_value(only)  # verbatim, e.g. $@
                 value = self.context.get_variable(name)
@@ -397,7 +401,7 @@ class BashParser:
         """
         name, special = self._var_name(node)
         if special == "?":
-            return "0"
+            return self.context.get_status()
         if special is not None:
             return self._leaf_value(node)
         value = self.context.get_variable(name)

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -324,7 +324,8 @@ class BashParser:
         atoms = word.children
 
         # Whole-word bare reference: ``$x`` / ``${x}`` as the entire,
-        # unquoted word. An unset or empty value drops the word; ``$?`` is 0.
+        # unquoted word. An unset or empty value drops the word; a special
+        # parameter like ``$?`` expands via _special_param.
         if len(atoms) == 1 and isinstance(atoms[0], Tree):
             only = atoms[0]
             if only.data in ("dollar_var", "dollar_brace"):

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -328,12 +328,10 @@ class BashParser:
         if len(atoms) == 1 and isinstance(atoms[0], Tree):
             only = atoms[0]
             if only.data in ("dollar_var", "dollar_brace"):
-                name, special = self._var_name(only)
-                if special == "?":
-                    return self.context.get_status()
+                special = self._special_param(only)
                 if special is not None:
-                    return self._leaf_value(only)  # verbatim, e.g. $@
-                value = self.context.get_variable(name)
+                    return special
+                value = self.context.get_variable(self._var_name(only)[0])
                 if not value:
                     return None
                 return value
@@ -399,15 +397,26 @@ class BashParser:
         the grammar (it never reaches here), so quoted awk/sed field references
         still survive.
         """
-        name, special = self._var_name(node)
-        if special == "?":
-            return self.context.get_status()
+        special = self._special_param(node)
         if special is not None:
-            return self._leaf_value(node)
-        value = self.context.get_variable(name)
+            return special
+        value = self.context.get_variable(self._var_name(node)[0])
         if value is None:
             return ""
         return value
+
+    def _special_param(self, node: Tree) -> str | None:
+        """Expand a special parameter ($?, $@, $#, ...) to its string value, or
+        None for an ordinary ``$name`` reference the caller should look up.
+
+        ``$?`` is the last exit status; the other specials are kept verbatim.
+        """
+        _, special = self._var_name(node)
+        if special is None:
+            return None
+        if special == "?":
+            return self.context.get_status()
+        return self._leaf_value(node)
 
     def _leaf_value(self, node: Tree) -> str:
         """Return the string value of a node's single leaf token."""

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -147,20 +147,33 @@ class ShellContext(Protocol):
 
 @dataclass
 class Command:
-    """A simple command / pipeline: a flat token list with operators kept."""
+    """A simple command / pipeline, structure only.
 
-    tokens: list[str] = field(default_factory=list)
+    ``items`` keeps the ordered word trees (still unevaluated) interleaved with
+    the control operator strings (``|``, ``>``, ``2>`` ...). Words are expanded
+    against the live shell by :meth:`BashParser.evaluate` only when the command
+    is about to run, so a same-line ``x=hi; echo $x`` sees the assignment.
+    ``op`` is the operator that joins this statement to the previous one
+    (``None`` / ``;`` / ``&&`` / ``||``); ``line`` is the source the word trees
+    point into.
+    """
+
+    items: list[str | Tree] = field(default_factory=list)
+    line: str = ""
+    op: str | None = None
 
 
 @dataclass
 class Subshell:
-    """A ``(...)`` group, holding its already-parsed inner statements.
+    """A ``(...)`` group, holding its parsed (still unevaluated) inner statements.
 
     Cowrie does not emulate a subshell's isolated environment, so the caller
-    runs these statements in order with the surrounding line.
+    runs these statements in order with the surrounding line. ``op`` joins this
+    group to the previous statement.
     """
 
     statements: list[Statement] = field(default_factory=list)
+    op: str | None = None
 
 
 @dataclass
@@ -204,15 +217,16 @@ class BashParser:
     def _split_statements(self, line: str, tree: Tree) -> list[Statement]:
         statements: list[Statement] = []
         units: list[Tree | Token] = []
+        # The operator joining the statement currently being accumulated to the
+        # previous one: None for the first, then ; / && / || as seen.
+        current_op: str | None = None
 
         def flush() -> bool:
             """Turn the accumulated units into a statement. Return False to stop."""
             if not units:
                 return True
-            stmt = self._build_statement(line, units)
+            stmt = self._build_statement(line, units, current_op)
             units.clear()
-            if stmt is None:
-                return True
             statements.append(stmt)
             return not isinstance(stmt, SyntaxError_)
 
@@ -223,14 +237,15 @@ class BashParser:
                     return statements
                 if not flush():
                     return statements
+                current_op = child.value
                 continue
             units.append(child)
         flush()
         return statements
 
     def _build_statement(
-        self, line: str, units: list[Tree | Token]
-    ) -> Statement | None:
+        self, line: str, units: list[Tree | Token], op: str | None
+    ) -> Statement:
         # A subshell is valid only at the start of a statement. There it runs
         # in sequence with the surrounding line; anything piped after it is
         # ignored. A subshell anywhere else is a syntax error reported on the
@@ -252,7 +267,9 @@ class BashParser:
             subshell = units[subshell_idx]
             assert isinstance(subshell, Tree)
             if subshell_idx == 0:
-                return Subshell(statements=self._subshell_statements(line, subshell))
+                return Subshell(
+                    statements=self._subshell_statements(line, subshell), op=op
+                )
             return SyntaxError_(token=self._error_token(line, subshell))
 
         # A redirection operator must be followed by a target word. A redirect at
@@ -266,20 +283,32 @@ class BashParser:
                 if isinstance(target, Token):
                     return SyntaxError_(token=target.value)
 
-        tokens: list[str] = []
-        for unit in units:
-            if isinstance(unit, Token):
-                # SEP never reaches here; PIPE / AMP / REDIR pass through.
-                tokens.append(unit.value)
-                continue
-            value = self._eval_word(line, unit)
-            if value is not None:
-                tokens.append(value)
-        if not tokens:
-            return None
-        return Command(tokens=tokens)
+        # Keep the structure; words are evaluated later by evaluate(). An
+        # operator token (PIPE / AMP / REDIR / IO_REDIR) is a fixed string;
+        # SEP never reaches here.
+        items: list[str | Tree] = [
+            unit.value if isinstance(unit, Token) else unit for unit in units
+        ]
+        return Command(items=items, line=line, op=op)
 
     # -- word evaluation ----------------------------------------------------
+
+    def evaluate(self, command: Command) -> list[str]:
+        """Expand a command's words against the live context, now.
+
+        Operator strings pass through; each word tree is evaluated against the
+        current shell (variables, command substitution), and a word that
+        resolves to nothing (an unquoted unset reference) is dropped.
+        """
+        tokens: list[str] = []
+        for item in command.items:
+            if isinstance(item, str):
+                tokens.append(item)
+                continue
+            value = self._eval_word(command.line, item)
+            if value is not None:
+                tokens.append(value)
+        return tokens
 
     def _eval_word(self, line: str, word: Tree) -> str | None:
         """Evaluate a word to its final string, or None if it should be dropped.

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -120,10 +120,16 @@ class HoneyPotCommand:
     def call(self) -> None:
         self.write(f"Hello World! [{self.args!r}]\n")
 
-    def exit(self) -> None:
+    def exit(self, code: int | None = None) -> None:
         """
         Sometimes client is disconnected and command exits after. So cmdstack is gone
+
+        ``code`` sets this command's exit status (``$?`` for the shell that ran
+        it). When omitted, the existing ``exit_code`` is kept, so a command that
+        set it earlier (e.g. in an error callback) can just call ``exit()``.
         """
+        if code is not None:
+            self.exit_code = code
         if (
             self.protocol
             and self.protocol.terminal
@@ -152,8 +158,7 @@ class HoneyPotCommand:
     def handle_CTRL_C(self) -> None:
         log.msg("Received CTRL-C, exiting..")
         self.write("^C\n")
-        self.exit_code = 130  # 128 + SIGINT, like a real shell
-        self.exit()
+        self.exit(130)  # 128 + SIGINT, like a real shell
 
     def lineReceived(self, line: str) -> None:
         log.msg(f"QUEUED INPUT: {line}")

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -19,6 +19,17 @@ from twisted.internet import error
 from twisted.python import failure, log
 
 
+def process_status(code: int) -> failure.Failure:
+    """A process-end reason carrying an exit status.
+
+    ``ProcessDone`` for 0 (a clean exit) and ``ProcessTerminated`` otherwise, so
+    the SSH session relays the right ``exit-status`` to the client.
+    """
+    if code == 0:
+        return failure.Failure(error.ProcessDone(status=""))
+    return failure.Failure(error.ProcessTerminated(exitCode=code))
+
+
 class HoneyPotCommand:
     """
     This is the super class for all commands in cowrie/commands
@@ -131,7 +142,7 @@ class HoneyPotCommand:
                 self.protocol.cmdstack[-1].last_exit_code = self.exit_code
                 self.protocol.cmdstack[-1].resume()
         else:
-            ret = failure.Failure(error.ProcessDone(status=""))
+            ret = process_status(self.exit_code)
             # The session could be disconnected already, when his happens .transport is gone
             try:
                 self.protocol.terminal.transport.processEnded(ret)

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -47,6 +47,9 @@ class HoneyPotCommand:
     def __init__(self, protocol, *args):
         self.protocol = protocol
         self.args = list(args)
+        # Exit status, propagated to the owning shell on exit() for $? and
+        # && / || . Commands set this (default 0 = success).
+        self.exit_code: int = 0
         self.environ = self.protocol.cmdstack[-1].environ
         self.exported = self.protocol.cmdstack[-1].exported
         self.fs = self.protocol.fs
@@ -123,6 +126,9 @@ class HoneyPotCommand:
             self.protocol.cmdstack.remove(self)
 
             if len(self.protocol.cmdstack):
+                # Hand the exit status to the shell that ran us, for $? and the
+                # && / || logic in runCommand.
+                self.protocol.cmdstack[-1].last_exit_code = self.exit_code
                 self.protocol.cmdstack[-1].resume()
         else:
             ret = failure.Failure(error.ProcessDone(status=""))
@@ -135,6 +141,7 @@ class HoneyPotCommand:
     def handle_CTRL_C(self) -> None:
         log.msg("Received CTRL-C, exiting..")
         self.write("^C\n")
+        self.exit_code = 130  # 128 + SIGINT, like a real shell
         self.exit()
 
     def lineReceived(self, line: str) -> None:

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -39,7 +39,9 @@ class HoneyPotShell:
         self.interactive: bool = interactive
         self.redirect: bool = redirect  # to support output redirection
         self.effective_user = effective_user  # For su: {uid, gid, username, home}
-        self.cmdpending: list[list[str]] = []
+        # Parsed-but-not-yet-evaluated statements; each is expanded against the
+        # live environment only when it is about to run (see runCommand).
+        self.cmdpending: list[Command] = []
         # A nested shell (e.g. a command substitution) inherits the live
         # environment of whichever shell is currently running; the very first
         # shell of a session falls back to the login environment, all of which
@@ -78,7 +80,7 @@ class HoneyPotShell:
         output = ""
         for statement in statements:
             if isinstance(statement, Command):
-                output += self._capture_command(statement.tokens)
+                output += self._capture_command(statement)
             elif isinstance(statement, Subshell):
                 output += self._capture_statements(statement.statements)
         return output
@@ -103,9 +105,14 @@ class HoneyPotShell:
         """
         for statement in statements:
             if isinstance(statement, Command):
-                self.cmdpending.append(statement.tokens)
+                self.cmdpending.append(statement)
             elif isinstance(statement, Subshell):
-                if not self._queue_statements(statement.statements):
+                # The group's join operator (e.g. the || in `x || (a; b)`) gates
+                # the whole group, so it applies to the first inner statement.
+                inner = statement.statements
+                if inner and isinstance(inner[0], (Command, Subshell)):
+                    inner[0].op = statement.op
+                if not self._queue_statements(inner):
                     return False
             elif isinstance(statement, SyntaxError_):
                 if statement.token:
@@ -119,17 +126,17 @@ class HoneyPotShell:
                 return False
         return True
 
-    def _capture_command(self, tokens: list[str]) -> str:
+    def _capture_command(self, command: Command) -> str:
         """Run one parsed command in an output-capturing subshell and return
         its stdout.
 
         Used for command substitution, where the output becomes a word instead
-        of reaching the terminal. The already-parsed tokens run directly, so no
-        quoting or expansion is repeated.
+        of reaching the terminal. The command's words are expanded in the
+        capture shell, so it sees the inherited environment.
         """
         shell = HoneyPotShell(self.protocol, interactive=False, redirect=True)
         self.protocol.cmdstack.append(shell)
-        shell.cmdpending.append(tokens)
+        shell.cmdpending.append(command)
         shell.runCommand()
         res = self.protocol.cmdstack.pop()
 
@@ -171,7 +178,9 @@ class HoneyPotShell:
                 self._finish()
             return
 
-        cmdAndArgs = self.cmdpending.pop(0)
+        # Expand the next statement's words against the *current* environment,
+        # just before it runs, so a same-line `x=hi; echo $x` sees the value.
+        cmdAndArgs = self.bashparser.evaluate(self.cmdpending.pop(0))
 
         # Probably no reason to be this comprehensive for just PATH...
         environ = copy.copy(self.environ)

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -10,8 +10,7 @@ import copy
 import os
 from typing import Any
 
-from twisted.internet import error
-from twisted.python import failure, log
+from twisted.python import log
 from twisted.python.compat import iterbytes
 
 from cowrie.core.config import CowrieConfig
@@ -450,8 +449,7 @@ class HoneyPotShell:
         EOF with the shell as the active reader (no command running) logs out.
         """
         log.msg("received eof, logging out")
-        status = failure.Failure(error.ProcessDone(status=""))
-        self.protocol.terminal.transport.processEnded(status)
+        self.protocol.terminal.transport.processEnded(process_status(0))
 
     def handle_CTRL_C(self) -> None:
         self.protocol.lineBuffer = []

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -179,11 +179,16 @@ class HoneyPotShell:
     def runCommand(self):
         pp = None
 
+        # Mid-pipeline: an earlier stage just finished but a downstream command
+        # has not run yet. Let the pipe machinery drive the rest before touching
+        # the next statement -- otherwise `a | b; c` would run c before b and
+        # drop b's output.
+        if self.protocol.pp is not None and self.protocol.pp.next_command is not None:
+            return
+
         if not self.cmdpending:
-            # Reached after a command completed. Stay quiet mid-pipeline (the
-            # pipe machinery drives the rest); otherwise the queue is drained.
-            if self.protocol.pp.next_command is None:
-                self._finish()
+            # The queue is drained.
+            self._finish()
             return
 
         command = self.cmdpending.pop(0)

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -58,12 +58,19 @@ class HoneyPotShell:
             self.environ["LINES"] = str(protocol.user.windowSize[0])
         self.parser = CommandParser()
         self.bashparser = BashParser(self)
+        # Exit status of the most recent command in this shell, for $? and the
+        # && / || short-circuit logic.
+        self.last_exit_code: int = 0
 
     # -- bashparse.ShellContext interface -----------------------------------
 
     def get_variable(self, name: str) -> str | None:
         """Look up a shell variable for the Lark word evaluator."""
         return self.environ.get(name)
+
+    def get_status(self) -> str:
+        """Return $? -- the last command's exit status as a string."""
+        return str(self.last_exit_code)
 
     def command_substitution(self, source: str) -> str:
         """Run ``source`` as a command substitution and return its captured
@@ -123,6 +130,7 @@ class HoneyPotShell:
                     self.protocol.terminal.write(
                         b"-bash: syntax error: unexpected end of file\n"
                     )
+                self.last_exit_code = 2  # bash uses 2 for a syntax error
                 return False
         return True
 
@@ -178,9 +186,19 @@ class HoneyPotShell:
                 self._finish()
             return
 
-        # Expand the next statement's words against the *current* environment,
-        # just before it runs, so a same-line `x=hi; echo $x` sees the value.
-        cmdAndArgs = self.bashparser.evaluate(self.cmdpending.pop(0))
+        command = self.cmdpending.pop(0)
+
+        # && / || short-circuit: skip this statement based on the previous
+        # command's exit status, leaving $? unchanged.
+        if (command.op == "&&" and self.last_exit_code != 0) or (
+            command.op == "||" and self.last_exit_code == 0
+        ):
+            self._advance()
+            return
+
+        # Expand the statement's words against the *current* environment, just
+        # before it runs, so a same-line `x=hi; echo $x` sees the value.
+        cmdAndArgs = self.bashparser.evaluate(command)
 
         # Probably no reason to be this comprehensive for just PATH...
         environ = copy.copy(self.environ)
@@ -198,8 +216,10 @@ class HoneyPotShell:
         if not cmd_tokens:
             # A statement of only assignments (no command) persists those
             # variables for the rest of the session. They are shell variables,
-            # not exported, so self.exported is left untouched.
+            # not exported, so self.exported is left untouched. A bare
+            # assignment succeeds, so $? is 0.
             self.environ = environ
+            self.last_exit_code = 0
             self._advance()
             return
 
@@ -308,6 +328,7 @@ class HoneyPotShell:
                 else:
                     self.protocol.terminal.write(message)
 
+                self.last_exit_code = 127  # command not found
                 self._advance()
                 pp = None  # Got a error. Don't run any piped commands
                 break

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -79,20 +79,35 @@ class HoneyPotShell:
         """Run ``source`` as a command substitution and return its captured
         stdout with trailing newlines stripped.
 
-        The inner source is parsed with the same Lark grammar as a top-level
-        line; each command runs in its own output-capturing subshell and a
-        nested ``(...)`` group recurses.
+        The inner source runs in a single capture subshell with the same
+        sequencing as a top-level line: a same-line assignment is visible to
+        later statements, ``$?`` carries across them, and ``&&`` / ``||``
+        short-circuit. A nested ``(...)`` group recurses. Output is captured
+        instead of reaching the terminal.
         """
-        return self._capture_statements(self.bashparser.parse(source)).rstrip("\n")
+        shell = HoneyPotShell(self.protocol, interactive=False, redirect=True)
+        self.protocol.cmdstack.append(shell)
+        try:
+            return shell._capture_statements(
+                self.bashparser.parse(source)
+            ).rstrip("\n")
+        finally:
+            self.protocol.cmdstack.pop()
 
     def _capture_statements(self, statements: list[Statement]) -> str:
-        """Run statements in capture mode, concatenating their stdout."""
+        """Run statements in this capture shell, concatenating their stdout and
+        honoring &&/|| short-circuit between them (a subshell's gate covers the
+        whole group)."""
         output = ""
         for statement in statements:
-            if isinstance(statement, Command):
-                output += self._capture_command(statement)
-            elif isinstance(statement, Subshell):
+            if not isinstance(statement, (Command, Subshell)):
+                continue  # ignore a syntax error inside a substitution
+            if self._short_circuit(statement.op):
+                continue
+            if isinstance(statement, Subshell):
                 output += self._capture_statements(statement.statements)
+            else:
+                output += self._capture_command(statement)
         return output
 
     def lineReceived(self, line: str) -> None:
@@ -151,25 +166,19 @@ class HoneyPotShell:
         self.last_exit_code = 2  # bash uses 2 for a syntax error
 
     def _capture_command(self, command: Command) -> str:
-        """Run one parsed command in an output-capturing subshell and return
-        its stdout.
+        """Run one command in this capture shell and return its captured stdout.
 
-        Used for command substitution, where the output becomes a word instead
-        of reaching the terminal. The command's words are expanded in the
-        capture shell, so it sees the inherited environment.
+        The command's words are expanded against the capture shell's live
+        environment, so it sees inherited and same-substitution variables.
+        ``protocol.pp`` is cleared first so a statement that builds no pipe
+        (a bare assignment, or a command-not-found) reads as empty output
+        rather than re-reading the previous statement's capture.
         """
-        shell = HoneyPotShell(self.protocol, interactive=False, redirect=True)
-        self.protocol.cmdstack.append(shell)
-        shell.cmdpending.append(command)
-        shell.runCommand()
-        res = self.protocol.cmdstack.pop()
-
-        try:
-            output: str = res.protocol.pp.redirected_data.decode()
-        except AttributeError:
-            return ""
-        else:
-            return output
+        self.protocol.pp = None
+        self.cmdpending.append(command)
+        self.runCommand()
+        pp = self.protocol.pp
+        return pp.redirected_data.decode() if pp is not None else ""
 
     def _finish(self) -> None:
         """The command queue is drained: do the shell's idle action.
@@ -188,6 +197,14 @@ class HoneyPotShell:
             self.protocol.terminal.transport.processEnded(
                 process_status(self.last_exit_code)
             )
+
+    def _short_circuit(self, op: str | None) -> bool:
+        """Whether a statement joined by ``op`` should be skipped given the last
+        command's exit status: ``&&`` after a failure, ``||`` after a success.
+        """
+        return (op == "&&" and self.last_exit_code != 0) or (
+            op == "||" and self.last_exit_code == 0
+        )
 
     def _advance(self) -> None:
         """Run the next queued command, or finish when the queue is drained."""
@@ -215,9 +232,7 @@ class HoneyPotShell:
 
         # && / || short-circuit: skip this statement (or whole group) based on
         # the previous command's exit status, leaving $? unchanged.
-        if (command.op == "&&" and self.last_exit_code != 0) or (
-            command.op == "||" and self.last_exit_code == 0
-        ):
+        if self._short_circuit(command.op):
             self._advance()
             return
 

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -23,6 +23,7 @@ from cowrie.shell.bashparse import (
     Subshell,
     SyntaxError_,
 )
+from cowrie.shell.command import process_status
 from cowrie.shell.parser import CommandParser
 from cowrie.shell.pipe import PipeProtocol
 
@@ -166,8 +167,12 @@ class HoneyPotShell:
         if self.interactive:
             self.showPrompt()
         elif len(self.protocol.cmdstack) == 1:
-            ret = failure.Failure(error.ProcessDone(status=""))
-            self.protocol.terminal.transport.processEnded(ret)
+            # Top-level non-interactive shell (an exec session): end the process
+            # with the last command's status so the SSH channel reports a real
+            # exit-status to the client.
+            self.protocol.terminal.transport.processEnded(
+                process_status(self.last_exit_code)
+            )
 
     def _advance(self) -> None:
         """Run the next queued command, or finish when the queue is drained."""

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -41,8 +41,10 @@ class HoneyPotShell:
         self.redirect: bool = redirect  # to support output redirection
         self.effective_user = effective_user  # For su: {uid, gid, username, home}
         # Parsed-but-not-yet-evaluated statements; each is expanded against the
-        # live environment only when it is about to run (see runCommand).
-        self.cmdpending: list[Command] = []
+        # live environment only when it is about to run (see runCommand). A
+        # subshell stays a single unit here so its &&/|| gate covers the whole
+        # group; runCommand splices its statements in only when it runs.
+        self.cmdpending: list[Command | Subshell] = []
         # A nested shell (e.g. a command substitution) inherits the live
         # environment of whichever shell is currently running; the very first
         # shell of a session falls back to the login environment, all of which
@@ -102,38 +104,51 @@ class HoneyPotShell:
     def _queue_statements(self, statements: list[Statement]) -> bool:
         """Append parsed statements to ``cmdpending`` for sequential execution.
 
-        A subshell's inner statements are flattened into the queue in place so
-        they run in order with the surrounding commands. Cowrie does not
+        A subshell is queued as one unit so its join operator (e.g. the || in
+        `x || (a; b)`) gates the whole group; runCommand splices the inner
+        statements in only when the group actually runs. Cowrie does not
         emulate a subshell's isolated environment (``cwd`` and friends live on
-        the protocol, not the shell), so flattening matches bash's output
-        ordering without a separate captured-output pass.
+        the protocol, not the shell), so the inner statements then run in the
+        parent shell.
 
         Returns False to stop queueing after a syntax error: commands already
         queued before the error still run, as in bash.
         """
         for statement in statements:
-            if isinstance(statement, Command):
-                self.cmdpending.append(statement)
-            elif isinstance(statement, Subshell):
-                # The group's join operator (e.g. the || in `x || (a; b)`) gates
-                # the whole group, so it applies to the first inner statement.
-                inner = statement.statements
-                if inner and isinstance(inner[0], (Command, Subshell)):
-                    inner[0].op = statement.op
-                if not self._queue_statements(inner):
-                    return False
-            elif isinstance(statement, SyntaxError_):
-                if statement.token:
-                    self.protocol.terminal.write(
-                        f"-bash: syntax error near unexpected token `{statement.token}'\n".encode()
-                    )
-                else:
-                    self.protocol.terminal.write(
-                        b"-bash: syntax error: unexpected end of file\n"
-                    )
-                self.last_exit_code = 2  # bash uses 2 for a syntax error
+            if isinstance(statement, SyntaxError_):
+                self._report_syntax_error(statement)
+                return False
+            if isinstance(statement, Subshell) and not self._reject_inner_error(
+                statement.statements
+            ):
+                return False
+            self.cmdpending.append(statement)
+        return True
+
+    def _reject_inner_error(self, statements: list[Statement]) -> bool:
+        """Report a syntax error nested anywhere inside a subshell, since the
+        whole line is rejected at parse time. Returns False once reported."""
+        for statement in statements:
+            if isinstance(statement, SyntaxError_):
+                self._report_syntax_error(statement)
+                return False
+            if isinstance(statement, Subshell) and not self._reject_inner_error(
+                statement.statements
+            ):
                 return False
         return True
+
+    def _report_syntax_error(self, statement: SyntaxError_) -> None:
+        """Write the message bash prints for a syntax error and set $? to 2."""
+        if statement.token:
+            self.protocol.terminal.write(
+                f"-bash: syntax error near unexpected token `{statement.token}'\n".encode()
+            )
+        else:
+            self.protocol.terminal.write(
+                b"-bash: syntax error: unexpected end of file\n"
+            )
+        self.last_exit_code = 2  # bash uses 2 for a syntax error
 
     def _capture_command(self, command: Command) -> str:
         """Run one parsed command in an output-capturing subshell and return
@@ -198,11 +213,19 @@ class HoneyPotShell:
 
         command = self.cmdpending.pop(0)
 
-        # && / || short-circuit: skip this statement based on the previous
-        # command's exit status, leaving $? unchanged.
+        # && / || short-circuit: skip this statement (or whole group) based on
+        # the previous command's exit status, leaving $? unchanged.
         if (command.op == "&&" and self.last_exit_code != 0) or (
             command.op == "||" and self.last_exit_code == 0
         ):
+            self._advance()
+            return
+
+        if isinstance(command, Subshell):
+            # The group runs: splice its statements to the front so they run in
+            # order. The group's own gate was checked above; each inner
+            # statement keeps its own &&/|| relative to its siblings.
+            self.cmdpending[0:0] = command.statements
             self._advance()
             return
 

--- a/src/cowrie/shell/pipe.py
+++ b/src/cowrie/shell/pipe.py
@@ -76,8 +76,10 @@ class PipeProtocol:
         self.targets[1] = (FD_PIPE, None) if self.next_command else (FD_TERMINAL, None)
         self.targets[2] = (FD_TERMINAL, None)
 
-        # If redirect is True (command substitution), stdout default is capture
-        if self.redirect:
+        # If redirect is True (command substitution), the *last* stage's stdout
+        # is captured. An earlier pipe stage must keep writing to the pipe, or
+        # the downstream command gets no input (`$(echo x | cat)` -> "x").
+        if self.redirect and not self.next_command:
             self.targets[1] = (FD_CAPTURE, None)
 
         # Defer stdin reading until after all redirections are processed

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -15,7 +15,6 @@ from typing import ClassVar
 
 from twisted.conch import recvline
 from twisted.conch.insults import insults
-from twisted.internet import error
 from twisted.internet.protocol import connectionDone
 from twisted.protocols.policies import TimeoutMixin
 from twisted.python import failure, log
@@ -135,7 +134,7 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         """
         this logs out when connection times out
         """
-        ret = failure.Failure(error.ProcessTerminated(exitCode=1))
+        ret = command.process_status(1)
         self.terminal.transport.processEnded(ret)
 
     def connectionLost(self, reason: failure.Failure = connectionDone) -> None:
@@ -278,7 +277,7 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
             self.cmdstack[-1].lineReceived(string)
         else:
             log.msg(f"discarding input {string}")
-            stat = failure.Failure(error.ProcessDone(status=""))
+            stat = command.process_status(0)
             self.terminal.transport.processEnded(stat)
 
     def call_command(self, pp, cmd, *args):
@@ -331,7 +330,7 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         if self.cmdstack:
             self.cmdstack[-1].eofReceived()
         else:
-            ret = failure.Failure(error.ProcessTerminated(exitCode=0))
+            ret = command.process_status(0)
             self.terminal.transport.processEnded(ret)
 
 

--- a/src/cowrie/test/test_bashparse.py
+++ b/src/cowrie/test/test_bashparse.py
@@ -41,10 +41,9 @@ class BashParseTokenTests(unittest.TestCase):
         self.parser = BashParser(self.ctx)
 
     def _tokens(self, line: str) -> list[str]:
-        statements = self.parser.parse(line)
-        self.assertEqual(len(statements), 1)
-        self.assertIsInstance(statements[0], Command)
-        return statements[0].tokens  # type: ignore[union-attr]
+        statement = self.parser.parse(line)[0]
+        assert isinstance(statement, Command)
+        return self.parser.evaluate(statement)
 
     def test_simple_words(self) -> None:
         self.assertEqual(self._tokens("echo hello world"), ["echo", "hello", "world"])
@@ -84,7 +83,7 @@ class BashParseVariableTests(unittest.TestCase):
     def _tokens(self, line: str) -> list[str]:
         statement = self.parser.parse(line)[0]
         assert isinstance(statement, Command)
-        return statement.tokens
+        return self.parser.evaluate(statement)
 
     def test_bare_variable_expands(self) -> None:
         self.assertEqual(self._tokens("echo $LOGNAME"), ["echo", "root"])
@@ -134,7 +133,7 @@ class BashParseRedirectionTests(unittest.TestCase):
     def _tokens(self, line: str) -> list[str]:
         statement = self.parser.parse(line)[0]
         assert isinstance(statement, Command)
-        return statement.tokens
+        return self.parser.evaluate(statement)
 
     def test_stdout_redirect(self) -> None:
         self.assertEqual(self._tokens("echo a > f"), ["echo", "a", ">", "f"])
@@ -178,37 +177,41 @@ class BashParseStatementTests(unittest.TestCase):
         self.ctx = FakeContext({"x": "hi"})
         self.parser = BashParser(self.ctx)
 
+    def _eval(self, statement: object) -> list[str]:
+        assert isinstance(statement, Command)
+        return self.parser.evaluate(statement)
+
     def test_semicolon_splits(self) -> None:
         statements = self.parser.parse("echo a; echo b")
         self.assertEqual(
-            [s.tokens for s in statements],  # type: ignore[union-attr]
+            [self._eval(s) for s in statements],
             [["echo", "a"], ["echo", "b"]],
         )
 
     def test_and_or_split_like_semicolon(self) -> None:
         statements = self.parser.parse("a && b || c")
         self.assertEqual(
-            [s.tokens for s in statements],  # type: ignore[union-attr]
+            [self._eval(s) for s in statements],
             [["a"], ["b"], ["c"]],
         )
 
     def test_command_substitution_captures_source(self) -> None:
         statements = self.parser.parse("echo $(echo inner)")
-        self.assertEqual(statements[0].tokens, ["echo", "<echo inner>"])  # type: ignore[union-attr]
+        self.assertEqual(self._eval(statements[0]), ["echo", "<echo inner>"])
         self.assertEqual(self.ctx.substitutions, ["echo inner"])
 
     def test_backtick_substitution(self) -> None:
         statements = self.parser.parse("echo `id`")
-        self.assertEqual(statements[0].tokens, ["echo", "<id>"])  # type: ignore[union-attr]
+        self.assertEqual(self._eval(statements[0]), ["echo", "<id>"])
 
     def test_command_substitution_as_whole_statement(self) -> None:
         # A command substitution that is the entire statement, or an assignment
         # value, parses as one command word -- not a misparsed bare "$" next to
         # a "(...)" subshell (which used to be a syntax error).
-        self.assertEqual(self.parser.parse("$(id)")[0].tokens, ["<id>"])  # type: ignore[union-attr]
-        self.assertEqual(self.parser.parse("x=$(id)")[0].tokens, ["x=<id>"])  # type: ignore[union-attr]
+        self.assertEqual(self._eval(self.parser.parse("$(id)")[0]), ["<id>"])
+        self.assertEqual(self._eval(self.parser.parse("x=$(id)")[0]), ["x=<id>"])
         self.assertEqual(
-            self.parser.parse("var=$( (echo a; echo b) )")[0].tokens,  # type: ignore[union-attr]
+            self._eval(self.parser.parse("var=$( (echo a; echo b) )")[0]),
             ["var=<(echo a; echo b)>"],
         )
 
@@ -216,8 +219,8 @@ class BashParseStatementTests(unittest.TestCase):
         # The inner $(...) source is handed to the context verbatim; the nested
         # shell parses it recursively rather than the grammar flattening it.
         statements = self.parser.parse("echo $(echo $(echo deep))")
+        self.assertEqual(self._eval(statements[0]), ["echo", "<echo $(echo deep)>"])
         self.assertEqual(self.ctx.substitutions, ["echo $(echo deep)"])
-        self.assertEqual(statements[0].tokens, ["echo", "<echo $(echo deep)>"])  # type: ignore[union-attr]
 
     def test_subshell_alone(self) -> None:
         statements = self.parser.parse("(echo one; echo two)")
@@ -225,7 +228,7 @@ class BashParseStatementTests(unittest.TestCase):
         self.assertIsInstance(statements[0], Subshell)
         inner = statements[0].statements  # type: ignore[union-attr]
         self.assertEqual(
-            [s.tokens for s in inner],  # type: ignore[union-attr]
+            [self._eval(s) for s in inner],
             [["echo", "one"], ["echo", "two"]],
         )
 
@@ -234,11 +237,13 @@ class BashParseStatementTests(unittest.TestCase):
         self.assertIsInstance(statements[0], Command)
         self.assertIsInstance(statements[1], Subshell)
 
-    def test_subshell_inner_substitution_runs_in_source_order(self) -> None:
-        # A subshell's inner statements are parsed up front, so a command
-        # substitution inside it is evaluated in source order with the rest of
-        # the line rather than deferred.
-        self.parser.parse("(echo $(a)); echo $(b)")
+    def test_substitution_is_lazy(self) -> None:
+        # Command substitutions run when a statement is evaluated, not at parse
+        # time; evaluating in order hits them in source order.
+        statements = self.parser.parse("echo $(a); echo $(b)")
+        self.assertEqual(self.ctx.substitutions, [])
+        for statement in statements:
+            self._eval(statement)
         self.assertEqual(self.ctx.substitutions, ["a", "b"])
 
     def test_subshell_in_middle_is_syntax_error(self) -> None:
@@ -255,7 +260,7 @@ class BashParseStatementTests(unittest.TestCase):
         # A syntax error stops parsing but earlier statements still run.
         statements = self.parser.parse("echo ok ; uname -a (bad) | tr a b")
         self.assertIsInstance(statements[0], Command)
-        self.assertEqual(statements[0].tokens, ["echo", "ok"])  # type: ignore[union-attr]
+        self.assertEqual(self._eval(statements[0]), ["echo", "ok"])
         self.assertIsInstance(statements[1], SyntaxError_)
 
     def test_empty_line(self) -> None:
@@ -274,7 +279,7 @@ class BashParseCommentTests(unittest.TestCase):
     def _tokens(self, line: str) -> list[str]:
         statement = self.parser.parse(line)[0]
         assert isinstance(statement, Command)
-        return statement.tokens
+        return self.parser.evaluate(statement)
 
     def test_trailing_comment_dropped(self) -> None:
         self.assertEqual(self._tokens("echo foo #comment"), ["echo", "foo"])

--- a/src/cowrie/test/test_bashparse.py
+++ b/src/cowrie/test/test_bashparse.py
@@ -23,9 +23,13 @@ class FakeContext:
     def __init__(self, env: dict[str, str] | None = None) -> None:
         self.env = env or {}
         self.substitutions: list[str] = []
+        self.status = "0"
 
     def get_variable(self, name: str) -> str | None:
         return self.env.get(name)
+
+    def get_status(self) -> str:
+        return self.status
 
     def command_substitution(self, source: str) -> str:
         self.substitutions.append(source)

--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -68,3 +68,11 @@ class CurlArtifactCleanupTests(unittest.TestCase):
             "failed download left an orphaned temp file behind",
         )
         self.assertEqual(os.listdir(self.tmpdir), [])
+
+    def test_missing_host_reports_error_without_crashing(self) -> None:
+        # A URL with no host must report an error and stop, not fall through
+        # to the download path and crash on the unset self.host.
+        self.proto.lineReceived(b"curl http://; echo rc=$?")
+        out = self.tr.value()
+        self.assertIn(b"curl: (3)", out)
+        self.assertIn(b"rc=3", out)

--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -53,7 +53,7 @@ class CurlArtifactCleanupTests(unittest.TestCase):
         cmd = Command_curl.__new__(Command_curl)
         cmd.protocol = self.proto
         cmd.errorWritefn = lambda _data: None
-        cmd.exit = lambda: None  # type: ignore[method-assign]  # process teardown is unrelated here
+        cmd.exit = lambda code=None: None  # type: ignore[method-assign]  # process teardown is unrelated here
         cmd.url = b"http://no.such.host/file"
         cmd.host = "no.such.host"
         cmd.port = 80

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -200,11 +200,10 @@ class ShellEchoCommandTests(unittest.TestCase):
         self.assertIn(b"second", output)
 
     def test_subshell_parentheses_009(self) -> None:
-        """Test subshell with OR operator"""
+        """`||` short-circuits: the first command succeeds, so the second is
+        skipped (like bash)."""
         self.proto.lineReceived(b"(echo first || echo second)")
-        output = self.tr.value()
-        self.assertIn(b"first", output)
-        self.assertIn(b"second", output)
+        self.assertEqual(self.tr.value(), b"first\n" + PROMPT)
 
     def test_subshell_parentheses_010(self) -> None:
         """Test subshell with multiple semicolons"""

--- a/src/cowrie/test/test_exit_status.py
+++ b/src/cowrie/test/test_exit_status.py
@@ -120,6 +120,25 @@ class ExitStatusTests(unittest.TestCase):
         # The group is skipped, but a `;`-joined statement after it still runs.
         self.assertEqual(self.run_line(b"true || (echo a); echo c"), b"c\n")
 
+    def test_substitution_carries_status_across_statements(self) -> None:
+        # The whole substitution runs in one shell, so a later statement's $?
+        # sees the earlier statement's status.
+        self.assertEqual(self.run_line(b"echo $(false; echo $?)"), b"1\n")
+
+    def test_substitution_short_circuits(self) -> None:
+        # &&/|| short-circuit inside a substitution like a top-level line.
+        self.assertEqual(self.run_line(b"echo $(true || echo x)"), b"\n")
+        self.assertEqual(self.run_line(b"echo $(false || echo y)"), b"y\n")
+
+    def test_substitution_assignment_visible_to_later_statement(self) -> None:
+        # A same-substitution assignment is visible to a later statement.
+        self.assertEqual(self.run_line(b"echo $(x=hi; echo $x)"), b"hi\n")
+
+    def test_substitution_assignment_only_statement_adds_no_output(self) -> None:
+        # A trailing assignment-only statement must not re-emit the previous
+        # statement's captured output.
+        self.assertEqual(self.run_line(b"echo $(echo a; z=1)"), b"a\n")
+
     def test_statement_after_pipeline_runs_in_order(self) -> None:
         # A statement after a pipeline runs after the pipeline finishes, and the
         # pipeline's output is not dropped.

--- a/src/cowrie/test/test_exit_status.py
+++ b/src/cowrie/test/test_exit_status.py
@@ -73,6 +73,23 @@ class ExitStatusTests(unittest.TestCase):
         # The `&&` branch is skipped, so $? stays at false's 1.
         self.assertEqual(self.run_line(b"false && echo x; echo $?"), b"1\n")
 
+    def test_nested_shell_propagates_exit_code(self) -> None:
+        # `bash -c '...'` exits with the status of its last command.
+        self.assertEqual(self.run_line(b"bash -c false; echo $?"), b"1\n")
+        self.assertEqual(self.run_line(b"bash -c true; echo $?"), b"0\n")
+
+    def test_nested_shell_status_gates_and(self) -> None:
+        # A failing nested shell short-circuits a following &&.
+        self.assertEqual(self.run_line(b"bash -c false && echo ran"), b"")
+
+    def test_failing_command_sets_nonzero_status(self) -> None:
+        # dd on a missing input file fails, so $? is non-zero and a following
+        # && does not run.
+        out = self.run_line(b"dd if=/nonexistentfile; echo $?")
+        self.assertTrue(out.endswith(b"1\n"), out)
+        out = self.run_line(b"dd if=/nonexistentfile && echo ran")
+        self.assertNotIn(b"ran", out)
+
     def test_syntax_error_is_2(self) -> None:
         self.run_line(b"echo x >")
         self.assertEqual(self.run_line(b"echo $?"), b"2\n")
@@ -81,6 +98,27 @@ class ExitStatusTests(unittest.TestCase):
         # A pipeline's status is its last stage's.
         self.assertEqual(self.run_line(b"true | false; echo $?"), b"1\n")
         self.assertEqual(self.run_line(b"false | true; echo $?"), b"0\n")
+
+    def test_subshell_group_runs_in_order(self) -> None:
+        # A group with no gate runs all its statements.
+        self.assertEqual(self.run_line(b"(echo a; echo b)"), b"a\nb\n")
+
+    def test_or_short_circuits_whole_group(self) -> None:
+        # true succeeds -> || skips the entire group, not just its first
+        # statement.
+        self.assertEqual(self.run_line(b"true || (echo a; echo b)"), b"")
+
+    def test_and_short_circuits_whole_group(self) -> None:
+        # false fails -> && skips the entire group.
+        self.assertEqual(self.run_line(b"false && (echo a; echo b)"), b"")
+
+    def test_or_runs_whole_group_on_failure(self) -> None:
+        # false fails -> || runs the whole group.
+        self.assertEqual(self.run_line(b"false || (echo a; echo b)"), b"a\nb\n")
+
+    def test_statement_after_group_runs_when_group_skipped(self) -> None:
+        # The group is skipped, but a `;`-joined statement after it still runs.
+        self.assertEqual(self.run_line(b"true || (echo a); echo c"), b"c\n")
 
     def test_statement_after_pipeline_runs_in_order(self) -> None:
         # A statement after a pipeline runs after the pipeline finishes, and the

--- a/src/cowrie/test/test_exit_status.py
+++ b/src/cowrie/test/test_exit_status.py
@@ -76,10 +76,13 @@ class ExitStatusTests(unittest.TestCase):
 
     def test_pipeline_status_is_last_stage(self) -> None:
         # A pipeline's status is its last stage's.
-        self.run_line(b"true | false")
-        self.assertEqual(self.run_line(b"echo $?"), b"1\n")
-        self.run_line(b"false | true")
-        self.assertEqual(self.run_line(b"echo $?"), b"0\n")
+        self.assertEqual(self.run_line(b"true | false; echo $?"), b"1\n")
+        self.assertEqual(self.run_line(b"false | true; echo $?"), b"0\n")
+
+    def test_statement_after_pipeline_runs_in_order(self) -> None:
+        # A statement after a pipeline runs after the pipeline finishes, and the
+        # pipeline's output is not dropped.
+        self.assertEqual(self.run_line(b"echo a | cat; echo done"), b"a\ndone\n")
 
 
 if __name__ == "__main__":

--- a/src/cowrie/test/test_exit_status.py
+++ b/src/cowrie/test/test_exit_status.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for command exit status ($?) and && / || short-circuiting.
+# ABOUTME: Covers true/false, not-found 127, syntax error 2, and Ctrl-C 130.
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+
+class ExitStatusTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def run_line(self, line: bytes) -> bytes:
+        self.tr.clear()
+        self.proto.lineReceived(line)
+        out: bytes = self.tr.value()
+        return out[: -len(PROMPT)] if out.endswith(PROMPT) else out
+
+    def test_status_of_true_and_false(self) -> None:
+        self.assertEqual(self.run_line(b"true; echo $?"), b"0\n")
+        self.assertEqual(self.run_line(b"false; echo $?"), b"1\n")
+
+    def test_status_of_successful_command(self) -> None:
+        self.assertEqual(self.run_line(b"echo hi; echo $?"), b"hi\n0\n")
+
+    def test_command_not_found_is_127(self) -> None:
+        out = self.run_line(b"nosuchcmd; echo $?")
+        self.assertTrue(out.endswith(b"127\n"), out)
+
+    def test_status_persists_across_lines(self) -> None:
+        self.run_line(b"false")
+        self.assertEqual(self.run_line(b"echo $?"), b"1\n")
+
+    def test_and_runs_second_only_on_success(self) -> None:
+        self.assertEqual(self.run_line(b"true && echo ran"), b"ran\n")
+        self.assertEqual(self.run_line(b"false && echo ran"), b"")
+
+    def test_or_runs_second_only_on_failure(self) -> None:
+        self.assertEqual(self.run_line(b"false || echo ran"), b"ran\n")
+        self.assertEqual(self.run_line(b"true || echo ran"), b"")
+
+    def test_and_or_are_left_associative(self) -> None:
+        # false fails -> skip `echo a`; || sees the failure -> run `echo b`.
+        self.assertEqual(self.run_line(b"false && echo a || echo b"), b"b\n")
+        # true succeeds -> run `echo a` (0); || skipped.
+        self.assertEqual(self.run_line(b"true && echo a || echo b"), b"a\n")
+
+    def test_skipped_command_leaves_status_unchanged(self) -> None:
+        # The `&&` branch is skipped, so $? stays at false's 1.
+        self.assertEqual(self.run_line(b"false && echo x; echo $?"), b"1\n")
+
+    def test_syntax_error_is_2(self) -> None:
+        self.run_line(b"echo x >")
+        self.assertEqual(self.run_line(b"echo $?"), b"2\n")
+
+    def test_pipeline_status_is_last_stage(self) -> None:
+        # A pipeline's status is its last stage's.
+        self.run_line(b"true | false")
+        self.assertEqual(self.run_line(b"echo $?"), b"1\n")
+        self.run_line(b"false | true")
+        self.assertEqual(self.run_line(b"echo $?"), b"0\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_exit_status.py
+++ b/src/cowrie/test/test_exit_status.py
@@ -90,6 +90,14 @@ class ExitStatusTests(unittest.TestCase):
         out = self.run_line(b"dd if=/nonexistentfile && echo ran")
         self.assertNotIn(b"ran", out)
 
+    def test_download_command_failure_sets_nonzero_status(self) -> None:
+        # A download command that fails validation reports a non-zero status,
+        # so a following && short-circuits.
+        for cmd in (b"wget", b"curl", b"tftp", b"ftpget"):
+            out = self.run_line(cmd + b"; echo rc=$?")
+            self.assertNotIn(b"rc=0", out, cmd)
+            self.assertNotIn(b"OK", self.run_line(cmd + b" && echo OK"), cmd)
+
     def test_syntax_error_is_2(self) -> None:
         self.run_line(b"echo x >")
         self.assertEqual(self.run_line(b"echo $?"), b"2\n")

--- a/src/cowrie/test/test_exit_status.py
+++ b/src/cowrie/test/test_exit_status.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import os
 import unittest
+from types import SimpleNamespace
 
+from cowrie.insults import insults
+from cowrie.shell import protocol
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
@@ -83,6 +86,54 @@ class ExitStatusTests(unittest.TestCase):
         # A statement after a pipeline runs after the pipeline finishes, and the
         # pipeline's output is not dropped.
         self.assertEqual(self.run_line(b"echo a | cat; echo done"), b"a\ndone\n")
+
+
+def run_exec(cmd: bytes) -> int:
+    """Run `cmd` over an exec channel and return the exit status the session
+    would report to the SSH client via processEnded."""
+    captured: dict[str, int] = {}
+
+    def process_ended(reason: object = None) -> None:
+        value = getattr(reason, "value", None)
+        captured["code"] = getattr(value, "exitCode", 0) if value is not None else 0
+
+    peer = SimpleNamespace(host="1.1.1.1", port=2222)
+    inner = SimpleNamespace(sessionno=1, getPeer=lambda: peer)
+    factory = SimpleNamespace(starttime=0, logDispatch=lambda **kw: None)
+    conn_transport = SimpleNamespace(transportId="t", factory=factory, transport=inner)
+    session = SimpleNamespace(
+        id="chan0", conn=SimpleNamespace(transport=conn_transport)
+    )
+    transport = SimpleNamespace(
+        session=session, write=lambda data: None, processEnded=process_ended
+    )
+
+    avatar = FakeAvatar(FakeServer())
+    avatar.server.initFileSystem = lambda home: None
+    lsp = insults.LoggingServerProtocol(protocol.HoneyPotExecProtocol, avatar, cmd)
+    lsp.makeConnection(transport)
+    return captured.get("code", 0)
+
+
+class ExecExitStatusTests(unittest.TestCase):
+    """The exec channel reports a real exit-status to the client."""
+
+    def test_exec_success(self) -> None:
+        self.assertEqual(run_exec(b"true"), 0)
+        self.assertEqual(run_exec(b"echo hi"), 0)
+
+    def test_exec_failure(self) -> None:
+        self.assertEqual(run_exec(b"false"), 1)
+
+    def test_exec_not_found(self) -> None:
+        self.assertEqual(run_exec(b"nosuchcmd"), 127)
+
+    def test_exec_status_is_last_statement(self) -> None:
+        self.assertEqual(run_exec(b"false; true"), 0)
+        self.assertEqual(run_exec(b"true; false"), 1)
+
+    def test_exec_explicit_exit_code(self) -> None:
+        self.assertEqual(run_exec(b"exit 7"), 7)
 
 
 if __name__ == "__main__":

--- a/src/cowrie/test/test_fd_redirection.py
+++ b/src/cowrie/test/test_fd_redirection.py
@@ -238,6 +238,13 @@ class ShellFdRedirectionTests(unittest.TestCase):
         self.assertIn(b"result=", output)
         self.assertTrue(output.endswith(PROMPT))
 
+    def test_command_substitution_through_pipe(self) -> None:
+        # The captured value is the last pipe stage's output. A capture used to
+        # force every stage's stdout to the capture buffer, breaking the pipe so
+        # the downstream command got no input.
+        self.proto.lineReceived(b"echo r=$(echo piped | cat | cat)")
+        self.assertEqual(self.tr.value(), b"r=piped\n" + PROMPT)
+
     def test_backtick_substitution(self) -> None:
         # Backtick style command substitution
         self.proto.lineReceived(b"echo `echo hello`")

--- a/src/cowrie/test/test_pipe_eof.py
+++ b/src/cowrie/test/test_pipe_eof.py
@@ -61,9 +61,11 @@ class PipeEofTests(unittest.TestCase):
                     before,
                     f"cmdstack leaked for {tail_cmd!r}: {before} -> {after}",
                 )
-                self.assertEqual(
-                    output,
-                    b"X:\n" + PROMPT,
+                # The capture must be empty, so the line ends in `X:` then a
+                # newline. (dd writes its stats to stderr, which legitimately
+                # reaches the terminal ahead of the echo, hence endswith.)
+                self.assertTrue(
+                    output.endswith(b"X:\n" + PROMPT),
                     f"unexpected output for {tail_cmd!r}: {output!r}",
                 )
 

--- a/src/cowrie/test/test_shell_variables.py
+++ b/src/cowrie/test/test_shell_variables.py
@@ -47,6 +47,13 @@ class ShellVariableTests(unittest.TestCase):
         self.proto.lineReceived(b"x=hi")
         self.assertEqual(self.run_line(b"echo $x"), b"hi\n")
 
+    # Each statement's words are expanded just before it runs, so a same-line
+    # assignment is visible to a later statement on the same line.
+    def test_same_line_assignment_is_seen(self) -> None:
+        self.assertEqual(self.run_line(b"x=hey; echo $x"), b"hey\n")
+        self.assertEqual(self.run_line(b'y=ho; echo "$y"'), b"ho\n")
+        self.assertEqual(self.run_line(b"a=1; b=2; echo $a$b"), b"12\n")
+
     # Cause 2: $VAR expands inside a larger token
     def test_expand_embedded_in_token(self) -> None:
         self.proto.lineReceived(b"x=hi")

--- a/src/cowrie/test/test_wget.py
+++ b/src/cowrie/test/test_wget.py
@@ -53,7 +53,7 @@ class WgetArtifactCleanupTests(unittest.TestCase):
         cmd = Command_wget.__new__(Command_wget)
         cmd.protocol = self.proto
         cmd.errorWritefn = lambda _data: None
-        cmd.exit = lambda: None  # type: ignore[method-assign]  # process teardown is unrelated here
+        cmd.exit = lambda code=None: None  # type: ignore[method-assign]  # process teardown is unrelated here
         cmd.url = b"http://no.such.host/file"
         cmd.host = "no.such.host"
         cmd.port = 80


### PR DESCRIPTION
Make the emulated shell track real command exit statuses so `$?`, `&&`/`||`,
and the SSH `exit-status` behave like a real shell.

## What changed

**Interleaved executor.** The parser now returns a statement list with
*unevaluated* word trees; each statement's words are expanded against the live
environment just before it runs (`BashParser.evaluate` in `runCommand`). This
makes same-line assignments visible (`x=hi; echo $x` -> `hi`) and is the
foundation for the rest.

**Exit status.** Each `HoneyPotCommand` has an `exit_code`; the shell keeps a
per-shell `last_exit_code` (so a `$(...)` subshell's status doesn't leak to the
parent). `$?` reads it, and `&&`/`||` short-circuit. command-not-found = 127,
syntax error = 2, Ctrl-C = 130. Added a `false` builtin. The exec channel now
reports the real status to the SSH client via `process_status` (ProcessDone for
0, ProcessTerminated otherwise), and `exit N` is supported.

**Correctness fixes found in review:**
- A subshell is queued as one unit so its `&&`/`||` gates the whole group
  (`true || (false; echo x)` prints nothing).
- `bash -c`/`sh -c`/`su -c`/scripts propagate the child shell's status.
- Command substitution runs the whole source in one capture shell, so `$?`,
  same-substitution assignments, and short-circuiting work across statements.
- `dd` and the download commands (wget/curl/tftp/ftpget) set a non-zero status
  on failure, so `wget badurl && ...` short-circuits.
- `curl http://` (hostless URL) stops with curl's real "(3)" error instead of
  crashing on the unset host.

**Cleanups:** `process_status` reused at the session-end sites; `$?`/special
expansion deduped into `_special_param`; the `&&`/`||` predicate factored into
`_short_circuit`. `dd` writes its stats to stderr (matching real `dd`).

## Tests

New `test_exit_status.py` plus additions across `test_bashparse`, `test_echo`,
`test_curl`, `test_fd_redirection`, `test_pipe_eof`, `test_shell_variables`.
Full suite: 508 tests pass; ruff and mypy clean.