### PR TITLE
fix: handle empty path in resolve_path and file tests

### DIFF
--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -1341,6 +1341,10 @@ class Command_test(HoneyPotCommand):
         raise _TestError("binary", op)
 
     def _file_test(self, op: str, operand: str) -> bool:
+        if not operand:
+            # An empty path is not any kind of file: bash reports every file
+            # test on "" as false. Short-circuit before resolving it.
+            return False
         path = self.fs.resolve_path(operand, self.protocol.cwd)
         if op in ("-L", "-h"):
             try:

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -164,7 +164,7 @@ class HoneyPotFilesystem:
 
         pieces = path.rstrip("/").split("/")
 
-        if path[0] == "/":
+        if path.startswith("/"):
             cwdpieces = []
         else:
             cwdpieces = [x for x in cwd.split("/") if len(x)]

--- a/src/cowrie/test/test_fs.py
+++ b/src/cowrie/test/test_fs.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: tests for cowrie/shell/fs.py path resolution
+# ABOUTME: covers resolve_path normalization and empty-path robustness
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from cowrie.shell import fs
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class ResolvePathTests(unittest.TestCase):
+    """resolve_path() normalizes a pathspec against a working directory."""
+
+    def setUp(self) -> None:
+        self.fs = fs.HoneyPotFilesystem("arch", "/root")
+
+    def test_absolute_path_is_returned_normalized(self) -> None:
+        self.assertEqual(self.fs.resolve_path("/etc/passwd", "/root"), "/etc/passwd")
+
+    def test_relative_path_joins_cwd(self) -> None:
+        self.assertEqual(self.fs.resolve_path("foo", "/home/user"), "/home/user/foo")
+
+    def test_dot_resolves_to_cwd(self) -> None:
+        self.assertEqual(self.fs.resolve_path(".", "/home/user"), "/home/user")
+
+    def test_empty_path_resolves_to_cwd_without_crashing(self) -> None:
+        # An empty pathspec must not raise IndexError on path[0]. It is reachable
+        # from any command that forwards an unset shell variable, e.g. an
+        # attacker's `[ -w "$mnt" ]` where $mnt expanded to nothing.
+        self.assertEqual(self.fs.resolve_path("", "/home/user"), "/home/user")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_test_builtin.py
+++ b/src/cowrie/test/test_test_builtin.py
@@ -77,6 +77,14 @@ class TestTrueFalseTests(unittest.TestCase):
     def test_bracket_file_exists(self) -> None:
         self.assertEqual(self._status("[ -f /etc/passwd ]"), b"0\n")
 
+    def test_file_test_empty_operand_is_false(self) -> None:
+        # An empty path is not any kind of file. Matching bash, every file test
+        # on "" is false; it must not crash resolving the empty path (an
+        # attacker's `[ -w "$mnt" ]` with an unset variable hit an IndexError).
+        for op in ("-e", "-f", "-d", "-w", "-r", "-x", "-L", "-s"):
+            with self.subTest(op=op):
+                self.assertEqual(self._status(f'[ {op} "" ]'), b"1\n")
+
     # -- string tests -------------------------------------------------------
 
     def test_string_equal(self) -> None:


### PR DESCRIPTION
## Problem

`HoneyPotFilesystem.resolve_path()` decides absolute-vs-relative with `if path[0] == "/"`, which raises `IndexError: string index out of range` on an empty pathspec. Any command that forwards an unset shell variable hits it. Seen crashing a live Telnet session:

```
[ -w "$mnt" ]      # $mnt expanded to empty
...
  File ".../cowrie/shell/fs.py", line 167, in resolve_path
    if path[0] == "/":
builtins.IndexError: string index out of range
```

The attacker's loop was `for mnt in $(... while read ...); do [ -w "$mnt" ] ...`; the inner `while read` produced no output, so `$mnt` was empty and `test -w ""` reached `resolve_path("")`.

## Fix

1. `resolve_path()`: use `path.startswith("/")` instead of `path[0] == "/"`, so an empty pathspec resolves like the current directory instead of raising. This protects every caller, not just `test`.
2. `_file_test()` in `commands/base.py`: short-circuit an empty operand to `False`. Real bash reports every file test on `""` as false (`[ -e "" ]`, `[ -w "" ]`, ... all exit 1); without this the empty path would resolve to the cwd and wrongly report true.

## Tests

- `test_fs.py`: `resolve_path("", cwd)` returns the cwd without raising (plus absolute/relative/`.` cases).
- `test_test_builtin.py`: every file-test operator on `""` exits 1, matching bash and covering the exact `[ -w "" ]` crash trigger.

Both fail before the fix (crash / `IndexError`).