### PR TITLE
fix: drop late output events for sessions that already closed

### DIFF
--- a/src/cowrie/core/output.py
+++ b/src/cowrie/core/output.py
@@ -211,8 +211,15 @@ class Output(metaclass=abc.ABCMeta):
         if ev["eventid"] == "cowrie.session.connect":
             self.sessions[sessionno] = ev["session"]
             self.ips[sessionno] = ev["src_ip"]
-        else:
+        elif sessionno in self.sessions:
             ev["session"] = self.sessions[sessionno]
+        else:
+            # A late event for a session that already closed: an async
+            # callback (e.g. a download completing or failing) can fire after
+            # connectionLost removed the session. The event can no longer be
+            # attributed to a session, so drop it, like the 'session' branch
+            # above does for an unknown session id.
+            return
 
         if sessionno[0] == "S":
             ev["protocol"] = "ssh"

--- a/src/cowrie/test/test_output.py
+++ b/src/cowrie/test/test_output.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for cowrie/core/output.py, the output plugin base class.
+# ABOUTME: Verifies emit() session attribution, including late events after close.
+
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+from cowrie.core.output import Output
+
+
+class CapturingOutput(Output):
+    """Output plugin that records what write() receives."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+        super().__init__()
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def write(self, event: dict[str, Any]) -> None:
+        self.events.append(event)
+
+
+class EmitSessionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.output = CapturingOutput()
+
+    def connect(self, sessionno: str = "T99", session: str = "abcd0123") -> None:
+        self.output.emit(
+            {
+                "eventid": "cowrie.session.connect",
+                "sessionno": sessionno,
+                "session": session,
+                "src_ip": "192.0.2.1",
+                "message": "connect",
+            }
+        )
+
+    def test_event_gets_session_attribution(self) -> None:
+        self.connect()
+        self.output.emit(
+            {
+                "eventid": "cowrie.command.input",
+                "sessionno": "T99",
+                "message": "CMD",
+            }
+        )
+        self.assertEqual(len(self.output.events), 2)
+        self.assertEqual(self.output.events[1]["session"], "abcd0123")
+        self.assertEqual(self.output.events[1]["src_ip"], "192.0.2.1")
+
+    def test_late_event_after_close_is_dropped(self) -> None:
+        # A download callback can fire after the session closed (the deferred
+        # outlives connectionLost). Its event can no longer be attributed to a
+        # session and must be dropped, not raise KeyError.
+        self.connect()
+        self.output.emit(
+            {
+                "eventid": "cowrie.session.closed",
+                "sessionno": "T99",
+                "message": "closed",
+            }
+        )
+        written = len(self.output.events)
+        self.output.emit(
+            {
+                "eventid": "cowrie.session.file_download.failed",
+                "sessionno": "T99",
+                "message": "late download failure",
+            }
+        )
+        self.assertEqual(
+            len(self.output.events),
+            written,
+            "late event for a closed session must be dropped, not written",
+        )


### PR DESCRIPTION
## Problem

Production log (telnet, wget in flight when the session dropped; the treq errback fired ~22s after connectionLost):

```
[twisted.internet.defer#critical] Unhandled error in Deferred:
    Traceback (most recent call last):
      File ".../cowrie/commands/wget.py", line 633, in error
        self.protocol.logDispatch(
      File ".../cowrie/shell/protocol.py", line 86, in logDispatch
        self.factory.logDispatch(**args)
      File ".../cowrie/telnet/factory.py", line 53, in logDispatch
        output.logDispatch(**args)
      File ".../cowrie/core/output.py", line 104, in logDispatch
        self.emit(ev)
      File ".../cowrie/core/output.py", line 215, in emit
        ev["session"] = self.sessions[sessionno]
    builtins.KeyError: 'T1475'
```

`Output.emit()` keeps per-plugin `sessions`/`ips` maps, populated on `cowrie.session.connect` and deleted on `cowrie.session.closed`. A download deferred outlives the session, so its late `file_download` / `file_download.failed` event arrives with a sessionno that is no longer in the map, and the unguarded lookup raises — killing the dispatch loop for every output plugin and leaving an unhandled error in the deferred. Any async command (wget, curl, tftp) can trigger this; it is the session-death variant of the late-callback class from #40274/#40278.

## Fix

Drop events whose sessionno is no longer in the session map. With the session gone the event cannot be attributed, and this matches the existing behavior of the `session`-based attribution branch, which already silently drops events for an unknown session id.

Fixed at the `emit()` boundary rather than in each command so every late dispatcher is covered at once.