### PR TITLE
fix: handle invalid IAC byte in telnet without crashing (#40218)

### DIFF
--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -86,6 +86,33 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         """
         self.transport.write(data.replace(b"\r\n", b"\n"))
 
+    def dataReceived(self, data: bytes) -> None:
+        """
+        Twisted's Telnet.dataReceived() raises ValueError on an unrecognised
+        byte following IAC (e.g. a scanner sending IAC 0x01 outside a WILL/DO
+        envelope). Unhandled, that escapes into the reactor as an "Unhandled
+        Error" and drops the transport without the normal connectionLost()
+        cleanup. Catch it, log the protocol error, and lose the connection so
+        the usual teardown runs.
+
+        Telnet.dataReceived() also re-enters the application stack
+        (applicationDataReceived -> protocol.dataReceived, negotiate,
+        commandReceived), so a ValueError raised by downstream honeypot code is
+        caught here too. Log the full traceback as well so a genuine bug is not
+        silently reduced to a one-line protocol error.
+        """
+        try:
+            TelnetTransport.dataReceived(self, data)
+        except ValueError as e:
+            log.msg(
+                eventid="cowrie.telnet.error",
+                format="Telnet protocol error %(error)s; dropping connection",
+                error=str(e),
+            )
+            log.err()
+            if self.transport:
+                self.transport.loseConnection()
+
     def timeoutConnection(self) -> None:
         """
         Make sure all sessions time out eventually.

--- a/src/cowrie/test/test_telnet_transport.py
+++ b/src/cowrie/test/test_telnet_transport.py
@@ -237,6 +237,49 @@ class TestNegotiationDuringConnectionLost(unittest.TestCase):
         self.assertEqual(self.tcp.data, b"")
 
 
+class TestInvalidIACSequence(unittest.TestCase):
+    """Regression test for issue #40218.
+
+    Twisted's Telnet.dataReceived() raises ValueError("Stumped", b) when a
+    client sends a byte after IAC (0xFF) that is not a recognised command --
+    e.g. a scanner sending IAC 0x01 outside a WILL/DO envelope. Inherited
+    unchanged, this propagates into the reactor as an "Unhandled Error" and
+    tears the transport down without the normal connectionLost() cleanup. The
+    override must catch it, log a telnet error, and drop the connection
+    cleanly.
+    """
+
+    def setUp(self) -> None:
+        self.transport = CowrieTelnetTransport()
+        self.tcp = MagicMock()
+        self.transport.transport = self.tcp
+
+    def _capture(self, run: Callable[[], None]) -> list[dict]:
+        events: list[dict] = []
+        log.addObserver(events.append)
+        try:
+            run()
+        finally:
+            log.removeObserver(events.append)
+        return [e for e in events if e.get("eventid") == "cowrie.telnet.error"]
+
+    def test_invalid_iac_byte_dropped_cleanly(self) -> None:
+        # IAC (0xFF) followed by 0x01, which is not a valid IAC command byte.
+        errors = self._capture(lambda: self.transport.dataReceived(b"\xff\x01"))
+
+        self.tcp.loseConnection.assert_called_once_with()
+        self.assertEqual(len(errors), 1)
+
+    def test_valid_data_still_delivered(self) -> None:
+        # A well-formed stream must pass through untouched.
+        self.transport.protocol = MagicMock()
+        errors = self._capture(lambda: self.transport.dataReceived(b"hello"))
+
+        self.transport.protocol.dataReceived.assert_called_once_with(b"hello")
+        self.tcp.loseConnection.assert_not_called()
+        self.assertEqual(errors, [])
+
+
 class TestOptionLoggingDeduplication(unittest.TestCase):
     """A scanner flooding the same option negotiation is logged once."""
 


### PR DESCRIPTION
## Problem

Twisted's `Telnet.dataReceived()` raises `ValueError("Stumped", b)` when a
client sends a byte after IAC (0xFF) that is not a recognised command — e.g. a
scanner sending `IAC 0x01` outside a WILL/DO envelope. `CowrieTelnetTransport`
inherited `dataReceived()` unchanged, so the exception escaped into the reactor
as an "Unhandled Error" and tore the transport down without the normal
`connectionLost()` cleanup (duration logging, `redirFiles`, ttylog
finalisation).

```
builtins.ValueError: ('Stumped', b'\x01')
```

Fixes #40218.

## Fix

Override `dataReceived()` to catch `ValueError`, log a `cowrie.telnet.error`
event, and `loseConnection()` so the usual teardown runs.

`Telnet.dataReceived()` also re-enters the application stack synchronously
(`applicationDataReceived` → `protocol.dataReceived`, `negotiate`,
`commandReceived`), so a `ValueError` raised by downstream honeypot code is
caught here too. Dropping the session on any such error is the right behaviour
for a honeypot, but to avoid silently flattening a genuine bug into a one-line
protocol error, the full traceback is also logged via `log.err()`.

## Tests

`TestInvalidIACSequence`:
- `IAC 0x01` is dropped cleanly (connection lost, one `cowrie.telnet.error`
  event) instead of raising.
- Well-formed data still passes through to the application protocol untouched.