### PR TITLE
Discard data that arrives after the terminal protocol is torn down

### DIFF
--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -106,6 +106,14 @@ class LoggingServerProtocol(insults.ServerProtocol):
         """
         Input received from user
         """
+        if self.terminalProtocol is None:
+            # connectionLost() has already run and Twisted's ServerProtocol has
+            # cleared terminalProtocol. A final data packet delivered in the same
+            # reactor iteration is discarded rather than crashing in
+            # ServerProtocol.dataReceived with 'NoneType' has no attribute
+            # 'keystrokeReceived'.
+            return
+
         self.bytesReceived += len(data)
         if self.bytesReceivedLimit and self.bytesReceived > self.bytesReceivedLimit:
             log.msg(format="Data upload limit reached")

--- a/src/cowrie/test/test_insults.py
+++ b/src/cowrie/test/test_insults.py
@@ -53,6 +53,22 @@ class WriteLineEndingTestCase(unittest.TestCase):
         self.assertEqual(lsp.transport.written, b"Linux server01 5.10.0 armv7l\r\n")
 
 
+class DataReceivedAfterTeardownTestCase(unittest.TestCase):
+    """dataReceived must discard data once the terminal protocol is gone."""
+
+    def test_data_after_teardown_is_discarded(self) -> None:
+        # connectionLost() clears terminalProtocol; a final data packet
+        # delivered in the same reactor iteration must be dropped rather than
+        # crashing in ServerProtocol.dataReceived (issue #40225).
+        lsp = make_protocol("i")
+        lsp.terminalProtocol = None
+        lsp.stdinlogOpen = False
+        lsp.bytesReceived = 0
+        lsp.dataReceived(b"late keystrokes")  # must not raise
+        # Discarded before being counted or delegated to the parent.
+        self.assertEqual(lsp.bytesReceived, 0)
+
+
 class ConnectionLostStdinTestCase(unittest.TestCase):
     """Tests for stdin-log cleanup in LoggingServerProtocol.connectionLost()."""
 


### PR DESCRIPTION
Fixes #40225.

## Problem

Twisted's `ServerProtocol.connectionLost()` sets `terminalProtocol = None`,
but the reactor can deliver a final `CHANNEL_DATA` packet in the same
iteration, after `connectionLost` has already run on this protocol instance.
`LoggingServerProtocol.dataReceived()` delegated to
`ServerProtocol.dataReceived` unconditionally, which then reached
`self.terminalProtocol.keystrokeReceived(ch, None)` and crashed:

```
builtins.AttributeError: 'NoneType' object has no attribute 'keystrokeReceived'
```

This surfaced as an "Unhandled Error" in the reactor loop. It is a race
between the TCP stack and the reactor; SCP uploads and clients that pipeline
data right up to disconnect provoke it in practice.

## Fix

Guard `dataReceived()` on `terminalProtocol`, mirroring the existing
`eofReceived()` guard in the same class: once the terminal protocol is gone,
the session is being torn down, so the packet is discarded. The guard is at
the top of the method so a torn-down session also skips the already-finalized
ttylog writes, not just the parent delegation.

Thanks to @vbontchev for the detailed diagnosis and proposed fix.

## Tests

Added a test that feeds data with `terminalProtocol = None` and asserts no
crash and that the bytes are not counted (it fails without the fix).

Full suite: 517 tests pass; ruff and mypy clean.