### PR TITLE
fix: annotate treq header dicts to match the expected type

### DIFF
--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -312,7 +312,9 @@ class Command_wget(HoneyPotCommand):
         """
         Download `url`
         """
-        headers = {"User-Agent": [f"Wget/{self.wget_version} (linux-gnu)"]}
+        headers: dict[bytes | str, list[bytes | str]] = {
+            "User-Agent": [f"Wget/{self.wget_version} (linux-gnu)"]
+        }
 
         # TODO: use designated outbound interface
         # out_addr = None

--- a/src/cowrie/output/signal.py
+++ b/src/cowrie/output/signal.py
@@ -56,10 +56,13 @@ class Output(cowrie.core.output.Output):
                 "message": message,
             }
         ).encode("utf-8")
+        headers: dict[bytes | str, list[bytes | str]] = {
+            b"Content-Type": [b"application/json"]
+        }
         d = treq.post(
             f"{self.api_url}/v2/send",
             data=payload,
-            headers={b"Content-Type": [b"application/json"]},
+            headers=headers,
             allow_redirects=False,
         )
         d.addErrback(log.err, "Signal plugin request failed")


### PR DESCRIPTION
## Problem

Building cowrie against **Twisted trunk** (the upcoming release past 26.4.0) surfaces two new mypy errors:

```
src/cowrie/output/signal.py:62  headers={b"Content-Type": [b"application/json"]}  → dict[bytes, list[bytes]]
src/cowrie/commands/wget.py:322 headers={"User-Agent": [...]}                     → dict[str, list[str]]
```

treq's `get()`/`post()` type the `headers` argument as `Headers | dict[bytes|str, bytes|str] | dict[bytes|str, list[bytes|str]] | None`. The two call sites pass dict literals inferred as `dict[str, list[str]]` / `dict[bytes, list[bytes]]`, which are **not** assignable to that union because `dict` is invariant in its key and value types.

The current released Twisted (26.4.0) resolves treq's signature loosely enough that mypy doesn't flag this (it was clean), but Twisted trunk tightens the annotations and the latent mismatch surfaces. It's a type-checker issue only — treq accepts these dicts fine at runtime.

## Fix

Annotate both header dicts with the accepted type (`dict[bytes | str, list[bytes | str]]`) so the call sites type-check cleanly. The annotation is valid on the current Twisted too, so this is safe to land now and future-proofs the next Twisted bump. No runtime change.

## Verification

`mypy --config-file=pyproject.toml src` reports **0 errors (254 files)** against a local build of Twisted trunk (`26.4.0.post0`); it was the only difference from the clean release build. ruff and `test_wget` pass.