### PR TITLE
Translate emulated-filesystem errors at the SFTP boundary

### DIFF
--- a/src/cowrie/shell/filetransfer.py
+++ b/src/cowrie/shell/filetransfer.py
@@ -9,7 +9,11 @@ This module contains ...
 
 from __future__ import annotations
 
+import errno
+import functools
 import os
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
 
 import twisted.conch.ls
 from twisted.conch.interfaces import ISFTPFile, ISFTPServer
@@ -29,6 +33,34 @@ from zope.interface import implementer
 import twisted
 from cowrie.core.config import CowrieConfig
 from cowrie.shell import pwd
+from cowrie.shell.fs import FileNotFound, PermissionDenied
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def translate_fs_errors(method: F) -> F:
+    """Translate the emulated filesystem's exceptions into ``OSError`` at the
+    SFTP boundary.
+
+    ``HoneyPotFilesystem`` raises ``FileNotFound`` / ``PermissionDenied`` for
+    some operations (a missing parent directory, a write under ``/proc`` ...).
+    The conch SFTP server only understands ``OSError`` / ``SFTPError``; a bare
+    cowrie exception reaches it as an unexpected error, logged as a critical
+    traceback and reported to the client as a generic failure. Mapping them to
+    the matching errno lets conch return ``FX_NO_SUCH_FILE`` /
+    ``FX_PERMISSION_DENIED`` instead.
+    """
+
+    @functools.wraps(method)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return method(*args, **kwargs)
+        except FileNotFound:
+            raise OSError(errno.ENOENT, os.strerror(errno.ENOENT)) from None
+        except PermissionDenied:
+            raise OSError(errno.EACCES, os.strerror(errno.EACCES)) from None
+
+    return cast("F", wrapper)
 
 
 @implementer(ISFTPFile)
@@ -178,32 +210,39 @@ class SFTPServerForCowrieUser:
     def gotVersion(self, otherVersion, extData):
         return {}
 
+    @translate_fs_errors
     def openFile(self, filename, flags, attrs):
         log.msg(f"SFTP openFile: {filename}")
         return CowrieSFTPFile(self, self._absPath(filename), flags, attrs)
 
+    @translate_fs_errors
     def removeFile(self, filename):
         log.msg(f"SFTP removeFile: {filename}")
         return self.fs.remove(self._absPath(filename))
 
+    @translate_fs_errors
     def renameFile(self, oldpath, newpath):
         log.msg(f"SFTP renameFile: {oldpath} {newpath}")
         return self.fs.rename(self._absPath(oldpath), self._absPath(newpath))
 
+    @translate_fs_errors
     def makeDirectory(self, path, attrs):
         log.msg(f"SFTP makeDirectory: {path}")
         path = self._absPath(path)
         self.fs.mkdir2(path)
         self._setAttrs(path, attrs)
 
+    @translate_fs_errors
     def removeDirectory(self, path):
         log.msg(f"SFTP removeDirectory: {path}")
         return self.fs.rmdir(self._absPath(path))
 
+    @translate_fs_errors
     def openDirectory(self, path):
         log.msg(f"SFTP OpenDirectory: {path}")
         return CowrieSFTPDirectory(self, self._absPath(path))
 
+    @translate_fs_errors
     def getAttrs(self, path, followLinks):
         log.msg(f"SFTP getAttrs: {path}")
         path = self._absPath(path)
@@ -213,11 +252,13 @@ class SFTPServerForCowrieUser:
             s = self.fs.lstat(path)
         return self._getAttrs(s)
 
+    @translate_fs_errors
     def setAttrs(self, path, attrs):
         log.msg(f"SFTP setAttrs: {path}")
         path = self._absPath(path)
         return self._setAttrs(path, attrs)
 
+    @translate_fs_errors
     def readLink(self, path):
         log.msg(f"SFTP readLink: {path}")
         path = self._absPath(path)

