### PR TITLE
Log a failed DNS lookup at info level, not as an "Unhandled Error"

### DIFF
--- a/src/cowrie/core/network.py
+++ b/src/cowrie/core/network.py
@@ -84,7 +84,11 @@ def resolve_cname(
                     # We found an AAAA record (IPv6 address), return it immediately
                     return str(rr.payload.dottedQuad())
     except Exception as e:
-        log.err(e)
+        # A failed lookup (NXDOMAIN for an attacker's single-word hostname, a
+        # timeout, ...) is routine and handled here by returning None. Log it at
+        # informational level; log.err would format it as an "Unhandled Error"
+        # with a traceback, which is misleading for a caught exception.
+        log.msg(f"DNS lookup failed for {address!r}: {e}")
         return None  # In case of any failure, return None
 
     log.msg("no valid a or cname record")

--- a/src/cowrie/test/test_network.py
+++ b/src/cowrie/test/test_network.py
@@ -3,10 +3,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import unittest
+from unittest import mock
 
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import fail, inlineCallbacks
+from twisted.names import error as names_error
+from twisted.python import log
 
-from cowrie.core.network import communication_allowed
+from cowrie.core.network import communication_allowed, resolve_cname
 
 # The communication_allowed function and other dependencies would already be imported here
 
@@ -82,6 +85,31 @@ class TestCommunicationAllowed(unittest.TestCase):
         # Test with a CNAME that resolves to a blocked IP (e.g., 127.0.0.1)
         allowed = yield communication_allowed("localhost")  # Should be blocked
         self.assertFalse(allowed)
+
+
+class TestResolveCnameLogging(unittest.TestCase):
+    """A failed DNS lookup is handled, so it must not be logged as an error."""
+
+    def test_failed_lookup_logged_without_unhandled_error(self) -> None:
+        events: list[dict] = []
+        log.addObserver(events.append)
+        try:
+            failed = fail(names_error.DNSNameError("bin"))
+            with mock.patch(
+                "cowrie.core.network.client.lookupAddress", return_value=failed
+            ):
+                results: list = []
+                resolve_cname("bin", set()).addBoth(results.append)
+        finally:
+            log.removeObserver(events.append)
+
+        # The lookup fails synchronously, so resolve_cname returns None.
+        self.assertEqual(results, [None])
+        # log.err marks events with isError=1 and prints "Unhandled Error"; the
+        # caught failure must instead be an informational message.
+        self.assertFalse(any(e.get("isError") for e in events))
+        messages = [log.textFromEventDict(e) or "" for e in events]
+        self.assertTrue(any("DNS lookup failed for 'bin'" in m for m in messages))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #40214.

## Problem

`resolve_cname()` in `core/network.py` catches a failed DNS lookup
(`DNSNameError` / NXDOMAIN, timeouts, ...) and returns `None`, which is
correct. But it logged the caught exception with `log.err(e)`, which
`twisted.python.log` formats as an **"Unhandled Error"** with a full traceback
-- reserved for genuinely unhandled failures.

NXDOMAIN is routine: an attacker running `curl http://bin/192.0.2.1/payload`
causes a single-word DNS lookup for `bin` that always fails, so the log fills
with misleading error-severity tracebacks for a handled case:

```
[DNSDatagramProtocol (UDP)] Unhandled Error
    Traceback (most recent call last):
      ...
    twisted.names.error.DNSNameError: <Message ... rCode=3 ... queries=[Query(b'bin', 1, 1)] ...>
```

## Fix

Use `log.msg()` instead of `log.err()` so the handled failure is recorded at
informational level without the "Unhandled Error" prefix or traceback.
`resolve_cname()` still returns `None`; behaviour is otherwise unchanged.

Thanks to @vbontchev for the diagnosis.

## Tests

`TestResolveCnameLogging` mocks `lookupAddress` to fail and asserts
`resolve_cname` returns `None`, logs no error-level event, and emits the
informational "DNS lookup failed for 'bin'" message. It fails without the fix.

Full suite: 525 tests pass; ruff and mypy clean.