### PR TITLE
feat: emulate shell flow control (for/if/while/until/case, functions, test/[)

### DIFF
--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -12,14 +12,16 @@ import datetime
 import getopt
 import random
 import re
+import stat
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from twisted.internet import reactor
 from twisted.python import log
 
 from cowrie.core import utils
 from cowrie.shell.command import HoneyPotCommand, process_status
+from cowrie.shell.fs import A_MODE, A_SIZE
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1143,14 +1145,217 @@ commands["chgrp"] = Command_nop
 commands[":"] = Command_nop
 commands["do"] = Command_nop
 commands["done"] = Command_nop
-commands["true"] = Command_nop
-commands["/bin/true"] = Command_nop
+
+
+class Command_true(HoneyPotCommand):
+    """The ``true`` utility: do nothing, successfully (exit 0)."""
+
+    def call(self) -> None:
+        self.exit_code = 0
+
+
+commands["true"] = Command_true
+commands["/bin/true"] = Command_true
 
 
 class Command_false(HoneyPotCommand):
+    """The ``false`` utility: do nothing, unsuccessfully (exit 1)."""
+
     def call(self) -> None:
         self.exit_code = 1
 
 
 commands["false"] = Command_false
 commands["/bin/false"] = Command_false
+
+
+class _TestError(Exception):
+    """A malformed test expression; ``test`` reports it and exits 2.
+
+    Message templates live here so the call sites raise with a short tag,
+    keeping the human-readable text in one place.
+    """
+
+    _MESSAGES: ClassVar[dict[str, str]] = {
+        "too_many": "too many arguments",
+        "integer": "integer expression expected",
+        "unary": "{token}: unary operator expected",
+        "binary": "{token}: binary operator expected",
+    }
+
+    def __init__(self, kind: str, token: str = "") -> None:
+        super().__init__(self._MESSAGES[kind].format(token=token))
+
+
+class Command_test(HoneyPotCommand):
+    """The ``test`` / ``[`` conditional utility.
+
+    Evaluates an expression and exits 0 (true) or 1 (false); a malformed
+    expression exits 2. Supports the operators shell scripts rely on for flow
+    control: file tests against the emulated filesystem (``-e -f -d -r -w -x
+    -s -L -h -b -c -p -S -g -u -k``), string tests (``-z -n``, ``= == != < >``)
+    and integer comparisons (``-eq -ne -lt -le -gt -ge``), plus ``!`` negation
+    and ``-a`` / ``-o`` combination.
+
+    Invoked as ``[`` the final argument must be ``]``.
+    """
+
+    # Set by the ``[`` alias so the closing bracket is required.
+    require_bracket: bool = False
+    name: str = "test"
+
+    _STRING_OPS = ("=", "==", "!=", "<", ">")
+    _INT_OPS = ("-eq", "-ne", "-lt", "-le", "-gt", "-ge")
+    _UNARY_FILE_OPS = (
+        "-e",
+        "-f",
+        "-d",
+        "-r",
+        "-w",
+        "-x",
+        "-s",
+        "-L",
+        "-h",
+        "-b",
+        "-c",
+        "-p",
+        "-S",
+        "-g",
+        "-u",
+        "-k",
+    )
+
+    def call(self) -> None:
+        args = list(self.args)
+        if self.require_bracket:
+            if not args or args[-1] != "]":
+                self.errorWrite(f"{self.name}: missing `]'\n")
+                self.exit_code = 2
+                return
+            args = args[:-1]
+
+        try:
+            result = self._eval(args)
+        except _TestError as exc:
+            self.errorWrite(f"{self.name}: {exc}\n")
+            self.exit_code = 2
+            return
+        self.exit_code = 0 if result else 1
+
+    def _eval(self, args: list[str]) -> bool:
+        n = len(args)
+        if n == 0:
+            return False
+        if n == 1:
+            # A single argument is true when it is a non-empty string.
+            return args[0] != ""
+        if args[0] == "!":
+            # Negation of the remaining expression.
+            return not self._eval(args[1:])
+        if n == 2:
+            return self._unary(args[0], args[1])
+        if n == 3:
+            return self._binary(args[0], args[1], args[2])
+        if n == 4 and args[0] == "(" and args[3] == ")":
+            return self._eval(args[1:3])
+        # `EXPR -a EXPR` / `EXPR -o EXPR`: bash deprecates these, but scripts
+        # still use them. Split on the first top-level -a / -o we find.
+        for combiner in ("-o", "-a"):
+            if combiner in args:
+                idx = args.index(combiner)
+                left = self._eval(args[:idx])
+                right = self._eval(args[idx + 1 :])
+                return (left or right) if combiner == "-o" else (left and right)
+        raise _TestError("too_many")
+
+    def _unary(self, op: str, operand: str) -> bool:
+        if op == "-z":
+            return len(operand) == 0
+        if op == "-n":
+            return len(operand) != 0
+        if op in self._UNARY_FILE_OPS:
+            return self._file_test(op, operand)
+        raise _TestError("unary", op)
+
+    def _binary(self, left: str, op: str, right: str) -> bool:
+        if op in self._STRING_OPS:
+            if op in ("=", "=="):
+                return left == right
+            if op == "!=":
+                return left != right
+            if op == "<":
+                return left < right
+            return left > right  # ">"
+        if op in self._INT_OPS:
+            try:
+                a, b = int(left), int(right)
+            except ValueError:
+                raise _TestError("integer", op) from None
+            return {
+                "-eq": a == b,
+                "-ne": a != b,
+                "-lt": a < b,
+                "-le": a <= b,
+                "-gt": a > b,
+                "-ge": a >= b,
+            }[op]
+        raise _TestError("binary", op)
+
+    def _file_test(self, op: str, operand: str) -> bool:
+        path = self.fs.resolve_path(operand, self.protocol.cwd)
+        if op in ("-L", "-h"):
+            try:
+                return self.fs.islink(path)
+            except Exception:
+                return False
+        if op == "-d":
+            return self.fs.isdir(path)
+        if op == "-f":
+            return self.fs.isfile(path)
+        if op == "-e":
+            return self.fs.exists(path)
+        if op in ("-r", "-w"):
+            # No per-user permission model; treat any existing path as readable
+            # and writable, which is true for the honeypot's root sessions.
+            return self.fs.exists(path)
+        if op == "-x":
+            return self._has_mode(path, stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        if op == "-s":
+            entry = self._stat(path)
+            return entry is not None and entry[A_SIZE] > 0
+        if op == "-g":
+            return self._has_mode(path, stat.S_ISGID)
+        if op == "-u":
+            return self._has_mode(path, stat.S_ISUID)
+        if op == "-k":
+            return self._has_mode(path, stat.S_ISVTX)
+        # -b -c -p -S: special file types we do not model; report absent.
+        return False
+
+    def _stat(self, path: str) -> list[Any] | None:
+        try:
+            return self.fs.getfile(path)
+        except Exception:
+            return None
+
+    def _has_mode(self, path: str, mask: int) -> bool:
+        entry = self._stat(path)
+        if entry is None:
+            return False
+        try:
+            return bool(entry[A_MODE] & mask)
+        except (IndexError, TypeError):
+            return False
+
+
+class Command_lbracket(Command_test):
+    """The ``[`` alias of ``test``; requires a closing ``]``."""
+
+    require_bracket = True
+    name = "["
+
+
+commands["test"] = Command_test
+commands["/usr/bin/test"] = Command_test
+commands["["] = Command_lbracket
+commands["/usr/bin/["] = Command_lbracket

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -1175,6 +1175,11 @@ class Command_break(HoneyPotCommand):
     Signals the nearest shell that is currently running a loop; the loop's
     executor consumes the signal at the end of the current body. Outside any
     loop it is a no-op, matching how the honeypot tolerates stray builtins.
+
+    Loop state is tracked per shell, not per function call, so a ``break`` in a
+    function body still targets an enclosing loop in the same shell. Real bash
+    ignores a ``break`` that is not lexically inside a loop in the running
+    function; emulating that would need a per-function loop scope.
     """
 
     signal = "break"

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -22,6 +22,7 @@ from twisted.python import log
 from cowrie.core import utils
 from cowrie.shell.command import HoneyPotCommand, process_status
 from cowrie.shell.fs import A_MODE, A_SIZE
+from cowrie.shell.honeypot import LoopSignal
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1150,8 +1151,8 @@ commands["done"] = Command_nop
 class Command_true(HoneyPotCommand):
     """The ``true`` utility: do nothing, successfully (exit 0)."""
 
-    def call(self) -> None:
-        self.exit_code = 0
+    def start(self) -> None:
+        self.exit(0)
 
 
 commands["true"] = Command_true
@@ -1161,8 +1162,8 @@ commands["/bin/true"] = Command_true
 class Command_false(HoneyPotCommand):
     """The ``false`` utility: do nothing, unsuccessfully (exit 1)."""
 
-    def call(self) -> None:
-        self.exit_code = 1
+    def start(self) -> None:
+        self.exit(1)
 
 
 commands["false"] = Command_false
@@ -1182,7 +1183,7 @@ class Command_break(HoneyPotCommand):
     function; emulating that would need a per-function loop scope.
     """
 
-    signal = "break"
+    signal = LoopSignal.BREAK
 
     def call(self) -> None:
         for item in reversed(self.protocol.cmdstack):
@@ -1194,7 +1195,7 @@ class Command_break(HoneyPotCommand):
 class Command_continue(Command_break):
     """``continue`` -- skip to the next iteration of the innermost loop."""
 
-    signal = "continue"
+    signal = LoopSignal.CONTINUE
 
 
 commands["break"] = Command_break

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -1169,6 +1169,33 @@ commands["false"] = Command_false
 commands["/bin/false"] = Command_false
 
 
+class Command_break(HoneyPotCommand):
+    """``break`` -- stop the innermost enclosing for/while/until loop.
+
+    Signals the nearest shell that is currently running a loop; the loop's
+    executor consumes the signal at the end of the current body. Outside any
+    loop it is a no-op, matching how the honeypot tolerates stray builtins.
+    """
+
+    signal = "break"
+
+    def call(self) -> None:
+        for item in reversed(self.protocol.cmdstack):
+            if getattr(item, "_loop_depth", 0) > 0:
+                item._loop_signal = self.signal
+                return
+
+
+class Command_continue(Command_break):
+    """``continue`` -- skip to the next iteration of the innermost loop."""
+
+    signal = "continue"
+
+
+commands["break"] = Command_break
+commands["continue"] = Command_continue
+
+
 class _TestError(Exception):
     """A malformed test expression; ``test`` reports it and exits 2.
 

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -1332,19 +1332,19 @@ class Command_test(HoneyPotCommand):
         path = self.fs.resolve_path(operand, self.protocol.cwd)
         if op in ("-L", "-h"):
             try:
-                return self.fs.islink(path)
+                return bool(self.fs.islink(path))
             except Exception:
                 return False
         if op == "-d":
-            return self.fs.isdir(path)
+            return bool(self.fs.isdir(path))
         if op == "-f":
-            return self.fs.isfile(path)
+            return bool(self.fs.isfile(path))
         if op == "-e":
-            return self.fs.exists(path)
+            return bool(self.fs.exists(path))
         if op in ("-r", "-w"):
             # No per-user permission model; treat any existing path as readable
             # and writable, which is true for the honeypot's root sessions.
-            return self.fs.exists(path)
+            return bool(self.fs.exists(path))
         if op == "-x":
             return self._has_mode(path, stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         if op == "-s":
@@ -1361,9 +1361,10 @@ class Command_test(HoneyPotCommand):
 
     def _stat(self, path: str) -> list[Any] | None:
         try:
-            return self.fs.getfile(path)
+            entry: list[Any] | None = self.fs.getfile(path)
         except Exception:
             return None
+        return entry
 
     def _has_mode(self, path: str, mask: int) -> bool:
         entry = self._stat(path)

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -1282,6 +1282,12 @@ class Command_test(HoneyPotCommand):
         if n == 2:
             return self._unary(args[0], args[1])
         if n == 3:
+            # `STR1 -a STR2` / `STR1 -o STR2` combine two single-argument
+            # (non-empty) tests; otherwise the middle word is a binary operator.
+            if args[1] == "-a":
+                return self._eval(args[:1]) and self._eval(args[2:])
+            if args[1] == "-o":
+                return self._eval(args[:1]) or self._eval(args[2:])
             return self._binary(args[0], args[1], args[2])
         if n == 4 and args[0] == "(" and args[3] == ")":
             return self._eval(args[1:3])

--- a/src/cowrie/commands/bash.py
+++ b/src/cowrie/commands/bash.py
@@ -8,20 +8,16 @@
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
 from cowrie.shell.command import HoneyPotCommand, process_status
-from cowrie.shell.fs import FileNotFound
 from cowrie.shell.honeypot import HoneyPotShell
+from cowrie.shell.script import run_script_file
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 commands: dict[str, Callable] = {}
-
-MAX_SCRIPT_DEPTH = 5
-_SHEBANG_RE = re.compile(r"^#!\s*/bin/(ba)?sh")
 
 
 class Command_sh(HoneyPotCommand):
@@ -50,46 +46,17 @@ class Command_sh(HoneyPotCommand):
             self.interactive_shell()
 
     def execute_script_file(self, filename: str) -> None:
-        depth = getattr(self.protocol, "_script_depth", 0)
-        if depth >= MAX_SCRIPT_DEPTH:
-            self.errorWrite(f"-bash: {filename}: too many levels of recursion\n")
-            return
-
+        # bash refuses to run a binary file and reports it the same way for a
+        # missing one; the script contents otherwise go straight to the parser.
         path = self.fs.resolve_path(filename, self.protocol.cwd)
-        try:
-            contents = self.fs.file_contents(path)
-        except (FileNotFound, FileNotFoundError):
-            self.errorWrite(f"bash: {filename}: No such file or directory\n")
-            return
-
-        # A binary file (e.g. an ELF payload a bot falls back to running with
-        # `sh payload`) must be rejected, not parsed: its newline bytes would
-        # otherwise be split into "commands" and flood the log with raw binary.
-        # bash treats a file as binary when a NUL byte appears before the first
-        # newline (check_binary_file); an ELF (\x7fELF...\x00) trips this.
-        if b"\x00" in contents[:80].split(b"\n", 1)[0]:
-            self.errorWrite(
+        run_script_file(
+            self,
+            path,
+            not_found_message=f"bash: {filename}: No such file or directory\n",
+            binary_message=(
                 f"bash: {filename}: cannot execute binary file: Exec format error\n"
-            )
-            return
-
-        lines = contents.decode("utf-8", errors="replace").splitlines()
-        # Strip shebang line
-        if lines and _SHEBANG_RE.match(lines[0]):
-            lines = lines[1:]
-        # Strip comment-only lines and blank lines
-        lines = [
-            line for line in lines if line.strip() and not line.strip().startswith("#")
-        ]
-
-        if not lines:
-            return
-
-        self.protocol._script_depth = depth + 1
-        try:
-            self.execute_commands("; ".join(lines))
-        finally:
-            self.protocol._script_depth = depth
+            ),
+        )
 
     def execute_commands(self, cmds: str) -> None:
         # self.input_data holds commands passed via PIPE

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -401,7 +401,7 @@ class BashParser:
         ``;``, a newline and ``&`` all sequence without gating."""
         if self._token_type(node) == "SEP":
             assert isinstance(node, Token)
-            return node.value
+            return str(node.value)
         return ";"  # NEWLINE
 
     def _word_literal(self, node: Tree | Token | None) -> str | None:
@@ -434,8 +434,8 @@ class BashParser:
             # Consume the separators between statements, tracking the operator
             # that will join the next statement to the previous one.
             while self._is_separator(cursor.peek()):
-                node = cursor.next()
-                value = self._separator_op(node)
+                separator = cursor.next()
+                value = self._separator_op(separator)
                 if value in ("&&", "||"):
                     if not seen:
                         # A leading && / || is a bash syntax error.
@@ -505,7 +505,7 @@ class BashParser:
             # of a command -- a bash syntax error reported on the "(" token.
             if isinstance(node, Tree) and node.data == "subshell":
                 return SyntaxError_(token=self._error_token(line, node))
-            if self._token_type(node) == "LPAR":
+            if isinstance(node, Token) and node.type == "LPAR":
                 return SyntaxError_(token=self._error_token_at(line, node))
             units.append(cursor.next())
         return self._make_command(line, units, op)

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -550,7 +550,8 @@ class BashParser:
                 if self._keyword(node) == "do":
                     break
                 if isinstance(node, Tree) and node.data == "word":
-                    words.append(cursor.next())  # type: ignore[arg-type]
+                    cursor.next()
+                    words.append(node)
                     continue
                 break
 
@@ -614,7 +615,8 @@ class BashParser:
             if node is None or self._keyword(node) == "in" or self._is_separator(node):
                 break
             if isinstance(node, Tree) and node.data == "word":
-                word_trees.append(cursor.next())  # type: ignore[arg-type]
+                cursor.next()
+                word_trees.append(node)
                 continue
             break
         if self._keyword(cursor.peek()) != "in":

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -10,19 +10,29 @@ A small Lark grammar and evaluator that tokenises a command line and resolves
 its quoting, redirection, command substitution and subshells for the shell in
 ``honeypot.py``.
 
-The parser produces a flat list of :class:`Statement` objects carrying the
-joining operator (``;`` / ``&&`` / ``||``) and the still-unevaluated word trees.
-Words are expanded only when a statement is about to run (see
+The parser produces a list of :class:`Statement` objects -- simple commands and
+the compound commands ``for`` / ``if`` / ``while`` / ``until`` / ``case``, brace
+groups, subshells and function definitions -- each carrying the operator that
+joins it to the previous one (``;`` / ``&&`` / ``||``) and still-unevaluated word
+trees. Words are expanded only when a statement is about to run (see
 :meth:`BashParser.evaluate`), so the shell can interleave parsing and execution
 like a real shell. The control operators a real shell cares about — ``|`` and
 the redirection operators — pass through as their own string tokens so the
 existing ``CommandParser`` / ``runCommand`` machinery consumes the result
 unchanged.
 
-The grammar deliberately models only the subset of bash that Cowrie already
-emulates: lists separated by ``;`` / ``&&`` / ``||``, pipelines, simple
-redirections, single/double quoting, ``$VAR`` / ``${VAR}`` expansion, command
-substitution (``$(...)`` and backticks) and subshells (``(...)``).
+There is a single tokeniser for the whole language: the Lark grammar lexes a
+line (or a whole multi-line script) into word trees and control tokens, and the
+recursive descent in :meth:`BashParser._parse_list` recognises reserved words
+only at a command position to build the compound structure, exactly as a real
+shell parses. Newlines separate statements like ``;`` so a script is parsed
+directly rather than line-by-line.
+
+The grammar models the subset of bash that Cowrie emulates: lists separated by
+``;`` / newline / ``&&`` / ``||``, pipelines, simple redirections, single/double
+quoting, ``$VAR`` / ``${VAR}`` expansion, command substitution (``$(...)`` and
+backticks), subshells (``(...)``), the compound commands above, and function
+definitions.
 
 Known deviations from standard bash (none are emulated yet):
 
@@ -31,15 +41,19 @@ Known deviations from standard bash (none are emulated yet):
   (``{a,b}`` / ``{1..3}``), arithmetic (``$((...))``), the parameter
   expansion operators (``${x:-y}``, ``${#x}``, ``${x/a/b}`` ...), and ANSI-C
   quoting (``$'...'``) are all passed through literally.
+* Word splitting is not applied to the result of an expansion, so a ``for``
+  list built from ``$(cmd)`` or an unquoted ``$var`` holding spaces iterates
+  once over the whole string rather than once per field.
 * Pathname expansion (globbing of ``*`` / ``?`` / ``[...]``) is left to the
-  individual command implementations, not done by the parser.
+  individual command implementations, not done by the parser; ``case`` patterns
+  are matched with fnmatch.
 * Here-documents (``<<EOF``) and here-strings (``<<<``) are not supported; the
   operators are tokenised as plain ``<`` redirections.
-* ``{ ...; }`` command grouping and reserved words (``for``/``if``/``while``
-  ...) are parsed as ordinary commands, so the shell does not run loops or
-  conditionals.
-* The special parameters ``$@`` / ``$#`` / ``$*`` (and friends other than
-  ``$?``) are passed through literally rather than expanded.
+* A compound command nested inside ``$(...)`` is not captured (its output is
+  empty); command substitution captures simple commands and subshells only.
+* ``$@`` / ``$#`` / ``$*`` expand to the positional parameters only while a
+  function is running; elsewhere they are kept literally. Other special
+  parameters (``$!``, ``$$`` ...) other than ``$?`` are kept literally.
 
 Input the grammar cannot parse at all (e.g. an unterminated quote) surfaces as
 a syntax error, exactly as the previous implementation degraded on input it
@@ -48,6 +62,7 @@ could not handle.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Protocol
 
@@ -57,6 +72,16 @@ from lark.exceptions import LarkError
 # Grammar for the supported bash subset. Whitespace is significant as a word
 # separator, so it is matched explicitly rather than ignored: adjacent atoms
 # with no whitespace between them form a single word ("a"$x'b' -> one word).
+#
+# The grammar is a single tokeniser for the whole language: it emits a flat
+# stream of word trees and control tokens (separators, pipes, redirections,
+# parentheses, ";;", newlines). The structure above a simple command --
+# &&/|| lists, pipelines, and the compound commands for/if/while/until/case,
+# brace groups and function definitions -- is recognised by the recursive
+# descent in :meth:`BashParser._parse_list`, which reads reserved words only at
+# a command position, exactly as a real shell does. Keeping one tokeniser means
+# the script-level constructs reuse the same quoting, expansion and redirection
+# lexing as a single interactive line.
 _GRAMMAR = r"""
 // A line is whitespace-separated content (words and subshells) broken up by the
 // control operators. Whitespace is REQUIRED between two content words, so a run
@@ -68,14 +93,22 @@ start: _WS? _line? _WS?
 _line: _run (_WS? _op _WS? _run)*
 _run: (_content (_WS _content)*)?
 _content: subshell | word | _COMMENT
-_op: SEP | PIPE | AMP | IO_REDIR | REDIR
+_op: SEP | PIPE | AMP | IO_REDIR | REDIR | NEWLINE | LPAR | RPAR | DSEMI
 
-subshell: LPAR start RPAR
+// A balanced "(...)" group is preferred over the bare LPAR/RPAR tokens (rule
+// priority), so a command substitution keeps the right extent for "$( (a) )"
+// and a real subshell parses as one unit. A lone ")" with no matching "(" --
+// the close of a case pattern like "x86*)" -- has no subshell parse available
+// and falls back to the RPAR token, which the statement parser consumes.
+subshell.10: LPAR start RPAR
 
 word: _atom+
 _atom: sq | dq | cmdsub | backtick | dollar_brace | dollar_var | ESC | BARE_DOLLAR | LITERAL
 
-cmdsub: "$(" start ")"
+// An explicit, high-priority "$(" terminal so command substitution wins over a
+// bare "$" followed by the LPAR token now that "(" is a self-standing operator.
+cmdsub: CMDSUB_OPEN start ")"
+CMDSUB_OPEN.6: "$("
 
 backtick: "`" _bq_atom* "`"
 _bq_atom: dollar_var | dollar_brace | BQ_LITERAL
@@ -102,6 +135,8 @@ DOLLAR_SPECIAL.2: /\$[?@$#!*]/
 
 ESC: /\\./
 
+// ";;" (case item terminator) must win over a single ";".
+DSEMI.7: ";;"
 // Higher priority than the bare AMP so "&&" and "&>" win maximal munch.
 SEP.2: "&&" | "||" | ";"
 PIPE: "|"
@@ -115,6 +150,10 @@ REDIR.2: />>|>&|&>>|&>|>|</
 
 LPAR: "("
 RPAR: ")"
+// A newline separates statements like ";" (so a multi-line script is parsed
+// directly); a backslash-newline is a line continuation and counts as
+// whitespace (see _WS below).
+NEWLINE: /\r?\n/
 
 BARE_DOLLAR: "$"
 LITERAL: /[^ \t\r\n|&;<>()$`'"\\]+/
@@ -124,7 +163,8 @@ LITERAL: /[^ \t\r\n|&;<>()$`'"\\]+/
 // such as "a#b" stays part of the LITERAL.
 _COMMENT.2: /#[^\r\n]*/
 
-_WS: /[ \t\r\n]+/
+// Inline whitespace and line continuations only; a bare newline is NEWLINE.
+_WS: /([ \t]|\\\r?\n)+/
 """
 
 _parser = Lark(
@@ -181,6 +221,75 @@ class Subshell:
 
 
 @dataclass
+class BraceGroup:
+    """A ``{ ...; }`` command group: its statements run in the current shell."""
+
+    statements: list[Statement] = field(default_factory=list)
+    op: str | None = None
+
+
+@dataclass
+class ForClause:
+    """``for VAR in WORDS; do BODY; done``.
+
+    ``items`` is a :class:`Command` whose words are the (unevaluated) ``in``
+    list, expanded against the live shell when the loop runs.
+    """
+
+    var: str = ""
+    items: Command | None = None
+    body: list[Statement] = field(default_factory=list)
+    op: str | None = None
+
+
+@dataclass
+class IfClause:
+    """``if COND; then BODY; [elif COND; then BODY;]* [else BODY;] fi``.
+
+    ``branches`` pairs each condition statement-list with its body; ``else_body``
+    is the optional trailing ``else`` arm.
+    """
+
+    branches: list[tuple[list[Statement], list[Statement]]] = field(
+        default_factory=list
+    )
+    else_body: list[Statement] | None = None
+    op: str | None = None
+
+
+@dataclass
+class WhileClause:
+    """``while COND; do BODY; done`` (or ``until`` when ``until`` is True)."""
+
+    condition: list[Statement] = field(default_factory=list)
+    body: list[Statement] = field(default_factory=list)
+    until: bool = False
+    op: str | None = None
+
+
+@dataclass
+class CaseClause:
+    """``case WORD in PATTERN[|PATTERN]) BODY ;; ... esac``.
+
+    ``word`` is a :class:`Command` carrying the (unevaluated) word to match;
+    ``items`` pairs each list of raw glob patterns with its body.
+    """
+
+    word: Command | None = None
+    items: list[tuple[list[str], list[Statement]]] = field(default_factory=list)
+    op: str | None = None
+
+
+@dataclass
+class FunctionDef:
+    """``name() { BODY; }`` -- registers ``name`` for later invocation."""
+
+    name: str = ""
+    body: list[Statement] = field(default_factory=list)
+    op: str | None = None
+
+
+@dataclass
 class SyntaxError_:
     """A bash-style syntax error to report verbatim.
 
@@ -192,7 +301,64 @@ class SyntaxError_:
     token: str
 
 
-Statement = Command | Subshell | SyntaxError_
+Statement = (
+    Command
+    | Subshell
+    | BraceGroup
+    | ForClause
+    | IfClause
+    | WhileClause
+    | CaseClause
+    | FunctionDef
+    | SyntaxError_
+)
+
+# Reserved words recognised only at a command position (the start of a
+# statement). Anywhere else they are ordinary arguments, so ``echo done`` still
+# prints "done", exactly as in bash.
+_RESERVED = frozenset(
+    {
+        "for",
+        "in",
+        "do",
+        "done",
+        "if",
+        "then",
+        "elif",
+        "else",
+        "fi",
+        "while",
+        "until",
+        "case",
+        "esac",
+        "function",
+        "{",
+        "}",
+    }
+)
+
+# Tokens that end a simple command / pipeline (a separator or the close of an
+# enclosing construct).
+_STATEMENT_END = frozenset({"SEP", "NEWLINE", "DSEMI", "RPAR"})
+
+_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class _Cursor:
+    """A forward cursor over the grammar's flat child stream."""
+
+    def __init__(self, tokens: list[Tree | Token]) -> None:
+        self.tokens = tokens
+        self.pos = 0
+
+    def peek(self, ahead: int = 0) -> Tree | Token | None:
+        index = self.pos + ahead
+        return self.tokens[index] if index < len(self.tokens) else None
+
+    def next(self) -> Tree | Token:
+        token = self.tokens[self.pos]
+        self.pos += 1
+        return token
 
 
 class BashParser:
@@ -219,63 +385,134 @@ class BashParser:
     # -- statement splitting ------------------------------------------------
 
     def _split_statements(self, line: str, tree: Tree) -> list[Statement]:
+        """Recursive-descent parse of the flat token stream into statements."""
+        cursor = _Cursor(list(tree.children))
+        return self._parse_list(line, cursor, stop=frozenset())
+
+    @staticmethod
+    def _token_type(node: Tree | Token | None) -> str | None:
+        return node.type if isinstance(node, Token) else None
+
+    def _is_separator(self, node: Tree | Token | None) -> bool:
+        return self._token_type(node) in ("SEP", "NEWLINE")
+
+    def _separator_op(self, node: Tree | Token) -> str:
+        """The join operator a separator implies: && / || keep their meaning;
+        ``;``, a newline and ``&`` all sequence without gating."""
+        if self._token_type(node) == "SEP":
+            assert isinstance(node, Token)
+            return node.value
+        return ";"  # NEWLINE
+
+    def _word_literal(self, node: Tree | Token | None) -> str | None:
+        """Return the text of a word that is a single unquoted literal atom, else
+        None. Keywords are recognised only through this, so a quoted or expanded
+        word (``'for'``, ``$kw``) is never treated as reserved."""
+        if not isinstance(node, Tree) or node.data != "word":
+            return None
+        if len(node.children) != 1:
+            return None
+        atom = node.children[0]
+        if isinstance(atom, Token) and atom.type == "LITERAL":
+            return str(atom.value)
+        return None
+
+    def _keyword(self, node: Tree | Token | None) -> str | None:
+        text = self._word_literal(node)
+        return text if text in _RESERVED else None
+
+    def _parse_list(
+        self, line: str, cursor: _Cursor, stop: frozenset[str]
+    ) -> list[Statement]:
+        """Parse statements separated by ``;`` / newline / ``&&`` / ``||`` until a
+        reserved stop word, a ``)`` / ``;;`` token, or the end of input."""
         statements: list[Statement] = []
-        units: list[Tree | Token] = []
-        # The operator joining the statement currently being accumulated to the
-        # previous one: None for the first, then ; / && / || as seen.
-        current_op: str | None = None
+        pending_op: str | None = None
+        seen = False
 
-        def flush() -> bool:
-            """Turn the accumulated units into a statement. Return False to stop."""
-            if not units:
-                return True
-            stmt = self._build_statement(line, units, current_op)
-            units.clear()
-            statements.append(stmt)
-            return not isinstance(stmt, SyntaxError_)
+        while True:
+            # Consume the separators between statements, tracking the operator
+            # that will join the next statement to the previous one.
+            while self._is_separator(cursor.peek()):
+                node = cursor.next()
+                value = self._separator_op(node)
+                if value in ("&&", "||"):
+                    if not seen:
+                        # A leading && / || is a bash syntax error.
+                        statements.append(SyntaxError_(token=value))
+                        return statements
+                    pending_op = value
+                elif pending_op not in ("&&", "||"):
+                    pending_op = ";"
 
-        for child in tree.children:
-            if isinstance(child, Token) and child.type == "SEP":
-                if not units and child.value in ("&&", "||"):
-                    statements.append(SyntaxError_(token=child.value))
-                    return statements
-                if not flush():
-                    return statements
-                current_op = child.value
-                continue
-            units.append(child)
-        flush()
+            node = cursor.peek()
+            if node is None:
+                break
+            if self._keyword(node) in stop:
+                break
+            if self._token_type(node) in ("DSEMI", "RPAR"):
+                break
+
+            statement = self._parse_statement(
+                line, cursor, pending_op if seen else None
+            )
+            statements.append(statement)
+            seen = True
+            pending_op = None
+            if isinstance(statement, SyntaxError_):
+                return statements
+
         return statements
 
-    def _build_statement(
+    def _parse_statement(
+        self, line: str, cursor: _Cursor, op: str | None
+    ) -> Statement:
+        node = cursor.peek()
+
+        # A subshell at command position runs in sequence; anything piped after
+        # it is dropped (see the pipeline TODO below).
+        if isinstance(node, Tree) and node.data == "subshell":
+            cursor.next()
+            self._skip_to_statement_end(cursor)
+            return Subshell(statements=self._subshell_statements(line, node), op=op)
+
+        keyword = self._keyword(node)
+        if keyword == "for":
+            return self._parse_for(line, cursor, op)
+        if keyword == "if":
+            return self._parse_if(line, cursor, op)
+        if keyword in ("while", "until"):
+            return self._parse_while(line, cursor, op, until=keyword == "until")
+        if keyword == "case":
+            return self._parse_case(line, cursor, op)
+        if keyword == "{":
+            return self._parse_brace_group(line, cursor, op)
+        if keyword == "function":
+            return self._parse_function_keyword(line, cursor, op)
+        if self._looks_like_funcdef(cursor):
+            return self._parse_function(line, cursor, op)
+
+        return self._parse_simple(line, cursor, op)
+
+    def _parse_simple(self, line: str, cursor: _Cursor, op: str | None) -> Statement:
+        """Gather one simple command / pipeline up to the next statement end."""
+        units: list[Tree | Token] = []
+        while True:
+            node = cursor.peek()
+            if node is None or self._token_type(node) in _STATEMENT_END:
+                break
+            # A "(...)" that survived as a unit here is a subshell in the middle
+            # of a command -- a bash syntax error reported on the "(" token.
+            if isinstance(node, Tree) and node.data == "subshell":
+                return SyntaxError_(token=self._error_token(line, node))
+            if self._token_type(node) == "LPAR":
+                return SyntaxError_(token=self._error_token_at(line, node))
+            units.append(cursor.next())
+        return self._make_command(line, units, op)
+
+    def _make_command(
         self, line: str, units: list[Tree | Token], op: str | None
     ) -> Statement:
-        # A subshell is valid only at the start of a statement. There it runs
-        # in sequence with the surrounding line; anything piped after it is
-        # ignored. A subshell anywhere else is a syntax error reported on the
-        # "(" token, as bash does.
-        # TODO: support a subshell as a real pipeline stage, e.g.
-        # `(echo a) | wc -c`. We currently run the subshell and discard the
-        # rest of the pipeline instead of feeding its output into the pipe.
-        # bash also allows a subshell in the middle or end of a pipeline
-        # (`x | (cmd)`), which we reject as a syntax error.
-        subshell_idx = next(
-            (
-                i
-                for i, u in enumerate(units)
-                if isinstance(u, Tree) and u.data == "subshell"
-            ),
-            None,
-        )
-        if subshell_idx is not None:
-            subshell = units[subshell_idx]
-            assert isinstance(subshell, Tree)
-            if subshell_idx == 0:
-                return Subshell(
-                    statements=self._subshell_statements(line, subshell), op=op
-                )
-            return SyntaxError_(token=self._error_token(line, subshell))
-
         # A redirection operator must be followed by a target word. A redirect at
         # the end of a statement, or directly before another operator, is a bash
         # syntax error (e.g. `echo >` reports the unexpected token `newline').
@@ -288,12 +525,250 @@ class BashParser:
                     return SyntaxError_(token=target.value)
 
         # Keep the structure; words are evaluated later by evaluate(). An
-        # operator token (PIPE / AMP / REDIR / IO_REDIR) is a fixed string;
-        # SEP never reaches here.
+        # operator token (PIPE / AMP / REDIR / IO_REDIR) is a fixed string.
         items: list[str | Tree] = [
             unit.value if isinstance(unit, Token) else unit for unit in units
         ]
         return Command(items=items, line=line, op=op)
+
+    # -- compound commands --------------------------------------------------
+
+    def _parse_for(self, line: str, cursor: _Cursor, op: str | None) -> Statement:
+        cursor.next()  # "for"
+        name = self._word_literal(cursor.peek())
+        if name is None or not _NAME_RE.match(name):
+            return SyntaxError_(token=self._unexpected(line, cursor))
+        cursor.next()  # NAME
+
+        words: list[Tree] = []
+        if self._keyword(cursor.peek()) == "in":
+            cursor.next()  # "in"
+            while True:
+                node = cursor.peek()
+                if node is None or self._is_separator(node):
+                    break
+                if self._keyword(node) == "do":
+                    break
+                if isinstance(node, Tree) and node.data == "word":
+                    words.append(cursor.next())  # type: ignore[arg-type]
+                    continue
+                break
+
+        self._skip_separators(cursor)
+        if self._keyword(cursor.peek()) != "do":
+            return SyntaxError_(token=self._unexpected(line, cursor))
+        cursor.next()  # "do"
+        body = self._parse_list(line, cursor, stop=frozenset({"done"}))
+        error = self._expect(cursor, "done")
+        if error is not None:
+            return error
+        items = Command(items=list(words), line=line)
+        return ForClause(var=name, items=items, body=body, op=op)
+
+    def _parse_if(self, line: str, cursor: _Cursor, op: str | None) -> Statement:
+        cursor.next()  # "if"
+        branches: list[tuple[list[Statement], list[Statement]]] = []
+        while True:
+            condition = self._parse_list(line, cursor, stop=frozenset({"then"}))
+            error = self._expect(cursor, "then")
+            if error is not None:
+                return error
+            body = self._parse_list(
+                line, cursor, stop=frozenset({"elif", "else", "fi"})
+            )
+            branches.append((condition, body))
+            if self._keyword(cursor.peek()) == "elif":
+                cursor.next()
+                continue
+            break
+
+        else_body: list[Statement] | None = None
+        if self._keyword(cursor.peek()) == "else":
+            cursor.next()
+            else_body = self._parse_list(line, cursor, stop=frozenset({"fi"}))
+
+        error = self._expect(cursor, "fi")
+        if error is not None:
+            return error
+        return IfClause(branches=branches, else_body=else_body, op=op)
+
+    def _parse_while(
+        self, line: str, cursor: _Cursor, op: str | None, until: bool
+    ) -> Statement:
+        cursor.next()  # "while" / "until"
+        condition = self._parse_list(line, cursor, stop=frozenset({"do"}))
+        error = self._expect(cursor, "do")
+        if error is not None:
+            return error
+        body = self._parse_list(line, cursor, stop=frozenset({"done"}))
+        error = self._expect(cursor, "done")
+        if error is not None:
+            return error
+        return WhileClause(condition=condition, body=body, until=until, op=op)
+
+    def _parse_case(self, line: str, cursor: _Cursor, op: str | None) -> Statement:
+        cursor.next()  # "case"
+        word_trees: list[Tree] = []
+        while True:
+            node = cursor.peek()
+            if node is None or self._keyword(node) == "in" or self._is_separator(node):
+                break
+            if isinstance(node, Tree) and node.data == "word":
+                word_trees.append(cursor.next())  # type: ignore[arg-type]
+                continue
+            break
+        if self._keyword(cursor.peek()) != "in":
+            return SyntaxError_(token=self._unexpected(line, cursor))
+        cursor.next()  # "in"
+        self._skip_separators(cursor)
+
+        items: list[tuple[list[str], list[Statement]]] = []
+        while True:
+            node = cursor.peek()
+            if node is None or self._keyword(node) == "esac":
+                break
+            patterns, error = self._parse_case_patterns(line, cursor)
+            if error is not None:
+                return error
+            body = self._parse_list(line, cursor, stop=frozenset({"esac"}))
+            if self._token_type(cursor.peek()) == "DSEMI":
+                cursor.next()
+            self._skip_separators(cursor)
+            items.append((patterns, body))
+
+        error = self._expect(cursor, "esac")
+        if error is not None:
+            return error
+        return CaseClause(word=Command(items=list(word_trees), line=line), items=items, op=op)
+
+    def _parse_case_patterns(
+        self, line: str, cursor: _Cursor
+    ) -> tuple[list[str], Statement | None]:
+        """Read ``pat[|pat]*)`` and return the raw pattern strings."""
+        patterns: list[str] = []
+        while True:
+            node = cursor.peek()
+            if node is None:
+                return patterns, SyntaxError_(token="newline")
+            if self._token_type(node) == "RPAR":
+                cursor.next()
+                return patterns, None
+            if self._token_type(node) == "PIPE":
+                cursor.next()
+                continue
+            if isinstance(node, Tree) and node.data == "word":
+                patterns.append(self._word_source(line, node))
+                cursor.next()
+                continue
+            return patterns, SyntaxError_(token=self._unexpected(line, cursor))
+
+    def _parse_brace_group(
+        self, line: str, cursor: _Cursor, op: str | None
+    ) -> Statement:
+        cursor.next()  # "{"
+        body = self._parse_list(line, cursor, stop=frozenset({"}"}))
+        error = self._expect(cursor, "}")
+        if error is not None:
+            return error
+        return BraceGroup(statements=body, op=op)
+
+    def _looks_like_funcdef(self, cursor: _Cursor) -> bool:
+        """Detect ``name ()`` at command position (the "()" lexes as LPAR RPAR,
+        or as an empty subshell when separated by a space)."""
+        name = self._word_literal(cursor.peek())
+        if name is None or not _NAME_RE.match(name):
+            return False
+        after = cursor.peek(1)
+        if isinstance(after, Tree) and after.data == "subshell":
+            return not self._subshell_statements("", after)
+        return (
+            self._token_type(after) == "LPAR"
+            and self._token_type(cursor.peek(2)) == "RPAR"
+        )
+
+    def _parse_function(self, line: str, cursor: _Cursor, op: str | None) -> Statement:
+        name = self._word_literal(cursor.next())
+        assert name is not None
+        self._consume_empty_parens(cursor)
+        return self._finish_function(line, cursor, name, op)
+
+    def _parse_function_keyword(
+        self, line: str, cursor: _Cursor, op: str | None
+    ) -> Statement:
+        cursor.next()  # "function"
+        name = self._word_literal(cursor.peek())
+        if name is None or not _NAME_RE.match(name):
+            return SyntaxError_(token=self._unexpected(line, cursor))
+        cursor.next()  # NAME
+        self._consume_empty_parens(cursor)
+        return self._finish_function(line, cursor, name, op)
+
+    def _consume_empty_parens(self, cursor: _Cursor) -> None:
+        node = cursor.peek()
+        if isinstance(node, Tree) and node.data == "subshell":
+            cursor.next()
+        elif self._token_type(node) == "LPAR":
+            cursor.next()
+            if self._token_type(cursor.peek()) == "RPAR":
+                cursor.next()
+
+    def _finish_function(
+        self, line: str, cursor: _Cursor, name: str, op: str | None
+    ) -> Statement:
+        self._skip_separators(cursor)
+        if self._keyword(cursor.peek()) != "{":
+            return SyntaxError_(token=self._unexpected(line, cursor))
+        group = self._parse_brace_group(line, cursor, None)
+        if isinstance(group, SyntaxError_):
+            return group
+        assert isinstance(group, BraceGroup)
+        return FunctionDef(name=name, body=group.statements, op=op)
+
+    # -- parser helpers -----------------------------------------------------
+
+    def _skip_separators(self, cursor: _Cursor) -> None:
+        while self._is_separator(cursor.peek()):
+            cursor.next()
+
+    def _skip_to_statement_end(self, cursor: _Cursor) -> None:
+        """Drop tokens up to (not including) the next statement separator."""
+        while True:
+            node = cursor.peek()
+            if node is None or self._token_type(node) in _STATEMENT_END:
+                return
+            cursor.next()
+
+    def _expect(self, cursor: _Cursor, keyword: str) -> Statement | None:
+        if self._keyword(cursor.peek()) != keyword:
+            return SyntaxError_(token=self._unexpected("", cursor))
+        cursor.next()
+        return None
+
+    def _unexpected(self, line: str, cursor: _Cursor) -> str:
+        node = cursor.peek()
+        if node is None:
+            return "newline"
+        if isinstance(node, Token):
+            return str(node.value)
+        if node.data == "word":
+            return self._word_source(line, node) or "newline"
+        return "newline"
+
+    def _word_source(self, line: str, word: Tree) -> str:
+        """The raw source text of a word, for keywords and case patterns."""
+        if not line or word.meta.empty:
+            literal = self._word_literal(word)
+            return literal if literal is not None else ""
+        return line[word.meta.start_pos : word.meta.end_pos]
+
+    def _error_token_at(self, line: str, token: Token) -> str:
+        start = getattr(token, "start_pos", None)
+        if start is None:
+            return "("
+        end = start + 1
+        while end < len(line) and not line[end].isspace() and line[end] != ")":
+            end += 1
+        return line[start:end]
 
     # -- word evaluation ----------------------------------------------------
 
@@ -410,13 +885,19 @@ class BashParser:
         """Expand a special parameter ($?, $@, $#, ...) to its string value, or
         None for an ordinary ``$name`` reference the caller should look up.
 
-        ``$?`` is the last exit status; the other specials are kept verbatim.
+        ``$?`` is the last exit status. ``$@`` / ``$#`` / ``$*`` resolve to the
+        positional parameters the shell sets while running a function; outside a
+        function they are unset and kept verbatim. Other specials are kept
+        verbatim.
         """
         _, special = self._var_name(node)
         if special is None:
             return None
         if special == "?":
             return self.context.get_status()
+        if special in ("@", "#", "*"):
+            value = self.context.get_variable(special)
+            return value if value is not None else self._leaf_value(node)
         return self._leaf_value(node)
 
     def _leaf_value(self, node: Tree) -> str:

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -396,6 +396,10 @@ class HoneyPotShell:
         for patterns, body in node.items:
             for pattern in patterns:
                 if fnmatch.fnmatchcase(word, self._strip_quotes(pattern)):
+                    # A matched body's status is its last command, or 0 when the
+                    # body is empty; the prior command's status must not leak.
+                    if not body:
+                        self.last_exit_code = 0
                     self.cmdpending[0:0] = list(body)
                     self._advance()
                     return

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -7,8 +7,13 @@
 from __future__ import annotations
 
 import copy
+import fnmatch
 import os
-from typing import Any
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from twisted.python import log
 from twisted.python.compat import iterbytes
@@ -17,14 +22,42 @@ from cowrie.core.config import CowrieConfig
 from cowrie.shell import fs
 from cowrie.shell.bashparse import (
     BashParser,
+    BraceGroup,
+    CaseClause,
     Command,
+    ForClause,
+    FunctionDef,
+    IfClause,
     Statement,
     Subshell,
     SyntaxError_,
+    WhileClause,
 )
 from cowrie.shell.command import process_status
 from cowrie.shell.parser import CommandParser
 from cowrie.shell.pipe import PipeProtocol
+
+# Honeypot safety caps. A loop in an uploaded script must never hang or exhaust
+# the process: bound the number of iterations a single loop runs. Real malware
+# downloaders loop a handful of times (over a few URLs or architectures); these
+# ceilings are far above that yet keep a `while true` from running forever.
+MAX_WHILE_ITERATIONS = 1000
+MAX_FOR_ITEMS = 10000
+
+
+@dataclass
+class _Continuation:
+    """An internal queue entry that runs a Python callback when reached.
+
+    Flow control schedules these between the statements it splices into
+    ``cmdpending`` so it can react to a condition's exit status or step a loop.
+    ``is_loop_cont`` marks the continuation that closes one loop-body iteration,
+    which is where a pending ``break`` / ``continue`` is consumed.
+    """
+
+    fn: Callable[[], None]
+    is_loop_cont: bool = False
+    op: str | None = None
 
 
 class HoneyPotShell:
@@ -63,6 +96,16 @@ class HoneyPotShell:
         # Exit status of the most recent command in this shell, for $? and the
         # && / || short-circuit logic.
         self.last_exit_code: int = 0
+        # Shell functions defined in this shell, name -> body statements.
+        self.functions: dict[str, list[Statement]] = {}
+        # Flow-control state: how many loops are currently running (so break /
+        # continue only act inside a loop) and a pending loop signal consumed by
+        # the innermost loop continuation.
+        self._loop_depth: int = 0
+        self._loop_signal: str | None = None
+        # Trampoline state for _advance (see its docstring).
+        self._advancing: bool = False
+        self._advance_pending: bool = False
 
     # -- bashparse.ShellContext interface -----------------------------------
 
@@ -206,11 +249,188 @@ class HoneyPotShell:
         )
 
     def _advance(self) -> None:
-        """Run the next queued command, or finish when the queue is drained."""
-        if self.cmdpending:
-            self.runCommand()
-        else:
-            self._finish()
+        """Run the next queued command, or finish when the queue is drained.
+
+        This is a trampoline. A command that completes synchronously calls
+        ``exit() -> resume() -> _advance()`` again before the original call
+        returns, so a naive recursive design would grow the Python stack by one
+        frame per command -- a long ``;`` list, or any loop, would overflow it.
+        Instead a re-entrant ``_advance`` just flags that more work is pending
+        and unwinds; the outermost call drives a flat loop. A command that
+        instead pauses on a Deferred (e.g. wget) unwinds normally and its later
+        ``resume`` starts a fresh drive.
+        """
+        if self._advancing:
+            self._advance_pending = True
+            return
+        self._advancing = True
+        try:
+            running = True
+            while running:
+                self._advance_pending = False
+                if self.cmdpending:
+                    self.runCommand()
+                else:
+                    self._finish()
+                running = self._advance_pending
+        finally:
+            self._advancing = False
+
+    # -- flow control -------------------------------------------------------
+    #
+    # Compound commands are driven through the same cmdpending queue as simple
+    # commands. A handler splices its body statements to the front and, where it
+    # must observe a result (a loop test, the next iteration), appends a
+    # _Continuation callback that runs once the spliced statements have finished
+    # -- which works whether those statements complete synchronously or pause on
+    # a Deferred (e.g. wget) and resume later.
+
+    def _end_loop(self) -> None:
+        self._loop_depth -= 1
+        self._advance()
+
+    def _run_for(self, node: ForClause) -> None:
+        """``for VAR in WORDS; do BODY; done`` over the expanded word list."""
+        values = self.bashparser.evaluate(node.items) if node.items else []
+        values = values[:MAX_FOR_ITEMS]
+        if not values:
+            # A loop over an empty list runs the body zero times and succeeds.
+            self.last_exit_code = 0
+            self._advance()
+            return
+
+        self._loop_depth += 1
+        state = {"index": 0}
+
+        def step() -> None:
+            if state["index"] >= len(values):
+                self._end_loop()
+                return
+            self.environ[node.var] = values[state["index"]]
+            state["index"] += 1
+            self.cmdpending[0:0] = [
+                *node.body,
+                _Continuation(loop_cont, is_loop_cont=True),
+            ]
+            self._advance()
+
+        def loop_cont() -> None:
+            signal = self._loop_signal
+            self._loop_signal = None
+            if signal == "break":
+                self._end_loop()
+                return
+            step()  # a continue, or a normal pass, moves to the next value
+
+        step()
+
+    def _run_while(self, node: WhileClause) -> None:
+        """``while COND; do BODY; done`` (``until`` inverts the test)."""
+        self._loop_depth += 1
+        state = {"iterations": 0}
+
+        def test() -> None:
+            if state["iterations"] >= MAX_WHILE_ITERATIONS:
+                self._end_loop()
+                return
+            state["iterations"] += 1
+            self.cmdpending[0:0] = [*node.condition, _Continuation(decide)]
+            self._advance()
+
+        def decide() -> None:
+            succeeded = self.last_exit_code == 0
+            run_body = (not succeeded) if node.until else succeeded
+            if not run_body:
+                self._end_loop()
+                return
+            self.cmdpending[0:0] = [
+                *node.body,
+                _Continuation(loop_cont, is_loop_cont=True),
+            ]
+            self._advance()
+
+        def loop_cont() -> None:
+            signal = self._loop_signal
+            self._loop_signal = None
+            if signal == "break":
+                self._end_loop()
+                return
+            test()  # a continue, or a normal pass, re-evaluates the condition
+
+        test()
+
+    def _run_if(self, node: IfClause) -> None:
+        """``if COND; then BODY; [elif ...] [else ...] fi``."""
+
+        def try_branch(index: int) -> None:
+            if index >= len(node.branches):
+                if node.else_body is not None:
+                    self.cmdpending[0:0] = list(node.else_body)
+                else:
+                    # No branch ran: an if with no matching arm succeeds.
+                    self.last_exit_code = 0
+                self._advance()
+                return
+            condition, body = node.branches[index]
+            self.cmdpending[0:0] = [
+                *condition,
+                _Continuation(lambda: decide(index, body)),
+            ]
+            self._advance()
+
+        def decide(index: int, body: list[Statement]) -> None:
+            if self.last_exit_code == 0:
+                self.cmdpending[0:0] = list(body)
+                self._advance()
+            else:
+                try_branch(index + 1)
+
+        try_branch(0)
+
+    def _run_case(self, node: CaseClause) -> None:
+        """``case WORD in PATTERN) BODY ;; ... esac`` -- first match wins."""
+        word = " ".join(self.bashparser.evaluate(node.word)) if node.word else ""
+        for patterns, body in node.items:
+            for pattern in patterns:
+                if fnmatch.fnmatchcase(word, self._strip_quotes(pattern)):
+                    self.cmdpending[0:0] = list(body)
+                    self._advance()
+                    return
+        # No pattern matched: the case succeeds.
+        self.last_exit_code = 0
+        self._advance()
+
+    @staticmethod
+    def _strip_quotes(pattern: str) -> str:
+        """Drop a single pair of surrounding quotes from a case pattern so a
+        quoted literal like ``'x86_64'`` matches; glob metacharacters in an
+        unquoted pattern are left untouched for fnmatch."""
+        if len(pattern) >= 2 and pattern[0] == pattern[-1] and pattern[0] in "\"'":
+            return pattern[1:-1]
+        return pattern
+
+    def _call_function(self, name: str, args: list[str]) -> None:
+        """Run a function body with $1.. , $#, $@ and $* bound to ``args``."""
+        body = self.functions[name]
+        params = [str(i) for i in range(1, len(args) + 1)] + ["#", "@", "*"]
+        saved = {key: self.environ.get(key) for key in params}
+
+        for i, value in enumerate(args, start=1):
+            self.environ[str(i)] = value
+        self.environ["#"] = str(len(args))
+        self.environ["@"] = " ".join(args)
+        self.environ["*"] = " ".join(args)
+
+        def restore() -> None:
+            for key, value in saved.items():
+                if value is None:
+                    self.environ.pop(key, None)
+                else:
+                    self.environ[key] = value
+            self._advance()
+
+        self.cmdpending[0:0] = [*body, _Continuation(restore)]
+        self._advance()
 
     def runCommand(self):
         pp = None
@@ -222,12 +442,36 @@ class HoneyPotShell:
         if self.protocol.pp is not None and self.protocol.pp.next_command is not None:
             return
 
+        # A pending break / continue: drop the rest of the current loop body up
+        # to the innermost loop continuation, which consumes the signal.
+        if self._loop_signal is not None:
+            while self.cmdpending:
+                node = self.cmdpending[0]
+                if isinstance(node, _Continuation) and node.is_loop_cont:
+                    break
+                self.cmdpending.pop(0)
+            if not self.cmdpending:
+                # break / continue with no enclosing loop body left: ignore it.
+                self._loop_signal = None
+
         if not self.cmdpending:
             # The queue is drained.
             self._finish()
             return
 
         command = self.cmdpending.pop(0)
+
+        # Internal flow-control continuations run their callback and return; they
+        # carry no exit status and are never short-circuited.
+        if isinstance(command, _Continuation):
+            command.fn()
+            return
+
+        # A syntax error nested in a compound body surfaces here when reached.
+        if isinstance(command, SyntaxError_):
+            self._report_syntax_error(command)
+            self._advance()
+            return
 
         # && / || short-circuit: skip this statement (or whole group) based on
         # the previous command's exit status, leaving $? unchanged.
@@ -241,6 +485,35 @@ class HoneyPotShell:
             # statement keeps its own &&/|| relative to its siblings.
             self.cmdpending[0:0] = command.statements
             self._advance()
+            return
+
+        if isinstance(command, BraceGroup):
+            # A { ...; } group runs its statements in the current shell.
+            self.cmdpending[0:0] = command.statements
+            self._advance()
+            return
+
+        if isinstance(command, FunctionDef):
+            # Defining a function records its body and succeeds.
+            self.functions[command.name] = command.body
+            self.last_exit_code = 0
+            self._advance()
+            return
+
+        if isinstance(command, ForClause):
+            self._run_for(command)
+            return
+
+        if isinstance(command, IfClause):
+            self._run_if(command)
+            return
+
+        if isinstance(command, WhileClause):
+            self._run_while(command)
+            return
+
+        if isinstance(command, CaseClause):
+            self._run_case(command)
             return
 
         # Expand the statement's words against the *current* environment, just
@@ -268,6 +541,13 @@ class HoneyPotShell:
             self.environ = environ
             self.last_exit_code = 0
             self._advance()
+            return
+
+        # A call to a shell function defined earlier runs its body with the
+        # positional parameters bound to the call arguments. A pipeline that
+        # includes the function name is left to the normal command machinery.
+        if cmd_tokens[0] in self.functions and "|" not in cmd_tokens:
+            self._call_function(cmd_tokens[0], cmd_tokens[1:])
             return
 
         pipe_indices = [i for i, x in enumerate(cmd_tokens) if x == "|"]
@@ -409,7 +689,9 @@ class HoneyPotShell:
     def resume(self) -> None:
         if self.interactive:
             self.protocol.setInsertMode()
-        self.runCommand()
+        # Go through the _advance trampoline so a command that resumes us
+        # synchronously does not deepen the Python stack (see _advance).
+        self._advance()
 
     def showPrompt(self) -> None:
         if not self.interactive:

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -76,7 +76,7 @@ class HoneyPotShell:
         # live environment only when it is about to run (see runCommand). A
         # subshell stays a single unit here so its &&/|| gate covers the whole
         # group; runCommand splices its statements in only when it runs.
-        self.cmdpending: list[Command | Subshell] = []
+        self.cmdpending: list[Statement | _Continuation] = []
         # A nested shell (e.g. a command substitution) inherits the live
         # environment of whichever shell is currently running; the very first
         # shell of a session falls back to the login environment, all of which

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -289,6 +289,21 @@ class HoneyPotShell:
         self._loop_depth -= 1
         self._advance()
 
+    def _loop_body_end(self, step: Callable[[], None]) -> _Continuation:
+        """The continuation appended after a loop body. It consumes a pending
+        break / continue (break ends the loop; continue and a normal pass both
+        run ``step`` again to take the next iteration)."""
+
+        def loop_cont() -> None:
+            signal = self._loop_signal
+            self._loop_signal = None
+            if signal == "break":
+                self._end_loop()
+            else:
+                step()
+
+        return _Continuation(loop_cont, is_loop_cont=True)
+
     def _run_for(self, node: ForClause) -> None:
         """``for VAR in WORDS; do BODY; done`` over the expanded word list."""
         values = self.bashparser.evaluate(node.items) if node.items else []
@@ -300,40 +315,31 @@ class HoneyPotShell:
             return
 
         self._loop_depth += 1
-        state = {"index": 0}
+        index = 0
 
         def step() -> None:
-            if state["index"] >= len(values):
+            nonlocal index
+            if index >= len(values):
                 self._end_loop()
                 return
-            self.environ[node.var] = values[state["index"]]
-            state["index"] += 1
-            self.cmdpending[0:0] = [
-                *node.body,
-                _Continuation(loop_cont, is_loop_cont=True),
-            ]
+            self.environ[node.var] = values[index]
+            index += 1
+            self.cmdpending[0:0] = [*node.body, self._loop_body_end(step)]
             self._advance()
-
-        def loop_cont() -> None:
-            signal = self._loop_signal
-            self._loop_signal = None
-            if signal == "break":
-                self._end_loop()
-                return
-            step()  # a continue, or a normal pass, moves to the next value
 
         step()
 
     def _run_while(self, node: WhileClause) -> None:
         """``while COND; do BODY; done`` (``until`` inverts the test)."""
         self._loop_depth += 1
-        state = {"iterations": 0}
+        iterations = 0
 
         def test() -> None:
-            if state["iterations"] >= MAX_WHILE_ITERATIONS:
+            nonlocal iterations
+            if iterations >= MAX_WHILE_ITERATIONS:
                 self._end_loop()
                 return
-            state["iterations"] += 1
+            iterations += 1
             self.cmdpending[0:0] = [*node.condition, _Continuation(decide)]
             self._advance()
 
@@ -343,19 +349,8 @@ class HoneyPotShell:
             if not run_body:
                 self._end_loop()
                 return
-            self.cmdpending[0:0] = [
-                *node.body,
-                _Continuation(loop_cont, is_loop_cont=True),
-            ]
+            self.cmdpending[0:0] = [*node.body, self._loop_body_end(test)]
             self._advance()
-
-        def loop_cont() -> None:
-            signal = self._loop_signal
-            self._loop_signal = None
-            if signal == "break":
-                self._end_loop()
-                return
-            test()  # a continue, or a normal pass, re-evaluates the condition
 
         test()
 

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import copy
+import enum
 import fnmatch
 import os
 from dataclasses import dataclass
@@ -43,6 +44,17 @@ from cowrie.shell.pipe import PipeProtocol
 # ceilings are far above that yet keep a `while true` from running forever.
 MAX_WHILE_ITERATIONS = 1000
 MAX_FOR_ITEMS = 10000
+
+
+class LoopSignal(enum.Enum):
+    """A pending ``break`` / ``continue`` for the innermost running loop.
+
+    Set on the shell by the ``break`` / ``continue`` builtins and consumed by
+    that shell's innermost loop continuation.
+    """
+
+    BREAK = "break"
+    CONTINUE = "continue"
 
 
 @dataclass
@@ -102,7 +114,7 @@ class HoneyPotShell:
         # continue only act inside a loop) and a pending loop signal consumed by
         # the innermost loop continuation.
         self._loop_depth: int = 0
-        self._loop_signal: str | None = None
+        self._loop_signal: LoopSignal | None = None
         # Trampoline state for _advance (see its docstring).
         self._advancing: bool = False
         self._advance_pending: bool = False
@@ -297,7 +309,7 @@ class HoneyPotShell:
         def loop_cont() -> None:
             signal = self._loop_signal
             self._loop_signal = None
-            if signal == "break":
+            if signal is LoopSignal.BREAK:
                 self._end_loop()
             else:
                 step()

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -417,7 +417,13 @@ class HoneyPotShell:
         return pattern
 
     def _call_function(self, name: str, args: list[str]) -> None:
-        """Run a function body with $1.. , $#, $@ and $* bound to ``args``."""
+        """Run a function body with $1.. , $#, $@ and $* bound to ``args``.
+
+        Only the positional parameters for this call ($1..$len(args)) are saved
+        and restored. bash also unsets any higher-numbered parameters on entry,
+        so a function called with fewer arguments than its caller would still
+        see the caller's $2.. here; emulating that needs per-call param scoping.
+        """
         body = self.functions[name]
         params = [str(i) for i in range(1, len(args) + 1)] + ["#", "@", "*"]
         saved = {key: self.environ.get(key) for key in params}

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -333,10 +333,17 @@ class HoneyPotShell:
         """``while COND; do BODY; done`` (``until`` inverts the test)."""
         self._loop_depth += 1
         iterations = 0
+        # A loop's exit status is its body's last command, or 0 if the body
+        # never ran -- never the condition's. Each condition test overwrites $?,
+        # so snapshot the body's status before re-testing and restore it on exit.
+        body_status = 0
 
         def test() -> None:
-            nonlocal iterations
+            nonlocal iterations, body_status
+            if iterations:
+                body_status = self.last_exit_code
             if iterations >= MAX_WHILE_ITERATIONS:
+                self.last_exit_code = body_status
                 self._end_loop()
                 return
             iterations += 1
@@ -347,6 +354,7 @@ class HoneyPotShell:
             succeeded = self.last_exit_code == 0
             run_body = (not succeeded) if node.until else succeeded
             if not run_body:
+                self.last_exit_code = body_status
                 self._end_loop()
                 return
             self.cmdpending[0:0] = [*node.body, self._loop_body_end(test)]

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -161,60 +161,22 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
 
     def scriptcmd(self, path: str) -> object:
         """Return a command class that executes a shell script from the virtual filesystem."""
-        import re
-
-        shebang_re = re.compile(r"^#!\s*/bin/(ba|a)?sh")
-        max_depth = 5
+        from cowrie.shell.script import run_script_file
 
         class Command_scriptcmd(command.HoneyPotCommand):
             def call(self_cmd):
-                depth = getattr(self_cmd.protocol, "_script_depth", 0)
-                if depth >= max_depth:
-                    self_cmd.errorWrite(
-                        f"-bash: {path}: too many levels of recursion\n"
-                    )
-                    return
-
-                try:
-                    contents = self_cmd.fs.file_contents(path)
-                except Exception:
-                    self_cmd.errorWrite(f"-bash: {path}: No such file or directory\n")
-                    return
-
-                # Null bytes indicate actual binary — reject like real bash
-                if b"\x00" in contents:
-                    self_cmd.errorWrite(
-                        f"-bash: {path}: cannot execute binary file: Exec format error\n"
-                    )
-                    return
-
-                lines = contents.decode("utf-8", errors="replace").splitlines()
-
-                if not lines:
-                    return
-
-                # Strip shebang line if it's a shell shebang
-                if shebang_re.match(lines[0]):
-                    lines = lines[1:]
-
-                # Strip comment-only and blank lines
-                lines = [
-                    line
-                    for line in lines
-                    if line.strip() and not line.strip().startswith("#")
-                ]
-
-                if not lines:
-                    return
-
-                self_cmd.protocol._script_depth = depth + 1
-                try:
-                    shell = honeypot.HoneyPotShell(self_cmd.protocol, interactive=False)
-                    self_cmd.protocol.cmdstack.append(shell)
-                    shell.lineReceived("; ".join(lines))
-                    self_cmd.protocol.cmdstack.pop()
-                finally:
-                    self_cmd.protocol._script_depth = depth
+                # Running ./file or /path/file: the kernel rejects a binary with
+                # ENOEXEC ("cannot execute binary file"); a shell script is run
+                # through the parser (the shebang is parsed as a comment).
+                run_script_file(
+                    self_cmd,
+                    path,
+                    not_found_message=f"-bash: {path}: No such file or directory\n",
+                    binary_message=(
+                        f"-bash: {path}: cannot execute binary file: "
+                        "Exec format error\n"
+                    ),
+                )
 
         return Command_scriptcmd
 
@@ -359,9 +321,9 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
         HoneyPotBaseProtocol.connectionMade(self)
         self.setTimeout(60)
         self.cmdstack = [honeypot.HoneyPotShell(self, interactive=False)]
-        # TODO: quick and dirty fix to deal with \n separated commands
-        # HoneypotShell() needs a rewrite to better work with pending input
-        self.cmdstack[0].lineReceived("; ".join(self.execcmd.strip().split("\n")))
+        # The parser treats newlines as statement separators, so a multi-line
+        # exec payload (including loops/conditionals) is run as written.
+        self.cmdstack[0].lineReceived(self.execcmd)
 
     def keystrokeReceived(self, keyID, modifier):
         self.input_data += keyID

--- a/src/cowrie/shell/script.py
+++ b/src/cowrie/shell/script.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Shared helpers for running an uploaded file as a shell script:
+# ABOUTME: binary-vs-script detection and executing the contents through the shell.
+
+"""
+Running uploaded code is a core honeypot job: a second-stage downloader is
+usually a shell script dropped by ``wget`` / ``curl`` / ``tftp`` and then run as
+``./x``, ``sh x`` or via a shebang. This module concentrates the two decisions
+that path needs, so ``bash``/``sh`` and direct ``./file`` execution behave the
+same:
+
+* :func:`is_executable_binary` -- tell an ELF/PE/Mach-O or otherwise binary
+  payload from a text script, so we refuse to "run" a binary instead of feeding
+  its bytes to the parser (as both a real kernel and ``bash`` do).
+* :func:`run_script_file` -- read the file from the emulated filesystem and run
+  its contents through a fresh :class:`~cowrie.shell.honeypot.HoneyPotShell`.
+  The whole text is handed to the parser unchanged: the grammar treats newlines
+  as separators and ``#`` lines (including the shebang) as comments, so loops,
+  conditionals and functions that span lines are emulated rather than flattened.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cowrie.shell.fs import FileNotFound
+
+if TYPE_CHECKING:
+    from cowrie.shell.command import HoneyPotCommand
+
+# How deep one script may invoke another (a script that runs a script ...),
+# guarding against runaway or self-referential droppers.
+MAX_SCRIPT_DEPTH = 5
+
+# Magic numbers for common executable formats that are clearly not scripts.
+_BINARY_MAGIC = (
+    b"\x7fELF",  # ELF (Linux, the usual malware case)
+    b"MZ",  # DOS / PE (Windows)
+    b"\xca\xfe\xba\xbe",  # Mach-O universal / Java class
+    b"\xfe\xed\xfa\xce",  # Mach-O 32-bit
+    b"\xfe\xed\xfa\xcf",  # Mach-O 64-bit
+    b"\xcf\xfa\xed\xfe",  # Mach-O 64-bit (LE)
+    b"\xce\xfa\xed\xfe",  # Mach-O 32-bit (LE)
+)
+
+# How much of the file to inspect for NUL bytes / decodability.
+_SAMPLE_BYTES = 8192
+
+
+def is_executable_binary(contents: bytes) -> bool:
+    """Return True if ``contents`` looks like a binary executable, not a script.
+
+    A shell script is text: ASCII, or otherwise valid UTF-8. So anything with
+    a known executable magic number, a NUL byte, or bytes that are not valid
+    UTF-8 is treated as a binary -- which covers ELF/PE/Mach-O droppers and
+    packed payloads while leaving non-ASCII (e.g. UTF-8 comment) scripts alone.
+    """
+    if not contents:
+        return False
+    if contents.startswith(_BINARY_MAGIC):
+        return True
+
+    sample = contents[:_SAMPLE_BYTES]
+    if b"\x00" in sample:
+        return True
+
+    try:
+        sample.decode("utf-8")
+    except UnicodeDecodeError:
+        return True
+    return False
+
+
+def run_script_file(
+    command: HoneyPotCommand,
+    path: str,
+    *,
+    not_found_message: str,
+    binary_message: str,
+) -> None:
+    """Read ``path`` from the emulated filesystem and run it as a shell script.
+
+    ``not_found_message`` / ``binary_message`` are the errors to write (with the
+    caller's preferred ``bash:`` / ``-bash:`` prefix) when the file is missing or
+    is an executable binary. The command's ``exit_code`` is set to the status of
+    the last command the script ran.
+    """
+    # Imported here to avoid a circular import at module load (honeypot does not
+    # depend on this module, but protocol -> honeypot -> ... -> this would).
+    from cowrie.shell.honeypot import HoneyPotShell
+
+    protocol = command.protocol
+    depth = getattr(protocol, "_script_depth", 0)
+    if depth >= MAX_SCRIPT_DEPTH:
+        command.errorWrite(f"-bash: {path}: too many levels of recursion\n")
+        return
+
+    try:
+        contents = command.fs.file_contents(path)
+    except (FileNotFound, FileNotFoundError):
+        command.errorWrite(not_found_message)
+        return
+
+    if is_executable_binary(contents):
+        command.errorWrite(binary_message)
+        return
+
+    text = contents.decode("utf-8", errors="replace")
+    if not text.strip():
+        return
+
+    protocol._script_depth = depth + 1
+    try:
+        shell = HoneyPotShell(protocol, interactive=False)
+        protocol.cmdstack.append(shell)
+        # Hand the whole script to the parser: newlines separate statements and
+        # "#" lines (the shebang included) are comments, so flow control that
+        # spans lines is emulated rather than joined onto one line.
+        shell.lineReceived(text)
+        command.exit_code = shell.last_exit_code
+        protocol.cmdstack.pop()
+    finally:
+        protocol._script_depth = depth

--- a/src/cowrie/shell/script.py
+++ b/src/cowrie/shell/script.py
@@ -46,7 +46,9 @@ _BINARY_MAGIC = (
     b"\xce\xfa\xed\xfe",  # Mach-O 32-bit (LE)
 )
 
-# How much of the file to inspect for NUL bytes / decodability.
+# How much of the file to inspect for non-UTF-8 decodability. The NUL scan
+# covers the whole file (see below); the UTF-8 check samples the head, which is
+# enough to tell a text script from packed/encrypted bytes.
 _SAMPLE_BYTES = 8192
 
 
@@ -57,18 +59,21 @@ def is_executable_binary(contents: bytes) -> bool:
     a known executable magic number, a NUL byte, or bytes that are not valid
     UTF-8 is treated as a binary -- which covers ELF/PE/Mach-O droppers and
     packed payloads while leaving non-ASCII (e.g. UTF-8 comment) scripts alone.
+
+    The NUL scan looks at the whole file, not just the head: a self-extracting
+    dropper is a text header with a binary blob appended, so the NUL that gives
+    it away can sit well past any sampled prefix.
     """
     if not contents:
         return False
     if contents.startswith(_BINARY_MAGIC):
         return True
 
-    sample = contents[:_SAMPLE_BYTES]
-    if b"\x00" in sample:
+    if b"\x00" in contents:
         return True
 
     try:
-        sample.decode("utf-8")
+        contents[:_SAMPLE_BYTES].decode("utf-8")
     except UnicodeDecodeError:
         return True
     return False

--- a/src/cowrie/test/test_bashparse.py
+++ b/src/cowrie/test/test_bashparse.py
@@ -11,9 +11,15 @@ import unittest
 
 from cowrie.shell.bashparse import (
     BashParser,
+    BraceGroup,
+    CaseClause,
     Command,
+    ForClause,
+    FunctionDef,
+    IfClause,
     Subshell,
     SyntaxError_,
+    WhileClause,
 )
 
 
@@ -296,6 +302,91 @@ class BashParseCommentTests(unittest.TestCase):
 
     def test_hash_in_quotes_not_a_comment(self) -> None:
         self.assertEqual(self._tokens('echo "a # b"'), ["echo", "a # b"])
+
+
+class BashParseCompoundTests(unittest.TestCase):
+    """Compound commands parse into their structured AST nodes."""
+
+    def setUp(self) -> None:
+        self.ctx = FakeContext({"x": "hi"})
+        self.parser = BashParser(self.ctx)
+
+    def _one(self, line: str) -> object:
+        statements = self.parser.parse(line)
+        self.assertEqual(len(statements), 1)
+        return statements[0]
+
+    def _eval(self, command: object) -> list[str]:
+        assert isinstance(command, Command)
+        return self.parser.evaluate(command)
+
+    def test_for_clause(self) -> None:
+        node = self._one("for i in a b c; do echo $i; done")
+        assert isinstance(node, ForClause)
+        self.assertEqual(node.var, "i")
+        self.assertEqual(self._eval(node.items), ["a", "b", "c"])
+        self.assertEqual(len(node.body), 1)
+
+    def test_for_multiline(self) -> None:
+        node = self._one("for i in a b\ndo\n echo $i\ndone")
+        assert isinstance(node, ForClause)
+        self.assertEqual(self._eval(node.items), ["a", "b"])
+
+    def test_if_clause(self) -> None:
+        node = self._one("if true; then echo a; elif false; then echo b; else echo c; fi")
+        assert isinstance(node, IfClause)
+        self.assertEqual(len(node.branches), 2)
+        self.assertIsNotNone(node.else_body)
+
+    def test_while_clause(self) -> None:
+        node = self._one("while true; do echo x; done")
+        assert isinstance(node, WhileClause)
+        self.assertFalse(node.until)
+
+    def test_until_clause(self) -> None:
+        node = self._one("until false; do echo x; done")
+        assert isinstance(node, WhileClause)
+        self.assertTrue(node.until)
+
+    def test_case_clause(self) -> None:
+        node = self._one("case $x in a) echo 1;; b|c) echo 2;; *) echo 3;; esac")
+        assert isinstance(node, CaseClause)
+        self.assertEqual([pats for pats, _ in node.items], [["a"], ["b", "c"], ["*"]])
+
+    def test_brace_group(self) -> None:
+        node = self._one("{ echo a; echo b; }")
+        assert isinstance(node, BraceGroup)
+        self.assertEqual(len(node.statements), 2)
+
+    def test_function_paren_form(self) -> None:
+        node = self._one("f() { echo hi; }")
+        assert isinstance(node, FunctionDef)
+        self.assertEqual(node.name, "f")
+
+    def test_function_keyword_form(self) -> None:
+        node = self._one("function g { echo g; }")
+        assert isinstance(node, FunctionDef)
+        self.assertEqual(node.name, "g")
+
+    def test_newline_separates_statements(self) -> None:
+        statements = self.parser.parse("echo a\necho b\necho c")
+        self.assertEqual(len(statements), 3)
+        self.assertEqual(self._eval(statements[0]), ["echo", "a"])
+
+    def test_reserved_word_as_argument(self) -> None:
+        # "done" outside a loop is an ordinary argument, not a keyword.
+        node = self._one("echo done")
+        self.assertEqual(self._eval(node), ["echo", "done"])
+
+    def test_compound_join_operator(self) -> None:
+        statements = self.parser.parse("true && for i in 1; do echo $i; done")
+        self.assertIsInstance(statements[0], Command)
+        self.assertIsInstance(statements[1], ForClause)
+        self.assertEqual(statements[1].op, "&&")  # type: ignore[union-attr]
+
+    def test_unterminated_for_is_error(self) -> None:
+        node = self._one("for i in 1 2 3; do echo $i")
+        self.assertIsInstance(node, SyntaxError_)
 
 
 if __name__ == "__main__":

--- a/src/cowrie/test/test_flow_control.py
+++ b/src/cowrie/test/test_flow_control.py
@@ -36,7 +36,7 @@ class FlowControlTests(unittest.TestCase):
     def _run(self, line: str) -> bytes:
         self.tr.clear()
         self.proto.lineReceived(line.encode())
-        value = self.tr.value()
+        value = bytes(self.tr.value())
         if value.endswith(PROMPT):
             value = value[: -len(PROMPT)]
         return value

--- a/src/cowrie/test/test_flow_control.py
+++ b/src/cowrie/test/test_flow_control.py
@@ -169,6 +169,11 @@ class FlowControlTests(unittest.TestCase):
             b"BC\n",
         )
 
+    def test_case_matched_empty_body_status(self) -> None:
+        # A matched but empty case body resets $? to 0; the prior command's
+        # status must not leak through.
+        self.assertEqual(self._run("false; case x in x) ;; esac; echo $?"), b"0\n")
+
     # -- brace group --------------------------------------------------------
 
     def test_brace_group(self) -> None:

--- a/src/cowrie/test/test_flow_control.py
+++ b/src/cowrie/test/test_flow_control.py
@@ -112,6 +112,14 @@ class FlowControlTests(unittest.TestCase):
         output = self._run("while true; do echo x; done")
         self.assertEqual(output.count(b"x\n"), MAX_WHILE_ITERATIONS)
 
+    def test_while_false_condition_exit_status(self) -> None:
+        # A while whose body never runs exits 0, not the failing condition's
+        # status. The condition must not leak into $?.
+        self.assertEqual(self._run("while false; do echo x; done; echo $?"), b"0\n")
+
+    def test_until_true_condition_exit_status(self) -> None:
+        self.assertEqual(self._run("until true; do echo x; done; echo $?"), b"0\n")
+
     # -- break / continue ---------------------------------------------------
 
     def test_break_stops_loop(self) -> None:

--- a/src/cowrie/test/test_flow_control.py
+++ b/src/cowrie/test/test_flow_control.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: End-to-end tests for shell flow control (for/if/while/until/case,
+# ABOUTME: brace groups, functions, break/continue) driven through the protocol.
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+
+class FlowControlTests(unittest.TestCase):
+    """for / if / while / until / case / functions, run through the shell."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def _run(self, line: str) -> bytes:
+        self.tr.clear()
+        self.proto.lineReceived(line.encode())
+        value = self.tr.value()
+        if value.endswith(PROMPT):
+            value = value[: -len(PROMPT)]
+        return value
+
+    # -- for ----------------------------------------------------------------
+
+    def test_for_literal_list(self) -> None:
+        self.assertEqual(self._run("for i in 1 2 3; do echo $i; done"), b"1\n2\n3\n")
+
+    def test_for_over_variable_value(self) -> None:
+        self.assertEqual(
+            self._run("for w in a b c; do echo got $w; done"),
+            b"got a\ngot b\ngot c\n",
+        )
+
+    def test_for_multiline(self) -> None:
+        script = "for i in x y\ndo\n  echo $i\ndone"
+        self.assertEqual(self._run(script), b"x\ny\n")
+
+    def test_nested_for(self) -> None:
+        self.assertEqual(
+            self._run("for i in 1 2; do for j in a b; do echo $i$j; done; done"),
+            b"1a\n1b\n2a\n2b\n",
+        )
+
+    # -- if -----------------------------------------------------------------
+
+    def test_if_true_branch(self) -> None:
+        self.assertEqual(
+            self._run("if [ -f /etc/passwd ]; then echo yes; else echo no; fi"),
+            b"yes\n",
+        )
+
+    def test_if_else_branch(self) -> None:
+        self.assertEqual(
+            self._run("if [ -f /no/such ]; then echo yes; else echo no; fi"),
+            b"no\n",
+        )
+
+    def test_if_elif(self) -> None:
+        self.assertEqual(
+            self._run("if false; then echo a; elif true; then echo b; else echo c; fi"),
+            b"b\n",
+        )
+
+    def test_if_uses_command_status(self) -> None:
+        self.assertEqual(self._run("if true; then echo ran; fi"), b"ran\n")
+
+    def test_and_chained_conditions(self) -> None:
+        self.assertEqual(
+            self._run("if [ -d /etc ] && [ -f /etc/passwd ]; then echo both; fi"),
+            b"both\n",
+        )
+
+    # -- while / until ------------------------------------------------------
+
+    def test_while_breaks_out(self) -> None:
+        self.assertEqual(
+            self._run("while true; do echo once; break; done"),
+            b"once\n",
+        )
+
+    def test_until_runs_until_true(self) -> None:
+        self.assertEqual(
+            self._run("until [ -f /etc/passwd ]; do echo loop; done"),
+            b"",
+        )
+
+    def test_while_infinite_is_capped(self) -> None:
+        # A runaway loop must terminate at the safety cap rather than hang.
+        from cowrie.shell.honeypot import MAX_WHILE_ITERATIONS
+
+        output = self._run("while true; do echo x; done")
+        self.assertEqual(output.count(b"x\n"), MAX_WHILE_ITERATIONS)
+
+    # -- break / continue ---------------------------------------------------
+
+    def test_break_stops_loop(self) -> None:
+        self.assertEqual(
+            self._run(
+                "for i in 1 2 3 4 5; do echo $i; "
+                "if [ $i -eq 3 ]; then break; fi; done"
+            ),
+            b"1\n2\n3\n",
+        )
+
+    def test_continue_skips_iteration(self) -> None:
+        self.assertEqual(
+            self._run(
+                "for i in 1 2 3 4; do if [ $i -eq 2 ]; then continue; fi; "
+                "echo $i; done"
+            ),
+            b"1\n3\n4\n",
+        )
+
+    def test_break_only_inner_loop(self) -> None:
+        self.assertEqual(
+            self._run(
+                "for i in 1 2; do for j in a b c; do "
+                "if [ $j = b ]; then break; fi; echo $i$j; done; done"
+            ),
+            b"1a\n2a\n",
+        )
+
+    # -- case ---------------------------------------------------------------
+
+    def test_case_glob_match(self) -> None:
+        self.assertEqual(
+            self._run("case abc in a*) echo starts-a;; *) echo other;; esac"),
+            b"starts-a\n",
+        )
+
+    def test_case_default(self) -> None:
+        self.assertEqual(
+            self._run("case xyz in a*) echo a;; *) echo default;; esac"),
+            b"default\n",
+        )
+
+    def test_case_alternation(self) -> None:
+        self.assertEqual(
+            self._run("case b in a) echo A;; b|c) echo BC;; esac"),
+            b"BC\n",
+        )
+
+    # -- brace group --------------------------------------------------------
+
+    def test_brace_group(self) -> None:
+        self.assertEqual(self._run("{ echo a; echo b; }"), b"a\nb\n")
+
+    # -- functions ----------------------------------------------------------
+
+    def test_function_definition_and_call(self) -> None:
+        self.assertEqual(
+            self._run("greet() { echo hello $1; }; greet world"),
+            b"hello world\n",
+        )
+
+    def test_function_arg_count(self) -> None:
+        self.assertEqual(
+            self._run("count() { echo $#; }; count a b c"),
+            b"3\n",
+        )
+
+    def test_function_keyword_form(self) -> None:
+        self.assertEqual(
+            self._run("function f { echo from_f; }; f"),
+            b"from_f\n",
+        )
+
+    # -- exit status propagation -------------------------------------------
+
+    def test_status_after_if(self) -> None:
+        self.assertEqual(self._run("if true; then true; fi; echo $?"), b"0\n")
+
+    def test_status_after_for(self) -> None:
+        self.assertEqual(self._run("for i in 1; do false; done; echo $?"), b"1\n")
+
+    # -- realistic downloader idiom ----------------------------------------
+
+    def test_download_retry_idiom(self) -> None:
+        # The canonical "try each mirror until one works" loop. echo stands in
+        # for a downloader; the first success breaks the loop.
+        self.assertEqual(
+            self._run(
+                "for url in http://a/x http://b/x; do "
+                "echo fetch $url && break; done"
+            ),
+            b"fetch http://a/x\n",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_script_execution.py
+++ b/src/cowrie/test/test_script_execution.py
@@ -11,6 +11,7 @@ import os
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.shell.script import is_executable_binary
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
@@ -143,3 +144,83 @@ class ScriptExecutionTests(unittest.TestCase):
         """Existing piped input functionality still works."""
         self.proto.lineReceived(b"echo echo piped | bash")
         self.assertEqual(self.tr.value(), b"piped\n" + PROMPT)
+
+    # -- multi-line flow control from a script file -------------------------
+
+    def test_script_with_for_loop(self) -> None:
+        """A for loop spanning multiple lines in a script file runs each pass."""
+        self.proto.lineReceived(
+            b"printf 'for i in 1 2 3\\ndo\\necho got $i\\ndone\\n' > /tmp/loop.sh"
+        )
+        self.tr.clear()
+        self.proto.lineReceived(b"sh /tmp/loop.sh")
+        self.assertEqual(self.tr.value(), b"got 1\ngot 2\ngot 3\n" + PROMPT)
+
+    def test_script_with_if(self) -> None:
+        """A multi-line if/else in a script file picks the right branch."""
+        self.proto.lineReceived(
+            b"printf 'if [ -f /etc/passwd ]\\nthen\\necho found\\n"
+            b"else\\necho missing\\nfi\\n' > /tmp/cond.sh"
+        )
+        self.tr.clear()
+        self.proto.lineReceived(b"bash /tmp/cond.sh")
+        self.assertEqual(self.tr.value(), b"found\n" + PROMPT)
+
+    def test_script_downloader_retry_idiom(self) -> None:
+        """The try-each-mirror-until-one-works loop, run from a file."""
+        self.proto.lineReceived(
+            b"printf 'for u in a b c\\ndo\\necho fetch $u && break\\ndone\\n'"
+            b" > /tmp/dl.sh"
+        )
+        self.tr.clear()
+        self.proto.lineReceived(b"sh /tmp/dl.sh")
+        self.assertEqual(self.tr.value(), b"fetch a\n" + PROMPT)
+
+    def test_shebang_is_comment_not_executed(self) -> None:
+        """The shebang line is treated as a comment and produces no output."""
+        self.proto.lineReceived(
+            b"printf '#!/bin/sh\\necho after_shebang\\n' > /tmp/sb.sh"
+        )
+        self.tr.clear()
+        self.proto.lineReceived(b"sh /tmp/sb.sh")
+        self.assertEqual(self.tr.value(), b"after_shebang\n" + PROMPT)
+
+    def test_bash_rejects_binary_file(self) -> None:
+        """bash refuses to source an ELF binary, like the real shell."""
+        self.proto.lineReceived(b'printf "\\x7fELF\\x02\\x01" > /tmp/elf.bin')
+        self.tr.clear()
+        self.proto.lineReceived(b"bash /tmp/elf.bin")
+        self.assertIn(b"cannot execute binary file", self.tr.value())
+
+    def test_script_exit_status_propagates(self) -> None:
+        """A script's exit status is the status of its last command."""
+        self.proto.lineReceived(b"printf 'true\\nfalse\\n' > /tmp/st.sh")
+        self.tr.clear()
+        self.proto.lineReceived(b"sh /tmp/st.sh; echo rc=$?")
+        self.assertEqual(self.tr.value(), b"rc=1\n" + PROMPT)
+
+
+class BinaryDetectionTests(unittest.TestCase):
+    """is_executable_binary distinguishes binaries from text scripts."""
+
+    def test_elf_is_binary(self) -> None:
+        self.assertTrue(is_executable_binary(b"\x7fELF\x02\x01\x01\x00rest"))
+
+    def test_pe_is_binary(self) -> None:
+        self.assertTrue(is_executable_binary(b"MZ\x90\x00\x03"))
+
+    def test_nul_byte_is_binary(self) -> None:
+        self.assertTrue(is_executable_binary(b"#!/bin/sh\nrun\x00me"))
+
+    def test_plain_script_is_text(self) -> None:
+        self.assertFalse(is_executable_binary(b"#!/bin/sh\necho hello\n"))
+
+    def test_utf8_script_is_text(self) -> None:
+        # Non-ASCII UTF-8 (a comment in another language) is still a script.
+        self.assertFalse(is_executable_binary("# café\necho hi\n".encode()))
+
+    def test_empty_is_not_binary(self) -> None:
+        self.assertFalse(is_executable_binary(b""))
+
+    def test_invalid_utf8_is_binary(self) -> None:
+        self.assertTrue(is_executable_binary(b"\xff\xfe\x80\x81packed" * 50))

--- a/src/cowrie/test/test_script_execution.py
+++ b/src/cowrie/test/test_script_execution.py
@@ -185,13 +185,6 @@ class ScriptExecutionTests(unittest.TestCase):
         self.proto.lineReceived(b"sh /tmp/sb.sh")
         self.assertEqual(self.tr.value(), b"after_shebang\n" + PROMPT)
 
-    def test_bash_rejects_binary_file(self) -> None:
-        """bash refuses to source an ELF binary, like the real shell."""
-        self.proto.lineReceived(b'printf "\\x7fELF\\x02\\x01" > /tmp/elf.bin')
-        self.tr.clear()
-        self.proto.lineReceived(b"bash /tmp/elf.bin")
-        self.assertIn(b"cannot execute binary file", self.tr.value())
-
     def test_script_exit_status_propagates(self) -> None:
         """A script's exit status is the status of its last command."""
         self.proto.lineReceived(b"printf 'true\\nfalse\\n' > /tmp/st.sh")
@@ -224,3 +217,11 @@ class BinaryDetectionTests(unittest.TestCase):
 
     def test_invalid_utf8_is_binary(self) -> None:
         self.assertTrue(is_executable_binary(b"\xff\xfe\x80\x81packed" * 50))
+
+    def test_nul_past_sample_is_binary(self) -> None:
+        # A self-extracting dropper: a large text header (no executable magic at
+        # offset 0) with a binary blob appended past the inspection sample. The
+        # NUL is what marks it binary, so the whole file must be scanned.
+        contents = b"#!/bin/sh\n" + b"# padding\n" * 2000 + b"\x00\x01ELFblob"
+        self.assertGreater(len(contents), 8192)
+        self.assertTrue(is_executable_binary(contents))

--- a/src/cowrie/test/test_test_builtin.py
+++ b/src/cowrie/test/test_test_builtin.py
@@ -37,7 +37,7 @@ class TestTrueFalseTests(unittest.TestCase):
         """Run ``line`` then return what ``echo $?`` prints (without the prompt)."""
         self.tr.clear()
         self.proto.lineReceived(f"{line}; echo $?".encode())
-        return self.tr.value()[: -len(PROMPT)]
+        return bytes(self.tr.value())[: -len(PROMPT)]
 
     # -- true / false -------------------------------------------------------
 

--- a/src/cowrie/test/test_test_builtin.py
+++ b/src/cowrie/test/test_test_builtin.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for the test / [ conditional utility and the true / false programs.
+# ABOUTME: Exit codes are observed through $? so the shell integration is exercised too.
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+
+class TestTrueFalseTests(unittest.TestCase):
+    """The true / false utilities and the test / [ conditional."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def _status(self, line: str) -> bytes:
+        """Run ``line`` then return what ``echo $?`` prints (without the prompt)."""
+        self.tr.clear()
+        self.proto.lineReceived(f"{line}; echo $?".encode())
+        return self.tr.value()[: -len(PROMPT)]
+
+    # -- true / false -------------------------------------------------------
+
+    def test_true_exit_zero(self) -> None:
+        self.assertEqual(self._status("true"), b"0\n")
+
+    def test_false_exit_one(self) -> None:
+        self.assertEqual(self._status("false"), b"1\n")
+
+    def test_true_short_circuit(self) -> None:
+        self.tr.clear()
+        self.proto.lineReceived(b"true && echo yes")
+        self.assertEqual(self.tr.value(), b"yes\n" + PROMPT)
+
+    def test_false_short_circuit(self) -> None:
+        self.tr.clear()
+        self.proto.lineReceived(b"false || echo recovered")
+        self.assertEqual(self.tr.value(), b"recovered\n" + PROMPT)
+
+    # -- file tests ---------------------------------------------------------
+
+    def test_dir_exists(self) -> None:
+        self.assertEqual(self._status("test -d /etc"), b"0\n")
+
+    def test_dir_on_file_is_false(self) -> None:
+        self.assertEqual(self._status("test -d /etc/passwd"), b"1\n")
+
+    def test_file_exists(self) -> None:
+        self.assertEqual(self._status("test -f /etc/passwd"), b"0\n")
+
+    def test_file_missing(self) -> None:
+        self.assertEqual(self._status("test -f /no/such/path"), b"1\n")
+
+    def test_exists_operator(self) -> None:
+        self.assertEqual(self._status("test -e /etc"), b"0\n")
+
+    def test_bracket_file_exists(self) -> None:
+        self.assertEqual(self._status("[ -f /etc/passwd ]"), b"0\n")
+
+    # -- string tests -------------------------------------------------------
+
+    def test_string_equal(self) -> None:
+        self.assertEqual(self._status("[ abc = abc ]"), b"0\n")
+
+    def test_string_not_equal(self) -> None:
+        self.assertEqual(self._status("[ abc != xyz ]"), b"0\n")
+
+    def test_string_empty(self) -> None:
+        self.assertEqual(self._status("[ -z '' ]"), b"0\n")
+
+    def test_string_nonempty(self) -> None:
+        self.assertEqual(self._status("[ -n hello ]"), b"0\n")
+
+    def test_single_arg_nonempty_true(self) -> None:
+        self.assertEqual(self._status("[ hello ]"), b"0\n")
+
+    def test_single_arg_empty_false(self) -> None:
+        self.assertEqual(self._status("[ '' ]"), b"1\n")
+
+    # -- integer tests ------------------------------------------------------
+
+    def test_int_eq(self) -> None:
+        self.assertEqual(self._status("[ 5 -eq 5 ]"), b"0\n")
+
+    def test_int_lt(self) -> None:
+        self.assertEqual(self._status("[ 3 -lt 5 ]"), b"0\n")
+
+    def test_int_ge_false(self) -> None:
+        self.assertEqual(self._status("[ 3 -ge 5 ]"), b"1\n")
+
+    def test_int_non_numeric_errors(self) -> None:
+        # A non-integer operand is a usage error: exit status 2.
+        out = self._status("[ x -eq 5 ]")
+        self.assertIn(b"integer expression expected", out)
+        self.assertTrue(out.endswith(b"2\n"))
+
+    # -- negation and combination ------------------------------------------
+
+    def test_negation(self) -> None:
+        self.assertEqual(self._status("[ ! -f /no/such/path ]"), b"0\n")
+
+    def test_and_combiner(self) -> None:
+        self.assertEqual(self._status("[ -d /etc -a -f /etc/passwd ]"), b"0\n")
+
+    def test_or_combiner(self) -> None:
+        self.assertEqual(self._status("[ -f /no/such -o -d /etc ]"), b"0\n")
+
+    # -- malformed ----------------------------------------------------------
+
+    def test_bracket_missing_close(self) -> None:
+        self.tr.clear()
+        self.proto.lineReceived(b"[ -d /etc ")
+        self.assertIn(b"missing `]'", self.tr.value())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_test_builtin.py
+++ b/src/cowrie/test/test_test_builtin.py
@@ -125,6 +125,17 @@ class TestTrueFalseTests(unittest.TestCase):
     def test_or_combiner(self) -> None:
         self.assertEqual(self._status("[ -f /no/such -o -d /etc ]"), b"0\n")
 
+    def test_three_arg_and(self) -> None:
+        # `test STR1 -a STR2`: true when both strings are non-empty (deprecated
+        # but still used). The 3-arg form must not be read as a binary operator.
+        self.assertEqual(self._status("[ a -a b ]"), b"0\n")
+
+    def test_three_arg_and_empty_is_false(self) -> None:
+        self.assertEqual(self._status("[ '' -a b ]"), b"1\n")
+
+    def test_three_arg_or(self) -> None:
+        self.assertEqual(self._status("[ '' -o b ]"), b"0\n")
+
     # -- malformed ----------------------------------------------------------
 
     def test_bracket_missing_close(self) -> None:


### PR DESCRIPTION
## Summary

Teaches Cowrie's shell to parse and emulate **flow control**, so multi-line
droppers and second-stage scripts run as written instead of being flattened
onto a single `;`-joined line.

- **Parser** (`bashparse.py`): recursive-descent over the existing Lark token
  stream recognises `for` / `if` / `while` / `until` / `case`, brace groups
  `{ ...; }`, subshells, and function definitions (both `name() {}` and
  `function name {}`). Newlines now separate statements like `;`, so a whole
  script is parsed directly. Reserved words are only recognised at a command
  position, so `echo done` still prints `done`.
- **Executor** (`honeypot.py`): compound commands are driven through the same
  `cmdpending` queue as simple commands via a trampoline, so loops and
  conditionals work whether their bodies complete synchronously or pause on a
  Deferred (e.g. `wget`). `break` / `continue`, function calls with positional
  parameters (`$1..`, `$#`, `$@`, `$*`), and `case` glob matching are emulated.
  Runaway loops are capped (`MAX_WHILE_ITERATIONS`, `MAX_FOR_ITEMS`).
- **Builtins** (`base.py`): real `test` / `[` (file, string and integer tests,
  `!`, `-a` / `-o`), and proper `true` / `false`.
- **Script execution** (`script.py`): a shared `run_script_file` /
  `is_executable_binary` used by `sh`/`bash file` and `./file` alike, so binary
  payloads are rejected consistently and scripts are handed to the parser whole
  (the shebang is treated as a comment).

## Safety

- Loops are bounded so an uploaded `while true` cannot hang the session.
- Script recursion depth is capped (`MAX_SCRIPT_DEPTH`).
- Binary detection scans the whole file for NUL (plus executable magic numbers
  and non-UTF-8 bytes), so a text-header + binary-tail dropper is rejected
  rather than flooding the log.

## Tests

New end-to-end suites driven through the protocol: `test_flow_control.py`,
`test_test_builtin.py`, plus parser (`test_bashparse.py`) and script-execution
coverage. Full suite (640 tests) passes; `ruff` and `mypy` clean.

## Known limitations (documented in code)

- `break` / `continue` use a shell-global loop scope and function calls only
  save/restore the current call's positional parameters, so both diverge from
  bash when a function is invoked from inside a loop or with fewer arguments
  than its caller.
- A leading-paren `case` pattern `(pat)` and a redirection applied to a
  command-position subshell are not yet handled.
