### PR TITLE
Report "Bad file descriptor" for an out-of-range redirect fd

### DIFF
--- a/src/cowrie/shell/pipe.py
+++ b/src/cowrie/shell/pipe.py
@@ -27,6 +27,11 @@ FD_FILE = "file"
 FD_FILE_INPUT = "file_input"
 FD_DEVNULL = "devnull"
 
+# Soft limit on open file descriptors (ulimit -n). A redirection naming an fd at
+# or above this is rejected by bash with "Bad file descriptor"; valid fds are
+# 0 .. MAX_OPEN_FILES - 1.
+MAX_OPEN_FILES = 1024
+
 
 class PipeProtocol:
     def __init__(
@@ -69,6 +74,22 @@ class PipeProtocol:
         )
         self.has_redirections = bool(self.redirections)
 
+    def _out_of_range_fd(self, op: dict[str, Any]) -> int | None:
+        """Return the first file descriptor in ``op`` that exceeds the open-file
+        limit, which bash rejects with "Bad file descriptor", or None.
+
+        A redirection like ``9999>file`` parses fine but names an fd the process
+        cannot open; ``2>&9999`` likewise duplicates from one. Only a ``dup``'s
+        ``target`` is an fd (a ``file`` / ``stdin`` target is a path).
+        """
+        candidates = [op["fd"]]
+        if op["type"] == "dup":
+            candidates.append(op["target"])
+        for fd in candidates:
+            if isinstance(fd, int) and fd >= MAX_OPEN_FILES:
+                return fd
+        return None
+
     def _setup_redirections(self) -> None:
         """Process redirection operations to build the FD table."""
         # Initialize default FDs
@@ -88,6 +109,15 @@ class PipeProtocol:
         pending_stdin_target: str | None = None
 
         for op in self.redirections:
+            bad_fd = self._out_of_range_fd(op)
+            if bad_fd is not None:
+                # bash reports the offending fd and drops the redirection, but
+                # still runs the command -- its other fds are unaffected.
+                self._write_to_terminal(
+                    f"bash: {bad_fd}: Bad file descriptor\n".encode()
+                )
+                continue
+
             if op["type"] == "file":
                 fd = op["fd"]
                 target = op["target"]

--- a/src/cowrie/test/test_fd_redirection.py
+++ b/src/cowrie/test/test_fd_redirection.py
@@ -310,3 +310,33 @@ class ShellFdRedirectionTests(unittest.TestCase):
         # Multiple commands with different redirects
         self.proto.lineReceived(b"echo first > f1; echo second > f2; cat f1; cat f2")
         self.assertEqual(self.tr.value(), b"first\nsecond\n" + PROMPT)
+
+    def test_out_of_range_fd_reports_bad_file_descriptor(self) -> None:
+        # An fd above the open-file limit is rejected with bash's error, but the
+        # command still runs (its stdout is unaffected). Issue #2921.
+        self.proto.lineReceived(b"echo test 9999>/dev/null")
+        self.assertEqual(
+            self.tr.value(), b"bash: 9999: Bad file descriptor\ntest\n" + PROMPT
+        )
+
+    def test_in_range_fd_has_no_error(self) -> None:
+        # Multi-digit fds below the limit are valid and produce no error.
+        self.proto.lineReceived(b"echo test 255>/dev/null")
+        self.assertEqual(self.tr.value(), b"test\n" + PROMPT)
+
+    def test_fd_at_limit_is_bad(self) -> None:
+        # The limit itself (1024) is the first invalid fd; 1023 is still valid.
+        self.proto.lineReceived(b"echo a 1023>/dev/null")
+        self.assertEqual(self.tr.value(), b"a\n" + PROMPT)
+        self.tr.clear()
+        self.proto.lineReceived(b"echo b 1024>/dev/null")
+        self.assertEqual(
+            self.tr.value(), b"bash: 1024: Bad file descriptor\nb\n" + PROMPT
+        )
+
+    def test_dup_from_out_of_range_fd_reports_error(self) -> None:
+        # Duplicating from an out-of-range fd reports that fd. Issue #2921.
+        self.proto.lineReceived(b"echo hi 2>&9999")
+        self.assertEqual(
+            self.tr.value(), b"bash: 9999: Bad file descriptor\nhi\n" + PROMPT
+        )


### PR DESCRIPTION
Fixes #2921.

## Problem

A redirection that names a file descriptor at or above the process's
open-file limit (e.g. `echo test 9999>/dev/null`) parses fine but names an
fd the process cannot open. Real bash drops the redirection, writes
`bash: 9999: Bad file descriptor` to stderr, and still runs the command.
Cowrie silently ignored it and ran the command with no error -- a detectable
difference.

```
$ echo test 9999>/dev/null
bash: 9999: Bad file descriptor
test
```

## Fix

When building the FD table, skip any redirection whose fd -- or a dup's
source/target fd -- is at or above the open-file limit, emit bash's error,
and leave the command's other fds untouched so it still runs. The limit is
the conventional `ulimit -n` soft default of 1024 (valid fds are 0..1023);
cowrie has no real fd-limit emulation, and `ulimit` is only a static txtcmd.

Verified against bash:
- `9999>/dev/null` -> error, then `test`
- `99` / `255` / `1023` -> valid, no error
- `1024>/dev/null` -> error (1024 is the first invalid fd)
- `2>&9999` (duplicating from an out-of-range fd) -> reports `9999`

## Tests

Four cases added to `test_fd_redirection.py` covering the out-of-range fd, an
in-range multi-digit fd, the limit boundary (1023 valid / 1024 invalid), and
a dup from an out-of-range fd.

Full suite: 515 tests pass; ruff and mypy clean.