### PR TITLE
Reject binary files passed to sh/bash instead of parsing their bytes

### DIFF
--- a/src/cowrie/commands/bash.py
+++ b/src/cowrie/commands/bash.py
@@ -62,6 +62,17 @@ class Command_sh(HoneyPotCommand):
             self.errorWrite(f"bash: {filename}: No such file or directory\n")
             return
 
+        # A binary file (e.g. an ELF payload a bot falls back to running with
+        # `sh payload`) must be rejected, not parsed: its newline bytes would
+        # otherwise be split into "commands" and flood the log with raw binary.
+        # bash treats a file as binary when a NUL byte appears before the first
+        # newline (check_binary_file); an ELF (\x7fELF...\x00) trips this.
+        if b"\x00" in contents[:80].split(b"\n", 1)[0]:
+            self.errorWrite(
+                f"bash: {filename}: cannot execute binary file: Exec format error\n"
+            )
+            return
+
         lines = contents.decode("utf-8", errors="replace").splitlines()
         # Strip shebang line
         if lines and _SHEBANG_RE.match(lines[0]):

--- a/src/cowrie/test/test_script_execution.py
+++ b/src/cowrie/test/test_script_execution.py
@@ -76,6 +76,28 @@ class ScriptExecutionTests(unittest.TestCase):
         output = self.tr.value()
         self.assertIn(b"cannot execute binary file", output)
 
+    def test_sh_rejects_binary_file(self) -> None:
+        """sh <ELF binary> rejects it instead of splitting its bytes into
+        commands and flooding the log (issue #40215)."""
+        self.proto.lineReceived(
+            b'printf "\\x7fELF\\x01\\x01\\x00\\nGARBAGE\\n" > /tmp/payload.x86'
+        )
+        self.tr.clear()
+        self.proto.lineReceived(b"sh /tmp/payload.x86")
+        output = self.tr.value()
+        self.assertIn(b"cannot execute binary file", output)
+        self.assertNotIn(b"GARBAGE", output)
+
+    def test_bash_rejects_binary_file(self) -> None:
+        self.proto.lineReceived(
+            b'printf "\\x7fELF\\x01\\x01\\x00\\nGARBAGE\\n" > /tmp/payload2.x86'
+        )
+        self.tr.clear()
+        self.proto.lineReceived(b"bash /tmp/payload2.x86")
+        output = self.tr.value()
+        self.assertIn(b"cannot execute binary file", output)
+        self.assertNotIn(b"GARBAGE", output)
+
     def test_shebang_line_stripped(self) -> None:
         """Shebang line is not echoed or executed as a command."""
         self.proto.lineReceived(


### PR DESCRIPTION
Fixes #40215.

## Problem

`Command_sh.execute_script_file()` reads the file given as an argument, decodes
it as UTF-8, splits on newlines, and feeds the chunks to the shell parser. An
ELF binary contains `0x0a` bytes at arbitrary offsets, so its raw contents get
split into dozens of bogus "commands", each logged as a `CMD:` event and again
as `Command not found` -- flooding the log with binary garbage for a single
`sh <binary>` invocation.

This is triggered by the architecture-iterating fallback common in
Mirai-family bots:

```sh
./payload.x86 || busybox sh payload.x86 || sh payload.x86
```

On a real system bash rejects it with
`bash: payload.x86: cannot execute binary file: Exec format error` and never
parses the contents.

## Fix

Reject a binary file before decoding/splitting, matching bash's
`check_binary_file`: a file is binary if a NUL byte appears before the first
newline in the leading bytes (an ELF's `\x7fELF...\x00` trips this). Emit
`cannot execute binary file: Exec format error` and stop.

I generalized the reporter's ELF-magic suggestion (`contents[:4] == b"\x7fELF"`)
to the NUL-before-newline heuristic so it also catches non-ELF binaries, which
flood the log identically, at the same cost. The `./binary` path already had an
equivalent guard; this brings `sh`/`bash <file>` in line.

Thanks to @vbontchev for the diagnosis.

## Tests

`test_sh_rejects_binary_file` / `test_bash_rejects_binary_file` assert the error
is emitted and the binary's trailing bytes are not parsed (they fail without
the fix). Full suite: 524 tests pass; ruff and mypy clean.