### PR TITLE
fix: tftp downloads produce empty hashes and crash the VirusTotal output

### DIFF
--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -326,14 +326,11 @@ class Command_tftp(HoneyPotCommand):
         return result
 
     def _download_success(self, _result: None) -> None:
-        """Called when download completes successfully"""
-        # Artifact.close() processes the file (hashing, renaming)
-        # The file handle is already closed by _ensure_artifact_closed
-        try:
-            self.artifactFile.close()
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass  # Already closed or empty file
+        """Called when download completes successfully.
 
+        The artifact is already hashed and stored by _ensure_artifact_closed,
+        so shasum and shasumFilename are populated here.
+        """
         url = f"tftp://{self.hostname}:{self.port}/{self.file_to_get.lstrip('/')}"
 
         # Log to cowrie.log
@@ -374,14 +371,11 @@ class Command_tftp(HoneyPotCommand):
         self._safe_exit()
 
     def _download_error(self, failure: Failure) -> None:
-        """Called when download fails"""
-        # File handle already closed by _ensure_artifact_closed
-        # Just clean up the temp file if it exists
-        try:
-            self.artifactFile.close()
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass  # Already closed or empty file
+        """Called when download fails.
 
+        The partial artifact is already closed and removed by
+        _ensure_artifact_closed.
+        """
         # Check if this is a cancellation (from CTRL-C)
         if failure.check(CancelledError):
             # User cancelled with CTRL-C, exit silently (^C already printed)

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -312,13 +312,17 @@ class Command_tftp(HoneyPotCommand):
         return self.tftp_client.deferred
 
     def _ensure_artifact_closed(self, result: Any) -> Any:
-        """Ensure artifact file handle is closed - called via addBoth"""
-        # Close the underlying file handle if still open
-        if hasattr(self.artifactFile, "fp") and not self.artifactFile.fp.closed:
-            try:
-                self.artifactFile.fp.close()
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
+        """Hash and store the artifact on every exit path - called via addBoth.
+
+        Artifact.close() computes the sha256 and renames the temp file to its
+        content-addressed name. The success/error callbacks read shasum and
+        shasumFilename, so close() must run before them; it is idempotent, so
+        their own close() calls become no-ops.
+        """
+        try:
+            self.artifactFile.close()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
         return result
 
     def _download_success(self, _result: None) -> None:
@@ -419,15 +423,9 @@ class Command_tftp(HoneyPotCommand):
             if self.tftp_client.timeout_call.active():
                 self.tftp_client.timeout_call.cancel()
 
-        # Close artifact file
-        if hasattr(self, "artifactFile"):
-            try:
-                if hasattr(self.artifactFile, "fp") and not self.artifactFile.fp.closed:
-                    self.artifactFile.fp.close()
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
-
-        # Cancel the deferred - this will trigger cleanup callback which stops UDP port
+        # Cancel the deferred - this triggers the cleanup callback (stops the UDP
+        # port) and _ensure_artifact_closed, which closes and removes the partial
+        # artifact.
         if self.tftp_client:
             if self.tftp_client.deferred and not self.tftp_client.deferred.called:
                 self.tftp_client.deferred.cancel()

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -282,6 +282,43 @@ class ShellTftpAsyncTests(unittest.TestCase):
         return d
 
 
+class TFTPArtifactCloseTests(unittest.TestCase):
+    """Tests for the artifact close sequence used by the download callbacks"""
+
+    def test_close_safety_net_hashes_artifact(self) -> None:
+        """The download close safety-net must hash and store the artifact.
+
+        The success/error callbacks read ``artifactFile.shasum`` and
+        ``shasumFilename`` to log the download and dispatch the
+        ``file_download`` event. If the close sequence fails to hash the
+        artifact, those fields stay empty and downstream consumers (e.g. the
+        VirusTotal output) receive an empty path.
+        """
+        import hashlib
+
+        from cowrie.commands.tftp import Command_tftp
+        from cowrie.core.artifact import Artifact
+
+        content = b"tftp artifact hashing regression\n"
+        expected_sha = hashlib.sha256(content).hexdigest()
+
+        cmd = Command_tftp.__new__(Command_tftp)
+        cmd.artifactFile = Artifact("tftp-download")
+        cmd.artifactFile.write(content)
+
+        cmd._ensure_artifact_closed(None)
+
+        self.assertEqual(cmd.artifactFile.shasum, expected_sha)
+        self.assertTrue(cmd.artifactFile.shasumFilename)
+        self.assertTrue(
+            os.path.exists(cmd.artifactFile.shasumFilename),
+            f"artifact not stored at {cmd.artifactFile.shasumFilename}",
+        )
+        with open(cmd.artifactFile.shasumFilename, "rb") as f:
+            self.assertEqual(f.read(), content)
+        os.remove(cmd.artifactFile.shasumFilename)
+
+
 class TFTPProtocolTests(unittest.TestCase):
     """Tests for TFTP protocol implementation"""
 


### PR DESCRIPTION
The TFTP command logged `Downloaded URL (...) with SHA-256  to` (empty
shasum and outfile) and the VirusTotal output then crashed with
`FileNotFoundError: [Errno 2] No such file or directory: ''`.

## Root cause

`Command_tftp`'s deferred chain closed the artifact's raw file pointer in
`_ensure_artifact_closed` (registered via `addBoth`, so it runs first)
*before* `_download_success` called `Artifact.close()` to hash and store
the file. Because the handle was already closed, `close()` raised on
`fp.tell()`, the exception was swallowed, and `shasum`/`shasumFilename`
stayed empty. `_download_success` then dispatched a
`cowrie.session.file_download` event with an empty `outfile`, which made
`output/virustotal.py` `postfile()` call `open('')`.

## Fix

- `_ensure_artifact_closed` now calls the idempotent `Artifact.close()`
  (which hashes, renames, and removes empty temp files), matching how the
  `curl` and `wget` commands already close their artifacts. The
  success/error callbacks then read populated `shasum`/`shasumFilename`.
- Drop the redundant raw-handle close in `handle_CTRL_C` so cancellation
  cleans up the partial artifact through the same path.
- Remove the now-redundant no-op `close()` calls from the download
  callbacks.

## Tests

Adds `TFTPArtifactCloseTests.test_close_safety_net_hashes_artifact`, a
synchronous test asserting the close safety-net hashes and stores the
artifact. (The existing async tftp tests return Deferreds that never run
under `unittest`, so a synchronous test was needed.) Full `test_tftp`
suite passes; `mypy` and `ruff` clean.
