### PR TITLE
reduce duplicate-download logging to one congruent message

### DIFF
--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -446,6 +446,7 @@ class Command_curl(HoneyPotCommand):
             url=self.url.decode(),
             outfile=self.artifact.shasumFilename,
             shasum=self.artifact.shasum,
+            duplicate=self.artifact.duplicate,
         )
         log.msg(
             eventid="cowrie.session.file_download",
@@ -453,6 +454,7 @@ class Command_curl(HoneyPotCommand):
             url=self.url.decode(),
             outfile=self.artifact.shasumFilename,
             shasum=self.artifact.shasum,
+            duplicate=self.artifact.duplicate,
         )
         self.exit()
 

--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -252,6 +252,7 @@ Download a file via FTP
             url=self.url_log,
             outfile=self.artifactFile.shasumFilename,
             shasum=self.artifactFile.shasum,
+            duplicate=self.artifactFile.duplicate,
         )
 
         self.protocol.logDispatch(
@@ -261,6 +262,7 @@ Download a file via FTP
             outfile=self.artifactFile.shasumFilename,
             shasum=self.artifactFile.shasum,
             destfile=self.local_file,
+            duplicate=self.artifactFile.duplicate,
         )
 
         # Update the honeyfs to point to downloaded file

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -339,6 +339,7 @@ class Command_tftp(HoneyPotCommand):
             url=url,
             outfile=self.artifactFile.shasumFilename,
             shasum=self.artifactFile.shasum,
+            duplicate=self.artifactFile.duplicate,
         )
 
         self.protocol.logDispatch(
@@ -348,6 +349,7 @@ class Command_tftp(HoneyPotCommand):
             outfile=self.artifactFile.shasumFilename,
             shasum=self.artifactFile.shasum,
             destfile=self.file_to_get,
+            duplicate=self.artifactFile.duplicate,
         )
 
         # Update honeyfs

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -30,10 +30,18 @@ commands = {}
 
 # Initialize rate limiter
 wget_rate_limiter = RateLimiter(
-    enabled=CowrieConfig.getboolean("honeypot", "wget_rate_limit_enabled", fallback=True),
-    max_requests=CowrieConfig.getint("honeypot", "wget_rate_limit_requests", fallback=5),
-    window_seconds=CowrieConfig.getint("honeypot", "wget_rate_limit_window", fallback=60),
-    max_keys=CowrieConfig.getint("honeypot", "wget_rate_limit_max_hosts", fallback=1000)
+    enabled=CowrieConfig.getboolean(
+        "honeypot", "wget_rate_limit_enabled", fallback=True
+    ),
+    max_requests=CowrieConfig.getint(
+        "honeypot", "wget_rate_limit_requests", fallback=5
+    ),
+    window_seconds=CowrieConfig.getint(
+        "honeypot", "wget_rate_limit_window", fallback=60
+    ),
+    max_keys=CowrieConfig.getint(
+        "honeypot", "wget_rate_limit_max_hosts", fallback=1000
+    ),
 )
 
 
@@ -100,7 +108,9 @@ class Command_wget(HoneyPotCommand):
     currentlength: int = 0  # partial size during download
     totallength: int = 0  # total length
     proglen: int = 0
-    wget_version: str = "1.25.0"  # GNU wget version used in --help and User-Agent header
+    wget_version: str = (
+        "1.25.0"  # GNU wget version used in --help and User-Agent header
+    )
     url: bytes
     host: str
     scheme: str
