### PR TITLE
Report "Is a directory" instead of disconnecting on a directory command

### DIFF
--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -253,7 +253,11 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         try:
             binary_data = read_data_bytes("txtcmds", *relpath.split("/"))
             return self.txtcmd(binary_data)
-        except FileNotFoundError:
+        except (FileNotFoundError, IsADirectoryError):
+            # No txtcmd at this path. IsADirectoryError happens when the command
+            # resolves to a directory (e.g. `/` -> empty relpath -> the txtcmds
+            # directory itself); fall through so the caller reports "Is a
+            # directory" instead of crashing the session.
             pass
 
         if path in self.commands:

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -47,6 +47,18 @@ class ShellBaseCommandsTests(unittest.TestCase):  # TODO: ps, history
         self.proto.lineReceived(b"logout\n")
         self.assertEqual(self.tr.value(), b"")
 
+    def test_directory_as_command_reports_is_a_directory(self) -> None:
+        # Typing a directory path as a command must report "Is a directory"
+        # like bash, not crash the session. `/` resolves to an empty txtcmd
+        # path that pointed at the txtcmds directory itself and raised an
+        # uncaught IsADirectoryError, disconnecting the client.
+        self.proto.lineReceived(b"/\n")
+        self.assertEqual(self.tr.value(), b"-bash: /: Is a directory\n" + PROMPT)
+
+    def test_subdirectory_as_command_reports_is_a_directory(self) -> None:
+        self.proto.lineReceived(b"/bin\n")
+        self.assertEqual(self.tr.value(), b"-bash: /bin: Is a directory\n" + PROMPT)
+
     def test_clear_command(self) -> None:
         self.proto.lineReceived(b"clear\n")
         self.assertEqual(self.tr.value(), PROMPT)


### PR DESCRIPTION
## Problem

Typing a directory path as a command crashed the session and disconnected the
client. For example:

```
$ /
```

`getCommand()` resolves `/` to the filesystem root, producing an empty
`relpath`, and then calls `read_data_bytes("txtcmds", "")` -- which points at
the `txtcmds` directory itself. `Path.read_bytes()` raises `IsADirectoryError`,
which was not caught (only `FileNotFoundError` was). The exception propagated
out of `lineReceived()` and tore down the session. The same happened for any
directory path used as a command (`/bin`, `/etc`, ...).

## Fix

Catch `IsADirectoryError` alongside `FileNotFoundError` in the txtcmd lookup, so
a directory is treated as "not a txtcmd" and falls through to the
command-not-found path. That path already emits bash's message via
`command_not_found_message()`:

```
$ /
-bash: /: Is a directory
$ /bin
-bash: /bin: Is a directory
```

## Tests

Added two cases to `test_base_commands.py` (`/` and `/bin`) asserting the
"Is a directory" message and no disconnect; both fail without the fix.

Full suite: 522 tests pass; ruff and mypy clean.