### PR TITLE
Remove empty download artifacts on early wget/curl exits

### DIFF
--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -346,6 +346,17 @@ class Command_curl(HoneyPotCommand):
         self.write("^C\n")
         self.exit()
 
+    def exit(self, code: int | None = None) -> None:
+        # Close the download artifact on every exit path so an aborted download
+        # (CTRL-C, a HEAD request, a size limit, ...) does not leave its empty
+        # temp file behind in the download directory. close() is idempotent and
+        # removes an empty artifact, so the normal success/error paths are
+        # unaffected.
+        artifact = getattr(self, "artifact", None)
+        if artifact is not None:
+            artifact.close()
+        HoneyPotCommand.exit(self, code)
+
     def success(self, response):
         """
         successful treq get

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -439,6 +439,16 @@ class Command_wget(HoneyPotCommand):
         self.write("^C\n")
         self.exit(130)  # 128 + SIGINT
 
+    def exit(self, code: int | None = None) -> None:
+        # Close the download artifact on every exit path so an aborted download
+        # (CTRL-C, size limit, ...) does not leave its empty temp file behind in
+        # the download directory. close() is idempotent and removes an empty
+        # artifact, so the normal success/error paths are unaffected.
+        artifact = getattr(self, "artifact", None)
+        if artifact is not None:
+            artifact.close()
+        HoneyPotCommand.exit(self, code)
+
     def success(self, response):
         """
         successful treq get

--- a/src/cowrie/core/artifact.py
+++ b/src/cowrie/core/artifact.py
@@ -71,6 +71,10 @@ class Artifact:
         return self.fp.fileno()
 
     def close(self, keepEmpty: bool = False) -> tuple[str, str] | None:
+        if self.closed:
+            # Closing is idempotent: a command can close on its normal path and
+            # again on exit() without the second call failing on the closed file.
+            return None
         size: int = self.fp.tell()
         if size == 0 and not keepEmpty:
             self.fp.close()

--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 from twisted.internet import error
 from twisted.python.failure import Failure
 
 from cowrie.commands.curl import Command_curl
 from cowrie.core.artifact import Artifact
+from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
@@ -76,3 +78,25 @@ class CurlArtifactCleanupTests(unittest.TestCase):
         out = self.tr.value()
         self.assertIn(b"curl: (3)", out)
         self.assertIn(b"rc=3", out)
+
+    def test_exit_removes_empty_artifact(self) -> None:
+        # An aborted download (CTRL-C, HEAD request, size limit) reaches exit()
+        # with an empty artifact; exit() must remove its temp file (#40216).
+        cmd = Command_curl.__new__(Command_curl)
+        cmd.protocol = self.proto
+        cmd.exit_code = 0
+        cmd.artifact = Artifact("curl-download")
+        temp_filename = cmd.artifact.tempFilename
+        self.assertTrue(os.path.exists(temp_filename))
+        with mock.patch.object(HoneyPotCommand, "exit"):
+            cmd.exit()
+        self.assertFalse(
+            os.path.exists(temp_filename),
+            "early exit left an orphaned temp file behind",
+        )
+
+    def test_artifact_close_is_idempotent(self) -> None:
+        # The normal path closes the artifact and exit() closes it again.
+        artifact = Artifact("curl-download")
+        artifact.close()
+        artifact.close()  # must not raise on the already-closed file

--- a/src/cowrie/test/test_wget.py
+++ b/src/cowrie/test/test_wget.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 from twisted.internet import error
 from twisted.python.failure import Failure
 
 from cowrie.commands.wget import Command_wget
 from cowrie.core.artifact import Artifact
+from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
@@ -68,3 +70,19 @@ class WgetArtifactCleanupTests(unittest.TestCase):
             "failed download left an orphaned temp file behind",
         )
         self.assertEqual(os.listdir(self.tmpdir), [])
+
+    def test_exit_removes_empty_artifact(self) -> None:
+        # An aborted download (CTRL-C, size limit) reaches exit() with an empty
+        # artifact; exit() must remove its temp file (#40216).
+        cmd = Command_wget.__new__(Command_wget)
+        cmd.protocol = self.proto
+        cmd.exit_code = 0
+        cmd.artifact = Artifact("wget-download")
+        temp_filename = cmd.artifact.tempFilename
+        self.assertTrue(os.path.exists(temp_filename))
+        with mock.patch.object(HoneyPotCommand, "exit"):
+            cmd.exit()
+        self.assertFalse(
+            os.path.exists(temp_filename),
+            "early exit left an orphaned temp file behind",
+        )


### PR DESCRIPTION
Fixes #40216.

## Problem

`Artifact.__init__()` opens a `NamedTemporaryFile(delete=False)` in
`download_path` as soon as a `wget`/`curl` download starts. Several early-exit
paths call `exit()` without closing the artifact, so its zero-byte temp file
(`tmpXXXXXXXX`) is orphaned:

| File | Method | Condition |
|------|--------|-----------|
| wget | `handle_CTRL_C()` | CTRL-C during download |
| wget | `success()` / `collect()` | `Content-Length` or running count over `download_limit_size` |
| curl | `handle_CTRL_C()` | CTRL-C during download |
| curl | `success()` | HEAD request (`curl -I`) completes (no body) |
| curl | `success()` / `collect()` | over `download_limit_size` |

## Fix

Rather than adding `try: self.artifact.close()` before each of the ~7 affected
`exit()` calls, close the artifact once in a `wget`/`curl` `exit()` override --
the single choke point every exit path goes through, including any future ones
-- and make `Artifact.close()` idempotent (it already set `self.closed` but
never checked it). `close()` already removes an empty artifact, so an aborted
download leaves nothing behind, and the normal success/error paths (which close
explicitly first) are unaffected by the second, no-op close.

Thanks to @vbontchev for the detailed diagnosis.

## Tests

`test_exit_removes_empty_artifact` (wget and curl) asserts an early `exit()`
removes the empty temp file, and `test_artifact_close_is_idempotent` covers the
double-close. Both fail without the fix. Full suite: 519 tests pass; ruff and
mypy clean.