### PR TITLE
fix: clean up unhandled wget error logging

### DIFF
--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -627,10 +627,7 @@ class Command_wget(HoneyPotCommand):
             self.exit()
             return
 
-        log.err(f"Unhandled wget error: {response!s}")
-        log.msg(f"Uhhandled wget traceback: {response.printTraceback()}")
-        if hasattr(response, "getErrorMessage"):  # Exceptions
-            log.msg(f"Unhandled wget error message: {response.getErrorMessage}")
+        log.err(response, "Unhandled wget error")
         self.errorWrite("\n")
         self.exit()
 


### PR DESCRIPTION
## Problem

When emulated `wget` hits a network error not matched by any explicit branch (e.g. `ConnectionRefusedError`), the catch-all in `Command_wget.error()` emits **four** log lines for a single error:

```python
log.err(f"Unhandled wget error: {response!s}")
log.msg(f"Uhhandled wget traceback: {response.printTraceback()}")
if hasattr(response, "getErrorMessage"):
    log.msg(f"Unhandled wget error message: {response.getErrorMessage}")
```

Three bugs:
1. Typo `Uhhandled` (double `h`).
2. `Failure.printTraceback()` writes the traceback to Twisted's log as a side-effect and returns `None` — producing a duplicate `[twisted.python.log#error]` block *and* logging `traceback: None`.
3. `getErrorMessage` is logged as a bound-method object instead of being called.

These were leftover debugging lines.

## Fix

Replace the block with the idiomatic Twisted pattern, which emits a single properly-attributed log entry:

```python
log.err(response, "Unhandled wget error")
```

Fixes #40250

## Testing

`ruff check` clean, `mypy` clean, `test_wget` passes.