### PR TITLE
Log each telnet option negotiation once per connection

### DIFF
--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -53,6 +53,9 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
 
     def connectionMade(self):
         self.transportId: str = uuid.uuid4().hex[:12]
+        # (command, option_byte) pairs already logged, to suppress a scanner
+        # flooding the same option negotiation (see _log_negotiation).
+        self._logged_options: set[tuple[str, int]] = set()
         sessionno = self.transport.sessionno
         self.startTime = time.time()
         self.setTimeout(
@@ -161,64 +164,44 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
             return TELNET_OPTIONS.get(option_byte, f"UNKNOWN-{option_byte}")
         return "UNKNOWN"
 
-    def telnet_WILL(self, option: bytes) -> None:
+    def _log_negotiation(self, command: str, option: bytes) -> None:
+        """Log a telnet option negotiation once per (command, option) per
+        connection.
+
+        Logged for security monitoring and CVE detection. A scanner can blast
+        the same negotiation (e.g. ``WONT NAWS``) hundreds of times; logging
+        each one floods the log, so identical repeats within a connection are
+        suppressed after the first.
         """
-        Client indicates willingness to enable an option.
-        Log for security monitoring and CVE detection.
-        """
-        option_name = self._get_option_name(option)
         option_byte = option[0] if option else 0
+        key = (command, option_byte)
+        if key in self._logged_options:
+            return
+        self._logged_options.add(key)
         log.msg(
             eventid="cowrie.telnet.option",
-            format="Telnet WILL %(option_name)s",
-            command="WILL",
-            option_name=option_name,
+            format=f"Telnet {command} %(option_name)s",
+            command=command,
+            option_name=self._get_option_name(option),
             option_byte=option_byte,
         )
-        # Call parent implementation
+
+    def telnet_WILL(self, option: bytes) -> None:
+        """Client indicates willingness to enable an option."""
+        self._log_negotiation("WILL", option)
         TelnetTransport.telnet_WILL(self, option)
 
     def telnet_WONT(self, option: bytes) -> None:
-        """
-        Client refuses to enable an option.
-        """
-        option_name = self._get_option_name(option)
-        option_byte = option[0] if option else 0
-        log.msg(
-            eventid="cowrie.telnet.option",
-            format="Telnet WONT %(option_name)s",
-            command="WONT",
-            option_name=option_name,
-            option_byte=option_byte,
-        )
+        """Client refuses to enable an option."""
+        self._log_negotiation("WONT", option)
         TelnetTransport.telnet_WONT(self, option)
 
     def telnet_DO(self, option: bytes) -> None:
-        """
-        Client requests that we enable an option.
-        """
-        option_name = self._get_option_name(option)
-        option_byte = option[0] if option else 0
-        log.msg(
-            eventid="cowrie.telnet.option",
-            format="Telnet DO %(option_name)s",
-            command="DO",
-            option_name=option_name,
-            option_byte=option_byte,
-        )
+        """Client requests that we enable an option."""
+        self._log_negotiation("DO", option)
         TelnetTransport.telnet_DO(self, option)
 
     def telnet_DONT(self, option: bytes) -> None:
-        """
-        Client requests that we disable an option.
-        """
-        option_name = self._get_option_name(option)
-        option_byte = option[0] if option else 0
-        log.msg(
-            eventid="cowrie.telnet.option",
-            format="Telnet DONT %(option_name)s",
-            command="DONT",
-            option_name=option_name,
-            option_byte=option_byte,
-        )
+        """Client requests that we disable an option."""
+        self._log_negotiation("DONT", option)
         TelnetTransport.telnet_DONT(self, option)

--- a/src/cowrie/test/test_telnet_transport.py
+++ b/src/cowrie/test/test_telnet_transport.py
@@ -9,14 +9,24 @@ from __future__ import annotations
 
 import gc
 import unittest
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
-from twisted.conch.telnet import ECHO, AlreadyNegotiating, ITelnetProtocol
+from twisted.conch.telnet import (
+    ECHO,
+    NAWS,
+    AlreadyNegotiating,
+    ITelnetProtocol,
+    TelnetTransport,
+)
 from twisted.internet.error import ConnectionDone
 from twisted.python import failure, log
 from zope.interface import implementer
 
 from cowrie.telnet.transport import CowrieTelnetTransport
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class MockOptionState:
@@ -225,6 +235,48 @@ class TestNegotiationDuringConnectionLost(unittest.TestCase):
             "willChain mutated self.options during teardown",
         )
         self.assertEqual(self.tcp.data, b"")
+
+
+class TestOptionLoggingDeduplication(unittest.TestCase):
+    """A scanner flooding the same option negotiation is logged once."""
+
+    def setUp(self) -> None:
+        self.transport = CowrieTelnetTransport()
+        self.transport.transport = MagicMock()
+        # Normally initialised in connectionMade.
+        self.transport._logged_options = set()
+
+    def _capture(self, run: Callable[[], None]) -> list[dict]:
+        events: list[dict] = []
+        log.addObserver(events.append)
+        try:
+            run()
+        finally:
+            log.removeObserver(events.append)
+        return [e for e in events if e.get("eventid") == "cowrie.telnet.option"]
+
+    def test_repeated_negotiation_logged_once(self) -> None:
+        def run() -> None:
+            for _ in range(5):
+                self.transport.telnet_WONT(NAWS)
+
+        with patch.object(TelnetTransport, "telnet_WONT"):
+            logs = self._capture(run)
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(logs[0]["command"], "WONT")
+
+    def test_distinct_negotiations_each_logged(self) -> None:
+        def run() -> None:
+            self.transport.telnet_WONT(NAWS)
+            self.transport.telnet_WONT(NAWS)
+            self.transport.telnet_WILL(NAWS)
+
+        with (
+            patch.object(TelnetTransport, "telnet_WONT"),
+            patch.object(TelnetTransport, "telnet_WILL"),
+        ):
+            logs = self._capture(run)
+        self.assertEqual(sorted(e["command"] for e in logs), ["WILL", "WONT"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`CowrieTelnetTransport` logs every telnet `WILL`/`WONT`/`DO`/`DONT` option
negotiation at info level (for security monitoring / CVE detection). A scanner
that blasts the same negotiation -- typically `WONT NAWS` repeated hundreds of
times -- floods the log:

```
[CowrieTelnetTransport,38,103.173.7.170] Telnet WONT NAWS
[CowrieTelnetTransport,38,103.173.7.170] Telnet WONT NAWS
... (dozens more) ...
```

## Not a loop

It looks like a negotiation loop but isn't: Twisted's `telnet_WONT` handlers
(`wont_no_false` / `wont_no_true`) send no reply, and cowrie's negotiation
retry only fires on `AlreadyNegotiating`, not on a refusal (`OptionRefused`),
and NAWS is `doChain`'d exactly once. So cowrie sends nothing back -- the
client is simply flooding `WONT NAWS` and each packet is logged.

## Fix

Deduplicate: log each `(command, option)` pair at most once per connection.
The first occurrence of every negotiation is still recorded (the signal Mirai/
CVE monitoring relies on), but identical repeats are suppressed, so a flood
becomes a single line. The four near-identical handlers are folded into one
`_log_negotiation` helper.

## Tests

`TestOptionLoggingDeduplication` asserts a repeated `WONT NAWS` logs once while
distinct negotiations each log. Both fail without the fix. Full suite: 527
tests pass; ruff and mypy clean.