### PR TITLE
fix: survive a late second exit() from pending download callbacks

### DIFF
--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -400,6 +400,11 @@ class Command_curl(HoneyPotCommand):
         """
         partial collect
         """
+        if self.exited:
+            # The command exited while the transfer was still in flight (size
+            # limit, CTRL-C); drop late chunks instead of writing to the
+            # closed artifact.
+            return
         self.currentlength += len(data)
         if self.limit_size > 0 and self.currentlength > self.limit_size:
             log.msg(
@@ -422,6 +427,11 @@ class Command_curl(HoneyPotCommand):
         """
         this gets called once collection is complete
         """
+        if self.exited:
+            # The command exited while the transfer was still in flight; the
+            # partial artifact was already handled by exit(), so don't report
+            # a download for a dead command or exit again.
+            return
         self.artifact.close()
 
         if self.outfile and not self.silent:
@@ -462,6 +472,10 @@ class Command_curl(HoneyPotCommand):
         """
         handle any exceptions
         """
+        if self.exited:
+            # The command exited while the transfer was still in flight; a
+            # late failure of that transfer is not this command's outcome.
+            return
         self.exit_code = 1
         # Close the artifact so a failed download leaves no orphaned temp file.
         # Artifact.close() removes the empty temp file backing the download.

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -514,6 +514,11 @@ class Command_wget(HoneyPotCommand):
         """
         partial collect
         """
+        if self.exited:
+            # The command exited while the transfer was still in flight (size
+            # limit, CTRL-C); drop late chunks instead of writing to the
+            # closed artifact.
+            return
         eta: float
         self.currentlength += len(data)
         if self.limit_size > 0 and self.currentlength > self.limit_size:
@@ -559,6 +564,11 @@ class Command_wget(HoneyPotCommand):
         """
         this gets called once collection is complete
         """
+        if self.exited:
+            # The command exited while the transfer was still in flight; the
+            # partial artifact was already handled by exit(), so don't report
+            # a download for a dead command or exit again.
+            return
         self.artifact.close()
 
         self.totallength = self.currentlength
@@ -622,6 +632,10 @@ class Command_wget(HoneyPotCommand):
         """
         handle errors
         """
+        if self.exited:
+            # The command exited while the transfer was still in flight; a
+            # late failure of that transfer is not this command's outcome.
+            return
         self.exit_code = 1
         # Close the artifact so a failed download leaves no orphaned temp file.
         # Artifact.close() removes the empty temp file backing the download.

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -35,6 +35,12 @@ class HoneyPotCommand:
     This is the super class for all commands in cowrie/commands
     """
 
+    # True once exit() has run. An async callback firing after the command
+    # already exited (a download completing after an abort) checks this so a
+    # late exit() is a no-op. Class-level so it holds even for instances
+    # created without __init__ (tests).
+    exited: bool = False
+
     @property
     def current_user(self) -> dict[str, str | int]:
         """
@@ -127,7 +133,14 @@ class HoneyPotCommand:
         ``code`` sets this command's exit status (``$?`` for the shell that ran
         it). When omitted, the existing ``exit_code`` is kept, so a command that
         set it earlier (e.g. in an error callback) can just call ``exit()``.