@@ -126,24 +136,34 @@ class Command_wget(HoneyPotCommand):
         (that are silently ignored for compatibility).
         """
 
-        self.write(f"GNU Wget {self.wget_version}, a non-interactive network retriever.\n")
+        self.write(
+            f"GNU Wget {self.wget_version}, a non-interactive network retriever.\n"
+        )
         self.write("Usage: wget [OPTION]... [URL]...\n\n")
         self.write("Startup:\n")
         self.write("  -h,  --help              print this help\n\n")
         self.write("Download:\n")
-        self.write("  -c,  --continue          resume getting a partially-downloaded file\n")
+        self.write(
+            "  -c,  --continue          resume getting a partially-downloaded file\n"
+        )
         self.write("  -O                       write documents to FILE\n")
         self.write("  -q,  --quiet             quiet (no output)\n")
         self.write("  -T,  --timeout=SECONDS   set all timeout values to SECONDS\n")
         self.write("       --tries=NUMBER      set number of retries to NUMBER\n\n")
         self.write("HTTP options:\n")
         self.write("       --header=STRING     insert STRING among the headers\n")
-        self.write("       --post-data=STRING  use the POST method; send STRING as the data\n")
-        self.write("       --max-redirect=NUM  maximum redirections allowed per page\n\n")
+        self.write(
+            "       --post-data=STRING  use the POST method; send STRING as the data\n"
+        )
+        self.write(
+            "       --max-redirect=NUM  maximum redirections allowed per page\n\n"
+        )
         self.write("Directories:\n")
         self.write("  -P,  --directory-prefix=PREFIX  save files to PREFIX/..\n\n")
         self.write("Email bug reports, questions, discussions to <bug-wget@gnu.org>\n")
-        self.write("and/or open issues at https://savannah.gnu.org/bugs/?func=additem&group=wget.\n")
+        self.write(
+            "and/or open issues at https://savannah.gnu.org/bugs/?func=additem&group=wget.\n"
+        )
 
     @inlineCallbacks
     def start(self):
@@ -224,7 +244,9 @@ class Command_wget(HoneyPotCommand):
 
         # Check rate limit before proceeding
         if not wget_rate_limiter.check(self.host):
-            log.msg(f"wget: rate limit exceeded for host: {self.host}. Simulating connection timeout")
+            log.msg(
+                f"wget: rate limit exceeded for host: {self.host}. Simulating connection timeout"
+            )
 
             # Simulate connection timeout
             self.errorWrite(f"Connecting to {self.host}:{self.port}... ")
@@ -271,7 +293,9 @@ class Command_wget(HoneyPotCommand):
             tm = time.strftime("%Y-%m-%d %H:%M:%S")
             self.errorWrite(f"--{tm}--  {url}\n")
             self.errorWrite(f"Connecting to {self.host}:{self.port}... connected.\n")
-            proto_label = "HTTP" if self.scheme in ("http", "https") else self.scheme.upper()
+            proto_label = (
+                "HTTP" if self.scheme in ("http", "https") else self.scheme.upper()
+            )
             self.errorWrite(f"{proto_label} request sent, awaiting response... ")
 
         if self.scheme == "ftp":
@@ -430,7 +454,11 @@ class Command_wget(HoneyPotCommand):
             else:
                 self.errorWrite(f"Length: unspecified [{self.contenttype}]\n")
 
-            dest = "STDOUT" if self.outfile is None or self.outfile == "-" else self.outfile
+            dest = (
+                "STDOUT"
+                if self.outfile is None or self.outfile == "-"
+                else self.outfile
+            )
             self.errorWrite(f"Saving to: `{dest}'\n\n")
 
         return True
@@ -539,7 +567,11 @@ class Command_wget(HoneyPotCommand):
                 )
             )
             self.errorWrite("\n\n")
-            dest = "stdout" if self.outfile is None or self.outfile == "-" else self.outfile
+            dest = (
+                "stdout"
+                if self.outfile is None or self.outfile == "-"
+                else self.outfile
+            )
             self.errorWrite(
                 "{} ({:3.2f} KB/s) - `{}' saved [{}/{}]\n\n".format(
                     time.strftime("%Y-%m-%d %H:%M:%S"),
@@ -569,6 +601,7 @@ class Command_wget(HoneyPotCommand):
             url=self.url.decode(),
             outfile=self.artifact.shasumFilename,
             shasum=self.artifact.shasum,
+            duplicate=self.artifact.duplicate,
         )
         log.msg(
             eventid="cowrie.session.file_download",
@@ -576,6 +609,7 @@ class Command_wget(HoneyPotCommand):
             url=self.url.decode(),
             outfile=self.artifact.shasumFilename,
             shasum=self.artifact.shasum,
+            duplicate=self.artifact.duplicate,
         )
         self.exit()
 

--- a/src/cowrie/core/artifact.py
+++ b/src/cowrie/core/artifact.py
@@ -29,8 +29,6 @@ import os
 import tempfile
 from typing import TYPE_CHECKING, Any
 
-from twisted.python import log
-
 from cowrie.core.config import CowrieConfig
 
 if TYPE_CHECKING:
@@ -51,6 +49,7 @@ class Artifact:
 
         self.shasum: str = ""
         self.shasumFilename: str = ""
+        self.duplicate: bool = False
 
     def __enter__(self) -> Any:
         return self.fp
@@ -94,12 +93,16 @@ class Artifact:
         self.shasumFilename = os.path.join(self.artifactDir, self.shasum)
 
         if os.path.exists(self.shasumFilename):
-            log.msg("Not storing duplicate content " + self.shasum)
+            # Content already captured; drop the temp copy. The dedup outcome is
+            # reported once, congruently, on the caller's file_download event
+            # (duplicate=True) rather than as a separate log line here.
             os.remove(self.fp.name)
+            self.duplicate = True
         else:
             os.rename(self.fp.name, self.shasumFilename)
             umask = os.umask(0)
             os.umask(umask)
             os.chmod(self.shasumFilename, 0o666 & ~umask)
+            self.duplicate = False
 
         return self.shasum, self.shasumFilename

--- a/src/cowrie/test/test_artifact.py
+++ b/src/cowrie/test/test_artifact.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for cowrie/core/artifact.py content-addressed storage.
+# ABOUTME: Verifies the duplicate flag set when close() dedupes by SHA-256.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from cowrie.core.artifact import Artifact
+
+
+class ArtifactDuplicateTests(unittest.TestCase):
+    """close() must record whether the content already existed on disk."""
+
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.mkdtemp()
+        self._orig_artifact_dir = Artifact.artifactDir
+        Artifact.artifactDir = self.tmpdir
+
+    def tearDown(self) -> None:
+        Artifact.artifactDir = self._orig_artifact_dir
+        for name in os.listdir(self.tmpdir):
+            os.remove(os.path.join(self.tmpdir, name))
+        os.rmdir(self.tmpdir)
+
+    def test_first_capture_is_not_duplicate(self) -> None:
+        a = Artifact("first")
+        a.write(b"unique-content-1")
+        a.close()
+        self.assertFalse(a.duplicate)
+
+    def test_identical_content_is_duplicate(self) -> None:
+        first = Artifact("first")
+        first.write(b"same-bytes")
+        first.close()
+
+        second = Artifact("second")
+        second.write(b"same-bytes")
+        second.close()
+
+        self.assertFalse(first.duplicate)
+        self.assertTrue(second.duplicate)
+
+    def test_empty_artifact_is_not_duplicate(self) -> None:
+        a = Artifact("empty")
+        a.close()
+        self.assertFalse(a.duplicate)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

A repeat download logged three lines from three subsystems that read as contradictory:

```
Not storing duplicate content f818...             # core/artifact.py
File with shasum 'f818...' was downloaded before   # output/virustotal.py (only if VT enabled)
Downloaded URL (http://.../tmips) with SHA-256 f818... to var/lib/cowrie/downloads/f818...
```

All three are individually true, but the last reads like a fresh save on a duplicate, and the Artifact line just restates what the download record should already say.

## Change

Report the dedup outcome **once**, on the record that already exists:

- `Artifact.close()` exposes a `duplicate` flag (True when the SHA-256 file already existed and the temp was discarded) instead of logging its own line.
- wget/curl/ftpget/tftp include `duplicate=...` on their `cowrie.session.file_download` event, matching the shell-redirect path in `insults.py`.
- The standalone `Artifact` "Not storing duplicate content" log line is removed — storage no longer logs; the single download event carries the outcome.

Net effect: a duplicate download drops from three lines to one self-describing `Downloaded URL … to …` record (plus VirusTotal's own note when VT is enabled, which is congruent — it explains why VT skips re-scanning). The message text is unchanged, so existing log/output consumers (OCSF, Slack, …) are unaffected.

## Test

`test_artifact.py` covers `Artifact.duplicate`: false for a first capture, true for identical content stored again, false for an empty artifact.