### PR TITLE
fix: reset exec idle timeout on inbound stdin

### DIFF
--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -121,6 +121,10 @@ class LoggingServerProtocol(insults.ServerProtocol):
             return
 
         if self.stdinlogOpen:
+            # Exec channels never reach characterReceived(), so their idle
+            # timeout is otherwise a hard cap on the whole session. Reset it on
+            # every inbound packet so a slow upload is not killed mid-transfer.
+            self.terminalProtocol.resetTimeout()
             with open(self.stdinlogFile, "ab") as f:
                 f.write(data)
         elif self.ttylogEnabled and self.ttylogOpen:


### PR DESCRIPTION
## Problem

`HoneyPotExecProtocol.connectionMade()` hardcodes `self.setTimeout(60)` and, unlike interactive sessions, never resets it. It was therefore a hard cap on total exec-session time rather than an idle timeout.

A slow or large stdin upload over an exec channel (e.g. an `scp -t` push) that runs past 60s is killed mid-transfer. When it fires, `timeoutConnection()` calls `processEnded()` directly, bypassing the command's `eofReceived()` — so `Command_scp.eofReceived` never strips the SCP wire framing, and the captured artifact is saved with raw framing or orphaned entirely.

## Fix

Reset the idle timeout on every inbound packet for exec channels, in `LoggingServerProtocol.dataReceived()`. This matches the per-keystroke reset that interactive sessions already perform via `characterReceived()`, and correctly makes the timer measure idle time rather than total session time. Placing it in `dataReceived()` (once per packet) rather than `keystrokeReceived()` (once per byte) avoids ~1.5M timer reschedules on a large transfer.

Root-cause analysis credit: @vbontchev in the issue.

Closes #40238