### PR TITLE
fix: release file handle before renaming captured logs on Windows

### DIFF
--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -153,13 +153,13 @@ class LoggingServerProtocol(insults.ServerProtocol):
                 if os.path.exists(self.stdinlogFile):
                     with open(self.stdinlogFile, "rb") as f:
                         shasum = hashlib.sha256(f.read()).hexdigest()
-                        shasumfile = os.path.join(self.downloadPath, shasum)
-                        if os.path.exists(shasumfile):
-                            os.remove(self.stdinlogFile)
-                            duplicate = True
-                        else:
-                            os.rename(self.stdinlogFile, shasumfile)
-                            duplicate = False
+                    shasumfile = os.path.join(self.downloadPath, shasum)
+                    if os.path.exists(shasumfile):
+                        os.remove(self.stdinlogFile)
+                        duplicate = True
+                    else:
+                        os.rename(self.stdinlogFile, shasumfile)
+                        duplicate = False
 
                     log.msg(
                         eventid="cowrie.session.file_download",
@@ -193,13 +193,13 @@ class LoggingServerProtocol(insults.ServerProtocol):
 
                     with open(rf, "rb") as f:
                         shasum = hashlib.sha256(f.read()).hexdigest()
-                        shasumfile = os.path.join(self.downloadPath, shasum)
-                        if os.path.exists(shasumfile):
-                            os.remove(rf)
-                            duplicate = True
-                        else:
-                            os.rename(rf, shasumfile)
-                            duplicate = False
+                    shasumfile = os.path.join(self.downloadPath, shasum)
+                    if os.path.exists(shasumfile):
+                        os.remove(rf)
+                        duplicate = True
+                    else:
+                        os.rename(rf, shasumfile)
+                        duplicate = False
                     log.msg(
                         eventid="cowrie.session.file_download",
                         format="Saved redir contents with SHA-256 %(shasum)s to %(outfile)s",


### PR DESCRIPTION
## Problem

On Windows, finalizing the stdin capture log fails with:

```
Failed to save stdin contents: [WinError 32] The process cannot access the file
because it is being used by another process: '...-stdin.log' -> '...<sha256>'
```

and the capture is silently discarded.

`LoggingServerProtocol.connectionLost()` computes the SHA-256 of the stdin and redir capture files *inside* the `open()` context manager, then calls `os.rename()`/`os.remove()` on the same file **while the handle is still open**. Windows `MoveFileEx`/`DeleteFile` fail with `ERROR_SHARING_VIOLATION` because Python's `open()` does not set `FILE_SHARE_DELETE`. Linux keeps the inode alive across an open handle, so the path worked there.

## Fix

Move the rename/remove out of the `with` block in both the stdin and redir-file paths, so the handle is closed before the file is renamed or removed. The TTY-log path below already closes its handle first and is unaffected.

Fixes #40249

## Testing

`ruff check` clean, `mypy` clean, `test_insults` passes. The bug is Windows-specific; on Linux/macOS both the old and new code succeed (rename/remove while open is allowed), so it cannot be reproduced by a unit test on the CI platforms.