--- a/src/cowrie/test/test_filetransfer.py
+++ b/src/cowrie/test/test_filetransfer.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: tests for cowrie/shell/filetransfer.py — the SFTP server adapter
+# ABOUTME: covers translating the emulated fs exceptions into OSError for conch
+
+from __future__ import annotations
+
+import errno
+import os
+import unittest
+from types import SimpleNamespace
+
+from twisted.conch.ssh.filetransfer import FXF_CREAT, FXF_WRITE
+
+from cowrie.shell import fs
+from cowrie.shell.filetransfer import SFTPServerForCowrieUser
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class SFTPErrorTranslationTests(unittest.TestCase):
+    """The SFTP adapter must surface OSError (not a bare cowrie exception) so
+    conch returns a proper status instead of a critical traceback."""
+
+    def setUp(self) -> None:
+        # Build the server without its avatar/initFileSystem wiring; only the
+        # filesystem and home directory matter for these operations.
+        self.server = SFTPServerForCowrieUser.__new__(SFTPServerForCowrieUser)
+        self.server.fs = fs.HoneyPotFilesystem("linux-x64-lsb", "/root")
+        self.server.avatar = SimpleNamespace(home="/root")
+
+    def test_open_directory_missing_raises_enoent(self) -> None:
+        # listdir() raises the cowrie FileNotFound for a missing directory.
+        with self.assertRaises(OSError) as ctx:
+            self.server.openDirectory("/nonexistent-dir")
+        self.assertEqual(ctx.exception.errno, errno.ENOENT)
+
+    def test_open_file_for_write_missing_parent_raises_enoent(self) -> None:
+        # open() -> mkfile() raises the cowrie FileNotFound for a missing parent.
+        with self.assertRaises(OSError) as ctx:
+            self.server.openFile("/nonexistent-dir/clean.sh", FXF_WRITE | FXF_CREAT, {})
+        self.assertEqual(ctx.exception.errno, errno.ENOENT)
+
+    def test_open_file_under_special_path_raises_eacces(self) -> None:
+        # mkfile() raises the cowrie PermissionDenied for a write under /proc.
+        with self.assertRaises(OSError) as ctx:
+            self.server.openFile("/proc/clean.sh", FXF_WRITE | FXF_CREAT, {})
+        self.assertEqual(ctx.exception.errno, errno.EACCES)
+
+    def test_get_attrs_missing_raises_enoent(self) -> None:
+        # stat() already raises OSError(ENOENT); it must pass through unchanged.
+        with self.assertRaises(OSError) as ctx:
+            self.server.getAttrs("/nonexistent-file", followLinks=True)
+        self.assertEqual(ctx.exception.errno, errno.ENOENT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Some SFTP operations reach the emulated filesystem on a path that does not
exist or is protected, and `HoneyPotFilesystem` raises its own
`FileNotFound` / `PermissionDenied`. The conch SFTP server only understands
`OSError` / `SFTPError`, so a bare cowrie exception surfaces as an unexpected
error: logged as a critical traceback and reported to the client as a generic
failure instead of "no such file" or "permission denied".

The leaking operations are:
- `openFile` for write — `mkfile` raises `FileNotFound` for a missing parent
  directory and `PermissionDenied` for a write under `/proc`, `/sys`,
  `/dev/pts`.
- `openDirectory` — `listdir` raises `FileNotFound` for a missing directory.
- `renameFile` — renaming into a missing directory raises `FileNotFound`.

The remaining server methods (`stat`, `lstat`, `remove`, `rmdir`,
`makeDirectory`, `chmod`, ...) already raise `OSError` themselves.

## Fix

A `translate_fs_errors` decorator on the SFTP server methods maps
`FileNotFound -> OSError(ENOENT)` and `PermissionDenied -> OSError(EACCES)`,
so conch returns `FX_NO_SUCH_FILE` / `FX_PERMISSION_DENIED`. It is applied
uniformly across the boundary (defensive for the methods that already raise
`OSError`, which pass through unchanged), keeping `fs.*` protocol-agnostic.

## Tests

New `test_filetransfer.py` exercises the boundary directly: missing directory
(open/openDirectory) -> ENOENT, write under `/proc` -> EACCES, and an
already-`OSError` operation passing through unchanged.

Full suite: 511 tests pass; ruff and mypy clean.