### PR TITLE
fix: escape non-printable bytes in logged untrusted input

### DIFF
--- a/src/cowrie/core/checkers.py
+++ b/src/cowrie/core/checkers.py
@@ -21,6 +21,7 @@ from zope.interface import implementer
 from cowrie.core import auth
 from cowrie.core import credentials as conchcredentials
 from cowrie.core.config import CowrieConfig
+from cowrie.core.utils import escape_nonprintable
 
 
 @implementer(ICredentialsChecker)
@@ -36,7 +37,7 @@ class HoneypotPublicKeyChecker:
         log.msg(
             eventid="cowrie.client.fingerprint",
             format="public key attempt for user %(username)s of type %(type)s with fingerprint %(fingerprint)s",
-            username=credentials.username,
+            username=escape_nonprintable(credentials.username),
             fingerprint=_pubKey.fingerprint(),
             key=_pubKey.toString("OPENSSH"),
             type=_pubKey.sshType(),
@@ -46,7 +47,7 @@ class HoneypotPublicKeyChecker:
             log.msg(
                 eventid="cowrie.login.success",
                 format="public key login attempt for [%(username)s] succeeded",
-                username=credentials.username,
+                username=escape_nonprintable(credentials.username),
                 fingerprint=_pubKey.fingerprint(),
                 key=_pubKey.toString("OPENSSH"),
                 type=_pubKey.sshType(),
@@ -56,7 +57,7 @@ class HoneypotPublicKeyChecker:
             log.msg(
                 eventid="cowrie.login.failed",
                 format="public key login attempt for [%(username)s] failed",
-                username=credentials.username,
+                username=escape_nonprintable(credentials.username),
                 fingerprint=_pubKey.fingerprint(),
                 key=_pubKey.toString("OPENSSH"),
                 type=_pubKey.sshType(),
@@ -76,7 +77,7 @@ class HoneypotNoneChecker:
         log.msg(
             eventid="cowrie.login.success",
             format="login attempt [%(username)s] succeeded",
-            username=credentials.username,
+            username=escape_nonprintable(credentials.username),
         )
         return defer.succeed(credentials.username)
 
@@ -134,15 +135,15 @@ class HoneypotPasswordChecker:
             log.msg(
                 eventid="cowrie.login.success",
                 format="login attempt [%(username)s/%(password)s] succeeded",
-                username=theusername,
-                password=thepassword,
+                username=escape_nonprintable(theusername),
+                password=escape_nonprintable(thepassword),
             )
             return True
 
         log.msg(
             eventid="cowrie.login.failed",
             format="login attempt [%(username)s/%(password)s] failed",
-            username=theusername,
-            password=thepassword,
+            username=escape_nonprintable(theusername),
+            password=escape_nonprintable(thepassword),
         )
         return False

--- a/src/cowrie/core/utils.py
+++ b/src/cowrie/core/utils.py
@@ -15,6 +15,25 @@ if TYPE_CHECKING:
     import configparser
 
 
+def escape_nonprintable(data: bytes) -> str:
+    """Return a log-safe printable representation of arbitrary bytes.
+
+    Bytes outside printable US-ASCII (0x20-0x7e) are rendered as ``\\xNN`` so
+    control characters and invalid UTF-8 from untrusted input cannot inject
+    newlines, terminal escape sequences, or other artifacts into log output.
+    The backslash itself is escaped so the representation is unambiguous.
+    """
+    out: list[str] = []
+    for b in data:
+        if b == 0x5C:  # backslash
+            out.append("\\\\")
+        elif 0x20 <= b <= 0x7E:
+            out.append(chr(b))
+        else:
+            out.append(f"\\x{b:02x}")
+    return "".join(out)
+
+
 def durationHuman(duration: float) -> str:
     """
     Turn number of seconds into human readable string

--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -26,6 +26,7 @@ from twisted.protocols.policies import TimeoutMixin
 from twisted.python import failure, log, randbytes
 
 from cowrie.core.config import CowrieConfig
+from cowrie.core.utils import escape_nonprintable
 
 
 class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
@@ -126,9 +127,7 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             self.otherVersionString: bytes = self.buf.split(b"\n")[0].strip()
             log.msg(
                 eventid="cowrie.client.version",
-                version=self.otherVersionString.decode(
-                    "utf-8", errors="backslashreplace"
-                ),
+                version=escape_nonprintable(self.otherVersionString),
                 format="Remote SSH version: %(version)s",
             )
             m = re.match(rb"SSH-(\d+\.\d+)-(.*)", self.otherVersionString)
@@ -199,10 +198,16 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
 
         # hassh SSH client fingerprint
         # https://github.com/salesforce/hassh
-        ckexAlgs = ",".join([alg.decode("utf-8") for alg in kexAlgs])
-        cencCS = ",".join([alg.decode("utf-8") for alg in encCS])
-        cmacCS = ",".join([alg.decode("utf-8") for alg in macCS])
-        ccompCS = ",".join([alg.decode("utf-8") for alg in compCS])
+        # backslashreplace, not escape_nonprintable: for every byte sequence
+        # that decodes as valid UTF-8 (all real clients) this is identical to a
+        # plain decode, so the hassh fingerprint is unchanged; it only avoids
+        # crashing on a malformed name-list that is not valid UTF-8.
+        ckexAlgs = ",".join(
+            [alg.decode("utf-8", "backslashreplace") for alg in kexAlgs]
+        )
+        cencCS = ",".join([alg.decode("utf-8", "backslashreplace") for alg in encCS])
+        cmacCS = ",".join([alg.decode("utf-8", "backslashreplace") for alg in macCS])
+        ccompCS = ",".join([alg.decode("utf-8", "backslashreplace") for alg in compCS])
         hasshAlgorithms = f"{ckexAlgs};{cencCS};{cmacCS};{ccompCS}"
         hassh = md5(hasshAlgorithms.encode("utf-8")).hexdigest()
 

--- a/src/cowrie/ssh_proxy/protocols/sftp.py
+++ b/src/cowrie/ssh_proxy/protocols/sftp.py
@@ -13,6 +13,7 @@ from twisted.conch.ssh import filetransfer
 from twisted.python import log
 
 from cowrie.core.config import CowrieConfig
+from cowrie.core.utils import escape_nonprintable
 from cowrie.ssh_proxy.protocols import base_protocol
 
 # PACKETLAYOUT = {
@@ -126,7 +127,9 @@ class SFTP(base_protocol.BaseProtocol):
         elif sftp_num == filetransfer.FXP_REALPATH:
             self.path = self.extract_string()
             self.command = b"cd " + self.path
-            log.msg(parent + "[SFTP] Entered Command: " + self.command.decode())
+            log.msg(
+                parent + "[SFTP] Entered Command: " + escape_nonprintable(self.command)
+            )
 
         elif sftp_num == filetransfer.FXP_OPEN:
             self.path = self.extract_string()
@@ -144,7 +147,9 @@ class SFTP(base_protocol.BaseProtocol):
                     parent + f"[SFTP] New SFTP pflag detected: {pflags!r} {self.data!r}"
                 )
 
-            log.msg(parent + " [SFTP] Entered Command: " + self.command.decode())
+            log.msg(
+                parent + " [SFTP] Entered Command: " + escape_nonprintable(self.command)
+            )
 
         elif sftp_num == filetransfer.FXP_READ:
             pass
@@ -184,18 +189,24 @@ class SFTP(base_protocol.BaseProtocol):
                 )
 
         elif sftp_num == filetransfer.FXP_EXTENDED_REPLY:
-            log.msg(parent + " [SFTP] Entered Command: " + self.command.decode())
+            log.msg(
+                parent + " [SFTP] Entered Command: " + escape_nonprintable(self.command)
+            )
             # self.out.command_entered(self.uuid, self.command)
 
         elif sftp_num == filetransfer.FXP_CLOSE:
             if self.handle == self.extract_string():
                 if b"get" in self.command:
                     log.msg(
-                        parent + " [SFTP] Finished Downloading: " + self.path.decode()
+                        parent
+                        + " [SFTP] Finished Downloading: "
+                        + escape_nonprintable(self.path)
                     )
                 elif b"put" in self.command:
                     log.msg(
-                        parent + " [SFTP] Finished Uploading: " + self.path.decode()
+                        parent
+                        + " [SFTP] Finished Uploading: "
+                        + escape_nonprintable(self.path)
                     )
 
                     # TODO: should use artifact functions
@@ -249,16 +260,18 @@ class SFTP(base_protocol.BaseProtocol):
                 if code in [0, 1]:
                     if b"get" not in self.command and b"put" not in self.command:
                         log.msg(
-                            parent + " [SFTP] Entered Command: " + self.command.decode()
+                            parent
+                            + " [SFTP] Entered Command: "
+                            + escape_nonprintable(self.command)
                         )
                 else:
                     message = self.extract_string()
                     log.msg(
                         parent
                         + " [SFTP] Failed Command: "
-                        + self.command.decode()
+                        + escape_nonprintable(self.command)
                         + " Reason: "
-                        + message.decode()
+                        + escape_nonprintable(message)
                     )
         else:
             log.msg("[SFTP] Unhandled packet: {sftp_num}")

--- a/src/cowrie/ssh_proxy/protocols/ssh.py
+++ b/src/cowrie/ssh_proxy/protocols/ssh.py
@@ -13,6 +13,7 @@ from twisted.conch.ssh import connection, transport, userauth
 from twisted.python import log
 
 from cowrie.core.config import CowrieConfig
+from cowrie.core.utils import escape_nonprintable
 from cowrie.ssh_proxy.protocols import (
     base_protocol,
     exec_term,
@@ -304,13 +305,17 @@ class SSH(base_protocol.BaseProtocol):
                     # UNKNOWN SUBSYSTEM
                     log.msg(f"MSG_CHANNEL_REQUEST: {channel_type!r}: {subsystem!r}")
                     log.msg(
-                        "[SSH] Unknown Subsystem Type Detected - " + subsystem.decode()
+                        "[SSH] Unknown Subsystem Type Detected - "
+                        + escape_nonprintable(subsystem)
                     )
             elif channel_type == b"env":
                 _ = self.extract_bool()
                 var = self.extract_string()
                 value = self.extract_string()
-                log.msg(f"MSG_CHANNEL_REQUEST: env: {var.decode()}={value.decode()}")
+                log.msg(
+                    f"MSG_CHANNEL_REQUEST: env: "
+                    f"{escape_nonprintable(var)}={escape_nonprintable(value)}"
+                )
 
             else:
                 # UNKNOWN CHANNEL REQUEST TYPE
@@ -321,7 +326,8 @@ class SSH(base_protocol.BaseProtocol):
                     b"exit-signal",
                 ]:
                     log.msg(
-                        f"[SSH] Unknown Channel Request Type Detected - {channel_type.decode()}"
+                        "[SSH] Unknown Channel Request Type Detected - "
+                        + escape_nonprintable(channel_type)
                     )
 
         elif message_num == connection.MSG_CHANNEL_FAILURE:

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -20,6 +20,7 @@ from twisted.protocols.policies import TimeoutMixin
 from twisted.python import failure, log, randbytes
 
 from cowrie.core.config import CowrieConfig
+from cowrie.core.utils import escape_nonprintable
 from cowrie.ssh_proxy import client_transport
 from cowrie.ssh_proxy.protocols import ssh
 
@@ -227,9 +228,7 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             self.otherVersionString = self.buf.split(b"\n")[0].strip()
             log.msg(
                 eventid="cowrie.client.version",
-                version=self.otherVersionString.decode(
-                    "utf-8", errors="backslashreplace"
-                ),
+                version=escape_nonprintable(self.otherVersionString),
                 format="Remote SSH version: %(version)s",
             )
             m = re.match(rb"SSH-(\d+.\d+)-(.*)", self.otherVersionString)

--- a/src/cowrie/test/test_checkers.py
+++ b/src/cowrie/test/test_checkers.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import unittest
 from unittest.mock import patch
 
+from twisted.python import log
+
 from cowrie.core import auth
 from cowrie.core.checkers import HoneypotPasswordChecker
 from cowrie.core.config import CowrieConfig
@@ -38,6 +40,32 @@ class TestHoneypotPasswordChecker(unittest.TestCase):
             result = checker.checkUserPass(b"root", b"toor", "1.2.3.4")
         self.assertFalse(result)
         mock_userdb.assert_called_once()
+
+    def _capture_login(self, run) -> list[dict]:
+        events: list[dict] = []
+        log.addObserver(events.append)
+        try:
+            run()
+        finally:
+            log.removeObserver(events.append)
+        return [
+            e
+            for e in events
+            if e.get("eventid") in ("cowrie.login.success", "cowrie.login.failed")
+        ]
+
+    def test_credentials_with_control_bytes_are_escaped(self) -> None:
+        """Attacker-controlled username/password must not log raw control bytes."""
+        checker = HoneypotPasswordChecker()
+        with patch.object(auth, "UserDB") as mock_userdb:
+            mock_userdb.return_value.checklogin.return_value = False
+            events = self._capture_login(
+                lambda: checker.checkUserPass(b"ro\x00ot", b"pa\r\nss", "1.2.3.4")
+            )
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["username"], "ro\\x00ot")
+        self.assertEqual(events[0]["password"], "pa\\x0d\\x0ass")
 
 
 if __name__ == "__main__":

--- a/src/cowrie/test/test_checkers.py
+++ b/src/cowrie/test/test_checkers.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import unittest
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from twisted.python import log
@@ -16,6 +16,9 @@ from twisted.python import log
 from cowrie.core import auth
 from cowrie.core.checkers import HoneypotPasswordChecker
 from cowrie.core.config import CowrieConfig
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class TestHoneypotPasswordChecker(unittest.TestCase):

--- a/src/cowrie/test/test_checkers.py
+++ b/src/cowrie/test/test_checkers.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import unittest
+from collections.abc import Callable
 from unittest.mock import patch
 
 from twisted.python import log
@@ -41,7 +42,7 @@ class TestHoneypotPasswordChecker(unittest.TestCase):
         self.assertFalse(result)
         mock_userdb.assert_called_once()
 
-    def _capture_login(self, run) -> list[dict]:
+    def _capture_login(self, run: Callable[[], object]) -> list[dict]:
         events: list[dict] = []
         log.addObserver(events.append)
         try:

--- a/src/cowrie/test/test_ssh_transport.py
+++ b/src/cowrie/test/test_ssh_transport.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for the SSH transport's handling of untrusted client bytes.
+# ABOUTME: Covers KEXINIT algorithm name-lists carrying non-printable bytes.
+
+from __future__ import annotations
+
+import unittest
+from hashlib import md5
+from unittest.mock import MagicMock, patch
+
+from twisted.conch.ssh.common import NS
+
+from cowrie.ssh import transport as ssh_transport
+
+
+def _kexinit_payload(kex_algs: list[bytes]) -> bytes:
+    """Build a minimal SSH_MSG_KEXINIT payload with the given kex name-list.
+
+    Layout (RFC 4253): 16-byte cookie, then 10 name-list strings, then a
+    boolean and a reserved uint32. ssh_KEXINIT only pulls the 10 name-lists.
+    """
+    cookie = b"\x00" * 16
+    name_lists = [
+        b",".join(kex_algs),  # kex algorithms
+        b"ssh-rsa",  # server host key algorithms
+        b"aes128-ctr",  # encryption client->server
+        b"aes128-ctr",  # encryption server->client
+        b"hmac-sha2-256",  # mac client->server
+        b"hmac-sha2-256",  # mac server->client
+        b"none",  # compression client->server
+        b"none",  # compression server->client
+        b"",  # languages client->server
+        b"",  # languages server->client
+    ]
+    return cookie + b"".join(NS(n) for n in name_lists) + b"\x00" + b"\x00\x00\x00\x00"
+
+
+class TestKexInitEscaping(unittest.TestCase):
+    """A malformed KEXINIT must not crash and must not log raw control bytes."""
+
+    def _kex_event(self, packet: bytes) -> dict:
+        t = ssh_transport.HoneyPotSSHTransport()
+        t.transport = MagicMock()
+        with (
+            patch("cowrie.ssh.transport.log.msg") as mock_msg,
+            patch("twisted.conch.ssh.transport.SSHServerTransport.ssh_KEXINIT"),
+        ):
+            t.ssh_KEXINIT(packet)
+        for call in mock_msg.call_args_list:
+            if call.kwargs.get("eventid") == "cowrie.client.kex":
+                return dict(call.kwargs)
+        self.fail("no cowrie.client.kex event was emitted")
+
+    def test_invalid_utf8_algorithm_name_does_not_crash(self) -> None:
+        # A client offering a kex name with a non-UTF8 byte used to raise
+        # UnicodeDecodeError out of ssh_KEXINIT.
+        event = self._kex_event(_kexinit_payload([b"weird\xff-kex"]))
+        self.assertIn("weird\\xff-kex", event["hasshAlgorithms"])
+
+    def test_legitimate_client_hassh_is_stable(self) -> None:
+        # The fingerprint must be byte-for-byte what the original plain
+        # decode("utf-8") path produced, so historical hassh values still match.
+        kex = [b"curve25519-sha256", b"ecdh-sha2-nistp256"]
+        event = self._kex_event(_kexinit_payload(kex))
+
+        ckex = ",".join(a.decode("utf-8") for a in kex)
+        expected_algs = f"{ckex};aes128-ctr;hmac-sha2-256;none"
+        expected_hassh = md5(expected_algs.encode("utf-8")).hexdigest()
+
+        self.assertEqual(event["hasshAlgorithms"], expected_algs)
+        self.assertEqual(event["hassh"], expected_hassh)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_utils.py
+++ b/src/cowrie/test/test_utils.py
@@ -14,6 +14,7 @@ from twisted.internet import protocol, reactor
 from cowrie.core.utils import (
     create_endpoint_services,
     durationHuman,
+    escape_nonprintable,
     get_endpoints_from_section,
 )
 
@@ -87,6 +88,19 @@ class UtilsTestCase(unittest.TestCase):
             [r"tcp:2222:interface=0.0.0.0", r"tcp6:2222:interface=\:\:"],
             get_endpoints_from_section(cfg, "ssh", 2222),
         )
+
+    def test_escape_nonprintable(self) -> None:
+        # Printable ASCII passes through unchanged.
+        self.assertEqual(
+            escape_nonprintable(b"SSH-2.0-OpenSSH_9.6"), "SSH-2.0-OpenSSH_9.6"
+        )
+        # Control characters are escaped, not emitted raw (log injection guard).
+        self.assertEqual(escape_nonprintable(b"a\r\n\x1b[2Jb"), "a\\x0d\\x0a\\x1b[2Jb")
+        # Invalid-UTF8 / high bytes are escaped.
+        self.assertEqual(escape_nonprintable(b"/*\xe0Cookie"), "/*\\xe0Cookie")
+        # The backslash itself is escaped so the output is unambiguous.
+        self.assertEqual(escape_nonprintable(b"a\\xff"), "a\\\\xff")
+        self.assertEqual(escape_nonprintable(b""), "")
 
     def test_create_endpoint_services(self) -> None:
         parent = MultiService()


### PR DESCRIPTION
## Summary

Untrusted bytes from SSH/SFTP clients were logged verbatim, allowing control characters, terminal escape sequences, and invalid UTF-8 to be injected into Cowrie's log output (log injection / log forging). This adds `escape_nonprintable()` and routes the affected log sites through it.

## Changes

- **`core/utils.py`**: add `escape_nonprintable(data: bytes) -> str` — renders bytes outside printable US-ASCII (0x20–0x7e) as `\xNN`, escaping the backslash itself so the representation is unambiguous.
- **`ssh/transport.py`**: escape non-printable bytes in logged SSH version string and KEXINIT data.
- **`core/checkers.py`**: escape non-printable bytes in logged SSH credentials (username/password).
- **`ssh_proxy/protocols/ssh.py`, `sftp.py`, `server_transport.py`**: escape untrusted bytes in ssh_proxy command/path logging.

## Tests

New tests in `test_utils.py`, `test_checkers.py`, and `test_ssh_transport.py` covering the escaping behavior. All passing; `ruff check` clean.
