### PR TITLE
fix: survive terminalProtocol teardown mid-dataReceived

### DIFF
--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 from twisted.conch.insults import insults
 from twisted.internet.protocol import connectionDone
 from twisted.logger import Logger
+from twisted.python.compat import iterbytes
 
 from cowrie.core import ttylog
 from cowrie.core.config import CowrieConfig
@@ -146,7 +147,18 @@ class LoggingServerProtocol(insults.ServerProtocol):
                 self.ttylogFile, len(data), ttylog.TYPE_INPUT, time.time(), data
             )
 
-        insults.ServerProtocol.dataReceived(self, data)
+        # Feed the parent one byte at a time so terminalProtocol can be
+        # re-checked between bytes. ServerProtocol.dataReceived loops over the
+        # buffer calling terminalProtocol.keystrokeReceived() per byte without
+        # re-checking; a keystroke handler can synchronously tear the session
+        # down (in-process session channels close without a reactor round-trip),
+        # clearing terminalProtocol mid-buffer, and the next byte would then
+        # dereference None. Its parser state lives on self, so splitting the
+        # call is behaviour-identical.
+        for ch in iterbytes(data):
+            if self.terminalProtocol is None:
+                break
+            insults.ServerProtocol.dataReceived(self, ch)
 
     def eofReceived(self) -> None:
         """

--- a/src/cowrie/test/test_insults.py
+++ b/src/cowrie/test/test_insults.py
@@ -68,6 +68,37 @@ class DataReceivedAfterTeardownTestCase(unittest.TestCase):
         # Discarded before being counted or delegated to the parent.
         self.assertEqual(lsp.bytesReceived, 0)
 
+    def test_teardown_during_iteration_is_discarded(self) -> None:
+        # A keystroke handler can synchronously tear the session down (in-process
+        # session channels close without a reactor round-trip), clearing
+        # terminalProtocol mid-way through the parent's byte-by-byte loop. The
+        # next byte then dereferences None inside ServerProtocol.dataReceived
+        # (issue #40248). The top-of-method guard cannot catch this because the
+        # reference is still set on entry.
+        lsp = make_protocol("i")
+        lsp.stdinlogOpen = False
+        lsp.bytesReceived = 0
+        lsp.state = b"data"  # parent loop's initial state
+
+        class _TeardownOnFirstKeystroke:
+            """Nulls terminalProtocol on the first keystroke, as an in-process
+            channel teardown does."""
+
+            def __init__(self) -> None:
+                self.received: list[bytes] = []
+
+            def keystrokeReceived(self, ch: bytes, modifier: object) -> None:
+                self.received.append(ch)
+                lsp.terminalProtocol = None
+
+        term = _TeardownOnFirstKeystroke()
+        lsp.terminalProtocol = term
+
+        lsp.dataReceived(b"ab")  # must not raise on the second byte
+
+        self.assertEqual(term.received, [b"a"])
+        self.assertIsNone(lsp.terminalProtocol)
+
 
 class ConnectionLostStdinTestCase(unittest.TestCase):
     """Tests for stdin-log cleanup in LoggingServerProtocol.connectionLost()."""


### PR DESCRIPTION
## Problem

`LoggingServerProtocol.dataReceived` guards against `terminalProtocol is None` on entry, but Twisted's `ServerProtocol.dataReceived` iterates the incoming bytes and calls `self.terminalProtocol.keystrokeReceived(ch, None)` per byte without re-checking the reference.

If a keystroke handler synchronously tears the session down — in-process session channels close without a reactor round-trip, so `connectionLost()` runs immediately and `ServerProtocol.connectionLost()` sets `self.terminalProtocol = None` — the next byte in the loop dereferences `None`:

```
File ".../twisted/conch/insults/insults.py", line 504, in dataReceived
    self.terminalProtocol.keystrokeReceived(ch, None)
builtins.AttributeError: 'NoneType' object has no attribute 'keystrokeReceived'
```

The entry guards can't catch this because the reference is still set when the method begins.

## Fix

Feed the parent `dataReceived` one byte at a time and re-check `terminalProtocol` between bytes, breaking out once it is cleared. `ServerProtocol`'s parser state (`state`, `escBuf`) lives on `self` and persists across calls, so splitting a single call into per-byte calls is behaviour-identical to passing the whole buffer — it just adds the re-check the parent loop omits.

This addresses the root cause (the loop not re-checking the reference) directly, rather than catching the resulting `AttributeError`.

## Test

`test_teardown_during_iteration_is_discarded` drives the **real** Twisted byte loop with a terminal whose `keystrokeReceived` nulls `terminalProtocol` on the first byte, so the second byte reproduces the crash. It fails before the fix with the exact `AttributeError`, and asserts only the first byte was processed and the rest discarded.

Closes #40248