### PR TITLE
fix: keep the session alive when exit runs inside a command substitution

### DIFF
--- a/src/cowrie/commands/bash.py
+++ b/src/cowrie/commands/bash.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from cowrie.shell.command import HoneyPotCommand, process_status
+from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.honeypot import HoneyPotShell
 from cowrie.shell.script import run_script_file
 
@@ -104,7 +104,8 @@ commands["sh"] = Command_sh
 class Command_exit(HoneyPotCommand):
     def call(self) -> None:
         # `exit [N]` exits with N, or the last command's status ($?) by default.
-        code = getattr(self.protocol.cmdstack[-2], "last_exit_code", 0)
+        shell = self.protocol.cmdstack[-2]
+        code = getattr(shell, "last_exit_code", 0)
         if self.args:
             try:
                 code = int(self.args[0]) & 0xFF
@@ -113,10 +114,14 @@ class Command_exit(HoneyPotCommand):
                     f"-bash: exit: {self.args[0]}: numeric argument required\n"
                 )
                 code = 2
-        # this removes the second last command, which is the shell
-        self.protocol.cmdstack.pop(-2)
-        if len(self.protocol.cmdstack) < 2:
-            self.protocol.terminal.transport.processEnded(process_status(code))
+        # The code is the dying shell's final status: whoever launched the
+        # shell (sh -c, su -c, a substitution) reads it from last_exit_code.
+        shell.last_exit_code = code
+        self.exit_code = code
+        self.protocol.cmdstack.remove(shell)
+        # start() follows with exit(); with the shell gone that either resumes
+        # the command that launched it (nested shell) or, on an empty cmdstack
+        # (top-level shell), ends the session with this exit_code.
 
 
 commands["exit"] = Command_exit

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -142,14 +142,17 @@ class HoneyPotCommand:
         if len(self.protocol.cmdstack):
             self.protocol.cmdstack.remove(self)
 
-            if len(self.protocol.cmdstack):
-                # Hand the exit status to the shell that ran us, for $? and the
-                # && / || logic in runCommand.
-                self.protocol.cmdstack[-1].last_exit_code = self.exit_code
-                self.protocol.cmdstack[-1].resume()
+        if len(self.protocol.cmdstack):
+            # Hand the exit status to the shell that ran us, for $? and the
+            # && / || logic in runCommand.
+            self.protocol.cmdstack[-1].last_exit_code = self.exit_code
+            self.protocol.cmdstack[-1].resume()
         else:
+            # No shell left to return to: either an `exit` builtin removed the
+            # shell before this command finished, or the session is being torn
+            # down. End the process with this command's status.
             ret = process_status(self.exit_code)
-            # The session could be disconnected already, when his happens .transport is gone
+            # The session could be disconnected already, when this happens .transport is gone
             try:
                 self.protocol.terminal.transport.processEnded(ret)
             except AttributeError:

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -144,7 +144,12 @@ class HoneyPotShell:
         try:
             return shell._capture_statements(self.bashparser.parse(source)).rstrip("\n")
         finally:
-            self.protocol.cmdstack.pop()
+            # Remove the capture shell by identity: an `exit` inside the
+            # substitution already removed it (ending the subshell), and a
+            # blind pop() would remove the real shell instead, leaving the
+            # cmdstack empty and crashing the next command's instantiation.
+            if shell in self.protocol.cmdstack:
+                self.protocol.cmdstack.remove(shell)
 
     def _capture_statements(self, statements: list[Statement]) -> str:
         """Run statements in this capture shell, concatenating their stdout and
@@ -152,6 +157,10 @@ class HoneyPotShell:
         whole group)."""
         output = ""
         for statement in statements:
+            if self not in self.protocol.cmdstack:
+                # An `exit` in the substitution ended this subshell; the
+                # remaining statements never run, as in bash.
+                break
             if not isinstance(statement, (Command, Subshell)):
                 continue  # ignore a syntax error inside a substitution
             if self._short_circuit(statement.op):

--- a/src/cowrie/test/test_exit_status.py
+++ b/src/cowrie/test/test_exit_status.py
@@ -153,6 +153,46 @@ class ExitStatusTests(unittest.TestCase):
         self.assertEqual(self.run_line(b"echo a | cat; echo done"), b"a\ndone\n")
 
 