+
+        Exiting twice is safe: a second call (a download callback firing after
+        the command already exited) returns without touching the cmdstack, so
+        the shell is not resumed again.
         """
+        if self.exited:
+            return
+        self.exited = True
         if code is not None:
             self.exit_code = code
         if (

--- a/src/cowrie/test/test_command.py
+++ b/src/cowrie/test/test_command.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for cowrie/shell/command.py, the command base class.
+# ABOUTME: Verifies exit() semantics, in particular that a late second exit is safe.
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from cowrie.shell.command import HoneyPotCommand
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class ExitTests(unittest.TestCase):
+    """exit() hands control back to the shell exactly once.
+
+    An async command (wget, curl) can exit early (size limit, CTRL-C) while
+    its download deferred is still pending; when the download later completes,
+    its callback calls exit() again. That late call must be a no-op: it must
+    not crash on the cmdstack and must not resume the shell a second time.
+    """
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def test_second_exit_is_noop(self) -> None:
+        # Bypass HoneyPotCommand.__init__: its stdout/stderr wiring needs a
+        # running process protocol (self.protocol.pp), which is irrelevant to
+        # the exit bookkeeping under test here.
+        cmd = HoneyPotCommand.__new__(HoneyPotCommand)
+        cmd.protocol = self.proto
+        cmd.exit_code = 0
+        shell = self.proto.cmdstack[0]
+        self.proto.cmdstack.append(cmd)
+
+        cmd.exit()
+        self.assertEqual(self.proto.cmdstack, [shell])
+        output_after_first_exit = self.tr.value()
+
+        cmd.exit()
+        self.assertEqual(self.proto.cmdstack, [shell])
+        self.assertEqual(
+            self.tr.value(),
+            output_after_first_exit,
+            "a late second exit() must not resume the shell again",
+        )

--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -100,3 +100,38 @@ class CurlArtifactCleanupTests(unittest.TestCase):
         artifact = Artifact("curl-download")
         artifact.close()
         artifact.close()  # must not raise on the already-closed file
+
+    def test_late_download_callbacks_after_exit_are_inert(self) -> None:
+        # The command can exit while treq is still delivering the body (size
+        # limit in collect(), CTRL-C). The late callbacks must not write to the
+        # closed artifact, dispatch file_download events for a dead command, or
+        # exit again.
+        cmd = Command_curl.__new__(Command_curl)
+        cmd.protocol = self.proto
+        cmd.writefn = lambda _data: None
+        cmd.errorWritefn = lambda _data: None
+        cmd.exit_code = 0
+        cmd.url = b"http://198.51.100.1/binary"
+        cmd.host = "198.51.100.1"
+        cmd.port = 80
+        cmd.artifact = Artifact("curl-download")
+        events: list[dict] = []
+        self.proto.logDispatch = lambda **kw: events.append(kw)  # type: ignore[method-assign]
+        self.proto.cmdstack.append(cmd)
+
+        cmd.artifact.write(b"partial data")
+        cmd.exit(130)  # CTRL-C while the transfer is still in flight
+
+        cmd.collect(b"late chunk")
+        cmd.collectioncomplete(None)
+        cmd.error(Failure(error.ConnectionDone()))
+
+        self.assertEqual(
+            [
+                ev
+                for ev in events
+                if str(ev.get("eventid", "")).startswith("cowrie.session.file_download")
+            ],
+            [],
+            "late download callbacks reported events for an exited command",
+        )

--- a/src/cowrie/test/test_wget.py
+++ b/src/cowrie/test/test_wget.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+import time
 import unittest
 from unittest import mock
 
@@ -85,4 +86,41 @@ class WgetArtifactCleanupTests(unittest.TestCase):
         self.assertFalse(
             os.path.exists(temp_filename),
             "early exit left an orphaned temp file behind",
+        )
+
+    def test_late_download_callbacks_after_exit_are_inert(self) -> None:
+        # The command can exit while treq is still delivering the body (size
+        # limit in collect(), CTRL-C). The late callbacks must not write to the
+        # closed artifact, dispatch file_download events for a dead command, or
+        # exit again.
+        cmd = Command_wget.__new__(Command_wget)
+        cmd.protocol = self.proto
+        cmd.writefn = lambda _data: None
+        cmd.errorWritefn = lambda _data: None
+        cmd.exit_code = 0
+        cmd.url = b"http://198.51.100.1/binary"
+        cmd.host = "198.51.100.1"
+        cmd.port = 80
+        cmd.quiet = True
+        cmd.started = time.time()
+        cmd.artifact = Artifact("wget-download")
+        events: list[dict] = []
+        self.proto.logDispatch = lambda **kw: events.append(kw)  # type: ignore[method-assign]
+        self.proto.cmdstack.append(cmd)
+
+        cmd.artifact.write(b"partial data")
+        cmd.exit(130)  # CTRL-C while the transfer is still in flight
+
+        cmd.collect(b"late chunk")
+        cmd.collectioncomplete(None)
+        cmd.error(Failure(error.ConnectionDone()))
+
+        self.assertEqual(
+            [
+                ev
+                for ev in events
+                if str(ev.get("eventid", "")).startswith("cowrie.session.file_download")
+            ],
+            [],
+            "late download callbacks reported events for an exited command",
         )


### PR DESCRIPTION
## Problem

Production log shows wget crashing when a download completes after the command already exited:

```
[HTTP11ClientProtocol,client] Unhandled wget error
    Traceback (most recent call last):
      ...
      File "/home/cowrie/cowrie/src/cowrie/commands/wget.py", line 621, in collectioncomplete
        self.exit()
      File "/home/cowrie/cowrie/src/cowrie/commands/wget.py", line 480, in exit
        HoneyPotCommand.exit(self, code)
      File "/home/cowrie/cowrie/src/cowrie/shell/command.py", line 143, in exit
        self.protocol.cmdstack.remove(self)
    builtins.ValueError: list.remove(x): x not in list
```

An async command (wget, curl) can exit early while its treq transfer is still in flight — the size-limit check in `collect()` and `handle_CTRL_C()` both do this. The transfer's callbacks then keep firing against the dead command: `collect()` writes to the closed artifact, `collectioncomplete()` dispatches a spurious `file_download` event (visible in the log as a duplicate "Downloaded URL" line) and calls `exit()` a second time. The cmdstack guard in `HoneyPotCommand.exit()` only checked that the stack was non-empty, not that the command was still on it, so the second exit raised `ValueError` inside the deferred.

## Fix

- `HoneyPotCommand.exit()` tracks that it has run; a late second call is a no-op, so the shell is neither crashed nor resumed twice. This covers every command, matching the guard's documented intent of tolerating late exits.
- wget and curl drop `collect` / `collectioncomplete` / `error` callbacks once the command has exited, so an aborted transfer no longer writes to the closed artifact or reports `file_download` / `file_download.failed` events for a dead command.

Both fixes are covered by new tests that reproduce the original failures.