### PR TITLE
fix: drop and log malformed SSH packets instead of crashing

### DIFF
--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -154,7 +154,24 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             packet = self.getPacket()
 
     def dispatchMessage(self, messageNum: int, payload: bytes) -> None:
-        transport.SSHServerTransport.dispatchMessage(self, messageNum, payload)
+        try:
+            transport.SSHServerTransport.dispatchMessage(self, messageNum, payload)
+        except struct.error:
+            # A truncated or garbage message body underflows getNS()/struct
+            # parsing inside a handler (any message type: service-request,
+            # userauth, channel ops, ...). Real OpenSSH treats this as a fatal
+            # protocol error, logging server-side and dropping the connection
+            # without a SSH_MSG_DISCONNECT; match that (which also avoids a
+            # cowrie-specific disconnect string), and record the probe -- these
+            # malformed pre-auth packets are a common exploit/scanner signal.
+            log.msg(
+                eventid="cowrie.client.malformed_packet",
+                format="Malformed SSH packet (message %(messagenum)d, %(datalen)d bytes); disconnecting",
+                messagenum=messageNum,
+                datalen=len(payload),
+                data=payload[:256].hex(),
+            )
+            self.transport.loseConnection()
 
     def sendPacket(self, messageType: int, payload: bytes) -> None:
         """

--- a/src/cowrie/test/test_ssh_transport.py
+++ b/src/cowrie/test/test_ssh_transport.py
@@ -12,6 +12,7 @@ from hashlib import md5
 from unittest.mock import MagicMock, patch
 
 from twisted.conch.ssh.common import NS
+from twisted.conch.ssh.transport import MSG_SERVICE_REQUEST
 
 from cowrie.ssh import transport as ssh_transport
 
@@ -72,6 +73,36 @@ class TestKexInitEscaping(unittest.TestCase):
 
         self.assertEqual(event["hasshAlgorithms"], expected_algs)
         self.assertEqual(event["hassh"], expected_hassh)
+
+
+class TestMalformedPacket(unittest.TestCase):
+    """A truncated message body must be logged and dropped, not crash."""
+
+    def test_truncated_message_disconnects_and_logs(self) -> None:
+        # A SERVICE_REQUEST whose body is too short for getNS()'s leading
+        # uint32 underflows struct.unpack inside the handler. dispatchMessage
+        # must catch that, emit a malformed_packet event, and drop the
+        # connection (as OpenSSH does) rather than letting it escape.
+        t = ssh_transport.HoneyPotSSHTransport()
+        t.transport = MagicMock()
+
+        with patch("cowrie.ssh.transport.log.msg") as mock_msg:
+            t.dispatchMessage(MSG_SERVICE_REQUEST, b"\x00\x00\x00")
+
+        t.transport.loseConnection.assert_called_once()
+
+        event = next(
+            (
+                dict(c.kwargs)
+                for c in mock_msg.call_args_list
+                if c.kwargs.get("eventid") == "cowrie.client.malformed_packet"
+            ),
+            None,
+        )
+        self.assertIsNotNone(event, "no malformed_packet event was emitted")
+        assert event is not None
+        self.assertEqual(event["messagenum"], MSG_SERVICE_REQUEST)
+        self.assertEqual(event["datalen"], 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

A truncated or garbage SSH message body underflows `getNS()` / `struct.unpack()` inside a message handler and raises `struct.error`. Neither Twisted's transport `dispatchMessage` nor `SSHService.packetReceived` guards the handler call, so it escapes as an unhandled reactor error and the connection is dropped without any protocol-level handling.

A fuzzer's short `publickey` userauth request is one trigger (#40247):

```
File ".../twisted/conch/ssh/userauth.py", line 277, in auth_publickey
    algName, blob, rest = getNS(packet[1:], 2)
struct.error: unpack requires a buffer of 4 bytes
```

but service-request, channel-open and other handlers are equally exposed — this is a whole class of malformed-packet crashes, not just userauth.

## Fix

Catch `struct.error` centrally in `HoneyPotSSHTransport.dispatchMessage`, which sits above both the transport `ssh_*` handlers (message < 50) and the service `packetReceived` path (userauth/connection), so every message type is covered.

**Behaviour matches real OpenSSH.** For an unparseable message body OpenSSH (the emulated 6.0p1 included) hits a fatal parse error, logs it server-side, and **drops the connection without sending `SSH_MSG_DISCONNECT`**. We do the same (`loseConnection`). This is also more fingerprint-resistant than the earlier approach of sending a cowrie-specific disconnect description string.

## Logging

The old handler logged a bare `log.msg(...)` with no `eventid`, so it never reached the structured outputs — invisible to any SIEM. Pre-auth malformed packets are a common exploit/scanner signal, so this now emits a structured `cowrie.client.malformed_packet` event with the message number, payload length, and the leading bytes hex-encoded (bounded to 256 bytes), reaching all output plugins.

## Test

`test_ssh_transport.py::TestMalformedPacket` dispatches a `SERVICE_REQUEST` whose body is too short for `getNS()`'s leading uint32, driving the real handler underflow. It asserts the connection is dropped and a `cowrie.client.malformed_packet` event is emitted with the right message number and length.

Closes #40247