### PR TITLE
fix: run async commands in scripts sequentially without cmdstack corruption

### DIFF
--- a/src/cowrie/commands/bash.py
+++ b/src/cowrie/commands/bash.py
@@ -70,8 +70,10 @@ class Command_sh(HoneyPotCommand):
         # `bash -c '...'` exits with the status of the last command it ran.
         self.exit_code = shell.last_exit_code
 
-        # remove the shell
-        self.protocol.cmdstack.pop()
+        # The shell removes itself from cmdstack in _finish() once its queue is
+        # drained. A pop() here would remove whatever is on top instead, which
+        # for a `-c` command that launched an async wget/curl is the in-flight
+        # command, not this shell.
 
     def interactive_shell(self) -> None:
         parentshell = self.protocol.cmdstack[-2]

--- a/src/cowrie/commands/su.py
+++ b/src/cowrie/commands/su.py
@@ -167,7 +167,10 @@ class Command_su(HoneyPotCommand):
         shell.lineReceived(command)
         # `su -c '...'` exits with the status of the command it ran.
         self.exit_code = shell.last_exit_code
-        self.protocol.cmdstack.pop()
+        # The shell removes itself from cmdstack in _finish() once its queue is
+        # drained. A pop() here would remove whatever is on top instead, which
+        # for a `-c` command that launched an async wget/curl is the in-flight
+        # command, not this shell.
         self.exit()
 
     def interactive_shell_as_user(

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -142,9 +142,7 @@ class HoneyPotShell:
         shell = HoneyPotShell(self.protocol, interactive=False, redirect=True)
         self.protocol.cmdstack.append(shell)
         try:
-            return shell._capture_statements(
-                self.bashparser.parse(source)
-            ).rstrip("\n")
+            return shell._capture_statements(self.bashparser.parse(source)).rstrip("\n")
         finally:
             self.protocol.cmdstack.pop()
 
@@ -239,8 +237,11 @@ class HoneyPotShell:
 
         An interactive shell shows the next prompt. A top-level non-interactive
         shell (an exec session) ends the process. A nested non-interactive shell
-        (a pipe stage or a command-substitution capture) just returns so its
-        parent can carry on.
+        that runs a script or ``-c`` commands (sh/bash/su) removes itself from
+        the cmdstack and resumes the command that launched it -- this is what
+        hands control back once the script's async commands (wget/curl) have all
+        finished. A command-substitution / redirect capture shell is left alone:
+        its creator pops it in a finally when capture returns.
         """
         if self.interactive:
             self.showPrompt()
@@ -251,6 +252,16 @@ class HoneyPotShell:
             self.protocol.terminal.transport.processEnded(
                 process_status(self.last_exit_code)
             )
+        elif not self.redirect and self.protocol.cmdstack[-1] is self:
+            # Nested script / `-c` shell whose queue is drained: unwind it and
+            # let the launching command carry on. Done here rather than with an
+            # unconditional pop() at the call site because an async command
+            # (wget/curl) leaves this shell mid-stack until it later resumes and
+            # drains us. A redirect/command-substitution capture shell is
+            # excluded -- it is popped by its own creator in a finally.
+            self.protocol.cmdstack.remove(self)
+            if self.protocol.cmdstack:
+                self.protocol.cmdstack[-1].resume()
 
     def _short_circuit(self, op: str | None) -> bool:
         """Whether a statement joined by ``op`` should be skipped given the last

--- a/src/cowrie/shell/script.py
+++ b/src/cowrie/shell/script.py
@@ -126,6 +126,10 @@ def run_script_file(
         # spans lines is emulated rather than joined onto one line.
         shell.lineReceived(text)
         command.exit_code = shell.last_exit_code
-        protocol.cmdstack.pop()
+        # The script shell removes itself from cmdstack in _finish() once its
+        # queue is drained -- which may be now (all-synchronous script) or later
+        # (an async wget/curl in the script keeps it mid-stack until it resumes
+        # and drains). A pop() here would remove whatever is on top, which is the
+        # in-flight async command, not this shell.
     finally:
         protocol._script_depth = depth

--- a/src/cowrie/test/test_script_execution.py
+++ b/src/cowrie/test/test_script_execution.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import os
 import unittest
+from typing import ClassVar
 
+from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.shell.script import is_executable_binary
 from cowrie.test.fake_server import FakeAvatar, FakeServer
@@ -128,9 +130,7 @@ class ScriptExecutionTests(unittest.TestCase):
 
     def test_absolute_path_with_shebang(self) -> None:
         """Absolute path /tmp/script.sh with shebang executes."""
-        self.proto.lineReceived(
-            b'printf "#!/bin/sh\\necho absolute\\n" > /tmp/abs.sh'
-        )
+        self.proto.lineReceived(b'printf "#!/bin/sh\\necho absolute\\n" > /tmp/abs.sh')
         self.tr.clear()
         self.proto.lineReceived(b"/tmp/abs.sh")
         self.assertEqual(self.tr.value(), b"absolute\n" + PROMPT)
@@ -225,3 +225,64 @@ class BinaryDetectionTests(unittest.TestCase):
         contents = b"#!/bin/sh\n" + b"# padding\n" * 2000 + b"\x00\x01ELFblob"
         self.assertGreater(len(contents), 8192)
         self.assertTrue(is_executable_binary(contents))
+
+
+class _AsyncCommand(HoneyPotCommand):
+    """A command that pauses like wget/curl: start() launches and returns
+    without exiting; the test fires completion by calling finish()."""
+
+    pending: ClassVar[list[_AsyncCommand]] = []
+
+    def start(self) -> None:
+        _AsyncCommand.pending.append(self)
+
+    def finish(self) -> None:
+        self.exit()
+
+
+class AsyncScriptExecutionTests(unittest.TestCase):
+    """A script containing async commands (wget/curl) must run them one at a
+    time and hand the prompt back when done (issue #40269)."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        _AsyncCommand.pending = []
+        # Shadow the shared command table with a copy carrying our fake command.
+        self.proto.commands = dict(self.proto.commands)
+        self.proto.commands["asyncdl"] = _AsyncCommand
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def test_sh_script_with_async_commands(self) -> None:
+        self.proto.lineReceived(b"printf 'asyncdl\\nasyncdl\\n' > /tmp/a.sh")
+        self.tr.clear()
+        self.proto.lineReceived(b"sh /tmp/a.sh")
+
+        # Sequential: only the first command has started; the second waits.
+        self.assertEqual(len(_AsyncCommand.pending), 1)
+
+        # Completing the first must not raise (the premature cmdstack.pop() left
+        # it off the stack, so exit()'s remove() raised ValueError) and must
+        # start the second.
+        _AsyncCommand.pending[0].finish()
+        self.assertEqual(len(_AsyncCommand.pending), 2)
+
+        _AsyncCommand.pending[1].finish()
+
+        # The script shell is gone and the interactive prompt is back, rather
+        # than the session hanging on a stranded nested shell.
+        self.assertEqual(len(self.proto.cmdstack), 1)
+        self.assertTrue(self.proto.cmdstack[0].interactive)
+        self.assertTrue(self.tr.value().endswith(PROMPT))
+
+    def test_su_c_with_async_command(self) -> None:
+        # su -c '<async>' takes the same nested-shell path as sh/bash.
+        self.proto.lineReceived(b"su -c asyncdl")
+        self.assertEqual(len(_AsyncCommand.pending), 1)
+        _AsyncCommand.pending[0].finish()  # must not raise
+        self.assertEqual(len(self.proto.cmdstack), 1)
+        self.assertTrue(self.tr.value().endswith(PROMPT))


### PR DESCRIPTION
## Problem (issue #40269)

Running a script that contains async commands (`wget`/`curl`) via `sh script.sh`, `bash -c`, or `su -c` caused two bugs:

1. `ValueError: list.remove(x): x not in list` in `HoneyPotCommand.exit()` for the first async command.
2. After the script's commands finish, the interactive session hangs until the client sends EOF.

## Root cause

`run_script_file()` (script.py), `Command_sh.execute_commands()` (bash.py) and su's `execute_command_as_user()` (su.py) each create a nested `HoneyPotShell`, call `shell.lineReceived(...)`, then unconditionally `protocol.cmdstack.pop()`.

That `pop()` assumes the nested shell is still on top of `cmdstack` — true only when the script ran to completion **synchronously**. When the first statement is async, `lineReceived()` returns with the in-flight command (e.g. wget) on top, so the `pop()` removes **that command**, not the shell. Then:

- the second script command is dispatched right away → both downloads run concurrently;
- when wget finishes, `exit()` → `cmdstack.remove(self)` on a command already popped → `ValueError`;
- the drained nested shell is left stranded on `cmdstack` → session hangs.

## Fix

- Remove the premature `pop()` in all three call sites.
- `HoneyPotShell._finish()` now unwinds a drained **nested script/`-c` shell** (removes itself and resumes the launching command), which works whether it drains synchronously now or later when an async command resumes it.

The new `_finish()` branch is gated on `not self.redirect`, so a **command-substitution / redirect capture shell** — which is popped by its own creator's `finally` — is never removed here. (I instrumented the capture path to confirm those shells don't hit this branch in current flows; the guard is the correct invariant regardless, covering edges like an async command inside `$(...)`.)

### Note vs. the issue's proposed patch

The issue proposed fixing script.py + bash.py. `su -c` (su.py) has the **identical** bug and is fixed here too. The `_finish()` branch is guarded (`not self.redirect`) rather than unconditional, to keep capture shells self-managed.

## Tests

`AsyncScriptExecutionTests` uses a fake async command (defers completion like wget) to drive the exact interleaving:
- `test_sh_script_with_async_commands`: the two commands run **sequentially** (only one in flight at a time), completing the first doesn't raise, and the prompt is restored (cmdstack back to just the interactive shell).
- `test_su_c_with_async_command`: `su -c '<async>'` completes without the `ValueError`.

Both fail before the fix (concurrency assertion / `ValueError`). Full suite: **656 tests pass**; ruff + full mypy clean.