### PR TITLE
fix: correct ConnectingDone typo in wget error handling

### DIFF
--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -622,7 +622,7 @@ class Command_wget(HoneyPotCommand):
             self.exit()
             return
 
-        if response.check(error.ConnectingDone) is not None:
+        if response.check(error.ConnectionDone) is not None:
             self.errorWrite("No data received.\n")
             self.exit()
             return


### PR DESCRIPTION
## Summary

`src/cowrie/commands/wget.py` referenced `error.ConnectingDone`, which does not exist in `twisted.internet.error` (the real name is `ConnectionDone`).

Because `response.check(...)` evaluates the attribute eagerly, *any* download error reaching that branch crashed with an `AttributeError` and an unhandled Deferred, never reaching the intended `No data received.` handler nor the catch-all below it.

Observed in production:

```
File "src/cowrie/commands/wget.py", line 625, in error
    if response.check(error.ConnectingDone) is not None:
builtins.AttributeError: module 'twisted.internet.error' has no attribute 'ConnectingDone'
```

## Fix

One-character correction: `ConnectingDone` -> `ConnectionDone`.

Introduced in #2665, latent since.