### PR TITLE
build: upgrade treq to 26.7.0 and drop requests/urllib3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,8 @@ dependencies = [
         "packaging==26.2",
         "pyasn1_modules==0.4.2",
         "service_identity==26.1.0",
-        "treq==25.5.0",
+        "treq==26.7.0",
         "twisted[conch]==26.4.0",
-        "urllib3==2.7.0",
 ]
 
 [project.urls]
@@ -93,7 +92,6 @@ dev = [
 "sphinxcontrib-googleanalytics==0.5",
 "tox==4.55.1",
 "types-redis==4.6.0.20241004",
-"types-requests==2.33.0.20260518",
 "yamllint==1.38.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,5 @@ lark==1.3.1
 packaging==26.2
 pyasn1_modules==0.4.2
 service_identity==26.1.0
-treq==25.5.0
+treq==26.7.0
 twisted[conch]==26.4.0
-urllib3==2.7.0


### PR DESCRIPTION
## Change

- Bump `treq` `25.5.0` → `26.7.0` (`pyproject.toml` + `requirements.txt`).
- Remove `types-requests` (dev/type-stub) and the `urllib3==2.7.0` core pin.

## Why

treq 26.7.0 (2026-07-01) [no longer depends on `requests`](https://github.com/twisted/treq/blob/trunk/CHANGELOG.rst) — that was the only reason `requests` (and, in turn, the `urllib3` pin) were in cowrie's core tree.

The only treq API change from dropping requests is that `cookies()` now returns `treq.cookies.IndexableCookieJar` instead of a `RequestsCookieJar`. cowrie never calls `cookies()` — its treq surface is `get` / `post` / `head` / `collect` / `client` — so no impact. (Python 3.8 support was also dropped; cowrie already requires 3.10+.)

Nothing in the codebase imports `requests` or `urllib3`:
- `types-requests` is a dead mypy stub → removed.
- `urllib3==2.7.0` was a **core** pin that only existed to constrain the `requests`→`urllib3` transitive. cowrie imports urllib3 nowhere, so it's removed from core. It is still a transitive dep of the **`s3` (`botocore`)** and **`elasticsearch` (`pyes`)** extras, which constrain it themselves — those installs are unaffected; only cowrie's redundant core pin is gone.

## Verification

- treq 26.7.0's `Requires-Dist` contains no `requests`.
- No `import requests` / `import urllib3` usage anywhere in the repo.
- Installed treq 26.7.0 locally: all treq-using modules (wget, curl, and the abuseipdb/cuckoo/dshield/greynoise/malshare/telegram/signal/axiom/crashreporter outputs) import cleanly; `test_wget` + `test_curl` pass. Core imports fine with urllib3 removed.