### PR TITLE
Register backing files for command-less output redirections

### DIFF
--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -284,7 +284,10 @@ class HoneyPotShell:
         first_args, first_ops = self.parser.parse_redirections(multipleCmdArgs.pop(0))
         if not first_args:
             if first_ops:
-                # Handle redirection without command (e.g. > file)
+                # Handle redirection without command (e.g. > file). This
+                # creates the backing files via _setup_redirections; register
+                # them so they are hashed/renamed or removed at session close
+                # instead of being orphaned in the download directory.
                 pp = PipeProtocol(
                     self.protocol,
                     None,
@@ -294,7 +297,8 @@ class HoneyPotShell:
                     self.redirect,
                     first_ops,
                 )
-                # This triggers _setup_redirections which creates files
+                for real_path, virtual_path in pp.redirect_real_files:
+                    self.protocol.terminal.redirFiles.add((real_path, virtual_path))
             self._advance()
             return
 

--- a/src/cowrie/test/test_fd_redirection.py
+++ b/src/cowrie/test/test_fd_redirection.py
@@ -311,6 +311,22 @@ class ShellFdRedirectionTests(unittest.TestCase):
         self.proto.lineReceived(b"echo first > f1; echo second > f2; cat f1; cat f2")
         self.assertEqual(self.tr.value(), b"first\nsecond\n" + PROMPT)
 
+    def test_bare_redirection_registers_backing_file(self) -> None:
+        # A redirection with no command still creates a real backing file; it
+        # must be registered for cleanup so it is not orphaned in the download
+        # directory at session close (issue #40217).
+        target = "/tmp/bare_redir_40217"
+        before = set(self.proto.terminal.redirFiles)
+        self.proto.lineReceived(b">/tmp/bare_redir_40217")
+        new = self.proto.terminal.redirFiles - before
+        self.assertTrue(
+            any(virtual == target for _real, virtual in new),
+            f"backing file for {target} was not registered: {new}",
+        )
+        for real, _virtual in new:
+            if os.path.exists(real):
+                os.remove(real)
+
     def test_out_of_range_fd_reports_bad_file_descriptor(self) -> None:
         # An fd above the open-file limit is rejected with bash's error, but the
         # command still runs (its stdout is unaffected). Issue #2921.


### PR DESCRIPTION
Fixes #40217.

## Problem

A shell redirection with no command on the left-hand side (e.g.
`>/tmp/testfile`, or the botnet writable-directory probe pattern
`>/tmp/.x && cd /tmp/`) builds a `PipeProtocol` whose `_setup_redirections`
creates a real backing file in `download_path`. The no-command branch in
`HoneyPotShell.runCommand()` then returns without registering that file into
`terminal.redirFiles`. Since no command runs, `exit()` never registers it
either, so at session close `LoggingServerProtocol.logDispatch()` -- which
only processes files in `redirFiles` -- never hashes, renames, or removes it.

The result is a permanent zero-byte file per redirection target per session
(`YYYYMMDD-HHMMSS-<transportId>-<sessionId>-redir_<safepath>`) accumulating
in the download directory indefinitely.

## Fix

In the no-command branch, after constructing the `PipeProtocol`, register its
`redirect_real_files` into `terminal.redirFiles`, mirroring the existing
command-not-found-with-redirects path. The backing files are then hashed and
renamed (if written) or deleted (if empty) at session close like any other
redirect target.

Thanks to @vbontchev for the detailed diagnosis and proposed fix.

## Tests

Added `test_bare_redirection_registers_backing_file` asserting a command-less
redirection registers its backing file for cleanup (it fails without the fix).

Full suite: 516 tests pass; ruff and mypy clean.