### PR TITLE
fix: type telnet transport protocol mock in test

### DIFF
--- a/src/cowrie/test/test_telnet_transport.py
+++ b/src/cowrie/test/test_telnet_transport.py
@@ -272,10 +272,11 @@ class TestInvalidIACSequence(unittest.TestCase):
 
     def test_valid_data_still_delivered(self) -> None:
         # A well-formed stream must pass through untouched.
-        self.transport.protocol = MagicMock()
+        protocol = MagicMock()
+        self.transport.protocol = protocol  # type: ignore[assignment]
         errors = self._capture(lambda: self.transport.dataReceived(b"hello"))
 
-        self.transport.protocol.dataReceived.assert_called_once_with(b"hello")
+        protocol.dataReceived.assert_called_once_with(b"hello")
         self.tcp.loseConnection.assert_not_called()
         self.assertEqual(errors, [])
 


### PR DESCRIPTION
## Summary

Fixes two `mypy` errors in `test_telnet_transport.py`. `CowrieTelnetTransport`
inherits `protocol` from Twisted's `TelnetTransport`, where it is typed as
`None`, so the test's `self.transport.protocol = MagicMock()` and the
subsequent `self.transport.protocol.dataReceived(...)` assertion both failed
type checking:

```
test_telnet_transport.py:275: error: Incompatible types in assignment
    (expression has type "MagicMock", variable has type "None")  [assignment]
test_telnet_transport.py:278: error: "None" has no attribute "dataReceived"  [attr-defined]
```

Hold the mock in a local variable for the assertion and annotate the
assignment with `# type: ignore[assignment]`, matching the pattern this file
already uses for `self.transport.transport`.

## Verification

- `mypy src` clean (248 files, 0 errors)
- `test_telnet_transport` (9 tests) passes
- `ruff check src` clean
