### PR TITLE
fix: report bundled-resource directory reads as FileNotFoundError

### DIFF
--- a/src/cowrie/core/resources.py
+++ b/src/cowrie/core/resources.py
@@ -34,9 +34,15 @@ def _data_resource(*parts: str) -> Traversable:
 def read_data_bytes(*parts: str) -> bytes:
     """Read bundled cowrie.data/<parts> as bytes.
 
-    Raises FileNotFoundError if the resource does not exist.
+    Raises FileNotFoundError if the resource does not exist or is not a
+    regular file (e.g. it resolves to a directory). Checking is_file() keeps
+    the error consistent across platforms: opening a directory raises
+    IsADirectoryError on POSIX but PermissionError on Windows.
     """
-    return _data_resource(*parts).read_bytes()
+    resource = _data_resource(*parts)
+    if not resource.is_file():
+        raise FileNotFoundError(str(resource))
+    return resource.read_bytes()
 
 
 @contextmanager
@@ -44,7 +50,11 @@ def open_data_binary(*parts: str) -> Generator[IO[bytes], None, None]:
     """Open bundled cowrie.data/<parts> as a binary stream.
 
     Use for pickle.load, json.load, or anything that wants a file object.
-    Raises FileNotFoundError if the resource does not exist.
+    Raises FileNotFoundError if the resource does not exist or is not a
+    regular file (e.g. it resolves to a directory); see read_data_bytes().
     """
-    with _data_resource(*parts).open("rb") as fh:
+    resource = _data_resource(*parts)
+    if not resource.is_file():
+        raise FileNotFoundError(str(resource))
+    with resource.open("rb") as fh:
         yield fh

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -215,10 +215,11 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         try:
             binary_data = read_data_bytes("txtcmds", *relpath.split("/"))
             return self.txtcmd(binary_data)
-        except (FileNotFoundError, IsADirectoryError):
-            # No txtcmd at this path. IsADirectoryError happens when the command
-            # resolves to a directory (e.g. `/` -> empty relpath -> the txtcmds
-            # directory itself); fall through so the caller reports "Is a
+        except FileNotFoundError:
+            # No txtcmd file at this path -- including when the command resolves
+            # to a directory (e.g. `/` -> empty relpath -> the txtcmds directory
+            # itself), which read_data_bytes reports as FileNotFoundError on
+            # every platform. Fall through so the caller reports "Is a
             # directory" instead of crashing the session.
             pass
 

--- a/src/cowrie/test/test_resources.py
+++ b/src/cowrie/test/test_resources.py
@@ -28,6 +28,20 @@ class ReadDataBytesTests(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             resources.read_data_bytes("arch", "no-such-arch")
 
+    def test_raises_file_not_found_for_directory(self) -> None:
+        # A resource that resolves to a directory (e.g. `/` -> the txtcmds
+        # directory itself) must raise FileNotFoundError on every platform,
+        # not the platform-dependent IsADirectoryError / PermissionError that
+        # opening a directory produces.
+        with self.assertRaises(FileNotFoundError):
+            resources.read_data_bytes("txtcmds")
+
+    def test_raises_file_not_found_for_directory_via_empty_subpath(self) -> None:
+        # The exact `/` command path: relpath "" -> "".split("/") == [""] ->
+        # read_data_bytes("txtcmds", "") resolves to the txtcmds directory.
+        with self.assertRaises(FileNotFoundError):
+            resources.read_data_bytes("txtcmds", "")
+
 
 class OpenDataBinaryTests(unittest.TestCase):
     """open_data_binary() — bundled-only binary stream."""
@@ -41,4 +55,12 @@ class OpenDataBinaryTests(unittest.TestCase):
     def test_raises_file_not_found_for_missing_resource(self) -> None:
         with self.assertRaises(FileNotFoundError):
             with resources.open_data_binary("does-not-exist"):
+                pass
+
+    def test_raises_file_not_found_for_directory(self) -> None:
+        # Opening a resource that resolves to a directory must raise
+        # FileNotFoundError on every platform, not IsADirectoryError /
+        # PermissionError.
+        with self.assertRaises(FileNotFoundError):
+            with resources.open_data_binary("txtcmds"):
                 pass


### PR DESCRIPTION
## Problem

On Windows, Cowrie crashes with an unhandled `PermissionError` when a command path resolves to a directory under the bundled `txtcmds` resources — the simplest trigger being the bare command `/` (relpath becomes `""`, so `read_data_bytes("txtcmds", "")` resolves to the `txtcmds` directory itself).

`read_data_bytes()` / `open_data_binary()` in `core/resources.py` opened the resolved `Traversable` without checking it is a regular file. Opening a directory raises a platform-dependent exception: `IsADirectoryError` on POSIX, `PermissionError` (errno 13) on Windows. The catch clause in `getCommand()` only handled `IsADirectoryError`, so on Windows the `PermissionError` propagated and disconnected the session.

## Fix

Check `Traversable.is_file()` before reading and raise a plain `FileNotFoundError` for the non-file case (missing resource or directory). This is consistent across platforms, unlike the `open()` failure modes. `getCommand()` then catches that single exception and falls through to `command_not_found_message()`, which reports `-bash: /: Is a directory` as it already does on Linux.

The `getCommand()` call site is simplified to `except FileNotFoundError` and its comment updated, since the directory case is now normalized in `resources.py` rather than enumerated at the call site.

## Test

`test_resources.py` gains directory cases for both helpers. These fail before the fix even on POSIX (they raise `IsADirectoryError`, not `FileNotFoundError`), so they pin the cross-platform normalization that the Windows-only crash can't otherwise be reproduced for. The existing `test_directory_as_command_reports_is_a_directory` continues to pass.

Closes #40258