### PR TITLE
Reuse an existing VirusTotal collection instead of re-creating it

### DIFF
--- a/src/cowrie/output/virustotal.py
+++ b/src/cowrie/output/virustotal.py
@@ -13,7 +13,7 @@ import datetime
 import json
 import os
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlencode, urlparse
+from urllib.parse import quote, urlencode, urlparse
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -561,10 +561,48 @@ class Output(cowrie.core.output.Output):
 
     def _init_collection(self) -> None:
         """
-        Initialize collection - create if doesn't exist or get ID if exists
-        This is called during start() if collection is configured
+        Resolve the collection id: look up an existing collection with this name
+        and reuse it, otherwise create one. Called during start() if a
+        collection is configured.
+
+        Looking up by name first reuses the server-assigned id across restarts
+        (it is not derivable from the name) and avoids creating a duplicate
+        collection on every start.
         """
-        # Try to create the collection (it's idempotent - won't duplicate if exists)
+        query = quote(f"name:{self.collection_name} owner:me")
+        vtUrl = f"{VTAPI_URL}collections?filter={query}&limit=40".encode()
+        headers = self._build_headers()
+
+        def process_response(body_bytes):
+            if self.debug:
+                log.msg(f"VT find collection result: {body_bytes}")
+            j = json.loads(body_bytes.decode("utf8"))
+            # The name filter may be loose, so match the name exactly.
+            if "error" not in j:
+                for item in j.get("data", []):
+                    attributes = item.get("attributes", {})
+                    if (
+                        attributes.get("name") == self.collection_name
+                        and item.get("id")
+                    ):
+                        self.collection_id = item["id"]
+                        log.msg(
+                            f"VT: Using existing collection '{self.collection_name}' with ID: {item['id']}"
+                        )
+                        return
+            # No existing collection found (or the search errored): create it.
+            self._create_collection()
+
+        self._make_request(
+            b"GET",
+            vtUrl,
+            headers,
+            process_response=process_response,
+            error_prefix="VT find collection",
+        )
+
+    def _create_collection(self) -> None:
+        """Create the configured collection and store its server-assigned id."""
         vtUrl = f"{VTAPI_URL}collections".encode()
         collection_data = {
             "data": {
@@ -581,29 +619,17 @@ class Output(cowrie.core.output.Output):
         def process_response(body_bytes):
             if self.debug:
                 log.msg(f"VT create collection result: {body_bytes}")
-            result = body_bytes.decode("utf8")
-            j = json.loads(result)
+            j = json.loads(body_bytes.decode("utf8"))
 
-            # Check for errors in v3 API response
             if "error" in j:
-                error_code = j["error"].get("code")
-                # AlreadyExistsError means collection exists - that's OK
-                if error_code == "AlreadyExistsError":
-                    log.msg(
-                        f"VT: Collection '{self.collection_name}' already exists - will use existing"
-                    )
-                    # We'll get the ID from the error details if available
-                    # Otherwise we'll get it on first add operation
-                else:
-                    log.msg(
-                        f"VT: Collection creation error - {j['error']['code']}: {j['error'].get('message', 'Unknown error')}"
-                    )
+                log.msg(
+                    f"VT: Collection creation error - {j['error'].get('code')}: "
+                    f"{j['error'].get('message', 'Unknown error')}"
+                )
                 return
 
-            # Process successful creation response
             if "data" in j:
-                data = j["data"]
-                collection_id = data.get("id")
+                collection_id = j["data"].get("id")
                 if collection_id:
                     self.collection_id = collection_id
                     log.msg(

--- a/src/cowrie/test/test_virustotal.py
+++ b/src/cowrie/test/test_virustotal.py
@@ -440,37 +440,77 @@ class VirusTotalOutputTests(unittest.TestCase):
                 # Reset mock for next test
                 self.output.agent.request.reset_mock()
 
-    def test_collection_initialization(self) -> None:
-        """Test collection initialization"""
-        # Create output plugin with collection configured
+    def test_create_collection_request(self) -> None:
+        """Creating a collection POSTs the v3 collection body."""
         output = Output()
         output.apiKey = "test-api-key"
         output.debug = True
         output.collection_name = "test-collection"
 
-        # Mock agent
         mock_agent = Mock()
         output.agent = mock_agent
 
-        # Initialize collection
-        output._init_collection()
+        output._create_collection()
 
-        # Verify request was made
         self.assertTrue(mock_agent.request.called)
-        call_args = mock_agent.request.call_args
-        method, url, _headers, body = call_args[0]
-
-        # Check method and URL
+        method, url, _headers, body = mock_agent.request.call_args[0]
         self.assertEqual(method, b"POST")
         self.assertEqual(url, b"https://www.virustotal.com/api/v3/collections")
-
-        # Check body format
-        body_content = body.body.decode()
-        collection_data = json.loads(body_content)
+        collection_data = json.loads(body.body.decode())
         self.assertEqual(collection_data["data"]["type"], "collection")
         self.assertEqual(
             collection_data["data"]["attributes"]["name"], "test-collection"
         )
+
+    def test_init_collection_reuses_existing(self) -> None:
+        """An existing collection found by name is reused without creating."""
+        self.output.collection_name = "cowrie"
+
+        captured: dict = {}
+
+        def fake_make_request(method, *args, **kwargs):
+            captured["method"] = method
+            captured["process_response"] = kwargs.get("process_response")
+            return defer.succeed(None)
+
+        self.output._make_request = fake_make_request  # type: ignore[method-assign]
+        self.output._create_collection = Mock()  # type: ignore[method-assign]
+
+        self.output._init_collection()
+        # The lookup is a GET against /collections.
+        self.assertEqual(captured["method"], b"GET")
+        captured["process_response"](
+            json.dumps(
+                {"data": [{"id": "EXISTING-ID", "attributes": {"name": "cowrie"}}]}
+            ).encode()
+        )
+
+        self.assertEqual(self.output.collection_id, "EXISTING-ID")
+        self.output._create_collection.assert_not_called()
+
+    def test_init_collection_creates_when_absent(self) -> None:
+        """When no collection matches the name, one is created."""
+        self.output.collection_name = "cowrie"
+
+        captured: dict = {}
+
+        def fake_make_request(method, *args, **kwargs):
+            captured["process_response"] = kwargs.get("process_response")
+            return defer.succeed(None)
+
+        self.output._make_request = fake_make_request  # type: ignore[method-assign]
+        self.output._create_collection = Mock()  # type: ignore[method-assign]
+
+        self.output._init_collection()
+        # A different collection is returned; the name does not match.
+        captured["process_response"](
+            json.dumps(
+                {"data": [{"id": "OTHER-ID", "attributes": {"name": "something-else"}}]}
+            ).encode()
+        )
+
+        self.assertIsNone(self.output.collection_id)
+        self.output._create_collection.assert_called_once()
 
     def test_add_file_to_collection(self) -> None:
         """Test adding a file to a collection"""


### PR DESCRIPTION
## Problem

`_init_collection` does `POST /collections` on every start. The first run
creates the collection and sets `collection_id`. Every subsequent run hits an
existing collection, so VirusTotal returns `AlreadyExistsError`; the code
logged "will use existing" but **never set `collection_id`**. Since
`_add_to_collection` early-returns when `collection_id` is unset, no file is
ever added to the collection after the run that created it.

The collection id is server-assigned (a 64-char hash, not derivable from the
name — verified against the create response).

## Fix

Look the collection up by name before creating it:
`GET /collections?filter=name:<name> owner:me`, match the name exactly in the
returned `data[]`, and reuse that collection's id. Only `POST` to create when
no collection matches.

This:
- recovers the id across restarts (and for collections created before this change),
- never creates a duplicate collection,
- needs no local state and no `AlreadyExistsError` handling.

Complements #40234 (which fixed commenting/collection by addressing the file by
its sha256 instead of the analysis id).

## Tests

- `test_init_collection_reuses_existing` — a name match in the lookup sets
  `collection_id` and does not create.
- `test_init_collection_creates_when_absent` — no name match falls through to
  create.
- `test_create_collection_request` — the create POSTs the v3 collection body.

Full suite: 530 tests pass; ruff and mypy clean.