### PR TITLE
fix: make late tftp download callbacks safe after session close

### DIFF
--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -352,23 +352,24 @@ class Command_tftp(HoneyPotCommand):
             duplicate=self.artifactFile.duplicate,
         )
 
-        # Update honeyfs
-        size = self.tftp_client.bytes_received if self.tftp_client else 0
-        self.fs.mkfile(
-            self.fakeoutfile,
-            self.current_user["uid"],
-            self.current_user["gid"],
-            size,
-            33188,
-        )
-
-        # Update the honeyfs to point to downloaded file
-        self.fs.update_realfile(
-            self.fs.getfile(self.fakeoutfile), self.artifactFile.shasumFilename
-        )
-        self.fs.chown(
-            self.fakeoutfile, self.current_user["uid"], self.current_user["gid"]
-        )
+        # Update the honeyfs to point to the downloaded file, unless the
+        # session already closed (a transfer completing after connectionLost
+        # has no user left to own the file).
+        if self.protocol.user:
+            size = self.tftp_client.bytes_received if self.tftp_client else 0
+            self.fs.mkfile(
+                self.fakeoutfile,
+                self.current_user["uid"],
+                self.current_user["gid"],
+                size,
+                33188,
+            )
+            self.fs.update_realfile(
+                self.fs.getfile(self.fakeoutfile), self.artifactFile.shasumFilename
+            )
+            self.fs.chown(
+                self.fakeoutfile, self.current_user["uid"], self.current_user["gid"]
+            )
 
         self._safe_exit()
 
@@ -399,7 +400,10 @@ class Command_tftp(HoneyPotCommand):
             url=url,
         )
 
-        self.write(f"tftp: {error_msg}\n")
+        # A failure reported after the session closed has no terminal to
+        # write to; writing anyway logs "Connection was probably lost".
+        if self.protocol.terminal:
+            self.write(f"tftp: {error_msg}\n")
         self._safe_exit()
 
     def _safe_exit(self) -> None:


### PR DESCRIPTION
Fixes #40278

A TFTP transfer that completes after the session closed (idle timeout, disconnect) fired its callbacks against the nulled session state, exactly as analyzed in the issue:

- `_download_success` logs the correct "Downloaded URL" line and dispatches the correct `file_download` event, but then dereferences `protocol.user.uid` for the honeyfs update — `connectionLost` has set `user = None`, so this raises `AttributeError: 'NoneType' object has no attribute 'uid'`.
- That exception travels down the deferred chain into `_download_error`, which reports a *failure* for a download that succeeded — including dispatching a spurious `cowrie.session.file_download.failed` event to all output plugins, not just a wrong log line.
- Its `self.write()` then hits the gone terminal, producing "Connection was probably lost. Could not write to terminal".

The fix follows the guard wget and curl already have at the same spot (`if self.outfile and self.protocol.user:` before their honeyfs update):

- `_download_success`: the honeyfs update is skipped when `protocol.user` is gone; the artifact save, log line, and `file_download` event are unaffected.
- `_download_error`: the terminal write is skipped when `protocol.terminal` is gone (the direct condition for the noise message). A genuinely late failure still logs and dispatches `file_download.failed`, which is then factually accurate.

Thanks @vbontchev for the precise root-cause analysis.