### PR TITLE
fix: avoid ZeroDivisionError in wget speed calculation

### DIFF
--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -30,10 +30,18 @@ commands = {}
 
 # Initialize rate limiter
 wget_rate_limiter = RateLimiter(
-    enabled=CowrieConfig.getboolean("honeypot", "wget_rate_limit_enabled", fallback=True),
-    max_requests=CowrieConfig.getint("honeypot", "wget_rate_limit_requests", fallback=5),
-    window_seconds=CowrieConfig.getint("honeypot", "wget_rate_limit_window", fallback=60),
-    max_keys=CowrieConfig.getint("honeypot", "wget_rate_limit_max_hosts", fallback=1000)
+    enabled=CowrieConfig.getboolean(
+        "honeypot", "wget_rate_limit_enabled", fallback=True
+    ),
+    max_requests=CowrieConfig.getint(
+        "honeypot", "wget_rate_limit_requests", fallback=5
+    ),
+    window_seconds=CowrieConfig.getint(
+        "honeypot", "wget_rate_limit_window", fallback=60
+    ),
+    max_keys=CowrieConfig.getint(
+        "honeypot", "wget_rate_limit_max_hosts", fallback=1000
+    ),
 )
 
 
@@ -100,7 +108,9 @@ class Command_wget(HoneyPotCommand):
     currentlength: int = 0  # partial size during download
     totallength: int = 0  # total length
     proglen: int = 0
-    wget_version: str = "1.25.0"  # GNU wget version used in --help and User-Agent header
+    wget_version: str = (
+        "1.25.0"  # GNU wget version used in --help and User-Agent header
+    )
     url: bytes
     host: str
     scheme: str
@@ -126,24 +136,34 @@ class Command_wget(HoneyPotCommand):
         (that are silently ignored for compatibility).
         """
 
-        self.write(f"GNU Wget {self.wget_version}, a non-interactive network retriever.\n")
+        self.write(
+            f"GNU Wget {self.wget_version}, a non-interactive network retriever.\n"
+        )
         self.write("Usage: wget [OPTION]... [URL]...\n\n")
         self.write("Startup:\n")
         self.write("  -h,  --help              print this help\n\n")
         self.write("Download:\n")
-        self.write("  -c,  --continue          resume getting a partially-downloaded file\n")
+        self.write(
+            "  -c,  --continue          resume getting a partially-downloaded file\n"
+        )
         self.write("  -O                       write documents to FILE\n")
         self.write("  -q,  --quiet             quiet (no output)\n")
         self.write("  -T,  --timeout=SECONDS   set all timeout values to SECONDS\n")
         self.write("       --tries=NUMBER      set number of retries to NUMBER\n\n")
         self.write("HTTP options:\n")
         self.write("       --header=STRING     insert STRING among the headers\n")
-        self.write("       --post-data=STRING  use the POST method; send STRING as the data\n")
-        self.write("       --max-redirect=NUM  maximum redirections allowed per page\n\n")
+        self.write(
+            "       --post-data=STRING  use the POST method; send STRING as the data\n"
+        )
+        self.write(
+            "       --max-redirect=NUM  maximum redirections allowed per page\n\n"
+        )
         self.write("Directories:\n")
         self.write("  -P,  --directory-prefix=PREFIX  save files to PREFIX/..\n\n")
         self.write("Email bug reports, questions, discussions to <bug-wget@gnu.org>\n")
-        self.write("and/or open issues at https://savannah.gnu.org/bugs/?func=additem&group=wget.\n")
+        self.write(
+            "and/or open issues at https://savannah.gnu.org/bugs/?func=additem&group=wget.\n"
+        )
 
     @inlineCallbacks
     def start(self):
@@ -224,7 +244,9 @@ class Command_wget(HoneyPotCommand):
 
         # Check rate limit before proceeding
         if not wget_rate_limiter.check(self.host):
-            log.msg(f"wget: rate limit exceeded for host: {self.host}. Simulating connection timeout")
+            log.msg(
+                f"wget: rate limit exceeded for host: {self.host}. Simulating connection timeout"
+            )
 
             # Simulate connection timeout
             self.errorWrite(f"Connecting to {self.host}:{self.port}... ")
@@ -271,7 +293,9 @@ class Command_wget(HoneyPotCommand):
             tm = time.strftime("%Y-%m-%d %H:%M:%S")
             self.errorWrite(f"--{tm}--  {url}\n")
             self.errorWrite(f"Connecting to {self.host}:{self.port}... connected.\n")
-            proto_label = "HTTP" if self.scheme in ("http", "https") else self.scheme.upper()
+            proto_label = (
+                "HTTP" if self.scheme in ("http", "https") else self.scheme.upper()
+            )
             self.errorWrite(f"{proto_label} request sent, awaiting response... ")
 
         if self.scheme == "ftp":
@@ -430,7 +454,11 @@ class Command_wget(HoneyPotCommand):
             else:
                 self.errorWrite(f"Length: unspecified [{self.contenttype}]\n")
 
-            dest = "STDOUT" if self.outfile is None or self.outfile == "-" else self.outfile
+            dest = (
+                "STDOUT"
+                if self.outfile is None or self.outfile == "-"
+                else self.outfile
+            )
             self.errorWrite(f"Saving to: `{dest}'\n\n")
 
         return True
@@ -497,7 +525,12 @@ class Command_wget(HoneyPotCommand):
 
         self.artifact.write(data)
 
-        self.speed = self.currentlength / (time.time() - self.started)
+        # Clamp elapsed to 1 microsecond: on a localhost transfer the first
+        # chunk can arrive within the same time.time() tick as self.started,
+        # which would divide by zero. 1e-6 is below any real network RTT, so it
+        # does not distort the reported speed on genuine connections.
+        elapsed = max(time.time() - self.started, 1e-6)
+        self.speed = self.currentlength / elapsed
         if self.totallength != 0:
             percent = int(self.currentlength / self.totallength * 100)
             spercent = f"{percent}%"
@@ -539,7 +572,11 @@ class Command_wget(HoneyPotCommand):
                 )
             )
             self.errorWrite("\n\n")
-            dest = "stdout" if self.outfile is None or self.outfile == "-" else self.outfile
+            dest = (
+                "stdout"
+                if self.outfile is None or self.outfile == "-"
+                else self.outfile
+            )
             self.errorWrite(
                 "{} ({:3.2f} KB/s) - `{}' saved [{}/{}]\n\n".format(
                     time.strftime("%Y-%m-%d %H:%M:%S"),


### PR DESCRIPTION
## Problem

`Command_wget.collect()` computes download speed as `currentlength / (time.time() - started)`. On a localhost or LAN transfer the first data chunk can arrive within the same `time.time()` resolution window as `started`, so the elapsed time is `0` and the division raises `ZeroDivisionError`, crashing the download mid-transfer:

```
File "cowrie/commands/wget.py", line 500, in collect
    self.speed = self.currentlength / (time.time() - self.started)
builtins.ZeroDivisionError: float division by zero
```

## Fix

Clamp elapsed to a minimum of `1e-6` seconds before dividing. That floor is below any real network round-trip time, so it does not distort the reported speed on genuine connections, and it keeps the dependent `eta = (totallength - currentlength) / speed` division safe as well.

`curl.py`'s `collect()` does not compute speed and is unaffected.

## Test

`WgetCollectSpeedTests.test_instant_chunk_does_not_divide_by_zero` pins `time.time()` so elapsed is exactly `0`, and asserts `collect()` no longer raises and reports a finite speed. It fails before the fix with `ZeroDivisionError`.

Closes #40265