+class ExitInSubstitutionTests(unittest.TestCase):
+    """`exit` inside $( ) ends only that subshell, as in bash (#40275).
+
+    It removes the capture shell from the cmdstack; the substitution's cleanup
+    must not then pop the real shell, or the emptied cmdstack crashes the next
+    command's instantiation with IndexError.
+    """
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def run_line(self, line: bytes) -> bytes:
+        self.tr.clear()
+        self.proto.lineReceived(line)
+        out: bytes = self.tr.value()
+        return out[: -len(PROMPT)] if out.endswith(PROMPT) else out
+
+    def test_exit_in_substitution_keeps_session_alive(self) -> None:
+        shell = self.proto.cmdstack[0]
+        self.assertEqual(self.run_line(b"echo $(exit)"), b"\n")
+        self.assertEqual(self.proto.cmdstack, [shell])
+        # The session must still run commands afterwards.
+        self.assertEqual(self.run_line(b"echo ok"), b"ok\n")
+
+    def test_exit_stops_remaining_substitution_statements(self) -> None:
+        # `exit` ends the subshell; a later statement in the same substitution
+        # never runs.
+        self.assertEqual(self.run_line(b"echo a$(exit; echo b)"), b"a\n")
+
+    def test_plain_exit_still_ends_session(self) -> None:
+        self.proto.lineReceived(b"exit")
+        self.assertEqual(self.proto.cmdstack, [])
+
+
 def run_exec(cmd: bytes) -> int:
     """Run `cmd` over an exec channel and return the exit status the session
     would report to the SSH client via processEnded."""

--- a/src/cowrie/test/test_exit_status.py
+++ b/src/cowrie/test/test_exit_status.py
@@ -78,6 +78,12 @@ class ExitStatusTests(unittest.TestCase):
         self.assertEqual(self.run_line(b"bash -c false; echo $?"), b"1\n")
         self.assertEqual(self.run_line(b"bash -c true; echo $?"), b"0\n")
 
+    def test_exit_code_propagates_from_nested_shell(self) -> None:
+        # `exit N` is the dying shell's status, which sh -c reports as its own.
+        self.assertEqual(self.run_line(b'sh -c "exit 5"; echo $?'), b"5\n")
+        # A bare `exit` reports the last command's status.
+        self.assertEqual(self.run_line(b'sh -c "false; exit"; echo $?'), b"1\n")
+
     def test_nested_shell_status_gates_and(self) -> None:
         # A failing nested shell short-circuits a following &&.
         self.assertEqual(self.run_line(b"bash -c false && echo ran"), b"")


### PR DESCRIPTION
Fixes #40275

## Root cause

The `IndexError` in `HoneyPotCommand.__init__` reported in #40275 fires when a command is instantiated while `cmdstack` is empty. The reporter's original trigger (a nested `sh <script>` shell popped unconditionally) was fixed by #40273, but one live path remained on main, reproducible with a single command:

```
echo $(exit)
```

`Command_exit.call()` removes the shell that ran it via `cmdstack.pop(-2)` — inside `$( )` that is the capture shell, which is correct bash semantics (`exit` ends the subshell). But `command_substitution()`'s cleanup then ran an unconditional `cmdstack.pop()`, assuming the capture shell was still on top. It popped the real shell instead, leaving the cmdstack empty; instantiating the next command (`echo`) then read `cmdstack[-1]` and raised the reported

```
builtins.IndexError: list index out of range
```

This is the same unconditional-pop pattern #40273 removed from the script/-c/su paths.

## Fix

- `command_substitution()` removes the capture shell by identity, and only if it is still on the stack.
- `_capture_statements()` stops once its subshell has exited, so `echo a$(exit; echo b)` prints `a` — statements after `exit` in a substitution never run, as in bash.

After the fix, `echo $(exit)` prints an empty line and the session stays alive, matching real bash. A plain top-level `exit` still ends the session (covered by a regression test).

## On the proposed `__init__` guard

I'd argue against adding the fallback guard to `HoneyPotCommand.__init__` itself: an empty cmdstack there means the session is gone, and instantiating and running a command against a dead session (with a synthesized environment) isn't correct shell behavior either — `exit; echo foo` shouldn't run `echo`. The unguarded access is what surfaced both this bug and #40269 as loud crashes with exact tracebacks; a silent fallback would have masked both while the stack accounting stayed wrong.