### PR TITLE
fix: check init before stop/force-stop/status

### DIFF
--- a/src/cowrie/scripts/cowrie.py
+++ b/src/cowrie/scripts/cowrie.py
@@ -85,6 +85,7 @@ def remove_stale_pidfile() -> None:
 
 def cowrie_status() -> None:
     """Print the current status of Cowrie."""
+    check_initialized()
     pid = read_pid()
     if pid is None:
         print("cowrie is not running.")
@@ -179,6 +180,7 @@ def cowrie_start(args: list[str]) -> NoReturn:
 
 def cowrie_stop() -> None:
     """Stop the Cowrie service."""
+    check_initialized()
     pid = read_pid()
     if pid is None:
         print("cowrie is not running.")
@@ -199,6 +201,7 @@ def cowrie_stop() -> None:
 
 def cowrie_force_stop() -> None:
     """Force stop the Cowrie service."""
+    check_initialized()
     pid = read_pid()
     if pid is None:
         print("cowrie is not running.")


### PR DESCRIPTION
## Problem

Running `cowrie stop`, `force-stop`, or `status` outside a cowrie state
directory read the cwd-relative pidfile, found nothing, and printed the
misleading `cowrie is not running.` instead of telling the user they were in
the wrong directory.

For `restart` the init error appeared only *after* the not-running message,
because `cowrie_restart` runs `cowrie_stop` before `cowrie_start`'s
`check_initialized()` check.

## Fix

Call `check_initialized()` first in `cowrie_stop`, `cowrie_force_stop`, and
`cowrie_status` so they report the wrong directory up front. `restart` is
covered transitively via `cowrie_stop`.