### PR TITLE
Session-scoped event pipeline: attribute events at emission, delete the log-observer path

### DIFF
--- a/docs/EVENT_PIPELINE.rst
+++ b/docs/EVENT_PIPELINE.rst
@@ -24,6 +24,15 @@ session
     (``transportId``, e.g. ``ce8abc71b984``). This is the key output
     consumers correlate on.
 
+channel
+    One terminal, exec, subsystem, or forwarding stream within a
+    connection. SSH multiplexes: a single transport can carry several
+    channels, concurrently or in sequence. Cowrie already captures ttylogs
+    and stdin per channel (``insults.py`` keys them by
+    ``(transportId, channelId)``), but events carry only the per-transport
+    ``session``, so activity on concurrent channels is indistinguishable in
+    the event stream. Telnet has exactly one channel per connection.
+
 sessionno
     A transport counter with an ``S`` (SSH) or ``T`` (Telnet) prefix, e.g.
     ``T1475``. An internal artifact of the current pipeline; not part of the
@@ -202,6 +211,29 @@ indistinguishable in ``cowrie.log``; with the prefix bound to the session,
 operator-facing lines are correctly attributed no matter where the code
 runs.
 
+Channels: one transport, many terminals
+=======================================
+
+An SSH transport can carry multiple channels -- several exec or shell
+sessions, SFTP, port forwards -- concurrently or in sequence. The transport
+owns the root ``EventLog``; a channel derives a child emitter that adds its
+identity to every event it dispatches::
+
+    def channelOpened(self):
+        self.events = self.conn.transport.events.child(channel=self.id)
+
+``child()`` returns a lightweight view sharing the dispatcher and the bound
+connection identity, overlaying extra fields -- the same idea as a
+structlog ``bind()``. Commands keep reaching their emitter through
+``self.protocol.events`` and need not know whether it is the root or a
+child. ``session`` remains the per-connection correlation key, so nothing
+changes for existing consumers; ``channel`` is an additive attribute that
+finally lets the event stream distinguish what the per-channel ttylog and
+stdin artifacts already distinguish, and lets file-transfer events (SCP,
+SFTP) name the channel they arrived on. A channel closing does not end the
+session: ``late`` refers to the *connection* having closed, not the
+channel.
+
 ``EventDispatcher`` -- single fan-out
 =====================================
 
@@ -316,6 +348,48 @@ Event flow after the change
       |  enrich once
       v
     plugin.write()  x N, error-isolated
+
+Relationship to Twisted, and alternatives considered
+****************************************************
+
+Cowrie emits through Twisted's *legacy* logging API (``twisted.python.log``);
+the attribution regexes parse that API's context prefixes. Twisted's own
+answer to structured events is the modern ``twisted.logger`` package:
+``Logger`` objects emitting keyword-structured events into observer chains,
+with ``FilteringLogObserver`` and predicates for routing. Three alternatives
+were considered against the proposed design:
+
+``twisted.logger`` with a filtered observer
+    Convert emitters to ``twisted.logger.Logger`` and register *one*
+    observer that filters on ``eventid`` and fans out to plugins. This fixes
+    the fan-out duplication (defect 4) idiomatically, but not attribution:
+    ``twisted.logger`` has no bound context that survives a deferred hop, so
+    the two-thirds of emitters that rely on execution context stay broken.
+    It is the right modernization for Cowrie's *diagnostic* logging, and can
+    happen independently of this design at any time.
+
+``contextvars``
+    Twisted (21.2+) runs deferred callbacks in the context captured when the
+    callback was added, so a ``ContextVar`` holding the current session's
+    emitter would follow download callbacks correctly with no explicit
+    references. Rejected: every reactor entry point (``dataReceived``,
+    ``connectionMade``, timers) must set the variable, and one missed entry
+    point *misattributes* events silently. In a security event stream, a
+    loud ``AttributeError`` on a missing ``self.events`` is preferable to
+    quietly wrong data.
+
+Status quo with patched tables
+    Tombstoning the per-plugin session tables and guarding the lookups fixes
+    the crashes but none of the attribution, duplication, or isolation
+    defects.
+
+The chosen design -- an explicit emitter object delivered through a single
+publisher -- is not how Twisted routes its own logs, and that is deliberate:
+security events are domain data with delivery guarantees, not diagnostics.
+It does follow Twisted's shape where it matters: ``EventDispatcher`` is
+structurally a domain-specific ``LogPublisher``, including its per-observer
+error isolation, which Twisted's publisher has and Cowrie's current dispatch
+loop lacks.
 
 Operational considerations
 **************************

--- a/docs/EVENT_PIPELINE.rst
+++ b/docs/EVENT_PIPELINE.rst
@@ -203,8 +203,9 @@ Non-goals:
 * No changes to the event schema in :doc:`OUTPUT`; plugins keep receiving the
   same dictionaries through the same ``write()`` method.
 * No changes to the human-readable ``cowrie.log`` format.
-* Operational/diagnostic logging (``log.msg`` without an ``eventid``) is out
-  of scope and remains plain Twisted logging.
+* Diagnostic logging keeps its own channel, but converts from the legacy
+  ``twisted.python.log`` API to ``twisted.logger`` once the event migration
+  frees the log stream from being parsed (see below).
 
 Proposed design
 ***************
@@ -399,6 +400,48 @@ Event flow after the change
       +--> plugin.write()  x N, error-isolated       |
       +--> console renderer -- one line per event ---+
 
+The diagnostic stream: converting to ``twisted.logger``
+*******************************************************
+
+Once no plugin parses the log stream, the diagnostic side gets its own
+modernization: from the legacy ``twisted.python.log`` API (~490 ``log.msg``
+/ ``log.err`` call sites) to ``twisted.logger``. The observer side is
+already there -- ``python/logfile.py`` writes ``cowrie.log`` through
+``textFileLogObserver`` and the twistd plugin registers ``ILogObserver``
+providers; legacy emissions reach them through Twisted's built-in adapter.
+Only the emitters are legacy.
+
+What the conversion buys:
+
+Levels and namespaces
+    Per-class ``Logger`` instances give every line a namespace
+    (``cowrie.ssh.transport``, ``cowrie.commands.wget``) and a real level.
+    Combined with ``LogLevelFilterPredicate`` this yields per-subsystem
+    verbosity control from configuration -- debug a single subsystem in
+    production without drowning in the rest. Today the log has exactly one
+    volume setting: everything.
+
+Lazy formatting
+    ``self._log.debug("block {n} received", n=num)`` costs nearly nothing
+    when filtered out, so debug statements can stay in the code permanently
+    instead of being commented in and out during development.
+
+Failures
+    ``self._log.failure("wget transfer failed")`` replaces ``log.err``
+    with explicit tracebacks attached as structured data.
+
+The console renderer emits through a ``Logger`` as well (namespace
+``cowrie.events``), so rendered event lines carry a namespace and level like
+every other line and obey the same filtering.
+
+Sequencing constraint: an ``eventid``-carrying ``log.msg`` must *not* be
+converted to ``twisted.logger`` while plugins still observe the legacy
+stream -- the adapter presents converted events with a different ``system``
+view, the attribution regexes miss them, and the event is lost silently.
+A file's diagnostics therefore convert only after its events have moved to
+``EventLog``; the bulk of the sweep lands after the observers are gone
+(phase 5). Files that emit no events can convert at any time.
+
 Relationship to Twisted, and alternatives considered
 ****************************************************
 
@@ -415,8 +458,8 @@ were considered against the proposed design:
     the fan-out duplication (defect 4) idiomatically, but not attribution:
     ``twisted.logger`` has no bound context that survives a deferred hop, so
     the two-thirds of emitters that rely on execution context stay broken.
-    It is the right modernization for Cowrie's *diagnostic* logging, and can
-    happen independently of this design at any time.
+    It is the right modernization for Cowrie's *diagnostic* logging, which
+    this plan adopts as phase 5.
 
 ``contextvars``
     Twisted (21.2+) runs deferred callbacks in the context captured when the
@@ -555,6 +598,14 @@ Phase 4 -- delete
     are unaffected throughout; ones that override ``emit()`` or
     ``logDispatch()`` themselves would break here and must be checked for
     before this phase (none in-tree do).
+
+Phase 5 -- modernize diagnostics
+    Convert the remaining legacy ``log.msg`` / ``log.err`` call sites to
+    per-class ``twisted.logger.Logger`` instances with namespaces and
+    levels, and add per-namespace level filtering to the configuration.
+    Safe to do wholesale only now: no consumer parses the log stream
+    anymore, so the emitted ``system`` view is free to change. Files with
+    no event emitters can convert earlier at will.
 
 Open questions
 **************

--- a/docs/EVENT_PIPELINE.rst
+++ b/docs/EVENT_PIPELINE.rst
@@ -6,10 +6,9 @@ Event Pipeline Design
 #####################
 
 This document describes how Cowrie events travel from the code that observes
-attacker activity to the output plugins, the defects in that pipeline, and the
-design that replaces it: a session-scoped event log feeding a single central
-dispatcher. The event *schema* (the event ids and their attributes) is
-documented in :doc:`OUTPUT` and is unchanged by this design.
+attacker activity to the output plugins: a session-scoped event log feeding a
+single central dispatcher. The event *schema* (the event ids and their
+attributes) is documented in :doc:`OUTPUT`.
 
 Terminology
 ***********
@@ -27,26 +26,17 @@ session
 channel
     One terminal, exec, subsystem, or forwarding stream within a
     connection. SSH multiplexes: a single transport can carry several
-    channels, concurrently or in sequence. Cowrie already captures ttylogs
-    and stdin per channel (``insults.py`` keys them by
-    ``(transportId, channelId)``), but events carry only the per-transport
-    ``session``, so activity on concurrent channels is indistinguishable in
-    the event stream. Telnet has exactly one channel per connection.
-
-sessionno
-    A transport counter with an ``S`` (SSH) or ``T`` (Telnet) prefix, e.g.
-    ``T1475``. An internal artifact of the current pipeline; not part of the
-    event schema.
+    channels, concurrently or in sequence. Telnet has exactly one channel
+    per connection.
 
 output plugin
     A subclass of ``cowrie.core.output.Output`` (jsonlog, mysql, s3, ...)
     that receives finished events through its ``write()`` method.
 
-Two streams on one channel
-**************************
+Two streams
+***********
 
-Cowrie produces two fundamentally different kinds of output that today share
-one channel, the Twisted log:
+Cowrie produces two fundamentally different kinds of output:
 
 diagnostic logging
     Everything Cowrie has to say about itself: debug statements, development
@@ -54,345 +44,27 @@ diagnostic logging
     tracebacks, plugin trouble. Its audience is the developer and the
     operator; its semantics are log semantics (levels, verbosity,
     best-effort, human-formatted). This stream is by nature the larger one:
-    most of what it carries never becomes an event.
+    most of what it carries never becomes an event. It stays on Twisted's
+    logging API and reaches ``cowrie.log``.
 
 events
     The curated subset: structured records of attacker behavior (logins,
     commands, downloads) whose audience is downstream consumers --
     databases, SIEMs, jsonlog. Their semantics are data semantics:
     guaranteed attribution, stable schema, reliable delivery to every
-    configured sink.
+    configured sink. These travel the event pipeline described here.
 
-Today the *derivation runs the wrong way*: the curated stream is extracted
-from the diagnostic one, by every plugin observing the global log and
-regex-parsing context prefixes out of it -- and consequently every debug
-line also passes through every plugin's filter. Most of the defects below
-are consequences of deriving data from logs. The design inverts the
-derivation for attacker activity: the structured event is primary, and its
-human-readable line in ``cowrie.log`` is rendered *from* it; purely
-diagnostic content -- the bulk of the log -- stays plain Twisted logging
-and never touches the event path. ``cowrie.log`` remains the superset it is
-today: all diagnostics, plus one rendered line per event, merged
-chronologically.
+The two streams are separate all the way down. An event is dispatched exactly
+once, to the output plugins and to a built-in console sink that renders its
+human-readable line into ``cowrie.log``; the event path has no dependency on
+the logging system. ``cowrie.log`` remains the superset it always was: all
+diagnostics, plus one rendered line per event, merged chronologically.
 
-Current architecture
-********************
-
-Two parallel paths deliver events to output plugins::
-
-    log.msg(eventid=..., ...)                protocol.logDispatch(eventid=...)
-      |                                        |
-      v                                        v  adds sessionno
-    Twisted global log                       factory.logDispatch()
-      |                                        |  prefixes "S"/"T"
-      |  every log line, including            |
-      |  non-Cowrie Twisted noise             |
-      v                                        v
-    plugin 1 emit()  plugin 2 emit() ...     for each plugin: logDispatch()
-      |                |                       |
-      +----------------+-----------------------+
-      |
-      v
-    per-plugin attribution and enrichment, then write()
-
-Every output plugin's ``emit()`` is registered as a *global* Twisted log
-observer (``cowrie_plugin.py``), so every log line in the process passes
-through every plugin. ``emit()`` filters (no ``eventid`` |rarr| drop) and then
-attributes the event to a session using, in order:
-
-1. an explicit ``sessionno`` key (the ``logDispatch`` path);
-2. an explicit ``session`` key, reverse-mapped to a sessionno by linear
-   search;
-3. a regular expression over Twisted's ``system`` log-context string
-   (``".*TelnetTransport,([0-9]+),..."``), i.e. the log prefix of whatever
-   context the emitting code happened to run in.
-
-The sessionno is then resolved to the session id through a private
-``sessions`` dict (and ``src_ip`` through a private ``ips`` dict) that every
-plugin instance maintains independently: entries are added when the plugin
-sees ``cowrie.session.connect`` and deleted when it sees
-``cowrie.session.closed``.
-
-A census of the emitters (July 2026): roughly 108 call sites pass an
-``eventid``. About a third carry explicit session identity (the
-``logDispatch`` path and the ``session.connect`` events); the other two
-thirds are plain ``log.msg`` calls that depend on mechanism 3, the log
-context regex.
-
-Defects
-*******
-
-1. Events from deferred callbacks are silently lost
-===================================================
-
-Mechanism 3 only works when the emitting code runs inside the transport's log
-context. Any ``log.msg(eventid=...)`` fired from a deferred callback -- an
-HTTP download completing, a DNS lookup, a timer -- carries that callback's
-context instead (``system="HTTP11ClientProtocol,client"``), matches neither
-regex, and is dropped without trace.
-
-This is not theoretical. When a downloaded script's execution is resumed by a
-download callback, the *entire remainder of the script* runs inside the HTTP
-client's log context: every ``cowrie.command.input`` event for those commands
-is invisible to every database and reporting plugin. The commands an attacker
-runs immediately after fetching a payload are precisely the ones a honeypot
-exists to record.
-
-2. The session table is deleted while work is still in flight
-=============================================================
-
-``cowrie.session.closed`` hard-deletes the plugin's ``sessions``/``ips``
-entries, but a download deferred routinely outlives its session: an attacker
-disconnects immediately after queueing ``wget``, and the transfer finishes or
-fails seconds later. The late ``file_download`` /
-``file_download.failed`` event then arrives with a sessionno that no longer
-resolves. Until July 2026 this raised ``KeyError`` inside every plugin's
-dispatch (an unhandled error in the deferred); it is now dropped instead.
-Either way the record of a completed payload download is lost, even though
-the emitting code knew the session id perfectly well -- only the table forgot
-it.
-
-3. Dual emission as a workaround
-================================
-
-Because path 1 does not work from download callbacks, wget and curl emit
-every download event *twice*: once via ``logDispatch`` (for the plugins) and
-once via ``log.msg`` (for the console log). The two payloads have already
-drifted apart in small ways, and the pattern is inconsistent across the
-download commands: wget's error path dispatches only, curl's does both, and
-tftp/ftpget log their failure line without any ``eventid`` at all. Plugins
-receive exactly one copy today only because the ``log.msg`` twin always fails
-the context regex -- the deduplication is accidental.
-
-4. N copies of state, N times the work
-======================================
-
-Each of the N configured plugins maintains an identical session table and
-independently re-runs regex matching, bytes conversion, timestamp formatting,
-and message interpolation for *every log line in the process*, including all
-non-Cowrie Twisted output. A single plugin that raises from ``write()`` skips
-its own ``closed`` cleanup and leaks table entries forever, silently
-desynchronizing from its siblings. There is also no error isolation on the
-``logDispatch`` path: one plugin raising aborts the dispatch loop for the
-plugins after it.
-
-5. Assorted fragility
-=====================
-
-The regexes are coupled to Twisted class names (``CowrieTelnetTransport``
-happens to match ``.*TelnetTransport``); the ``S``/``T`` prefixing is
-duplicated in both factories and re-parsed character-wise in ``emit()``; the
-``session`` |rarr| ``sessionno`` reverse lookup is a linear scan; events
-arriving before ``connect`` are dropped.
-
-Design goals
+Architecture
 ************
 
-* Every event is attributed to its session *at the point of emission*, where
-  the identity is simply known -- never reconstructed downstream.
-* Late events (callbacks that outlive their session) keep full attribution
-  and are delivered, not dropped.
-* Attribution, enrichment, and lifecycle live in exactly one place.
-* Events and diagnostic logging are separate streams; one emission call per
-  event, with the ``cowrie.log`` rendering produced by a sink, not by the
-  emitter.
-* A plugin failure affects only that plugin.
-
-Non-goals:
-
-* No changes to the event schema in :doc:`OUTPUT`; plugins keep receiving the
-  same dictionaries through the same ``write()`` method.
-* No changes to the human-readable ``cowrie.log`` format.
-* Diagnostic logging keeps its own channel, but converts from the legacy
-  ``twisted.python.log`` API to ``twisted.logger`` once the event migration
-  frees the log stream from being parsed (see below).
-
-Proposed design
-***************
-
-Two new pieces in ``cowrie.core``:
-
-``EventLog`` -- session-scoped emitter
-======================================
-
-A small object created by the transport in ``connectionMade()``, carrying the
-session's identity once::
-
-    class EventLog:
-        """Emits events for one session, with identity bound at creation."""
-
-        def __init__(self, dispatcher, *, session, protocol, src_ip, src_port,
-                     dst_ip, dst_port):
-            ...
-
-        def dispatch(self, eventid: str, format: str, **fields) -> None:
-            """Build the event dict, stamp identity and time, hand it to the
-            dispatcher, and emit the formatted console log line."""
-
-The transport owns it (``self.events = EventLog(...)``); the protocol and
-commands reach it through the objects they already hold
-(``self.protocol.events``), and ``connectionLost`` leaves the reference in
-place. A download command's deferred callbacks close over the command
-instance, so a transfer that completes after ``connectionLost`` still holds
-the ``EventLog`` and its event arrives fully attributed -- fixing defect 2 by
-construction rather than by table lifecycle. Events dispatched after the
-session emitted ``cowrie.session.closed`` carry an additional ``late: true``
-attribute so consumers can distinguish them.
-
-``dispatch()`` emits the event and nothing else -- it does not write to the
-diagnostic log. The familiar event lines in ``cowrie.log`` come from the
-console renderer described below, so the event path has no dependency on the
-logging system at all.
-
-Channels: one transport, many terminals
-=======================================
-
-An SSH transport can carry multiple channels -- several exec or shell
-sessions, SFTP, port forwards -- concurrently or in sequence. The transport
-owns the root ``EventLog``; a channel derives a child emitter that adds its
-identity to every event it dispatches::
-
-    def channelOpened(self):
-        self.events = self.conn.transport.events.child(channel=self.id)
-
-``child()`` returns a lightweight view sharing the dispatcher and the bound
-connection identity, overlaying extra fields -- the same idea as a
-structlog ``bind()``. Commands keep reaching their emitter through
-``self.protocol.events`` and need not know whether it is the root or a
-child. ``session`` remains the per-connection correlation key, so nothing
-changes for existing consumers; ``channel`` is an additive attribute that
-finally lets the event stream distinguish what the per-channel ttylog and
-stdin artifacts already distinguish, and lets file-transfer events (SCP,
-SFTP) name the channel they arrived on. A channel closing does not end the
-session: ``late`` refers to the *connection* having closed, not the
-channel.
-
-``EventDispatcher`` -- single fan-out
-=====================================
-
-One instance, owned by the application container (the ``tac``), holding the
-plugin list that ``cowrie_plugin.py`` already builds::
-
-    class EventDispatcher:
-        def dispatch(self, event: dict) -> None:
-            """Enrich once (sensor, timestamp, message interpolation, bytes
-            conversion), then deliver to each plugin's write(), isolating
-            failures per plugin."""
-
-Enrichment runs once per event instead of once per plugin per log line.
-Plugin exceptions are caught, logged, and do not affect other plugins or the
-emitting session. The per-plugin ``sessions``/``ips`` tables, the regexes,
-and the global log observer registration are deleted at the end of the
-migration; ``Output`` shrinks to ``start()``/``stop()``/``write()``.
-
-The console renderer -- events back into ``cowrie.log``
-========================================================
-
-Developers and operators read one merged, chronological ``cowrie.log`` in
-which event lines sit among the (far more numerous) diagnostic lines; that
-experience is preserved by a small built-in sink that renders each event's
-``format`` into a log line and hands it to the diagnostic stream, stamping
-the session's ``system`` prefix explicitly. This fixes a long-standing operator pain: a
-download callback's lines currently appear under
-``[HTTP11ClientProtocol,client]``, making concurrent sessions
-indistinguishable in the log; rendered from the attributed event, the line
-carries its session no matter where the emitting code ran. Rendering
-events is thereby just another consumer -- jsonlog renders to JSON, the
-console renderer renders to the diagnostic log -- rather than something the
-emitter does as a side effect. Because the renderer only prints dispatcher
-events and unconverted emitters still print through their own ``log.msg``,
-every event line appears exactly once throughout the migration.
-
-Events without a session
-========================
-
-A few emitters are not tied to an attacker session (backend pool state,
-proxy backend bookkeeping). These call ``dispatcher.dispatch()`` directly
-with whatever identity they have. The current pipeline drops most of them
-anyway (they match no regex); making them first-class is deliberately left
-until the main migration is done.
-
-Output plugins are not pure sinks: virustotal, reversedns, and greynoise
-emit session-attributed enrichment events (``cowrie.virustotal.scanfile``,
-``cowrie.reversedns.connect``, ...) and abuseipdb emits session-less
-operational events. These are events, not diagnostics: they must reach
-every configured sink. Plugins therefore hold a reference to the
-``EventDispatcher`` and emit through ``Output.dispatch()``, carrying the
-attribution (session, src_ip) of the event that triggered them, into the
-same fan-out as everything else.
-
-Calling patterns
-================
-
-Transport, at ``connectionMade()`` -- identity is bound exactly once::
-
-    self.events = EventLog(
-        self.factory.tac.dispatcher,
-        session=self.transportId,
-        protocol="telnet",
-        src_ip=self.transport.getPeer().host,
-        src_port=self.transport.getPeer().port,
-        dst_ip=self.transport.getHost().host,
-        dst_port=self.transport.getHost().port,
-    )
-    self.events.dispatch(
-        "cowrie.session.connect",
-        "New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s)"
-        " [session: %(session)s]",
-    )
-
-A shell emitter such as command input. Before, in ``shell/honeypot.py``,
-attributed by log-context regex and lost when running inside a download
-callback::
-
-    log.msg(eventid="cowrie.command.input", input=line, format="CMD: %(input)s")
-
-After -- attributed by the bound identity, delivered from any context::
-
-    self.protocol.events.dispatch("cowrie.command.input", "CMD: %(input)s",
-                                  input=line)
-
-A download command's completion callback. Before, in ``commands/wget.py``,
-the event is emitted twice (``logDispatch`` for the plugins, ``log.msg`` for
-the console) and crashes or is dropped when the transfer outlives the
-session. After -- one call, correct in both cases::
-
-    def collectioncomplete(self, data: None) -> None:
-        ...
-        self.protocol.events.dispatch(
-            "cowrie.session.file_download",
-            "Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
-            url=self.url.decode(),
-            outfile=self.artifact.shasumFilename,
-            shasum=self.artifact.shasum,
-            duplicate=self.artifact.duplicate,
-        )
-
-If this fires after the attacker disconnected, the event arrives with
-``late: true`` and full session attribution, and the console renderer prints
-it under the session's log prefix rather than the HTTP client's.
-
-A transport-level event, e.g. the SSH client version string::
-
-    self.events.dispatch(
-        "cowrie.client.version",
-        "Remote SSH version: %(version)s",
-        version=self.otherVersionString,
-    )
-
-A session-less emitter (backend pool), calling the dispatcher directly::
-
-    self.tac.dispatcher.dispatch(
-        {
-            "eventid": "cowrie.pool.vm_error",
-            "message": f"Backend VM {vm_id} unreachable",
-        }
-    )
-
-Event flow after the change
-===========================
-
-::
+Two pieces in ``cowrie.core.events`` carry every event from emission to the
+sinks::
 
     command / protocol / transport                 diagnostics
       |                                              |
@@ -406,18 +78,280 @@ Event flow after the change
       +--> plugin.write()  x N, error-isolated       |
       +--> console renderer -- one line per event ---+
 
-The diagnostic stream: converting to ``twisted.logger``
-*******************************************************
+``EventLog`` -- session-scoped emitter
+======================================
 
-Once no plugin parses the log stream, the diagnostic side gets its own
-modernization: from the legacy ``twisted.python.log`` API (~490 ``log.msg``
-/ ``log.err`` call sites) to ``twisted.logger``. The observer side is
-already there -- ``python/logfile.py`` writes ``cowrie.log`` through
-``textFileLogObserver`` and the twistd plugin registers ``ILogObserver``
-providers; legacy emissions reach them through Twisted's built-in adapter.
-Only the emitters are legacy.
+A small object created by the transport in ``connectionMade()``, carrying the
+session's identity once::
 
-What the conversion buys:
+    class EventLog:
+        """Emits events for one attacker connection, identity bound at
+        creation."""
+
+        def __init__(self, dispatcher, **identity):
+            ...
+
+        def dispatch(self, eventid: str, fmt: str, **fields) -> None:
+            """Stamp the bound identity, hand the event to the dispatcher."""
+
+The transport owns it (``self.events = EventLog(...)``); the protocol and
+commands reach it through the objects they already hold
+(``self.protocol.events``), and ``connectionLost`` leaves the reference in
+place. Because identity is bound at creation, an event is attributable from
+*any* execution context. A download command's deferred callbacks close over
+the command instance, so a transfer that completes after ``connectionLost``
+still holds the ``EventLog`` and its event arrives fully attributed -- there
+is no downstream table that could have forgotten the session.
+
+The bound identity is authoritative: ``session``, ``src_ip``, and
+``protocol`` from the identity always win over same-named ``fields`` passed
+to ``dispatch()``. This matters because some events carry
+attacker-influenced values under those names -- a direct-tcpip request's
+claimed originator, for instance -- which must not masquerade as the
+connection's real source.
+
+Transports construct the ``EventLog`` and emit the connection event through
+one helper::
+
+    self.events = transport_events(
+        self.factory, self.transport,
+        session=self.transportId, protocol="ssh", src_ip=src_ip,
+    )
+
+``transport_events()`` returns the emitter (or ``None`` when the running
+application provides no dispatcher, e.g. in some tests) and dispatches
+``cowrie.session.connect`` from the bound identity. Symmetrically,
+``EventLog.session_closed(duration_ms)`` dispatches ``cowrie.session.closed``
+and marks the emitter closed. Keeping both in the ``EventLog`` means the four
+transports (ssh, telnet, and the two proxy frontends) do not each carry a
+copy of the connection event's id and format string.
+
+Late events
+===========
+
+Events dispatched after the connection has closed carry an additional
+``late: true`` attribute so consumers can distinguish them. ``late`` refers
+to the *connection* having closed, not a channel: a channel ending mid-session
+is not late.
+
+Late events exist only while some live object (a pending deferred's command
+instance) still references the session's ``EventLog``; when the last
+reference is collected, no further events can be emitted for that session.
+The bound is therefore the lifetime of in-flight work, not wall time -- an
+attacker cannot keep a closed session emitting indefinitely without also
+keeping a transfer open, which existing timeouts already bound (treq
+``timeout=10``, TFTP retry caps).
+
+Channels
+========
+
+``EventLog.child(**extra)`` returns a lightweight view sharing the dispatcher
+and the bound connection identity, overlaying extra fields -- the same idea
+as a structlog ``bind()`` -- and following the parent connection's closed
+state. It is the mechanism by which a channel could add a ``channel``
+attribute to every event it dispatches, distinguishing concurrent SSH
+channels in the event stream the way the per-channel ttylog and stdin
+artifacts already do. The channels do not currently derive a child emitter;
+they share the transport's root ``EventLog``. The capability is in place for
+when per-channel attribution is wired.
+
+``EventDispatcher`` -- single fan-out
+=====================================
+
+One instance, owned by the application container (the ``tac``), holding the
+list of sinks -- the configured output plugins plus the console renderer::
+
+    class EventDispatcher:
+        def dispatch(self, event: dict) -> None:
+            """Enrich once (sensor, uuid, timestamp, message interpolation,
+            bytes conversion), then deliver to each sink, isolating failures
+            per sink."""
+
+Enrichment runs once per event. Each sink receives its own copy so a plugin
+that mutates the event it is handed cannot corrupt what the sinks after it
+see. Sink exceptions are caught and logged (rate-limited per sink), and do
+not affect other sinks or the emitting session. The dispatcher keeps
+counters -- events dispatched, events dropped after stop, per-sink failures
+-- as the natural hook for pipeline observability.
+
+Session-less events
+===================
+
+Most events carry a ``session``; the output plugins' ``write()`` assumes it.
+A few events are operational rather than session-scoped (abuseipdb rate-limit
+notices, the plugin-started banner). The dispatcher routes an event with no
+``session`` only to sinks that opt in by setting ``accepts_sessionless =
+True`` -- the console renderer does. A session-scoped sink never sees a
+session-less event and so never has to guard for the missing key.
+
+Output plugins as event sources
+===============================
+
+Output plugins are not only sinks. virustotal, reversedns, and greynoise
+emit session-attributed enrichment events (``cowrie.virustotal.scanfile``,
+``cowrie.reversedns.connect``, ...) and abuseipdb emits session-less
+operational events. These are events, not diagnostics, and must reach every
+configured sink. Plugins therefore hold a reference to the ``EventDispatcher``
+(set on the ``Output`` base class before any plugin loads, so an event
+dispatched from a plugin's ``start()`` is delivered) and emit through
+``Output.dispatch()``, carrying the attribution of the event that triggered
+them, into the same fan-out as everything else.
+
+The console renderer -- events back into ``cowrie.log``
+=======================================================
+
+Developers and operators read one merged, chronological ``cowrie.log`` in
+which event lines sit among the (far more numerous) diagnostic lines. A small
+built-in sink renders each event's ``message`` into that log, stamping the
+session's ``protocol,session,src_ip`` prefix explicitly. Rendered from the
+attributed event, a line carries its session no matter where the emitting
+code ran -- a download callback's lines no longer appear under
+``[HTTP11ClientProtocol,client]``, making concurrent sessions distinguishable
+in the log. Rendering is thereby just another consumer -- jsonlog renders to
+JSON, the console renderer renders to the diagnostic log -- rather than
+something the emitter does as a side effect.
+
+Calling patterns
+****************
+
+A shell emitter such as command input, attributed by the bound identity and
+delivered from any execution context::
+
+    self.protocol.events.dispatch("cowrie.command.input", "CMD: %(input)s",
+                                  input=line)
+
+A download command's completion callback. If this fires after the attacker
+disconnected, the event arrives with ``late: true`` and full attribution, and
+the console renderer prints it under the session's log prefix::
+
+    def collectioncomplete(self, data: None) -> None:
+        ...
+        self.protocol.events.dispatch(
+            "cowrie.session.file_download",
+            "Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
+            url=self.url.decode(),
+            outfile=self.artifact.shasumFilename,
+            shasum=self.artifact.shasum,
+            duplicate=self.artifact.duplicate,
+        )
+
+A transport-level event, e.g. the SSH client version string::
+
+    self.events.dispatch(
+        "cowrie.client.version",
+        "Remote SSH version: %(version)s",
+        version=self.otherVersionString,
+    )
+
+An output plugin emitting an enrichment event for the event it is
+processing::
+
+    self.dispatch(
+        eventid="cowrie.virustotal.scanfile",
+        format="VT: New file %(sha256)s",
+        session=event["session"],
+        src_ip=event["src_ip"],
+        protocol=event["protocol"],
+        sha256=event["shasum"],
+    )
+
+Login events attach the session's emitter to the credential object rather
+than reaching a transport directly, since the credential is what the auth
+checker receives::
+
+    creds = UsernamePasswordIP(username, password, src_ip, events=self.events)
+
+For public-key authentication Twisted constructs the credential internally,
+so the SSH userauth service wraps the portal for that one call
+(``EventsAttachingPortal``) and attaches the transport's emitter to whatever
+credential passes through, letting the public-key checker dispatch attributed
+events.
+
+Operational considerations
+**************************
+
+No configuration changes
+    Plugin selection, loading, and configuration are untouched;
+    ``cowrie_plugin.py`` builds the same plugin list and hands it to the
+    dispatcher. An upgrade is a restart.
+
+Plugin failure handling
+    ``write()`` exceptions are caught per plugin and rate-limited (first
+    failure, then periodic summaries), so an unreachable database does not
+    turn every attacker keystroke into an error line and flood ``cowrie.log``.
+    One plugin raising does not stop delivery to the others.
+
+Shutdown
+    The dispatcher and each plugin's ``stop()`` run at *after*-shutdown, so
+    the final events of connections torn down during shutdown
+    (``cowrie.session.closed``, the ttylog-closed record) deliver before a
+    sink's backend (a database pool, an hpfeeds client) is closed. The
+    dispatcher tolerates dispatch-after-stop (drop and count) so a late
+    deferred firing during teardown cannot raise into the reactor.
+
+Blocking plugins
+    ``write()`` is called synchronously in the reactor thread -- a plugin
+    doing blocking I/O stalls the honeypot. The dispatcher is the single
+    place a delivery queue or thread pool could be added later.
+
+Pipeline observability
+    The dispatcher's counters (events dispatched, dropped, per-sink failures)
+    are the natural point to expose delivery health -- turning "is my ELK
+    feed complete?" from guesswork into a metric. They are maintained but not
+    yet surfaced to a plugin or command.
+
+Log volume
+    ``cowrie.log`` content is unchanged: one console line per event, plus
+    diagnostics as before. Plugins no longer scan every Twisted log line, so
+    per-event plugin work is (events x N plugins), not (all log lines x N
+    plugins).
+
+Security considerations
+***********************
+
+Audit-trail integrity
+    Per-plugin error isolation means a plugin crash -- including one
+    triggered by crafted attacker input -- cannot suppress delivery of that
+    event to the remaining plugins. There is no per-plugin session table left
+    to desynchronize.
+
+Attacker-controlled data
+    Event fields (commands, URLs, filenames, version strings) are attacker
+    input, and the bound identity overrides same-named fields so an attacker
+    cannot spoof ``session``/``src_ip``/``protocol`` in the structured
+    output. The dispatcher's enrichment step is the single choke point where
+    console rendering could additionally strip control characters and escape
+    sequences (log-injection via ``\n`` or ANSI codes) while the structured
+    event keeps the raw bytes for forensics; that stripping is a candidate
+    for future work.
+
+Event floods
+    An attacker spamming commands generates events at line rate, unchanged
+    from before. The dispatcher's counters provide a detection hook;
+    rate-limiting event *generation* stays with the emitting subsystems
+    (e.g. the download rate limiter).
+
+Testing
+*******
+
+``EventLog`` and ``EventDispatcher`` are plain objects with no dependency on
+the global Twisted log, so unit tests inject a capturing fake sink and assert
+on delivered dictionaries -- no log-observer fixtures, no regex setup. The
+helpers in ``cowrie.test.eventcapture`` (``capture_eventlog``,
+``capture_events``, ``events_of``, ``make_exec_transport``) wire a capturing
+pipeline onto a protocol or transport; the shell tests' ``FakeTransport``
+carries one so command tests can assert on ``tr.dispatchedEvents``.
+
+Future work: diagnostics to ``twisted.logger``
+**********************************************
+
+The event side is complete; the diagnostic side is still on the legacy
+``twisted.python.log`` API (~490 ``log.msg`` / ``log.err`` call sites). Now
+that no consumer parses the log stream, those can convert to per-class
+``twisted.logger.Logger`` instances. The observer side is already there --
+``python/logfile.py`` writes ``cowrie.log`` through ``textFileLogObserver``
+and the twistd plugin registers ``ILogObserver`` providers -- so only the
+emitters need converting. What the conversion buys:
 
 Levels and namespaces
     Per-class ``Logger`` instances give every line a namespace
@@ -433,203 +367,32 @@ Lazy formatting
     instead of being commented in and out during development.
 
 Failures
-    ``self._log.failure("wget transfer failed")`` replaces ``log.err``
-    with explicit tracebacks attached as structured data.
+    ``self._log.failure("wget transfer failed")`` replaces ``log.err`` with
+    explicit tracebacks attached as structured data.
 
-The console renderer emits through a ``Logger`` as well (namespace
-``cowrie.events``), so rendered event lines carry a namespace and level like
-every other line and obey the same filtering.
+A small number of session-less emitters (backend pool, proxy backend
+bookkeeping) also remain on ``log.msg(eventid=...)``; they never reached the
+output plugins historically, and making them first-class events is a separate
+follow-up.
 
-Sequencing constraint: an ``eventid``-carrying ``log.msg`` must *not* be
-converted to ``twisted.logger`` while plugins still observe the legacy
-stream -- the adapter presents converted events with a different ``system``
-view, the attribution regexes miss them, and the event is lost silently.
-A file's diagnostics therefore convert only after its events have moved to
-``EventLog``; the bulk of the sweep lands after the observers are gone
-(phase 5). Files that emit no events can convert at any time.
+Why not ``twisted.logger`` for events too
+=========================================
 
-Relationship to Twisted, and alternatives considered
-****************************************************
-
-Cowrie emits through Twisted's *legacy* logging API (``twisted.python.log``);
-the attribution regexes parse that API's context prefixes. Twisted's own
-answer to structured events is the modern ``twisted.logger`` package:
-``Logger`` objects emitting keyword-structured events into observer chains,
-with ``FilteringLogObserver`` and predicates for routing. Three alternatives
-were considered against the proposed design:
-
-``twisted.logger`` with a filtered observer
-    Convert emitters to ``twisted.logger.Logger`` and register *one*
-    observer that filters on ``eventid`` and fans out to plugins. This fixes
-    the fan-out duplication (defect 4) idiomatically, but not attribution:
-    ``twisted.logger`` has no bound context that survives a deferred hop, so
-    the two-thirds of emitters that rely on execution context stay broken.
-    It is the right modernization for Cowrie's *diagnostic* logging, which
-    this plan adopts as phase 5.
-
-``contextvars``
-    Twisted (21.2+) runs deferred callbacks in the context captured when the
-    callback was added, so a ``ContextVar`` holding the current session's
-    emitter would follow download callbacks correctly with no explicit
-    references. Rejected: every reactor entry point (``dataReceived``,
-    ``connectionMade``, timers) must set the variable, and one missed entry
-    point *misattributes* events silently. In a security event stream, a
-    loud ``AttributeError`` on a missing ``self.events`` is preferable to
-    quietly wrong data.
-
-Status quo with patched tables
-    Tombstoning the per-plugin session tables and guarding the lookups fixes
-    the crashes but none of the attribution, duplication, or isolation
-    defects.
+Twisted's own answer to structured events is the ``twisted.logger`` package:
+``Logger`` objects emitting keyword-structured events into observer chains.
+It is the right modernization for Cowrie's *diagnostic* logging (above), but
+not for the event pipeline: ``twisted.logger`` has no bound context that
+survives a deferred hop, so events fired from a download callback would lose
+their attribution -- exactly the failure the ``EventLog`` exists to prevent.
+A ``ContextVar`` holding the current session's emitter was also considered
+and rejected: every reactor entry point would have to set it, and one missed
+entry point misattributes events silently. In a security event stream, a loud
+``AttributeError`` on a missing ``self.events`` is preferable to quietly
+wrong data.
 
 The chosen design -- an explicit emitter object delivered through a single
 publisher -- is not how Twisted routes its own logs, and that is deliberate:
-security events are domain data with delivery guarantees, not diagnostics.
-It does follow Twisted's shape where it matters: ``EventDispatcher`` is
-structurally a domain-specific ``LogPublisher``, including its per-observer
-error isolation, which Twisted's publisher has and Cowrie's current dispatch
-loop lacks.
-
-Operational considerations
-**************************
-
-No configuration changes
-    Plugin selection, loading, and configuration are untouched;
-    ``cowrie_plugin.py`` builds the same plugin list and hands it to the
-    dispatcher instead of registering observers. An upgrade is a restart.
-
-Plugin failure handling
-    ``write()`` exceptions are caught per plugin. Error logging must be
-    rate-limited per plugin (first failure, then periodic summaries): an
-    unreachable database otherwise turns every attacker keystroke into an
-    error line and floods ``cowrie.log``. Today the same outage aborts the
-    dispatch loop mid-way, so plugins listed after the failing one silently
-    lose the event.
-
-Pipeline observability
-    The dispatcher is one natural place to count events dispatched, events
-    dropped, per-plugin deliveries, and per-plugin errors. Exposing these
-    counters (to the prometheus plugin, or the status command) turns "is my
-    ELK feed complete?" from guesswork into a metric. The current design has
-    no such point; losses are invisible by construction.
-
-Blocking plugins
-    ``write()`` is called synchronously in the reactor thread, exactly as
-    today -- a plugin doing blocking I/O stalls the honeypot either way. The
-    dispatcher is the single place a delivery queue or thread pool could be
-    added later; that change is deliberately out of scope here.
-
-Shutdown
-    Plugin ``stop()`` keeps its reactor shutdown trigger. The dispatcher
-    tolerates dispatch-after-stop (drop and count) so a late deferred firing
-    during shutdown cannot raise into the reactor teardown.
-
-Log volume
-    ``cowrie.log`` content is unchanged: one console line per event, plus
-    diagnostics as before. Plugins stop scanning every Twisted log line, so
-    per-event plugin work drops from (all log lines x N plugins) to
-    (events x N plugins).
-
-Security considerations
-***********************
-
-Audit-trail integrity
-    Per-plugin error isolation means a plugin crash -- including one
-    triggered by crafted attacker input -- can no longer suppress delivery
-    of that event to the remaining plugins, and a plugin that raises no
-    longer desynchronizes its private session table (there is none). Today
-    both are possible, and the second is permanent for the process lifetime.
-
-Attacker-controlled data
-    Event fields (commands, URLs, filenames, version strings) are attacker
-    input. The dispatcher's enrichment step is the single choke point where
-    the *console* rendering can strip control characters and escape
-    sequences (log-injection via ``\n`` or ANSI codes in a command line),
-    while the structured event delivered to plugins keeps the raw bytes for
-    forensics. Today every plugin and the console formatter each interpolate
-    raw attacker strings independently.
-
-Bounding late events
-    Late events exist only while some live object (a pending deferred's
-    command instance) still references the session's ``EventLog``; when the
-    last reference is collected, no further events can be emitted for that
-    session. The bound is therefore the lifetime of in-flight work, not wall
-    time -- an attacker cannot keep a closed session emitting indefinitely
-    without also keeping a transfer open, which existing timeouts already
-    bound (treq ``timeout=10``, TFTP retry caps).
-
-Event floods
-    An attacker spamming commands generates events at line rate, unchanged
-    from today. The dispatcher's counters provide the detection hook;
-    rate-limiting event *generation* stays with the emitting subsystems
-    (e.g. the download rate limiter).
-
-Testing
-*******
-
-``EventLog`` and ``EventDispatcher`` are plain objects with no dependency on
-the global Twisted log, so unit tests inject a capturing fake plugin and
-assert on delivered dictionaries -- no log-observer fixtures, no regex
-setup. Each phase-3 file conversion gets a test that the emitter delivers an
-attributed event from a deferred context (the case the old pipeline fails).
-The emit-site census (July 2026) doubles as the conversion checklist.
-
-Migration plan
-**************
-
-The old and new pipelines can run side by side; an event travels exactly one
-of them, so nothing is double-delivered.
-
-Phase 1 -- introduce
-    Add ``EventLog``, ``EventDispatcher``, and the console renderer;
-    transports create the ``EventLog`` and keep emitting the old way. No
-    behavior change (the renderer has nothing to render yet).
-
-Phase 2 -- convert the bleeding edges
-    Convert the download commands (wget, curl, tftp, ftpget, scp) and the
-    other ``logDispatch`` call sites. This removes the dual-emission pattern
-    and ends the loss of late download events -- the two defects with active
-    production impact. The ``factory.logDispatch`` chain becomes unused and
-    is removed.
-
-Phase 3 -- sweep
-    Convert the remaining ``log.msg(eventid=...)`` sites file by file
-    (~45 files, mechanical). Each conversion moves that emitter from
-    context-regex attribution to bound identity. ``cowrie.session.connect``
-    and ``cowrie.session.closed`` are the one exception: they stay on the
-    log path throughout this phase, because every plugin's ``emit()`` still
-    builds its session table from ``connect`` -- converting them starves
-    attribution for anything not yet converted (including the plugin-emitted
-    enrichment events above). They convert atomically with phase 4. The
-    public-key checker also stays legacy: Twisted constructs its credential
-    object, so it carries no emitter.
-
-Phase 4 -- delete
-    Remove the ``log.addObserver(plugin.emit)`` registration, the regexes,
-    the per-plugin tables, and the attribution half of ``Output.emit()``.
-    Third-party plugins that only implement ``start``/``stop``/``write``
-    are unaffected throughout; ones that override ``emit()`` or
-    ``logDispatch()`` themselves would break here and must be checked for
-    before this phase (none in-tree do).
-
-Phase 5 -- modernize diagnostics
-    Convert the remaining legacy ``log.msg`` / ``log.err`` call sites to
-    per-class ``twisted.logger.Logger`` instances with namespaces and
-    levels, and add per-namespace level filtering to the configuration.
-    Safe to do wholesale only now: no consumer parses the log stream
-    anymore, so the emitted ``system`` view is free to change. Files with
-    no event emitters can convert earlier at will.
-
-Open questions
-**************
-
-* Ordering: plugins currently see events in global log order. The dispatcher
-  preserves per-session ordering trivially; is cross-session ordering worth
-  guaranteeing? (No known consumer depends on it.)
-* Whether ``sessionno`` should be dropped from the delivered event once
-  nothing derives from it, or kept for operators who grep by transport
-  number.
-* Whether the dispatcher's counters ship in phase 1 (cheap, immediately
-  useful for validating the migration itself) or as a follow-up.
-
-.. |rarr| unicode:: 0x2192
+security events are domain data with delivery guarantees, not diagnostics. It
+does follow Twisted's shape where it matters: ``EventDispatcher`` is
+structurally a domain-specific ``LogPublisher``, including the per-observer
+error isolation Twisted's publisher has.

--- a/docs/EVENT_PIPELINE.rst
+++ b/docs/EVENT_PIPELINE.rst
@@ -316,10 +316,11 @@ Output plugins are not pure sinks: virustotal, reversedns, and greynoise
 emit session-attributed enrichment events (``cowrie.virustotal.scanfile``,
 ``cowrie.reversedns.connect``, ...) through the legacy log path, attributed
 by the per-plugin session-table reverse lookup, and abuseipdb emits
-session-less operational events. Deleting the log observers would silently
-drop all of them, so before phase 4 these plugins need an emission path --
-a dispatcher reference for enrichment events, or reclassification as
-diagnostics -- decided per plugin.
+session-less operational events. These are events, not diagnostics: they
+must keep reaching every configured sink. In phase 4 plugins receive a
+reference to the ``EventDispatcher`` so an enrichment event is emitted
+once, session-attributed, into the same fan-out as everything else --
+deleting the log observers before that would silently drop them.
 
 Calling patterns
 ================

--- a/docs/EVENT_PIPELINE.rst
+++ b/docs/EVENT_PIPELINE.rst
@@ -314,13 +314,12 @@ until the main migration is done.
 
 Output plugins are not pure sinks: virustotal, reversedns, and greynoise
 emit session-attributed enrichment events (``cowrie.virustotal.scanfile``,
-``cowrie.reversedns.connect``, ...) through the legacy log path, attributed
-by the per-plugin session-table reverse lookup, and abuseipdb emits
-session-less operational events. These are events, not diagnostics: they
-must keep reaching every configured sink. In phase 4 plugins receive a
-reference to the ``EventDispatcher`` so an enrichment event is emitted
-once, session-attributed, into the same fan-out as everything else --
-deleting the log observers before that would silently drop them.
+``cowrie.reversedns.connect``, ...) and abuseipdb emits session-less
+operational events. These are events, not diagnostics: they must reach
+every configured sink. Plugins therefore hold a reference to the
+``EventDispatcher`` and emit through ``Output.dispatch()``, carrying the
+attribution (session, src_ip) of the event that triggered them, into the
+same fan-out as everything else.
 
 Calling patterns
 ================

--- a/docs/EVENT_PIPELINE.rst
+++ b/docs/EVENT_PIPELINE.rst
@@ -186,12 +186,21 @@ session's identity once::
 
 The transport owns it (``self.events = EventLog(...)``); the protocol and
 commands reach it through the objects they already hold
-(``self.protocol.events``). A download command's deferred callbacks close
-over the command instance, so a transfer that completes after
-``connectionLost`` still holds the ``EventLog`` and its event arrives fully
-attributed -- fixing defect 2 by construction rather than by table lifecycle.
-Events dispatched after the session emitted ``cowrie.session.closed`` carry
-an additional ``late: true`` attribute so consumers can distinguish them.
+(``self.protocol.events``), and ``connectionLost`` leaves the reference in
+place. A download command's deferred callbacks close over the command
+instance, so a transfer that completes after ``connectionLost`` still holds
+the ``EventLog`` and its event arrives fully attributed -- fixing defect 2 by
+construction rather than by table lifecycle. Events dispatched after the
+session emitted ``cowrie.session.closed`` carry an additional ``late: true``
+attribute so consumers can distinguish them.
+
+``dispatch()`` also emits the console log line, stamping the session's
+``system`` log-context prefix explicitly rather than inheriting whatever
+context the caller runs in. Today a download callback's console lines appear
+under ``[HTTP11ClientProtocol,client]``, which makes concurrent sessions
+indistinguishable in ``cowrie.log``; with the prefix bound to the session,
+operator-facing lines are correctly attributed no matter where the code
+runs.
 
 ``EventDispatcher`` -- single fan-out
 =====================================
@@ -220,6 +229,77 @@ with whatever identity they have. The current pipeline drops most of them
 anyway (they match no regex); making them first-class is deliberately left
 until the main migration is done.
 
+Output plugins themselves emit no events (verified against the tree), so
+plugins remain pure sinks and need no emission path.
+
+Calling patterns
+================
+
+Transport, at ``connectionMade()`` -- identity is bound exactly once::
+
+    self.events = EventLog(
+        self.factory.tac.dispatcher,
+        session=self.transportId,
+        protocol="telnet",
+        src_ip=self.transport.getPeer().host,
+        src_port=self.transport.getPeer().port,
+        dst_ip=self.transport.getHost().host,
+        dst_port=self.transport.getHost().port,
+    )
+    self.events.dispatch(
+        "cowrie.session.connect",
+        "New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s)"
+        " [session: %(session)s]",
+    )
+
+A shell emitter such as command input. Before, in ``shell/honeypot.py``,
+attributed by log-context regex and lost when running inside a download
+callback::
+
+    log.msg(eventid="cowrie.command.input", input=line, format="CMD: %(input)s")
+
+After -- attributed by the bound identity, delivered from any context::
+
+    self.protocol.events.dispatch("cowrie.command.input", "CMD: %(input)s",
+                                  input=line)
+
+A download command's completion callback. Before, in ``commands/wget.py``,
+the event is emitted twice (``logDispatch`` for the plugins, ``log.msg`` for
+the console) and crashes or is dropped when the transfer outlives the
+session. After -- one call, correct in both cases::
+
+    def collectioncomplete(self, data: None) -> None:
+        ...
+        self.protocol.events.dispatch(
+            "cowrie.session.file_download",
+            "Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
+            url=self.url.decode(),
+            outfile=self.artifact.shasumFilename,
+            shasum=self.artifact.shasum,
+            duplicate=self.artifact.duplicate,
+        )
+
+If this fires after the attacker disconnected, the event arrives with
+``late: true`` and full session attribution, and the console line still
+carries the session's log prefix.
+
+A transport-level event, e.g. the SSH client version string::
+
+    self.events.dispatch(
+        "cowrie.client.version",
+        "Remote SSH version: %(version)s",
+        version=self.otherVersionString,
+    )
+
+A session-less emitter (backend pool), calling the dispatcher directly::
+
+    self.tac.dispatcher.dispatch(
+        {
+            "eventid": "cowrie.pool.vm_error",
+            "message": f"Backend VM {vm_id} unreachable",
+        }
+    )
+
 Event flow after the change
 ===========================
 
@@ -236,6 +316,90 @@ Event flow after the change
       |  enrich once
       v
     plugin.write()  x N, error-isolated
+
+Operational considerations
+**************************
+
+No configuration changes
+    Plugin selection, loading, and configuration are untouched;
+    ``cowrie_plugin.py`` builds the same plugin list and hands it to the
+    dispatcher instead of registering observers. An upgrade is a restart.
+
+Plugin failure handling
+    ``write()`` exceptions are caught per plugin. Error logging must be
+    rate-limited per plugin (first failure, then periodic summaries): an
+    unreachable database otherwise turns every attacker keystroke into an
+    error line and floods ``cowrie.log``. Today the same outage aborts the
+    dispatch loop mid-way, so plugins listed after the failing one silently
+    lose the event.
+
+Pipeline observability
+    The dispatcher is one natural place to count events dispatched, events
+    dropped, per-plugin deliveries, and per-plugin errors. Exposing these
+    counters (to the prometheus plugin, or the status command) turns "is my
+    ELK feed complete?" from guesswork into a metric. The current design has
+    no such point; losses are invisible by construction.
+
+Blocking plugins
+    ``write()`` is called synchronously in the reactor thread, exactly as
+    today -- a plugin doing blocking I/O stalls the honeypot either way. The
+    dispatcher is the single place a delivery queue or thread pool could be
+    added later; that change is deliberately out of scope here.
+
+Shutdown
+    Plugin ``stop()`` keeps its reactor shutdown trigger. The dispatcher
+    tolerates dispatch-after-stop (drop and count) so a late deferred firing
+    during shutdown cannot raise into the reactor teardown.
+
+Log volume
+    ``cowrie.log`` content is unchanged: one console line per event, plus
+    diagnostics as before. Plugins stop scanning every Twisted log line, so
+    per-event plugin work drops from (all log lines x N plugins) to
+    (events x N plugins).
+
+Security considerations
+***********************
+
+Audit-trail integrity
+    Per-plugin error isolation means a plugin crash -- including one
+    triggered by crafted attacker input -- can no longer suppress delivery
+    of that event to the remaining plugins, and a plugin that raises no
+    longer desynchronizes its private session table (there is none). Today
+    both are possible, and the second is permanent for the process lifetime.
+
+Attacker-controlled data
+    Event fields (commands, URLs, filenames, version strings) are attacker
+    input. The dispatcher's enrichment step is the single choke point where
+    the *console* rendering can strip control characters and escape
+    sequences (log-injection via ``\n`` or ANSI codes in a command line),
+    while the structured event delivered to plugins keeps the raw bytes for
+    forensics. Today every plugin and the console formatter each interpolate
+    raw attacker strings independently.
+
+Bounding late events
+    Late events exist only while some live object (a pending deferred's
+    command instance) still references the session's ``EventLog``; when the
+    last reference is collected, no further events can be emitted for that
+    session. The bound is therefore the lifetime of in-flight work, not wall
+    time -- an attacker cannot keep a closed session emitting indefinitely
+    without also keeping a transfer open, which existing timeouts already
+    bound (treq ``timeout=10``, TFTP retry caps).
+
+Event floods
+    An attacker spamming commands generates events at line rate, unchanged
+    from today. The dispatcher's counters provide the detection hook;
+    rate-limiting event *generation* stays with the emitting subsystems
+    (e.g. the download rate limiter).
+
+Testing
+*******
+
+``EventLog`` and ``EventDispatcher`` are plain objects with no dependency on
+the global Twisted log, so unit tests inject a capturing fake plugin and
+assert on delivered dictionaries -- no log-observer fixtures, no regex
+setup. Each phase-3 file conversion gets a test that the emitter delivers an
+attributed event from a deferred context (the case the old pipeline fails).
+The emit-site census (July 2026) doubles as the conversion checklist.
 
 Migration plan
 **************
@@ -263,19 +427,20 @@ Phase 4 -- delete
     Remove the ``log.addObserver(plugin.emit)`` registration, the regexes,
     the per-plugin tables, and the attribution half of ``Output.emit()``.
     Third-party plugins that only implement ``start``/``stop``/``write``
-    are unaffected throughout.
+    are unaffected throughout; ones that override ``emit()`` or
+    ``logDispatch()`` themselves would break here and must be checked for
+    before this phase (none in-tree do).
 
 Open questions
 **************
 
-* Should ``late`` events be delivered indefinitely, or bounded (e.g. only
-  while the command's deferred is pending)? Unbounded matches "never lose a
-  download record"; a bound protects consumers that assume session recency.
 * Ordering: plugins currently see events in global log order. The dispatcher
   preserves per-session ordering trivially; is cross-session ordering worth
   guaranteeing? (No known consumer depends on it.)
 * Whether ``sessionno`` should be dropped from the delivered event once
   nothing derives from it, or kept for operators who grep by transport
   number.
+* Whether the dispatcher's counters ship in phase 1 (cheap, immediately
+  useful for validating the migration itself) or as a follow-up.
 
 .. |rarr| unicode:: 0x2192

--- a/docs/EVENT_PIPELINE.rst
+++ b/docs/EVENT_PIPELINE.rst
@@ -312,8 +312,14 @@ with whatever identity they have. The current pipeline drops most of them
 anyway (they match no regex); making them first-class is deliberately left
 until the main migration is done.
 
-Output plugins themselves emit no events (verified against the tree), so
-plugins remain pure sinks and need no emission path.
+Output plugins are not pure sinks: virustotal, reversedns, and greynoise
+emit session-attributed enrichment events (``cowrie.virustotal.scanfile``,
+``cowrie.reversedns.connect``, ...) through the legacy log path, attributed
+by the per-plugin session-table reverse lookup, and abuseipdb emits
+session-less operational events. Deleting the log observers would silently
+drop all of them, so before phase 4 these plugins need an emission path --
+a dispatcher reference for enrichment events, or reclassification as
+diagnostics -- decided per plugin.
 
 Calling patterns
 ================
@@ -589,7 +595,14 @@ Phase 2 -- convert the bleeding edges
 Phase 3 -- sweep
     Convert the remaining ``log.msg(eventid=...)`` sites file by file
     (~45 files, mechanical). Each conversion moves that emitter from
-    context-regex attribution to bound identity.
+    context-regex attribution to bound identity. ``cowrie.session.connect``
+    and ``cowrie.session.closed`` are the one exception: they stay on the
+    log path throughout this phase, because every plugin's ``emit()`` still
+    builds its session table from ``connect`` -- converting them starves
+    attribution for anything not yet converted (including the plugin-emitted
+    enrichment events above). They convert atomically with phase 4. The
+    public-key checker also stays legacy: Twisted constructs its credential
+    object, so it carries no emitter.
 
 Phase 4 -- delete
     Remove the ``log.addObserver(plugin.emit)`` registration, the regexes,

--- a/docs/EVENT_PIPELINE.rst
+++ b/docs/EVENT_PIPELINE.rst
@@ -42,6 +42,39 @@ output plugin
     A subclass of ``cowrie.core.output.Output`` (jsonlog, mysql, s3, ...)
     that receives finished events through its ``write()`` method.
 
+Two streams on one channel
+**************************
+
+Cowrie produces two fundamentally different kinds of output that today share
+one channel, the Twisted log:
+
+diagnostic logging
+    Everything Cowrie has to say about itself: debug statements, development
+    traces, protocol negotiation detail, factories starting and stopping,
+    tracebacks, plugin trouble. Its audience is the developer and the
+    operator; its semantics are log semantics (levels, verbosity,
+    best-effort, human-formatted). This stream is by nature the larger one:
+    most of what it carries never becomes an event.
+
+events
+    The curated subset: structured records of attacker behavior (logins,
+    commands, downloads) whose audience is downstream consumers --
+    databases, SIEMs, jsonlog. Their semantics are data semantics:
+    guaranteed attribution, stable schema, reliable delivery to every
+    configured sink.
+
+Today the *derivation runs the wrong way*: the curated stream is extracted
+from the diagnostic one, by every plugin observing the global log and
+regex-parsing context prefixes out of it -- and consequently every debug
+line also passes through every plugin's filter. Most of the defects below
+are consequences of deriving data from logs. The design inverts the
+derivation for attacker activity: the structured event is primary, and its
+human-readable line in ``cowrie.log`` is rendered *from* it; purely
+diagnostic content -- the bulk of the log -- stays plain Twisted logging
+and never touches the event path. ``cowrie.log`` remains the superset it is
+today: all diagnostics, plus one rendered line per event, merged
+chronologically.
+
 Current architecture
 ********************
 
@@ -160,7 +193,9 @@ Design goals
 * Late events (callbacks that outlive their session) keep full attribution
   and are delivered, not dropped.
 * Attribution, enrichment, and lifecycle live in exactly one place.
-* One emission call produces both the console log line and the plugin event.
+* Events and diagnostic logging are separate streams; one emission call per
+  event, with the ``cowrie.log`` rendering produced by a sink, not by the
+  emitter.
 * A plugin failure affects only that plugin.
 
 Non-goals:
@@ -203,13 +238,10 @@ construction rather than by table lifecycle. Events dispatched after the
 session emitted ``cowrie.session.closed`` carry an additional ``late: true``
 attribute so consumers can distinguish them.
 
-``dispatch()`` also emits the console log line, stamping the session's
-``system`` log-context prefix explicitly rather than inheriting whatever
-context the caller runs in. Today a download callback's console lines appear
-under ``[HTTP11ClientProtocol,client]``, which makes concurrent sessions
-indistinguishable in ``cowrie.log``; with the prefix bound to the session,
-operator-facing lines are correctly attributed no matter where the code
-runs.
+``dispatch()`` emits the event and nothing else -- it does not write to the
+diagnostic log. The familiar event lines in ``cowrie.log`` come from the
+console renderer described below, so the event path has no dependency on the
+logging system at all.
 
 Channels: one transport, many terminals
 =======================================
@@ -251,6 +283,24 @@ Plugin exceptions are caught, logged, and do not affect other plugins or the
 emitting session. The per-plugin ``sessions``/``ips`` tables, the regexes,
 and the global log observer registration are deleted at the end of the
 migration; ``Output`` shrinks to ``start()``/``stop()``/``write()``.
+
+The console renderer -- events back into ``cowrie.log``
+========================================================
+
+Developers and operators read one merged, chronological ``cowrie.log`` in
+which event lines sit among the (far more numerous) diagnostic lines; that
+experience is preserved by a small built-in sink that renders each event's
+``format`` into a log line and hands it to the diagnostic stream, stamping
+the session's ``system`` prefix explicitly. This fixes a long-standing operator pain: a
+download callback's lines currently appear under
+``[HTTP11ClientProtocol,client]``, making concurrent sessions
+indistinguishable in the log; rendered from the attributed event, the line
+carries its session no matter where the emitting code ran. Rendering
+events is thereby just another consumer -- jsonlog renders to JSON, the
+console renderer renders to the diagnostic log -- rather than something the
+emitter does as a side effect. Because the renderer only prints dispatcher
+events and unconverted emitters still print through their own ``log.msg``,
+every event line appears exactly once throughout the migration.
 
 Events without a session
 ========================
@@ -312,8 +362,8 @@ session. After -- one call, correct in both cases::
         )
 
 If this fires after the attacker disconnected, the event arrives with
-``late: true`` and full session attribution, and the console line still
-carries the session's log prefix.
+``late: true`` and full session attribution, and the console renderer prints
+it under the session's log prefix rather than the HTTP client's.
 
 A transport-level event, e.g. the SSH client version string::
 
@@ -337,17 +387,17 @@ Event flow after the change
 
 ::
 
-    command / protocol / transport
-      |
-      |  self.protocol.events.dispatch(eventid=..., ...)
-      v
-    EventLog (identity bound at connectionMade)
-      |                       \
-      v                        v
-    EventDispatcher          console log line (once)
-      |  enrich once
-      v
-    plugin.write()  x N, error-isolated
+    command / protocol / transport                 diagnostics
+      |                                              |
+      |  self.protocol.events.dispatch(...)          |  log.msg(...)
+      v                                              v
+    EventLog (identity bound at connectionMade)    Twisted log --> cowrie.log
+      |                                              ^
+      v                                              |
+    EventDispatcher -- enrich once                   |
+      |                                              |
+      +--> plugin.write()  x N, error-isolated       |
+      +--> console renderer -- one line per event ---+
 
 Relationship to Twisted, and alternatives considered
 ****************************************************
@@ -482,8 +532,9 @@ The old and new pipelines can run side by side; an event travels exactly one
 of them, so nothing is double-delivered.
 
 Phase 1 -- introduce
-    Add ``EventLog`` and ``EventDispatcher``; transports create the
-    ``EventLog`` and keep emitting the old way. No behavior change.
+    Add ``EventLog``, ``EventDispatcher``, and the console renderer;
+    transports create the ``EventLog`` and keep emitting the old way. No
+    behavior change (the renderer has nothing to render yet).
 
 Phase 2 -- convert the bleeding edges
     Convert the download commands (wget, curl, tftp, ftpget, scp) and the

--- a/docs/EVENT_PIPELINE.rst
+++ b/docs/EVENT_PIPELINE.rst
@@ -1,0 +1,281 @@
+.. SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+..
+.. SPDX-License-Identifier: BSD-3-Clause
+
+Event Pipeline Design
+#####################
+
+This document describes how Cowrie events travel from the code that observes
+attacker activity to the output plugins, the defects in that pipeline, and the
+design that replaces it: a session-scoped event log feeding a single central
+dispatcher. The event *schema* (the event ids and their attributes) is
+documented in :doc:`OUTPUT` and is unchanged by this design.
+
+Terminology
+***********
+
+event
+    A dictionary describing one observed action, carrying an ``eventid``
+    (e.g. ``cowrie.session.file_download``), a human-readable ``message`` or
+    ``format``, and event-specific attributes.
+
+session
+    The unique identifier of one attacker connection
+    (``transportId``, e.g. ``ce8abc71b984``). This is the key output
+    consumers correlate on.
+
+sessionno
+    A transport counter with an ``S`` (SSH) or ``T`` (Telnet) prefix, e.g.
+    ``T1475``. An internal artifact of the current pipeline; not part of the
+    event schema.
+
+output plugin
+    A subclass of ``cowrie.core.output.Output`` (jsonlog, mysql, s3, ...)
+    that receives finished events through its ``write()`` method.
+
+Current architecture
+********************
+
+Two parallel paths deliver events to output plugins::
+
+    log.msg(eventid=..., ...)                protocol.logDispatch(eventid=...)
+      |                                        |
+      v                                        v  adds sessionno
+    Twisted global log                       factory.logDispatch()
+      |                                        |  prefixes "S"/"T"
+      |  every log line, including            |
+      |  non-Cowrie Twisted noise             |
+      v                                        v
+    plugin 1 emit()  plugin 2 emit() ...     for each plugin: logDispatch()
+      |                |                       |
+      +----------------+-----------------------+
+      |
+      v
+    per-plugin attribution and enrichment, then write()
+
+Every output plugin's ``emit()`` is registered as a *global* Twisted log
+observer (``cowrie_plugin.py``), so every log line in the process passes
+through every plugin. ``emit()`` filters (no ``eventid`` |rarr| drop) and then
+attributes the event to a session using, in order:
+
+1. an explicit ``sessionno`` key (the ``logDispatch`` path);
+2. an explicit ``session`` key, reverse-mapped to a sessionno by linear
+   search;
+3. a regular expression over Twisted's ``system`` log-context string
+   (``".*TelnetTransport,([0-9]+),..."``), i.e. the log prefix of whatever
+   context the emitting code happened to run in.
+
+The sessionno is then resolved to the session id through a private
+``sessions`` dict (and ``src_ip`` through a private ``ips`` dict) that every
+plugin instance maintains independently: entries are added when the plugin
+sees ``cowrie.session.connect`` and deleted when it sees
+``cowrie.session.closed``.
+
+A census of the emitters (July 2026): roughly 108 call sites pass an
+``eventid``. About a third carry explicit session identity (the
+``logDispatch`` path and the ``session.connect`` events); the other two
+thirds are plain ``log.msg`` calls that depend on mechanism 3, the log
+context regex.
+
+Defects
+*******
+
+1. Events from deferred callbacks are silently lost
+===================================================
+
+Mechanism 3 only works when the emitting code runs inside the transport's log
+context. Any ``log.msg(eventid=...)`` fired from a deferred callback -- an
+HTTP download completing, a DNS lookup, a timer -- carries that callback's
+context instead (``system="HTTP11ClientProtocol,client"``), matches neither
+regex, and is dropped without trace.
+
+This is not theoretical. When a downloaded script's execution is resumed by a
+download callback, the *entire remainder of the script* runs inside the HTTP
+client's log context: every ``cowrie.command.input`` event for those commands
+is invisible to every database and reporting plugin. The commands an attacker
+runs immediately after fetching a payload are precisely the ones a honeypot
+exists to record.
+
+2. The session table is deleted while work is still in flight
+=============================================================
+
+``cowrie.session.closed`` hard-deletes the plugin's ``sessions``/``ips``
+entries, but a download deferred routinely outlives its session: an attacker
+disconnects immediately after queueing ``wget``, and the transfer finishes or
+fails seconds later. The late ``file_download`` /
+``file_download.failed`` event then arrives with a sessionno that no longer
+resolves. Until July 2026 this raised ``KeyError`` inside every plugin's
+dispatch (an unhandled error in the deferred); it is now dropped instead.
+Either way the record of a completed payload download is lost, even though
+the emitting code knew the session id perfectly well -- only the table forgot
+it.
+
+3. Dual emission as a workaround
+================================
+
+Because path 1 does not work from download callbacks, wget and curl emit
+every download event *twice*: once via ``logDispatch`` (for the plugins) and
+once via ``log.msg`` (for the console log). The two payloads have already
+drifted apart in small ways, and the pattern is inconsistent across the
+download commands: wget's error path dispatches only, curl's does both, and
+tftp/ftpget log their failure line without any ``eventid`` at all. Plugins
+receive exactly one copy today only because the ``log.msg`` twin always fails
+the context regex -- the deduplication is accidental.
+
+4. N copies of state, N times the work
+======================================
+
+Each of the N configured plugins maintains an identical session table and
+independently re-runs regex matching, bytes conversion, timestamp formatting,
+and message interpolation for *every log line in the process*, including all
+non-Cowrie Twisted output. A single plugin that raises from ``write()`` skips
+its own ``closed`` cleanup and leaks table entries forever, silently
+desynchronizing from its siblings. There is also no error isolation on the
+``logDispatch`` path: one plugin raising aborts the dispatch loop for the
+plugins after it.
+
+5. Assorted fragility
+=====================
+
+The regexes are coupled to Twisted class names (``CowrieTelnetTransport``
+happens to match ``.*TelnetTransport``); the ``S``/``T`` prefixing is
+duplicated in both factories and re-parsed character-wise in ``emit()``; the
+``session`` |rarr| ``sessionno`` reverse lookup is a linear scan; events
+arriving before ``connect`` are dropped.
+
+Design goals
+************
+
+* Every event is attributed to its session *at the point of emission*, where
+  the identity is simply known -- never reconstructed downstream.
+* Late events (callbacks that outlive their session) keep full attribution
+  and are delivered, not dropped.
+* Attribution, enrichment, and lifecycle live in exactly one place.
+* One emission call produces both the console log line and the plugin event.
+* A plugin failure affects only that plugin.
+
+Non-goals:
+
+* No changes to the event schema in :doc:`OUTPUT`; plugins keep receiving the
+  same dictionaries through the same ``write()`` method.
+* No changes to the human-readable ``cowrie.log`` format.
+* Operational/diagnostic logging (``log.msg`` without an ``eventid``) is out
+  of scope and remains plain Twisted logging.
+
+Proposed design
+***************
+
+Two new pieces in ``cowrie.core``:
+
+``EventLog`` -- session-scoped emitter
+======================================
+
+A small object created by the transport in ``connectionMade()``, carrying the
+session's identity once::
+
+    class EventLog:
+        """Emits events for one session, with identity bound at creation."""
+
+        def __init__(self, dispatcher, *, session, protocol, src_ip, src_port,
+                     dst_ip, dst_port):
+            ...
+
+        def dispatch(self, eventid: str, format: str, **fields) -> None:
+            """Build the event dict, stamp identity and time, hand it to the
+            dispatcher, and emit the formatted console log line."""
+
+The transport owns it (``self.events = EventLog(...)``); the protocol and
+commands reach it through the objects they already hold
+(``self.protocol.events``). A download command's deferred callbacks close
+over the command instance, so a transfer that completes after
+``connectionLost`` still holds the ``EventLog`` and its event arrives fully
+attributed -- fixing defect 2 by construction rather than by table lifecycle.
+Events dispatched after the session emitted ``cowrie.session.closed`` carry
+an additional ``late: true`` attribute so consumers can distinguish them.
+
+``EventDispatcher`` -- single fan-out
+=====================================
+
+One instance, owned by the application container (the ``tac``), holding the
+plugin list that ``cowrie_plugin.py`` already builds::
+
+    class EventDispatcher:
+        def dispatch(self, event: dict) -> None:
+            """Enrich once (sensor, timestamp, message interpolation, bytes
+            conversion), then deliver to each plugin's write(), isolating
+            failures per plugin."""
+
+Enrichment runs once per event instead of once per plugin per log line.
+Plugin exceptions are caught, logged, and do not affect other plugins or the
+emitting session. The per-plugin ``sessions``/``ips`` tables, the regexes,
+and the global log observer registration are deleted at the end of the
+migration; ``Output`` shrinks to ``start()``/``stop()``/``write()``.
+
+Events without a session
+========================
+
+A few emitters are not tied to an attacker session (backend pool state,
+proxy backend bookkeeping). These call ``dispatcher.dispatch()`` directly
+with whatever identity they have. The current pipeline drops most of them
+anyway (they match no regex); making them first-class is deliberately left
+until the main migration is done.
+
+Event flow after the change
+===========================
+
+::
+
+    command / protocol / transport
+      |
+      |  self.protocol.events.dispatch(eventid=..., ...)
+      v
+    EventLog (identity bound at connectionMade)
+      |                       \
+      v                        v
+    EventDispatcher          console log line (once)
+      |  enrich once
+      v
+    plugin.write()  x N, error-isolated
+
+Migration plan
+**************
+
+The old and new pipelines can run side by side; an event travels exactly one
+of them, so nothing is double-delivered.
+
+Phase 1 -- introduce
+    Add ``EventLog`` and ``EventDispatcher``; transports create the
+    ``EventLog`` and keep emitting the old way. No behavior change.
+
+Phase 2 -- convert the bleeding edges
+    Convert the download commands (wget, curl, tftp, ftpget, scp) and the
+    other ``logDispatch`` call sites. This removes the dual-emission pattern
+    and ends the loss of late download events -- the two defects with active
+    production impact. The ``factory.logDispatch`` chain becomes unused and
+    is removed.
+
+Phase 3 -- sweep
+    Convert the remaining ``log.msg(eventid=...)`` sites file by file
+    (~45 files, mechanical). Each conversion moves that emitter from
+    context-regex attribution to bound identity.
+
+Phase 4 -- delete
+    Remove the ``log.addObserver(plugin.emit)`` registration, the regexes,
+    the per-plugin tables, and the attribution half of ``Output.emit()``.
+    Third-party plugins that only implement ``start``/``stop``/``write``
+    are unaffected throughout.
+
+Open questions
+**************
+
+* Should ``late`` events be delivered indefinitely, or bounded (e.g. only
+  while the command's deferred is pending)? Unbounded matches "never lose a
+  download record"; a bound protects consumers that assume session recency.
+* Ordering: plugins currently see events in global log order. The dispatcher
+  preserves per-session ordering trivially; is cross-session ordering worth
+  guaranteeing? (No known consumer depends on it.)
+* Whether ``sessionno`` should be dropped from the delivered event once
+  nothing derives from it, or kept for operators who grep by transport
+  number.
+
+.. |rarr| unicode:: 0x2192

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Welcome to Cowrie's documentation!
    BACKEND_POOL.rst
    SNAPSHOTS.rst
    OUTPUT.rst
+   EVENT_PIPELINE.rst
    datadog/README.rst
    docker/README.rst
    elk/README.rst

--- a/src/cowrie/commands/awk.py
+++ b/src/cowrie/commands/awk.py
@@ -14,8 +14,6 @@ import getopt
 import re
 from re import Match
 
-from twisted.python import log
-
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.fs import FileNotFound
 
@@ -147,11 +145,11 @@ class Command_awk(HoneyPotCommand):
         """
         This function logs standard input from the user send to awk
         """
-        log.msg(
-            eventid="cowrie.session.input",
+        self.protocol.events.dispatch(
+            "cowrie.session.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="awk",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
 
         self.output(line.encode())

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -843,11 +843,11 @@ class Command_passwd(HoneyPotCommand):
         self.exit()
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.command.success",
+        self.protocol.events.dispatch(
+            "cowrie.command.success",
+            "INPUT (%(realm)s): %(input)s",
             realm="passwd",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
         self.password = line.strip()
         self.callbacks.pop(0)(line)
@@ -1039,11 +1039,11 @@ class Command_php(HoneyPotCommand):
             self.exit()
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.command.success",
+        self.protocol.events.dispatch(
+            "cowrie.command.success",
+            "INPUT (%(realm)s): %(input)s",
             realm="php",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
 
     def eofReceived(self) -> None:

--- a/src/cowrie/commands/base64.py
+++ b/src/cowrie/commands/base64.py
@@ -139,11 +139,11 @@ Try 'base64 --help' for more information.
                 self.errorWrite("base64: invalid input\n")
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.session.input",
+        self.protocol.events.dispatch(
+            "cowrie.session.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="base64",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
 
         self.dojob(line.encode("ascii"))

--- a/src/cowrie/commands/busybox.py
+++ b/src/cowrie/commands/busybox.py
@@ -6,8 +6,6 @@
 
 from __future__ import annotations
 
-from twisted.python import log
-
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.pipe import PipeProtocol
 
@@ -83,10 +81,10 @@ class Command_busybox(HoneyPotCommand):
         )
         if cmdclass:
             # log found command
-            log.msg(
-                eventid="cowrie.command.success",
+            self.protocol.events.dispatch(
+                "cowrie.command.success",
+                "Command found: %(input)s",
                 input=line,
-                format="Command found: %(input)s",
             )
 
             # prepare command arguments, passing through the redirections the

--- a/src/cowrie/commands/cat.py
+++ b/src/cowrie/commands/cat.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 import getopt
 import os
 
-from twisted.python import log
-
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.fs import FileNotFound
 
@@ -91,11 +89,11 @@ class Command_cat(HoneyPotCommand):
         """
         This function logs standard input from the user send to cat
         """
-        log.msg(
-            eventid="cowrie.session.input",
+        self.protocol.events.dispatch(
+            "cowrie.session.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="cat",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
 
         self.output(line.encode("utf-8"))

--- a/src/cowrie/commands/chpasswd.py
+++ b/src/cowrie/commands/chpasswd.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 import getopt
 
-from twisted.python import log
-
 from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
@@ -50,11 +48,11 @@ class Command_chpasswd(HoneyPotCommand):
                             self.write(f"chpasswd: line {c}: missing new password\n")
                         else:
                             username = _u.decode(errors="ignore")
-                            log.msg(
-                                eventid="cowrie.command.chpasswd",
+                            self.protocol.events.dispatch(
+                                "cowrie.command.chpasswd",
+                                "Password change attempt for %(username)s",
                                 realm="chpasswd",
                                 username=username,
-                                format="Password change attempt for %(username)s",
                             )
                 c += 1
         except Exception:
@@ -88,11 +86,11 @@ class Command_chpasswd(HoneyPotCommand):
             self.exit()
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.command.input",
+        self.protocol.events.dispatch(
+            "cowrie.command.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="chpasswd",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
         self.chpasswd_application(line.encode())
 

--- a/src/cowrie/commands/crontab.py
+++ b/src/cowrie/commands/crontab.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 import getopt
 
-from twisted.python import log
-
 from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
@@ -65,11 +63,11 @@ class Command_crontab(HoneyPotCommand):
             pass
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.command.input",
+        self.protocol.events.dispatch(
+            "cowrie.command.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="crontab",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
 
     def eofReceived(self) -> None:

--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -440,17 +440,9 @@ class Command_curl(HoneyPotCommand):
                 self.fs.getfile(self.outfile), self.artifact.shasumFilename
             )
 
-        self.protocol.logDispatch(
-            eventid="cowrie.session.file_download",
-            format="Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
-            url=self.url.decode(),
-            outfile=self.artifact.shasumFilename,
-            shasum=self.artifact.shasum,
-            duplicate=self.artifact.duplicate,
-        )
-        log.msg(
-            eventid="cowrie.session.file_download",
-            format="Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
+        self.protocol.events.dispatch(
+            "cowrie.session.file_download",
+            "Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
             url=self.url.decode(),
             outfile=self.artifact.shasumFilename,
             shasum=self.artifact.shasum,
@@ -468,14 +460,9 @@ class Command_curl(HoneyPotCommand):
         if getattr(self, "artifact", None) is not None:
             self.artifact.close()
 
-        self.protocol.logDispatch(
-            eventid="cowrie.session.file_download.failed",
-            format="Attempt to download file(s) from URL (%(url)s) failed",
-            url=self.url.decode(),
-        )
-        log.msg(
-            eventid="cowrie.session.file_download.failed",
-            format="Attempt to download file(s) from URL (%(url)s) failed",
+        self.protocol.events.dispatch(
+            "cowrie.session.file_download.failed",
+            "Attempt to download file(s) from URL (%(url)s) failed",
             url=self.url.decode(),
         )
 

--- a/src/cowrie/commands/cut.py
+++ b/src/cowrie/commands/cut.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 import getopt
 
-from twisted.python import log
-
 from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
@@ -125,11 +123,11 @@ class Command_cut(HoneyPotCommand):
             self.write(self.delimiter.join(selected) + "\n")
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.command.input",
+        self.protocol.events.dispatch(
+            "cowrie.command.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="cut",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
         self._process(line.encode("utf-8"))
 

--- a/src/cowrie/commands/dd.py
+++ b/src/cowrie/commands/dd.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 
 import re
 
-from twisted.python import log
-
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.fs import FileNotFound
 
@@ -98,11 +96,11 @@ class Command_dd(HoneyPotCommand):
             self.exit(1)
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.session.input",
+        self.protocol.events.dispatch(
+            "cowrie.session.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="dd",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
 
     def eofReceived(self) -> None:

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -16,8 +16,6 @@ import os.path
 import re
 from typing import TYPE_CHECKING
 
-from twisted.python import log
-
 from cowrie.shell import fs
 from cowrie.shell.command import HoneyPotCommand
 
@@ -105,11 +103,11 @@ class Command_grep(HoneyPotCommand):
         self.exit()
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.command.input",
+        self.protocol.events.dispatch(
+            "cowrie.command.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="grep",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
 
     def eofReceived(self) -> None:
@@ -177,11 +175,11 @@ class Command_tail(HoneyPotCommand):
         self.exit()
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.command.input",
+        self.protocol.events.dispatch(
+            "cowrie.command.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="tail",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
 
     def eofReceived(self) -> None:
@@ -254,11 +252,11 @@ class Command_head(HoneyPotCommand):
         self.exit()
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.command.input",
+        self.protocol.events.dispatch(
+            "cowrie.command.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="head",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
 
     def eofReceived(self) -> None:

--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -15,7 +15,6 @@ from twisted.internet import defer, reactor
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.protocol import ClientCreator, Protocol
 from twisted.protocols.ftp import CommandFailed, FTPClient
-from twisted.python import log
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
@@ -247,17 +246,9 @@ Download a file via FTP
         self.artifactFile.close()
 
         # log to cowrie.log
-        log.msg(
-            format="Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
-            url=self.url_log,
-            outfile=self.artifactFile.shasumFilename,
-            shasum=self.artifactFile.shasum,
-            duplicate=self.artifactFile.duplicate,
-        )
-
-        self.protocol.logDispatch(
-            eventid="cowrie.session.file_download",
-            format="Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
+        self.protocol.events.dispatch(
+            "cowrie.session.file_download",
+            "Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
             url=self.url_log,
             outfile=self.artifactFile.shasumFilename,
             shasum=self.artifactFile.shasum,
@@ -296,16 +287,11 @@ Download a file via FTP
             # Network/connection error
             error_msg = f"Connection failed: {failure.getErrorMessage()}"
 
-        log.msg(
-            format="Attempt to download file(s) from URL (%(url)s) failed: %(error)s",
+        self.protocol.events.dispatch(
+            "cowrie.session.file_download.failed",
+            "Attempt to download file(s) from URL (%(url)s) failed: %(error)s",
             url=self.url_log,
             error=error_msg,
-        )
-
-        self.protocol.logDispatch(
-            eventid="cowrie.session.file_download.failed",
-            format="Attempt to download file(s) from URL (%(url)s) failed",
-            url=self.url_log,
         )
 
         self.errorWrite(f"ftpget: {error_msg}\n")

--- a/src/cowrie/commands/perl.py
+++ b/src/cowrie/commands/perl.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 import getopt
 
-from twisted.python import log
-
 from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
@@ -112,11 +110,11 @@ class Command_perl(HoneyPotCommand):
             pass
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.command.input",
+        self.protocol.events.dispatch(
+            "cowrie.command.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="perl",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
 
     def eofReceived(self) -> None:

--- a/src/cowrie/commands/python.py
+++ b/src/cowrie/commands/python.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 import getopt
 
-from twisted.python import log
-
 from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
@@ -121,11 +119,11 @@ class Command_python(HoneyPotCommand):
             pass
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.command.input",
+        self.protocol.events.dispatch(
+            "cowrie.command.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="python",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
 
     def eofReceived(self) -> None:

--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -10,8 +10,6 @@ import os
 import re
 import time
 
-from twisted.python import log
-
 from cowrie.core.config import CowrieConfig
 from cowrie.shell import fs
 from cowrie.shell.command import HoneyPotCommand
@@ -72,11 +70,11 @@ class Command_scp(HoneyPotCommand):
         self.write("\x00")
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.session.file_download",
+        self.protocol.events.dispatch(
+            "cowrie.session.file_download",
+            "INPUT (%(realm)s): %(input)s",
             realm="scp",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
         self.protocol.terminal.write("\x00")
 

--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -108,9 +108,9 @@ class Command_scp(HoneyPotCommand):
                 os.remove(self.safeoutfile)
                 duplicate = True
 
-            log.msg(
-                format='SCP Uploaded file "%(filename)s" to %(outfile)s',
-                eventid="cowrie.session.file_upload",
+            self.protocol.events.dispatch(
+                "cowrie.session.file_upload",
+                'SCP Uploaded file "%(filename)s" to %(outfile)s',
                 filename=os.path.basename(fname),
                 duplicate=duplicate,
                 url=fname,

--- a/src/cowrie/commands/tee.py
+++ b/src/cowrie/commands/tee.py
@@ -104,11 +104,11 @@ class Command_tee(HoneyPotCommand):
         """
         This function logs standard input from the user send to tee
         """
-        log.msg(
-            eventid="cowrie.session.input",
+        self.protocol.events.dispatch(
+            "cowrie.session.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="tee",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
 
         self.output(line.encode("utf-8"))

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -333,18 +333,9 @@ class Command_tftp(HoneyPotCommand):
         """
         url = f"tftp://{self.hostname}:{self.port}/{self.file_to_get.lstrip('/')}"
 
-        # Log to cowrie.log
-        log.msg(
-            format="Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
-            url=url,
-            outfile=self.artifactFile.shasumFilename,
-            shasum=self.artifactFile.shasum,
-            duplicate=self.artifactFile.duplicate,
-        )
-
-        self.protocol.logDispatch(
-            eventid="cowrie.session.file_download",
-            format="Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
+        self.protocol.events.dispatch(
+            "cowrie.session.file_download",
+            "Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
             url=url,
             outfile=self.artifactFile.shasumFilename,
             shasum=self.artifactFile.shasum,
@@ -388,16 +379,11 @@ class Command_tftp(HoneyPotCommand):
         error_msg = failure.getErrorMessage()
         url = f"tftp://{self.hostname}:{self.port}/{self.file_to_get.lstrip('/')}"
 
-        log.msg(
-            format="Attempt to download file(s) from URL (%(url)s) failed: %(error)s",
+        self.protocol.events.dispatch(
+            "cowrie.session.file_download.failed",
+            "Attempt to download file(s) from URL (%(url)s) failed: %(error)s",
             url=url,
             error=error_msg,
-        )
-
-        self.protocol.logDispatch(
-            eventid="cowrie.session.file_download.failed",
-            format="Attempt to download file(s) from URL (%(url)s) failed",
-            url=url,
         )
 
         # A failure reported after the session closed has no terminal to

--- a/src/cowrie/commands/uniq.py
+++ b/src/cowrie/commands/uniq.py
@@ -10,8 +10,6 @@ uniq command
 
 from __future__ import annotations
 
-from twisted.python import log
-
 from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
@@ -69,11 +67,11 @@ class Command_uniq(HoneyPotCommand):
             self.exit()
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.command.input",
+        self.protocol.events.dispatch(
+            "cowrie.command.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="uniq",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
         self.grep_input(line.encode())
 

--- a/src/cowrie/commands/wc.py
+++ b/src/cowrie/commands/wc.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 import getopt
 import re
 
-from twisted.python import log
-
 from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
@@ -125,11 +123,11 @@ class Command_wc(HoneyPotCommand):
         self.exit()
 
     def lineReceived(self, line: str) -> None:
-        log.msg(
-            eventid="cowrie.command.input",
+        self.protocol.events.dispatch(
+            "cowrie.command.input",
+            "INPUT (%(realm)s): %(input)s",
             realm="wc",
             input=line,
-            format="INPUT (%(realm)s): %(input)s",
         )
 
     def eofReceived(self) -> None:

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -602,17 +602,9 @@ class Command_wget(HoneyPotCommand):
                 self.fs.getfile(self.outfile), self.artifact.shasumFilename
             )
 
-        self.protocol.logDispatch(
-            eventid="cowrie.session.file_download",
-            format="Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
-            url=self.url.decode(),
-            outfile=self.artifact.shasumFilename,
-            shasum=self.artifact.shasum,
-            duplicate=self.artifact.duplicate,
-        )
-        log.msg(
-            eventid="cowrie.session.file_download",
-            format="Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
+        self.protocol.events.dispatch(
+            "cowrie.session.file_download",
+            "Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
             url=self.url.decode(),
             outfile=self.artifact.shasumFilename,
             shasum=self.artifact.shasum,
@@ -630,9 +622,9 @@ class Command_wget(HoneyPotCommand):
         if getattr(self, "artifact", None) is not None:
             self.artifact.close()
 
-        self.protocol.logDispatch(
-            eventid="cowrie.session.file_download.failed",
-            format="Attempt to download file(s) from URL (%(url)s) failed",
+        self.protocol.events.dispatch(
+            "cowrie.session.file_download.failed",
+            "Attempt to download file(s) from URL (%(url)s) failed",
             url=self.url.decode(),
         )
 

--- a/src/cowrie/core/checkers.py
+++ b/src/cowrie/core/checkers.py
@@ -79,11 +79,12 @@ class HoneypotNoneChecker:
     credentialInterfaces = (conchcredentials.IUsername,)
 
     def requestAvatarId(self, credentials):
-        credentials.events.dispatch(
-            "cowrie.login.success",
-            "login attempt [%(username)s] succeeded",
-            username=escape_nonprintable(credentials.username),
-        )
+        if credentials.events:
+            credentials.events.dispatch(
+                "cowrie.login.success",
+                "login attempt [%(username)s] succeeded",
+                username=escape_nonprintable(credentials.username),
+            )
         return defer.succeed(credentials.username)
 
 
@@ -128,7 +129,11 @@ class HoneypotPasswordChecker:
         return defer.fail(UnauthorizedLogin())
 
     def checkUserPass(
-        self, theusername: bytes, thepassword: bytes, ip: str, events: EventLog
+        self,
+        theusername: bytes,
+        thepassword: bytes,
+        ip: str,
+        events: EventLog | None,
     ) -> bool:
         # Is the auth_class defined in the config file?
         authclass = CowrieConfig.get("honeypot", "auth_class", fallback="UserDB")
@@ -145,18 +150,20 @@ class HoneypotPasswordChecker:
         theauth = authname()
 
         if theauth.checklogin(theusername, thepassword, ip):
+            if events:
+                events.dispatch(
+                    "cowrie.login.success",
+                    "login attempt [%(username)s/%(password)s] succeeded",
+                    username=escape_nonprintable(theusername),
+                    password=escape_nonprintable(thepassword),
+                )
+            return True
+
+        if events:
             events.dispatch(
-                "cowrie.login.success",
-                "login attempt [%(username)s/%(password)s] succeeded",
+                "cowrie.login.failed",
+                "login attempt [%(username)s/%(password)s] failed",
                 username=escape_nonprintable(theusername),
                 password=escape_nonprintable(thepassword),
             )
-            return True
-
-        events.dispatch(
-            "cowrie.login.failed",
-            "login attempt [%(username)s/%(password)s] failed",
-            username=escape_nonprintable(theusername),
-            password=escape_nonprintable(thepassword),
-        )
         return False

--- a/src/cowrie/core/checkers.py
+++ b/src/cowrie/core/checkers.py
@@ -39,34 +39,40 @@ class HoneypotPublicKeyChecker:
 
     def requestAvatarId(self, credentials):
         _pubKey = keys.Key.fromString(credentials.blob)
-        log.msg(
-            eventid="cowrie.client.fingerprint",
-            format="public key attempt for user %(username)s of type %(type)s with fingerprint %(fingerprint)s",
-            username=escape_nonprintable(credentials.username),
-            fingerprint=_pubKey.fingerprint(),
-            key=_pubKey.toString("OPENSSH"),
-            type=_pubKey.sshType(),
-        )
+        # Twisted constructs this credential; the userauth service attaches
+        # the transport's emitter before portal.login.
+        events = getattr(credentials, "events", None)
+        if events:
+            events.dispatch(
+                "cowrie.client.fingerprint",
+                "public key attempt for user %(username)s of type %(type)s with fingerprint %(fingerprint)s",
+                username=escape_nonprintable(credentials.username),
+                fingerprint=_pubKey.fingerprint(),
+                key=_pubKey.toString("OPENSSH"),
+                type=_pubKey.sshType(),
+            )
 
         if CowrieConfig.getboolean("ssh", "auth_publickey_allow_any", fallback=False):
-            log.msg(
-                eventid="cowrie.login.success",
-                format="public key login attempt for [%(username)s] succeeded",
-                username=escape_nonprintable(credentials.username),
-                fingerprint=_pubKey.fingerprint(),
-                key=_pubKey.toString("OPENSSH"),
-                type=_pubKey.sshType(),
-            )
+            if events:
+                events.dispatch(
+                    "cowrie.login.success",
+                    "public key login attempt for [%(username)s] succeeded",
+                    username=escape_nonprintable(credentials.username),
+                    fingerprint=_pubKey.fingerprint(),
+                    key=_pubKey.toString("OPENSSH"),
+                    type=_pubKey.sshType(),
+                )
             return defer.succeed(credentials.username)
         else:
-            log.msg(
-                eventid="cowrie.login.failed",
-                format="public key login attempt for [%(username)s] failed",
-                username=escape_nonprintable(credentials.username),
-                fingerprint=_pubKey.fingerprint(),
-                key=_pubKey.toString("OPENSSH"),
-                type=_pubKey.sshType(),
-            )
+            if events:
+                events.dispatch(
+                    "cowrie.login.failed",
+                    "public key login attempt for [%(username)s] failed",
+                    username=escape_nonprintable(credentials.username),
+                    fingerprint=_pubKey.fingerprint(),
+                    key=_pubKey.toString("OPENSSH"),
+                    type=_pubKey.sshType(),
+                )
             return failure.Failure(error.ConchError("Incorrect signature"))
 
 

--- a/src/cowrie/core/checkers.py
+++ b/src/cowrie/core/checkers.py
@@ -9,6 +9,8 @@ This module contains ...
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from twisted.conch import error
 from twisted.conch.ssh import keys
 from twisted.cred.checkers import ICredentialsChecker
@@ -22,6 +24,9 @@ from cowrie.core import auth
 from cowrie.core import credentials as conchcredentials
 from cowrie.core.config import CowrieConfig
 from cowrie.core.utils import escape_nonprintable
+
+if TYPE_CHECKING:
+    from cowrie.core.events import EventLog
 
 
 @implementer(ICredentialsChecker)
@@ -74,9 +79,9 @@ class HoneypotNoneChecker:
     credentialInterfaces = (conchcredentials.IUsername,)
 
     def requestAvatarId(self, credentials):
-        log.msg(
-            eventid="cowrie.login.success",
-            format="login attempt [%(username)s] succeeded",
+        credentials.events.dispatch(
+            "cowrie.login.success",
+            "login attempt [%(username)s] succeeded",
             username=escape_nonprintable(credentials.username),
         )
         return defer.succeed(credentials.username)
@@ -96,27 +101,35 @@ class HoneypotPasswordChecker:
     def requestAvatarId(self, credentials):
         if hasattr(credentials, "password"):
             if self.checkUserPass(
-                credentials.username, credentials.password, credentials.ip
+                credentials.username,
+                credentials.password,
+                credentials.ip,
+                credentials.events,
             ):
                 return defer.succeed(credentials.username)
             return defer.fail(UnauthorizedLogin())
         if hasattr(credentials, "pamConversion"):
             return self.checkPamUser(
-                credentials.username, credentials.pamConversion, credentials.ip
+                credentials.username,
+                credentials.pamConversion,
+                credentials.ip,
+                credentials.events,
             )
         return defer.fail(UnhandledCredentials())
 
-    def checkPamUser(self, username, pamConversion, ip):
+    def checkPamUser(self, username, pamConversion, ip, events):
         r = pamConversion((("Password:", 1),))
-        return r.addCallback(self.cbCheckPamUser, username, ip)
+        return r.addCallback(self.cbCheckPamUser, username, ip, events)
 
-    def cbCheckPamUser(self, responses, username, ip):
+    def cbCheckPamUser(self, responses, username, ip, events):
         for response, _ in responses:
-            if self.checkUserPass(username, response, ip):
+            if self.checkUserPass(username, response, ip, events):
                 return defer.succeed(username)
         return defer.fail(UnauthorizedLogin())
 
-    def checkUserPass(self, theusername: bytes, thepassword: bytes, ip: str) -> bool:
+    def checkUserPass(
+        self, theusername: bytes, thepassword: bytes, ip: str, events: EventLog
+    ) -> bool:
         # Is the auth_class defined in the config file?
         authclass = CowrieConfig.get("honeypot", "auth_class", fallback="UserDB")
 
@@ -132,17 +145,17 @@ class HoneypotPasswordChecker:
         theauth = authname()
 
         if theauth.checklogin(theusername, thepassword, ip):
-            log.msg(
-                eventid="cowrie.login.success",
-                format="login attempt [%(username)s/%(password)s] succeeded",
+            events.dispatch(
+                "cowrie.login.success",
+                "login attempt [%(username)s/%(password)s] succeeded",
                 username=escape_nonprintable(theusername),
                 password=escape_nonprintable(thepassword),
             )
             return True
 
-        log.msg(
-            eventid="cowrie.login.failed",
-            format="login attempt [%(username)s/%(password)s] failed",
+        events.dispatch(
+            "cowrie.login.failed",
+            "login attempt [%(username)s/%(password)s] failed",
             username=escape_nonprintable(theusername),
             password=escape_nonprintable(thepassword),
         )

--- a/src/cowrie/core/checkers.py
+++ b/src/cowrie/core/checkers.py
@@ -42,14 +42,18 @@ class HoneypotPublicKeyChecker:
         # Twisted constructs this credential; the userauth service attaches
         # the transport's emitter before portal.login.
         events = getattr(credentials, "events", None)
+        # Every pubkey event carries the same attacker key material.
+        keyfields = {
+            "username": escape_nonprintable(credentials.username),
+            "fingerprint": _pubKey.fingerprint(),
+            "key": _pubKey.toString("OPENSSH"),
+            "type": _pubKey.sshType(),
+        }
         if events:
             events.dispatch(
                 "cowrie.client.fingerprint",
                 "public key attempt for user %(username)s of type %(type)s with fingerprint %(fingerprint)s",
-                username=escape_nonprintable(credentials.username),
-                fingerprint=_pubKey.fingerprint(),
-                key=_pubKey.toString("OPENSSH"),
-                type=_pubKey.sshType(),
+                **keyfields,
             )
 
         if CowrieConfig.getboolean("ssh", "auth_publickey_allow_any", fallback=False):
@@ -57,10 +61,7 @@ class HoneypotPublicKeyChecker:
                 events.dispatch(
                     "cowrie.login.success",
                     "public key login attempt for [%(username)s] succeeded",
-                    username=escape_nonprintable(credentials.username),
-                    fingerprint=_pubKey.fingerprint(),
-                    key=_pubKey.toString("OPENSSH"),
-                    type=_pubKey.sshType(),
+                    **keyfields,
                 )
             return defer.succeed(credentials.username)
         else:
@@ -68,10 +69,7 @@ class HoneypotPublicKeyChecker:
                 events.dispatch(
                     "cowrie.login.failed",
                     "public key login attempt for [%(username)s] failed",
-                    username=escape_nonprintable(credentials.username),
-                    fingerprint=_pubKey.fingerprint(),
-                    key=_pubKey.toString("OPENSSH"),
-                    type=_pubKey.sshType(),
+                    **keyfields,
                 )
             return failure.Failure(error.ConchError("Incorrect signature"))
 

--- a/src/cowrie/core/credentials.py
+++ b/src/cowrie/core/credentials.py
@@ -12,6 +12,8 @@ from zope.interface import implementer
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from cowrie.core.events import EventLog
+
 
 class IUsername(ICredentials):
     """
@@ -49,16 +51,24 @@ class PluggableAuthenticationModulesIP:
     Twisted removed IPAM in 15, adding in Cowrie now
     """
 
-    def __init__(self, username: bytes, pamConversion: Callable, ip: str) -> None:
+    def __init__(
+        self,
+        username: bytes,
+        pamConversion: Callable,
+        ip: str,
+        events: EventLog | None = None,
+    ) -> None:
         self.username: bytes = username
         self.pamConversion: Callable = pamConversion
         self.ip: str = ip
+        self.events: EventLog | None = events
 
 
 @implementer(IUsername)
 class Username:
-    def __init__(self, username: bytes):
+    def __init__(self, username: bytes, events: EventLog | None = None):
         self.username: bytes = username
+        self.events: EventLog | None = events
 
 
 @implementer(IUsernamePasswordIP)
@@ -67,10 +77,17 @@ class UsernamePasswordIP:
     This credential interface also provides an IP address
     """
 
-    def __init__(self, username: bytes, password: bytes, ip: str) -> None:
+    def __init__(
+        self,
+        username: bytes,
+        password: bytes,
+        ip: str,
+        events: EventLog | None = None,
+    ) -> None:
         self.username: bytes = username
         self.password: bytes = password
         self.ip: str = ip
+        self.events: EventLog | None = events
 
     def checkPassword(self, password: bytes) -> bool:
         return self.password == password

--- a/src/cowrie/core/events.py
+++ b/src/cowrie/core/events.py
@@ -85,14 +85,24 @@ class EventDispatcher:
                 ev["message"] = ev["format"]
 
         self.dispatched += 1
-        for sink in self.sinks:
+        # Output plugins' write() assumes session attribution (every event
+        # in the OUTPUT schema carries one); operational events without a
+        # session go only to sinks that accept them (the console renderer).
+        sessionless = "session" not in ev
+        sinks = [
+            sink
+            for sink in self.sinks
+            if not sessionless or getattr(sink, "accepts_sessionless", False)
+        ]
+        for i, sink in enumerate(sinks):
             try:
                 # Each sink owns its copy, nested containers included:
                 # several output plugins mutate the event they receive,
                 # which must not corrupt what the sinks after them see.
                 # convert() rebuilds dicts and lists recursively, so it
-                # doubles as the per-sink deep copy.
-                sink.write(convert(ev))
+                # doubles as the per-sink deep copy; the last sink takes
+                # the enriched event itself, which no one else holds.
+                sink.write(ev if i == len(sinks) - 1 else convert(ev))
             except Exception as e:  # one sink must not stop the rest
                 count = self.failures.get(id(sink), 0) + 1
                 self.failures[id(sink)] = count
@@ -101,6 +111,12 @@ class EventDispatcher:
                         f"Event sink {sink.__class__.__name__} failed"
                         f" ({count} failures): {e}"
                     )
+
+    def registerShutdown(self, reactor: Any) -> None:
+        """Stop only after reactor teardown: connections closed during
+        shutdown still emit their final events (ttylog closed, stdin
+        capture); the stopped-guard is for deferreds firing later still."""
+        reactor.addSystemEventTrigger("after", "shutdown", self.stop)
 
     def stop(self) -> None:
         """Drop events dispatched during shutdown instead of raising into
@@ -145,6 +161,15 @@ class EventLog:
         derived._root = self._root
         return derived
 
+    def session_closed(self, duration_ms: int) -> None:
+        """Announce the connection's end and mark the emitter closed."""
+        self.dispatch(
+            "cowrie.session.closed",
+            "Connection lost after %(duration_ms)d milliseconds",
+            duration_ms=duration_ms,
+        )
+        self.close()
+
     def close(self) -> None:
         """The connection ended: events dispatched from now on are late.
 
@@ -164,15 +189,16 @@ def transport_events(
     src_ip: str | None = None,
 ) -> EventLog | None:
     """The session EventLog for a listening transport, bound to the
-    connection's endpoints, or None when the running application provides
-    no dispatcher. src_ip defaults to the connection peer; the SSH
-    transport passes its IPv4-normalized form instead."""
+    connection's endpoints and announcing it with cowrie.session.connect,
+    or None when the running application provides no dispatcher. src_ip
+    defaults to the connection peer; the SSH transport passes its
+    IPv4-normalized form instead."""
     dispatcher = getattr(getattr(factory, "tac", None), "dispatcher", None)
     if dispatcher is None:
         return None
     peer = transport.getPeer()
     host = transport.getHost()
-    return EventLog(
+    events = EventLog(
         dispatcher,
         session=session,
         protocol=protocol,
@@ -181,6 +207,12 @@ def transport_events(
         dst_ip=host.host,
         dst_port=host.port,
     )
+    events.dispatch(
+        "cowrie.session.connect",
+        "New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s)"
+        " [session: %(session)s]",
+    )
+    return events
 
 
 class ConsoleRenderer:
@@ -189,6 +221,9 @@ class ConsoleRenderer:
     session's identity so the line is attributable no matter which execution
     context emitted the event.
     """
+
+    # Session-less operational events still deserve their log line.
+    accepts_sessionless = True
 
     def __init__(self, logmsg: Callable[..., None] = log.msg) -> None:
         self.logmsg = logmsg

--- a/src/cowrie/core/events.py
+++ b/src/cowrie/core/events.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import socket
 import time
+from os import environ
 from typing import TYPE_CHECKING, Any
 
 from twisted.logger import formatTime
@@ -51,7 +52,13 @@ class EventDispatcher:
             "honeypot", "sensor_name", fallback=socket.gethostname()
         )
         self.uuid: str = CowrieConfig.get("honeypot", "uuid", fallback="unknown")
-        self.timeFormat: str = "%Y-%m-%dT%H:%M:%S.%fZ"
+        # The Z suffix (Zulu) only when running in UTC; a local-time
+        # timestamp carries its numeric offset instead.
+        self.timeFormat: str
+        if environ.get("TZ") == "UTC":
+            self.timeFormat = "%Y-%m-%dT%H:%M:%S.%fZ"
+        else:
+            self.timeFormat = "%Y-%m-%dT%H:%M:%S.%f%z"
         self.stopped: bool = False
         # Delivery bookkeeping, also the hook for pipeline observability.
         self.dispatched: int = 0
@@ -80,7 +87,10 @@ class EventDispatcher:
         self.dispatched += 1
         for sink in self.sinks:
             try:
-                sink.write(ev)
+                # Each sink owns its copy: several output plugins mutate the
+                # event they receive (del event[i]), which must not corrupt
+                # what the sinks after them see.
+                sink.write(dict(ev))
             except Exception as e:  # one sink must not stop the rest
                 count = self.failures.get(id(sink), 0) + 1
                 self.failures[id(sink)] = count
@@ -126,7 +136,12 @@ class EventLog:
         return derived
 
     def close(self) -> None:
-        """The connection ended: events dispatched from now on are late."""
+        """The connection ended: events dispatched from now on are late.
+
+        This closes the whole connection's emitter, including on a child:
+        only the owning transport calls it. A channel closing is not a
+        session end and needs no call here.
+        """
         self._root._closed = True
 
 

--- a/src/cowrie/core/events.py
+++ b/src/cowrie/core/events.py
@@ -155,6 +155,34 @@ class EventLog:
         self._root._closed = True
 
 
+def transport_events(
+    factory: Any,
+    transport: Any,
+    *,
+    session: str,
+    protocol: str,
+    src_ip: str | None = None,
+) -> EventLog | None:
+    """The session EventLog for a listening transport, bound to the
+    connection's endpoints, or None when the running application provides
+    no dispatcher. src_ip defaults to the connection peer; the SSH
+    transport passes its IPv4-normalized form instead."""
+    dispatcher = getattr(getattr(factory, "tac", None), "dispatcher", None)
+    if dispatcher is None:
+        return None
+    peer = transport.getPeer()
+    host = transport.getHost()
+    return EventLog(
+        dispatcher,
+        session=session,
+        protocol=protocol,
+        src_ip=src_ip if src_ip is not None else peer.host,
+        src_port=peer.port,
+        dst_ip=host.host,
+        dst_port=host.port,
+    )
+
+
 class ConsoleRenderer:
     """
     Renders each event's message into the diagnostic log, prefixed with the

--- a/src/cowrie/core/events.py
+++ b/src/cowrie/core/events.py
@@ -87,10 +87,12 @@ class EventDispatcher:
         self.dispatched += 1
         for sink in self.sinks:
             try:
-                # Each sink owns its copy: several output plugins mutate the
-                # event they receive (del event[i]), which must not corrupt
-                # what the sinks after them see.
-                sink.write(dict(ev))
+                # Each sink owns its copy, nested containers included:
+                # several output plugins mutate the event they receive,
+                # which must not corrupt what the sinks after them see.
+                # convert() rebuilds dicts and lists recursively, so it
+                # doubles as the per-sink deep copy.
+                sink.write(convert(ev))
             except Exception as e:  # one sink must not stop the rest
                 count = self.failures.get(id(sink), 0) + 1
                 self.failures[id(sink)] = count
@@ -119,9 +121,17 @@ class EventLog:
         self._closed: bool = False
         self._root: EventLog = self
 
+    # Attribution keys the bound identity always wins over emitter fields:
+    # attacker-influenced values (a direct-tcpip request's claimed
+    # originator) must not masquerade as the connection's source.
+    AUTHORITATIVE = ("session", "src_ip", "protocol")
+
     def dispatch(self, eventid: str, fmt: str, **fields: Any) -> None:
         event: dict[str, Any] = dict(self.identity)
         event.update(fields)
+        for key in self.AUTHORITATIVE:
+            if key in self.identity:
+                event[key] = self.identity[key]
         event["eventid"] = eventid
         event["format"] = fmt
         if self._root._closed:
@@ -156,9 +166,14 @@ class ConsoleRenderer:
         self.logmsg = logmsg
 
     def write(self, event: dict[str, Any]) -> None:
+        message = event.get("message", "")
+        if not message:
+            # Some events (cowrie.session.params) carry data only; a blank
+            # line per session is just log noise.
+            return
         system = "{},{},{}".format(
             event.get("protocol", "-"),
             event.get("session", "-"),
             event.get("src_ip", "-"),
         )
-        self.logmsg(event.get("message", ""), system=system)
+        self.logmsg(message, system=system)

--- a/src/cowrie/core/events.py
+++ b/src/cowrie/core/events.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Session-scoped event pipeline: EventLog emitters bound to a session
+# ABOUTME: deliver attacker-activity events through one enriching dispatcher.
+
+"""
+Events are structured records of attacker behavior, delivered to output
+sinks (the configured output plugins and the console renderer) with their
+session identity bound at the point of emission. Diagnostic logging is a
+separate concern and stays on the Twisted log. See docs/EVENT_PIPELINE.rst
+for the design.
+"""
+
+from __future__ import annotations
+
+import socket
+import time
+from typing import TYPE_CHECKING, Any
+
+from twisted.logger import formatTime
+from twisted.python import log
+
+from cowrie.core.config import CowrieConfig
+from cowrie.core.output import convert
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Log every FAILURE_LOG_INTERVAL'th delivery failure per sink after the
+# first, so an unreachable database does not turn every event into an
+# error line.
+FAILURE_LOG_INTERVAL = 100
+
+
+class EventDispatcher:
+    """
+    Delivers events to every sink, enriching each event exactly once and
+    isolating sink failures from each other and from the emitting session.
+    """
+
+    def __init__(
+        self,
+        sinks: list[Any],
+        logmsg: Callable[..., None] = log.msg,
+    ) -> None:
+        self.sinks = sinks
+        self.logmsg = logmsg
+        self.sensor: str = CowrieConfig.get(
+            "honeypot", "sensor_name", fallback=socket.gethostname()
+        )
+        self.uuid: str = CowrieConfig.get("honeypot", "uuid", fallback="unknown")
+        self.timeFormat: str = "%Y-%m-%dT%H:%M:%S.%fZ"
+        self.stopped: bool = False
+        # Delivery bookkeeping, also the hook for pipeline observability.
+        self.dispatched: int = 0
+        self.dropped_after_stop: int = 0
+        self.failures: dict[int, int] = {}  # id(sink) -> failure count
+
+    def dispatch(self, event: dict[str, Any]) -> None:
+        if self.stopped:
+            self.dropped_after_stop += 1
+            return
+
+        ev: dict[str, Any] = convert(event)
+        ev["sensor"] = self.sensor
+        ev["uuid"] = self.uuid
+        if "time" not in ev:
+            ev["time"] = time.time()
+        ev["timestamp"] = formatTime(ev["time"], timeFormat=self.timeFormat)
+
+        if "format" in ev and "message" not in ev:
+            try:
+                ev["message"] = ev["format"] % ev
+                del ev["format"]
+            except (KeyError, TypeError, ValueError):
+                ev["message"] = ev["format"]
+
+        self.dispatched += 1
+        for sink in self.sinks:
+            try:
+                sink.write(ev)
+            except Exception as e:  # one sink must not stop the rest
+                count = self.failures.get(id(sink), 0) + 1
+                self.failures[id(sink)] = count
+                if count == 1 or count % FAILURE_LOG_INTERVAL == 0:
+                    self.logmsg(
+                        f"Event sink {sink.__class__.__name__} failed"
+                        f" ({count} failures): {e}"
+                    )
+
+    def stop(self) -> None:
+        """Drop events dispatched during shutdown instead of raising into
+        reactor teardown."""
+        self.stopped = True
+
+
+class EventLog:
+    """
+    Emits events for one attacker connection, with the session identity
+    bound at creation so an event is attributable from any execution
+    context -- including a deferred callback that outlives the session.
+    """
+
+    def __init__(self, dispatcher: EventDispatcher, **identity: Any) -> None:
+        self.dispatcher = dispatcher
+        self.identity = identity
+        self._closed: bool = False
+        self._root: EventLog = self
+
+    def dispatch(self, eventid: str, fmt: str, **fields: Any) -> None:
+        event: dict[str, Any] = dict(self.identity)
+        event.update(fields)
+        event["eventid"] = eventid
+        event["format"] = fmt
+        if self._root._closed:
+            event["late"] = True
+        self.dispatcher.dispatch(event)
+
+    def child(self, **extra: Any) -> EventLog:
+        """A derived emitter (e.g. one SSH channel) that adds ``extra`` to
+        every event and follows this connection's closed state."""
+        derived = EventLog(self.dispatcher, **{**self.identity, **extra})
+        derived._root = self._root
+        return derived
+
+    def close(self) -> None:
+        """The connection ended: events dispatched from now on are late."""
+        self._root._closed = True
+
+
+class ConsoleRenderer:
+    """
+    Renders each event's message into the diagnostic log, prefixed with the
+    session's identity so the line is attributable no matter which execution
+    context emitted the event.
+    """
+
+    def __init__(self, logmsg: Callable[..., None] = log.msg) -> None:
+        self.logmsg = logmsg
+
+    def write(self, event: dict[str, Any]) -> None:
+        system = "{},{},{}".format(
+            event.get("protocol", "-"),
+            event.get("session", "-"),
+            event.get("src_ip", "-"),
+        )
+        self.logmsg(event.get("message", ""), system=system)

--- a/src/cowrie/core/output.py
+++ b/src/cowrie/core/output.py
@@ -84,8 +84,9 @@ class Output(metaclass=abc.ABCMeta):
         else:
             self.timeFormat = "%Y-%m-%dT%H:%M:%S.%f%z"
 
-        # Event trigger so that stop() is called by the reactor when stopping
-        reactor.addSystemEventTrigger("before", "shutdown", self.stop)
+        # Stop only after reactor teardown, so the final events of sessions
+        # closed during shutdown deliver before the sink's resources close.
+        reactor.addSystemEventTrigger("after", "shutdown", self.stop)
 
         self.start()
 

--- a/src/cowrie/core/output.py
+++ b/src/cowrie/core/output.py
@@ -10,12 +10,15 @@ import socket
 import time
 from os import environ
 from re import Pattern
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from twisted.internet import reactor
 from twisted.logger import formatTime
 
 from cowrie.core.config import CowrieConfig
+
+if TYPE_CHECKING:
+    from cowrie.core.events import EventDispatcher
 
 # Events:
 #  cowrie.client.fingerprint
@@ -68,6 +71,10 @@ class Output(metaclass=abc.ABCMeta):
     methods: stop, start and write
     """
 
+    # The event pipeline for plugins that emit enrichment events of their
+    # own (virustotal, reversedns, ...), set by the application container.
+    dispatcher: EventDispatcher | None = None
+
     def __init__(self) -> None:
         self.sessions: dict[str, str] = {}
         self.ips: dict[str, str] = {}
@@ -102,6 +109,12 @@ class Output(metaclass=abc.ABCMeta):
         ev = kw
         # ev["message"] = msg
         self.emit(ev)
+
+    def dispatch(self, **event: Any) -> None:
+        """Emit an enrichment event into the event pipeline, carrying
+        whatever attribution (session, src_ip) the plugin has."""
+        if self.dispatcher:
+            self.dispatcher.dispatch(event)
 
     @abc.abstractmethod
     def start(self) -> None:

--- a/src/cowrie/core/output.py
+++ b/src/cowrie/core/output.py
@@ -5,15 +5,11 @@
 from __future__ import annotations
 
 import abc
-import re
 import socket
-import time
 from os import environ
-from re import Pattern
 from typing import TYPE_CHECKING, Any
 
 from twisted.internet import reactor
-from twisted.logger import formatTime
 
 from cowrie.core.config import CowrieConfig
 
@@ -76,14 +72,6 @@ class Output(metaclass=abc.ABCMeta):
     dispatcher: EventDispatcher | None = None
 
     def __init__(self) -> None:
-        self.sessions: dict[str, str] = {}
-        self.ips: dict[str, str] = {}
-
-        # Need these for each individual transport, or else the session numbers overlap
-        self.sshRegex: Pattern[str] = re.compile(".*SSHTransport,([0-9]+),[0-9a-f:.]+$")
-        self.telnetRegex: Pattern[str] = re.compile(
-            ".*TelnetTransport,([0-9]+),[0-9a-f:.]+$"
-        )
         self.sensor: str = CowrieConfig.get(
             "honeypot", "sensor_name", fallback=socket.gethostname()
         )
@@ -100,15 +88,6 @@ class Output(metaclass=abc.ABCMeta):
         reactor.addSystemEventTrigger("before", "shutdown", self.stop)
 
         self.start()
-
-    def logDispatch(self, **kw: str) -> None:
-        """
-        Use logDispatch when the HoneypotTransport prefix is not available.
-        Here you can explicitly set the sessionIds to tie the sessions together
-        """
-        ev = kw
-        # ev["message"] = msg
-        self.emit(ev)
 
     def dispatch(self, **event: Any) -> None:
         """Emit an enrichment event into the event pipeline, carrying
@@ -136,107 +115,3 @@ class Output(metaclass=abc.ABCMeta):
         Handle a general event within the output plugin
         """
         pass
-
-    def emit(self, event: dict) -> None:
-        """
-        This is the main emit() hook that gets called by the the Twisted logging
-
-        To make this work with Cowrie, the event dictionary needs the following keys:
-        - 'eventid'
-        - 'sessionno' or 'session'
-        - 'message' or 'format'
-        """
-        sessionno: str
-
-        # Ignore stdout and stderr in output plugins
-        if "printed" in event:
-            return
-
-        # Ignore anything without eventid
-        if "eventid" not in event:
-            return
-
-        # Ignore anything without session information
-        if (
-            "sessionno" not in event
-            and "session" not in event
-            and "system" not in event
-        ):
-            return
-
-        # Ignore anything without message
-        if "message" not in event and "format" not in event:
-            return
-
-        ev: dict[str, any] = convert(event)  # type: ignore
-        ev["sensor"] = self.sensor
-        ev["uuid"] = self.uuid
-
-        ev.pop("isError", None)
-
-        # Add ISO timestamp and sensor data
-        if "time" not in ev:
-            ev["time"] = time.time()
-        ev["timestamp"] = formatTime(ev["time"], timeFormat=self.timeFormat)
-
-        if "format" in ev and ("message" not in ev or ev["message"] == ()):
-            try:
-                ev["message"] = ev["format"] % ev  # type: ignore
-                del ev["format"]
-            except Exception:
-                pass
-
-        # Explicit sessionno (from logDispatch) overrides from 'system'
-        if "sessionno" in ev:
-            sessionno = ev["sessionno"]
-            del ev["sessionno"]
-        # Maybe it's passed explicitly
-        elif "session" in ev:
-            # reverse engineer sessionno
-            try:
-                sessionno = next(
-                    key
-                    for key, value in self.sessions.items()
-                    if value == ev["session"]
-                )
-            except StopIteration:
-                return
-        # Extract session id from the twisted log prefix
-        elif "system" in ev:
-            sessionno = "0"
-            telnetmatch = self.telnetRegex.match(ev["system"])
-            if telnetmatch:
-                sessionno = f"T{telnetmatch.groups()[0]}"
-            else:
-                sshmatch = self.sshRegex.match(ev["system"])
-                if sshmatch:
-                    sessionno = f"S{sshmatch.groups()[0]}"
-            if sessionno == "0":
-                return
-        else:
-            print(f"Can't determine sessionno: {ev!r}")  # noqa: T201
-            return
-
-        if sessionno in self.ips:
-            ev["src_ip"] = self.ips[sessionno]
-
-        # Connection event is special. adds to session list
-        if ev["eventid"] == "cowrie.session.connect":
-            self.sessions[sessionno] = ev["session"]
-            self.ips[sessionno] = ev["src_ip"]
-        else:
-            ev["session"] = self.sessions[sessionno]
-
-        if sessionno[0] == "S":
-            ev["protocol"] = "ssh"
-        elif sessionno[0] == "T":
-            ev["protocol"] = "telnet"
-        else:
-            ev["protocol"] = "unknown"
-
-        self.write(ev)
-
-        # Disconnect is special, remove cached data
-        if ev["eventid"] == "cowrie.session.closed":
-            del self.sessions[sessionno]
-            del self.ips[sessionno]

--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -266,5 +266,5 @@ class LoggingTelnetServerProtocol(LoggingServerProtocol):
         return (transportId, sn)
 
     def getEventLog(self) -> EventLog:
-        events: EventLog = self.transport.session.events
+        events: EventLog = self.transport.session.transport.events
         return events

--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import hashlib
 import os
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from twisted.conch.insults import insults
 from twisted.internet.protocol import connectionDone
@@ -17,6 +17,9 @@ from twisted.python import failure, log
 from cowrie.core import ttylog
 from cowrie.core.config import CowrieConfig
 from cowrie.shell import protocol
+
+if TYPE_CHECKING:
+    from cowrie.core.events import EventLog
 
 
 class LoggingServerProtocol(insults.ServerProtocol):
@@ -58,8 +61,15 @@ class LoggingServerProtocol(insults.ServerProtocol):
         channelId = self.transport.session.id
         return (transportId, channelId)
 
+    def getEventLog(self) -> EventLog:
+        events: EventLog = self.transport.session.conn.transport.events
+        return events
+
     def connectionMade(self) -> None:
         transportId, channelId = self.getSessionId()
+        # The session's event emitter, owned by the transport. Kept across
+        # connectionLost so the artifacts finalized there arrive attributed.
+        self.events = self.getEventLog()
         self.startTime = time.time()
 
         if self.ttylogEnabled:
@@ -165,9 +175,9 @@ class LoggingServerProtocol(insults.ServerProtocol):
                         os.rename(self.stdinlogFile, shasumfile)
                         duplicate = False
 
-                    log.msg(
-                        eventid="cowrie.session.file_download",
-                        format="Saved stdin contents with SHA-256 %(shasum)s to %(outfile)s",
+                    self.events.dispatch(
+                        "cowrie.session.file_download",
+                        "Saved stdin contents with SHA-256 %(shasum)s to %(outfile)s",
                         duplicate=duplicate,
                         outfile=shasumfile,
                         shasum=shasum,
@@ -204,9 +214,9 @@ class LoggingServerProtocol(insults.ServerProtocol):
                     else:
                         os.rename(rf, shasumfile)
                         duplicate = False
-                    log.msg(
-                        eventid="cowrie.session.file_download",
-                        format="Saved redir contents with SHA-256 %(shasum)s to %(outfile)s",
+                    self.events.dispatch(
+                        "cowrie.session.file_download",
+                        "Saved redir contents with SHA-256 %(shasum)s to %(outfile)s",
                         duplicate=duplicate,
                         outfile=shasumfile,
                         shasum=shasum,
@@ -232,9 +242,9 @@ class LoggingServerProtocol(insults.ServerProtocol):
                 os.umask(umask)
                 os.chmod(shasumfile, 0o666 & ~umask)
 
-            log.msg(
-                eventid="cowrie.log.closed",
-                format="Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
+            self.events.dispatch(
+                "cowrie.log.closed",
+                "Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
                 ttylog=shasumfile,
                 size=self.ttylogSize,
                 shasum=shasum,
@@ -254,3 +264,7 @@ class LoggingTelnetServerProtocol(LoggingServerProtocol):
         transportId = self.transport.session.transportId
         sn = self.transport.session.transport.transport.sessionno
         return (transportId, sn)
+
+    def getEventLog(self) -> EventLog:
+        events: EventLog = self.transport.session.events
+        return events

--- a/src/cowrie/llm/protocol.py
+++ b/src/cowrie/llm/protocol.py
@@ -60,13 +60,6 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         """
         return self.terminal.transport.session.conn.transport
 
-    def logDispatch(self, **args):
-        """
-        Send log directly to factory, avoiding normal log dispatch
-        """
-        args["sessionno"] = self.sessionno
-        self.factory.logDispatch(**args)
-
     def connectionMade(self) -> None:
         pt = self.getProtoTransport()
 

--- a/src/cowrie/llm/protocol.py
+++ b/src/cowrie/llm/protocol.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import re
 import socket
 import time
+from typing import TYPE_CHECKING
 
 from twisted.conch import recvline
 from twisted.conch.insults import insults
@@ -17,6 +18,9 @@ from twisted.python import failure, log
 
 from cowrie.core.config import CowrieConfig
 from cowrie.llm.llm import LLMClient
+
+if TYPE_CHECKING:
+    from cowrie.core.events import EventLog
 
 
 def strip_markdown(text: str) -> str:
@@ -34,6 +38,9 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
     """
     Base protocol for interactive and non-interactive use
     """
+
+    # The session's event emitter, set from the transport in connectionMade.
+    events: EventLog
 
     def __init__(self, avatar):
         self.user = avatar
@@ -64,6 +71,10 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         pt = self.getProtoTransport()
 
         self.factory = pt.factory
+        # The session's event emitter, owned by the transport. Kept across
+        # connectionLost so work that outlives the session can still emit an
+        # attributed, late-flagged event.
+        self.events = pt.events
         self.sessionno = pt.transport.sessionno
         self.realClientIP = pt.transport.getPeer().host
         self.realClientPort = pt.transport.getPeer().port
@@ -94,7 +105,9 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         else:
             try:
                 with socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) as s:
-                    s.connect(("2001:4860:4860::8888", 80))  # NOSONAR - probe target to detect host GUA, not a secret
+                    s.connect(
+                        ("2001:4860:4860::8888", 80)
+                    )  # NOSONAR - probe target to detect host GUA, not a secret
                     addr = s.getsockname()[0]
                     # Only use GUA, not link-local
                     self.kippoIPv6 = addr if not addr.lower().startswith("fe80") else ""
@@ -129,7 +142,7 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         """
         string = line.decode("utf8")
 
-        log.msg(eventid="cowrie.command.input", input=string, format="CMD: %(input)s")
+        self.events.dispatch("cowrie.command.input", "CMD: %(input)s", input=string)
 
         # Use LLM client to get a response
         self._process_command_with_llm(string)

--- a/src/cowrie/llm/session.py
+++ b/src/cowrie/llm/session.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from twisted.conch.interfaces import ISession
 from twisted.conch.ssh import session
-from twisted.python import log
 from zope.interface import implementer
 
 from cowrie.insults import insults
@@ -38,11 +37,11 @@ class SSHSessionForCowrieUser:
 
     def getPty(self, terminal, windowSize, attrs):
         self.environ["TERM"] = terminal.decode("utf-8")
-        log.msg(
-            eventid="cowrie.client.size",
+        self.avatar.conn.transport.events.dispatch(
+            "cowrie.client.size",
+            "Terminal Size: %(width)s %(height)s",
             width=windowSize[1],
             height=windowSize[0],
-            format="Terminal Size: %(width)s %(height)s",
         )
         self.windowSize = windowSize
 

--- a/src/cowrie/output/abuseipdb.py
+++ b/src/cowrie/output/abuseipdb.py
@@ -25,7 +25,6 @@ from time import sleep, time
 
 from treq import post
 from twisted.internet import defer, reactor, threads
-from twisted.python import log
 from twisted.web import http
 
 from cowrie.core import output
@@ -50,10 +49,10 @@ class Output(output.Output):
         self.state_path = Path(CowrieConfig.get("output_abuseipdb", "dump_path"))
         self.state_dump = self.state_path / DUMP_FILE
 
-        self.logbook = LogBook(self.tolerance_attempts, self.state_dump)
+        self.logbook = LogBook(self.tolerance_attempts, self.state_dump, self.dispatch)
         # Pass our instance of LogBook() to Reporter() so we don't end up
         # working with different records.
-        self.reporter = Reporter(self.logbook, self.tolerance_attempts)
+        self.reporter = Reporter(self.logbook, self.tolerance_attempts, self.dispatch)
 
         # We store the LogBook state any time a shutdown occurs. The rest of
         # our start-up is just for loading and cleaning the previous state.
@@ -108,7 +107,7 @@ class Output(output.Output):
         except UnboundLocalError:
             pass
 
-        log.msg(
+        self.dispatch(
             eventid="cowrie.abuseipdb.started",
             format=f"AbuseIPDB Plugin version {__version__} started. Currently in beta.",
         )
@@ -179,7 +178,8 @@ class LogBook(dict):
     Reporter(). Sharing is caring.
     """
 
-    def __init__(self, tolerance_attempts, state_dump):
+    def __init__(self, tolerance_attempts, state_dump, dispatch):
+        self.dispatch = dispatch
         self.sleeping = False
         self.sleep_until: float = 0.0
         self.tolerance_attempts = tolerance_attempts
@@ -203,7 +203,7 @@ class LogBook(dict):
         self.sleeping = False
         self.sleep_until = 0
         self.recall = reactor.callLater(CLEAN_DUMP_SCHED, self.cleanup_and_dump_state)
-        log.msg(
+        self.dispatch(
             eventid="cowrie.abuseipdb.wakeup",
             format="AbuseIPDB plugin resuming activity after receiving "
             "Retry-After header in previous response.",
@@ -323,9 +323,10 @@ class Reporter:
     HTTP client and methods for preparing report paramaters.
     """
 
-    def __init__(self, logbook, attempts):
+    def __init__(self, logbook, attempts, dispatch):
         self.logbook = logbook
         self.attempts = attempts
+        self.dispatch = dispatch
         self.headers = {
             "User-Agent": "Cowrie Honeypot AbuseIPDB plugin",
             "Accept": "application/json",
@@ -368,9 +369,8 @@ class Reporter:
         t_utc = datetime.fromtimestamp(t, timezone.utc)
         return t_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    @staticmethod
-    def log_response_failed(ip, response, reason):
-        log.msg(
+    def log_response_failed(self, ip, response, reason):
+        self.dispatch(
             eventid="cowrie.abuseipdb.reportfail",
             format="AbuseIPDB plugin failed to report IP %(IP)s. Received HTTP "
             "status code %(response)s in response. Reason: %(reason)s.",
@@ -390,7 +390,7 @@ class Reporter:
             )
 
         except Exception as e:
-            log.msg(
+            self.dispatch(
                 eventid="cowrie.abuseipdb.reportfail",
                 format="AbuseIPDB plugin failed to report IP %(IP)s. "
                 "Exception raised: %(exception)s.",
@@ -414,7 +414,7 @@ class Reporter:
 
         j = yield response.json()
 
-        log.msg(
+        self.dispatch(
             eventid="cowrie.abuseipdb.reportedip",
             format="AbuseIPDB plugin successfully reported %(IP)s. Current "
             "AbuseIPDB confidence score for this IP is %(confidence)s",
@@ -445,7 +445,7 @@ class Reporter:
             if retry > 86340:
                 yield threads.deferToThread(self.sleeper_thread)
 
-                log.msg(
+                self.dispatch(
                     eventid="cowrie.abuseipdb.ratelimited",
                     format="AbuseIPDB plugin received Retry-After header > 86340 "
                     "seconds in previous response. Possible delayed quota "
@@ -466,7 +466,7 @@ class Reporter:
             self.logbook.cleanup_and_dump_state(mode=1)
 
             self.epoch_to_string_utc(self.logbook.sleep_until)
-            log.msg(
+            self.dispatch(
                 eventid="cowrie.abuseipdb.ratelimited",
                 format="AbuseIPDB plugin received Retry-After header in "
                 "response. Reporting activity will resume in "

--- a/src/cowrie/output/greynoise.py
+++ b/src/cowrie/output/greynoise.py
@@ -52,16 +52,20 @@ class Output(cowrie.core.output.Output):
 
         def message(query):
             if query["noise"]:
-                log.msg(
+                self.dispatch(
                     eventid="cowrie.greynoise.result",
                     session=event["session"],
+                    src_ip=event["src_ip"],
+                    protocol=event["protocol"],
                     format=f"GreyNoise: {query['ip']} has been observed scanning the Internet. GreyNoise "
                     f"classification is {query['classification']} and the believed owner is {query['name']}",
                 )
             if query["riot"]:
-                log.msg(
+                self.dispatch(
                     eventid="cowrie.greynoise.result",
                     session=event["session"],
+                    src_ip=event["src_ip"],
+                    protocol=event["protocol"],
                     format=f"GreyNoise: {query['ip']} belongs to a benign service or provider. "
                     f"The owner is {query['name']}.",
                 )

--- a/src/cowrie/output/reversedns.py
+++ b/src/cowrie/output/reversedns.py
@@ -52,9 +52,10 @@ class Output(cowrie.core.output.Output):
                 return
 
             payload = result[0][0].payload
-            log.msg(
+            self.dispatch(
                 eventid="cowrie.reversedns.connect",
                 session=event["session"],
+                protocol=event["protocol"],
                 format="reversedns: PTR record for IP %(src_ip)s is %(ptr)s"
                 " ttl=%(ttl)i",
                 src_ip=event["src_ip"],
@@ -69,9 +70,11 @@ class Output(cowrie.core.output.Output):
             if result is None:
                 return
             payload = result[0][0].payload
-            log.msg(
+            self.dispatch(
                 eventid="cowrie.reversedns.forward",
                 session=event["session"],
+                src_ip=event["src_ip"],
+                protocol=event["protocol"],
                 format="reversedns: PTR record for IP %(dst_ip)s is %(ptr)s"
                 " ttl=%(ttl)i",
                 dst_ip=event["dst_ip"],

--- a/src/cowrie/output/virustotal.py
+++ b/src/cowrie/output/virustotal.py
@@ -236,10 +236,12 @@ class Output(cowrie.core.output.Output):
             if "error" in j:
                 if j["error"]["code"] == "NotFoundError":
                     log.msg("VT: New file - not found in database")
-                    log.msg(
+                    self.dispatch(
                         eventid="cowrie.virustotal.scanfile",
                         format="VT: New file %(sha256)s",
                         session=event["session"],
+                        src_ip=event["src_ip"],
+                        protocol=event["protocol"],
                         sha256=event["shasum"],
                         is_new="true",
                     )
@@ -276,11 +278,13 @@ class Output(cowrie.core.output.Output):
                 total_count = sum(stats.values())
                 scan_date = attributes.get("last_analysis_date", "unknown")
 
-                log.msg(
+                self.dispatch(
                     eventid="cowrie.virustotal.scanfile",
                     format="VT: Binary file with sha256 %(sha256)s was found malicious "
                     "by %(positives)s out of %(total)s feeds (scanned on %(scan_date)s)",
                     session=event["session"],
+                    src_ip=event["src_ip"],
+                    protocol=event["protocol"],
                     positives=malicious_count,
                     total=total_count,
                     scan_date=scan_date,
@@ -393,10 +397,12 @@ class Output(cowrie.core.output.Output):
             if "error" in j:
                 if j["error"]["code"] == "NotFoundError":
                     log.msg("VT: New URL - not found in database")
-                    log.msg(
+                    self.dispatch(
                         eventid="cowrie.virustotal.scanurl",
                         format="VT: New URL %(url)s",
                         session=event["session"],
+                        src_ip=event["src_ip"],
+                        protocol=event["protocol"],
                         url=event["url"],
                         is_new="true",
                     )
@@ -428,11 +434,13 @@ class Output(cowrie.core.output.Output):
                 total_count = sum(stats.values())
                 scan_date = attributes.get("last_analysis_date", "unknown")
 
-                log.msg(
+                self.dispatch(
                     eventid="cowrie.virustotal.scanurl",
                     format="VT: URL %(url)s was found malicious by "
                     "%(positives)s out of %(total)s feeds (scanned on %(scan_date)s)",
                     session=event["session"],
+                    src_ip=event["src_ip"],
+                    protocol=event["protocol"],
                     positives=malicious_count,
                     total=total_count,
                     scan_date=scan_date,
@@ -454,9 +462,9 @@ class Output(cowrie.core.output.Output):
         if d:
             # Log success message on successful response
             d.addCallback(
-                lambda _: log.msg("VT scanurl successful: 200 OK")
-                if _ is not None
-                else None
+                lambda _: (
+                    log.msg("VT scanurl successful: 200 OK") if _ is not None else None
+                )
             )
         return d
 
@@ -581,9 +589,8 @@ class Output(cowrie.core.output.Output):
             if "error" not in j:
                 for item in j.get("data", []):
                     attributes = item.get("attributes", {})
-                    if (
-                        attributes.get("name") == self.collection_name
-                        and item.get("id")
+                    if attributes.get("name") == self.collection_name and item.get(
+                        "id"
                     ):
                         self.collection_id = item["id"]
                         log.msg(

--- a/src/cowrie/shell/filetransfer.py
+++ b/src/cowrie/shell/filetransfer.py
@@ -184,6 +184,8 @@ class SFTPServerForCowrieUser:
         self.avatar = avatar
         self.avatar.server.initFileSystem(self.avatar.home)
         self.fs = self.avatar.server.fs
+        # Bind the session's event emitter so SFTP uploads are attributed.
+        self.fs.events = self.avatar.conn.transport.events
 
     def _absPath(self, path):
         home = self.avatar.home

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -16,13 +16,16 @@ import stat
 import sys
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from twisted.python import log
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.resources import read_data_bytes
 from cowrie.shell import honeyfs
+
+if TYPE_CHECKING:
+    from cowrie.core.events import EventLog
 
 (
     A_NAME,
@@ -106,6 +109,10 @@ class PermissionDenied(Exception):
 
 
 class HoneyPotFilesystem:
+    # The session's event emitter, bound by the SFTP adapter; file writes
+    # reaching close() only arrive through SFTP.
+    events: EventLog
+
     def __init__(self, arch: str, home: str) -> None:
         try:
             self.fs: list[Any] = honeyfs.get_tree()
@@ -498,9 +505,9 @@ class HoneyPotFilesystem:
             else:
                 os.rename(self.tempfiles[fd], shasumfile)
             self.update_realfile(self.getfile(self.filenames[fd]), shasumfile)
-            log.msg(
-                format='SFTP Uploaded file "%(filename)s" to %(outfile)s',
-                eventid="cowrie.session.file_upload",
+            self.events.dispatch(
+                "cowrie.session.file_upload",
+                'SFTP Uploaded file "%(filename)s" to %(outfile)s',
                 filename=os.path.basename(self.filenames[fd]),
                 outfile=shasumfile,
                 shasum=shasum,

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -173,7 +173,9 @@ class HoneyPotShell:
 
     def lineReceived(self, line: str) -> None:
         """Parse a command line with the Lark grammar and run the result."""
-        log.msg(eventid="cowrie.command.input", input=line, format="CMD: %(input)s")
+        self.protocol.events.dispatch(
+            "cowrie.command.input", "CMD: %(input)s", input=line
+        )
         self._queue_statements(self.bashparser.parse(line))
         self._advance()
 
@@ -681,10 +683,10 @@ class HoneyPotShell:
                     )
                     lastpp = pp
             else:
-                log.msg(
-                    eventid="cowrie.command.failed",
+                self.protocol.events.dispatch(
+                    "cowrie.command.failed",
+                    "Command not found: %(input)s",
                     input=cmd["command"] + " " + " ".join(cmd["rargs"]),
-                    format="Command not found: %(input)s",
                 )
                 message = self.command_not_found_message(cmd["command"]).encode("utf8")
                 redirects = cmd.get("redirects", [])

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -34,7 +34,7 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
     """
 
     # The session's event emitter, set from the transport in connectionMade.
-    events: EventLog | None = None
+    events: EventLog
 
     commands: ClassVar[dict] = {}
     for c in cowrie.commands.command_modules:
@@ -92,13 +92,13 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         # connectionLost so a command's deferred callback that outlives the
         # session (a download completing after disconnect) can still emit an
         # attributed, late-flagged event.
-        self.events = getattr(pt, "events", None)
+        self.events = pt.events
         self.sessionno = pt.transport.sessionno
         self.realClientIP = pt.transport.getPeer().host
         self.realClientPort = pt.transport.getPeer().port
         self.logintime = time.time()
 
-        log.msg(eventid="cowrie.session.params", arch=self.user.server.arch)
+        self.events.dispatch("cowrie.session.params", "", arch=self.user.server.arch)
 
         idle_timeout = CowrieConfig.getint("honeypot", "idle_timeout", fallback=180)
         self.setTimeout(idle_timeout)

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -84,13 +84,6 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         """
         return self.terminal.transport.session.conn.transport
 
-    def logDispatch(self, **args):
-        """
-        Send log directly to factory, avoiding normal log dispatch
-        """
-        args["sessionno"] = self.sessionno
-        self.factory.logDispatch(**args)
-
     def connectionMade(self) -> None:
         pt = self.getProtoTransport()
 

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -11,7 +11,7 @@ import time
 import traceback
 from importlib import import_module
 from pathlib import Path
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from twisted.conch import recvline
 from twisted.conch.insults import insults
@@ -24,11 +24,17 @@ from cowrie.core.config import CowrieConfig
 from cowrie.core.resources import read_data_bytes
 from cowrie.shell import command, honeypot
 
+if TYPE_CHECKING:
+    from cowrie.core.events import EventLog
+
 
 class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
     """
     Base protocol for interactive and non-interactive use
     """
+
+    # The session's event emitter, set from the transport in connectionMade.
+    events: EventLog | None = None
 
     commands: ClassVar[dict] = {}
     for c in cowrie.commands.command_modules:
@@ -89,6 +95,11 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         pt = self.getProtoTransport()
 
         self.factory = pt.factory
+        # The session's event emitter, owned by the transport. Kept across
+        # connectionLost so a command's deferred callback that outlives the
+        # session (a download completing after disconnect) can still emit an
+        # attributed, late-flagged event.
+        self.events = getattr(pt, "events", None)
         self.sessionno = pt.transport.sessionno
         self.realClientIP = pt.transport.getPeer().host
         self.realClientPort = pt.transport.getPeer().port

--- a/src/cowrie/shell/session.py
+++ b/src/cowrie/shell/session.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from twisted.conch.interfaces import ISession
 from twisted.internet.protocol import connectionDone
-from twisted.python import log
 from zope.interface import implementer
 
 from cowrie.insults import insults
@@ -91,11 +90,11 @@ class SSHSessionForCowrieUser:
 
     def getPty(self, terminal, windowSize, attrs):
         self.environ["TERM"] = terminal.decode("utf-8")
-        log.msg(
-            eventid="cowrie.client.size",
+        self.avatar.conn.transport.events.dispatch(
+            "cowrie.client.size",
+            "Terminal Size: %(width)s %(height)s",
             width=windowSize[1],
             height=windowSize[0],
-            format="Terminal Size: %(width)s %(height)s",
         )
         self.windowSize = windowSize
 

--- a/src/cowrie/ssh/channel.py
+++ b/src/cowrie/ssh/channel.py
@@ -25,6 +25,12 @@ if TYPE_CHECKING:
 class CowrieSSHChannel(channel.SSHChannel):
     """
     This is an SSH channel with built-in logging
+
+    Not wired into the SSH service: the session channel is
+    HoneyPotSSHSession and the forwarding channels subclass conch's
+    forwarding channel, so no production code instantiates this class;
+    only tests do. Its ttylog duplicates what
+    insults.LoggingServerProtocol records.
     """
 
     ttylogFile: str = ""

--- a/src/cowrie/ssh/channel.py
+++ b/src/cowrie/ssh/channel.py
@@ -10,12 +10,16 @@ and session size limiting
 from __future__ import annotations
 
 import time
+from typing import TYPE_CHECKING
 
 from twisted.conch.ssh import channel
 from twisted.python import log
 
 from cowrie.core import ttylog
 from cowrie.core.config import CowrieConfig
+
+if TYPE_CHECKING:
+    from cowrie.core.events import EventLog
 
 
 class CowrieSSHChannel(channel.SSHChannel):
@@ -26,6 +30,8 @@ class CowrieSSHChannel(channel.SSHChannel):
     ttylogFile: str = ""
     bytesReceived: int = 0
     bytesWritten: int = 0
+    # The session's event emitter, bound from the transport in channelOpen.
+    events: EventLog
     name: bytes = b"cowrie-ssh-channel"
     startTime: float = 0.0
     ttylogPath: str = CowrieConfig.get("honeypot", "log_path", fallback=".")
@@ -52,24 +58,25 @@ class CowrieSSHChannel(channel.SSHChannel):
 
     def channelOpen(self, specificData: bytes) -> None:
         self.startTime = time.time()
+        self.events = self.conn.transport.events
         self.ttylogFile = "{}/tty/{}-{}-{}.log".format(
             self.ttylogPath,
             time.strftime("%Y%m%d-%H%M%S"),
             self.conn.transport.transportId,
             self.id,
         )
-        log.msg(
-            eventid="cowrie.log.open",
+        self.events.dispatch(
+            "cowrie.log.open",
+            "Opening TTY Log: %(ttylog)s",
             ttylog=self.ttylogFile,
-            format="Opening TTY Log: %(ttylog)s",
         )
         ttylog.ttylog_open(self.ttylogFile, time.time())
         channel.SSHChannel.channelOpen(self, specificData)
 
     def closed(self) -> None:
-        log.msg(
-            eventid="cowrie.log.closed",
-            format="Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
+        self.events.dispatch(
+            "cowrie.log.closed",
+            "Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
             ttylog=self.ttylogFile,
             size=self.bytesReceived + self.bytesWritten,
             duration_ms=round((time.time() - self.startTime) * 1000),

--- a/src/cowrie/ssh/factory.py
+++ b/src/cowrie/ssh/factory.py
@@ -59,7 +59,6 @@ class CowrieSSHFactory(factory.SSHFactory):
         }
         super().__init__()
 
-
     def startFactory(self) -> None:
         # For use by the uptime command
         self.starttime = time.time()

--- a/src/cowrie/ssh/factory.py
+++ b/src/cowrie/ssh/factory.py
@@ -59,13 +59,6 @@ class CowrieSSHFactory(factory.SSHFactory):
         }
         super().__init__()
 
-    def logDispatch(self, **args):
-        """
-        Special delivery to the loggers to avoid scope problems
-        """
-        args["sessionno"] = "S{}".format(args["sessionno"])
-        for output in self.tac.output_plugins:
-            output.logDispatch(**args)
 
     def startFactory(self) -> None:
         # For use by the uptime command

--- a/src/cowrie/ssh/forwarding.py
+++ b/src/cowrie/ssh/forwarding.py
@@ -28,14 +28,15 @@ def cowrieOpenConnectForwardingClient(remoteWindow, remoteMaxPacket, data, avata
     remoteHP, origHP = forwarding.unpackOpen_direct_tcpip(data)
     events = avatar.conn.transport.events
 
-    events.dispatch(
-        "cowrie.direct-tcpip.request",
-        "direct-tcp connection request to %(dst_ip)s:%(dst_port)s from %(src_ip)s:%(src_port)s",
-        dst_ip=remoteHP[0],
-        dst_port=remoteHP[1],
-        src_ip=origHP[0],
-        src_port=origHP[1],
-    )
+    if events:
+        events.dispatch(
+            "cowrie.direct-tcpip.request",
+            "direct-tcp connection request to %(dst_ip)s:%(dst_port)s from %(orig_ip)s:%(orig_port)s",
+            dst_ip=remoteHP[0],
+            dst_port=remoteHP[1],
+            orig_ip=origHP[0],
+            orig_port=origHP[1],
+        )
 
     # Forward redirect
     redirectEnabled: bool = CowrieConfig.getboolean(
@@ -51,17 +52,18 @@ def cowrieOpenConnectForwardingClient(remoteWindow, remoteMaxPacket, data, avata
                 redirects[int(destPort)] = (redirectHP[0], int(redirectHP[1]))
         if remoteHP[1] in redirects:
             remoteHPNew = redirects[remoteHP[1]]
-            events.dispatch(
-                "cowrie.direct-tcpip.redirect",
-                "redirected direct-tcp connection request from %(src_ip)s:%(src_port)"
-                + "d to %(dst_ip)s:%(dst_port)d to %(new_ip)s:%(new_port)d",
-                new_ip=remoteHPNew[0],
-                new_port=remoteHPNew[1],
-                dst_ip=remoteHP[0],
-                dst_port=remoteHP[1],
-                src_ip=origHP[0],
-                src_port=origHP[1],
-            )
+            if events:
+                events.dispatch(
+                    "cowrie.direct-tcpip.redirect",
+                    "redirected direct-tcp connection request from %(orig_ip)s:%(orig_port)"
+                    + "d to %(dst_ip)s:%(dst_port)d to %(new_ip)s:%(new_port)d",
+                    new_ip=remoteHPNew[0],
+                    new_port=remoteHPNew[1],
+                    dst_ip=remoteHP[0],
+                    dst_port=remoteHP[1],
+                    orig_ip=origHP[0],
+                    orig_port=origHP[1],
+                )
             return SSHConnectForwardingChannel(
                 remoteHPNew, remoteWindow=remoteWindow, remoteMaxPacket=remoteMaxPacket
             )
@@ -80,17 +82,18 @@ def cowrieOpenConnectForwardingClient(remoteWindow, remoteMaxPacket, data, avata
                 tunnels[int(destPort)] = (tunnelHP[0], int(tunnelHP[1]))
         if remoteHP[1] in tunnels:
             remoteHPNew = tunnels[remoteHP[1]]
-            events.dispatch(
-                "cowrie.direct-tcpip.tunnel",
-                "tunneled direct-tcp connection request %(src_ip)s:%(src_port)"
-                + "d->%(dst_ip)s:%(dst_port)d to %(new_ip)s:%(new_port)d",
-                new_ip=remoteHPNew[0],
-                new_port=remoteHPNew[1],
-                dst_ip=remoteHP[0],
-                dst_port=remoteHP[1],
-                src_ip=origHP[0],
-                src_port=origHP[1],
-            )
+            if events:
+                events.dispatch(
+                    "cowrie.direct-tcpip.tunnel",
+                    "tunneled direct-tcp connection request %(orig_ip)s:%(orig_port)"
+                    + "d->%(dst_ip)s:%(dst_port)d to %(new_ip)s:%(new_port)d",
+                    new_ip=remoteHPNew[0],
+                    new_port=remoteHPNew[1],
+                    dst_ip=remoteHP[0],
+                    dst_port=remoteHP[1],
+                    orig_ip=origHP[0],
+                    orig_port=origHP[1],
+                )
             return TCPTunnelForwardingChannel(
                 remoteHPNew,
                 remoteHP,
@@ -125,6 +128,7 @@ class FakeForwardingChannel(forwarding.SSHConnectForwardingChannel):
         pass
 
     def dataReceived(self, data: bytes) -> None:
+        events = self.conn.transport.events
         # Try to fingerprint the forwarded traffic
 
         # Check for TLS Client Hello (0x16 = Handshake, 0x01 = Client Hello)
@@ -140,13 +144,14 @@ class FakeForwardingChannel(forwarding.SSHConnectForwardingChannel):
                         alpn=tls_info["alpn"],
                         signature_algorithms=tls_info["signature_algorithms"],
                     )
-                    self.conn.transport.events.dispatch(
-                        "cowrie.direct-tcpip.ja4",
-                        "JA4 fingerprint for forwarded TLS to %(dst_ip)s:%(dst_port)s: %(ja4)s",
-                        dst_ip=self.hostport[0],
-                        dst_port=self.hostport[1],
-                        ja4=ja4,
-                    )
+                    if events:
+                        events.dispatch(
+                            "cowrie.direct-tcpip.ja4",
+                            "JA4 fingerprint for forwarded TLS to %(dst_ip)s:%(dst_port)s: %(ja4)s",
+                            dst_ip=self.hostport[0],
+                            dst_port=self.hostport[1],
+                            ja4=ja4,
+                        )
                 except Exception as e:
                     log.msg(f"Error generating JA4 fingerprint: {e}")
 
@@ -167,24 +172,26 @@ class FakeForwardingChannel(forwarding.SSHConnectForwardingChannel):
                         referer=http_info["referer"],
                         accept_language=http_info["accept_language"],
                     )
-                    self.conn.transport.events.dispatch(
-                        "cowrie.direct-tcpip.ja4h",
-                        "JA4H fingerprint for forwarded HTTP to %(dst_ip)s:%(dst_port)s: %(ja4h)s",
-                        dst_ip=self.hostport[0],
-                        dst_port=self.hostport[1],
-                        ja4h=ja4h,
-                    )
+                    if events:
+                        events.dispatch(
+                            "cowrie.direct-tcpip.ja4h",
+                            "JA4H fingerprint for forwarded HTTP to %(dst_ip)s:%(dst_port)s: %(ja4h)s",
+                            dst_ip=self.hostport[0],
+                            dst_port=self.hostport[1],
+                            ja4h=ja4h,
+                        )
                 except Exception as e:
                     log.msg(f"Error generating JA4H fingerprint: {e}")
 
-        self.conn.transport.events.dispatch(
-            "cowrie.direct-tcpip.data",
-            "discarded direct-tcp forward request %(id)s to %(dst_ip)s:%(dst_port)s with data %(data)s",
-            dst_ip=self.hostport[0],
-            dst_port=self.hostport[1],
-            data=repr(data),
-            id=self.id,
-        )
+        if events:
+            events.dispatch(
+                "cowrie.direct-tcpip.data",
+                "discarded direct-tcp forward request %(id)s to %(dst_ip)s:%(dst_port)s with data %(data)s",
+                dst_ip=self.hostport[0],
+                dst_port=self.hostport[1],
+                data=repr(data),
+                id=self.id,
+            )
         self._close("Connection refused")
 
 
@@ -213,6 +220,7 @@ class TCPTunnelForwardingChannel(forwarding.SSHConnectForwardingChannel):
         forwarding.SSHConnectForwardingChannel.dataReceived(self, connect_hdr)
 
     def dataReceived(self, data: bytes) -> None:
+        events = self.conn.transport.events
         # Try to fingerprint the tunneled traffic
 
         # Check for TLS Client Hello
@@ -228,13 +236,14 @@ class TCPTunnelForwardingChannel(forwarding.SSHConnectForwardingChannel):
                         alpn=tls_info["alpn"],
                         signature_algorithms=tls_info["signature_algorithms"],
                     )
-                    self.conn.transport.events.dispatch(
-                        "cowrie.direct-tcpip.ja4",
-                        "JA4 fingerprint for tunneled TLS to %(dst_ip)s:%(dst_port)s: %(ja4)s",
-                        dst_ip=self.dstport[0],
-                        dst_port=self.dstport[1],
-                        ja4=ja4,
-                    )
+                    if events:
+                        events.dispatch(
+                            "cowrie.direct-tcpip.ja4",
+                            "JA4 fingerprint for tunneled TLS to %(dst_ip)s:%(dst_port)s: %(ja4)s",
+                            dst_ip=self.dstport[0],
+                            dst_port=self.dstport[1],
+                            ja4=ja4,
+                        )
                 except Exception as e:
                     log.msg(f"Error generating JA4 fingerprint in tunnel: {e}")
 
@@ -255,21 +264,23 @@ class TCPTunnelForwardingChannel(forwarding.SSHConnectForwardingChannel):
                         referer=http_info["referer"],
                         accept_language=http_info["accept_language"],
                     )
-                    self.conn.transport.events.dispatch(
-                        "cowrie.direct-tcpip.ja4h",
-                        "JA4H fingerprint for tunneled HTTP to %(dst_ip)s:%(dst_port)s: %(ja4h)s",
-                        dst_ip=self.dstport[0],
-                        dst_port=self.dstport[1],
-                        ja4h=ja4h,
-                    )
+                    if events:
+                        events.dispatch(
+                            "cowrie.direct-tcpip.ja4h",
+                            "JA4H fingerprint for tunneled HTTP to %(dst_ip)s:%(dst_port)s: %(ja4h)s",
+                            dst_ip=self.dstport[0],
+                            dst_port=self.dstport[1],
+                            ja4h=ja4h,
+                        )
                 except Exception as e:
                     log.msg(f"Error generating JA4H fingerprint in tunnel: {e}")
 
-        self.conn.transport.events.dispatch(
-            "cowrie.tunnelproxy-tcpip.data",
-            "sending via tunnel proxy %(data)s",
-            data=repr(data),
-        )
+        if events:
+            events.dispatch(
+                "cowrie.tunnelproxy-tcpip.data",
+                "sending via tunnel proxy %(data)s",
+                data=repr(data),
+            )
         forwarding.SSHConnectForwardingChannel.dataReceived(self, data)
 
     def write(self, data: bytes) -> None:

--- a/src/cowrie/ssh/forwarding.py
+++ b/src/cowrie/ssh/forwarding.py
@@ -26,10 +26,11 @@ def cowrieOpenConnectForwardingClient(remoteWindow, remoteMaxPacket, data, avata
     or will log the request and do nothing
     """
     remoteHP, origHP = forwarding.unpackOpen_direct_tcpip(data)
+    events = avatar.conn.transport.events
 
-    log.msg(
-        eventid="cowrie.direct-tcpip.request",
-        format="direct-tcp connection request to %(dst_ip)s:%(dst_port)s from %(src_ip)s:%(src_port)s",
+    events.dispatch(
+        "cowrie.direct-tcpip.request",
+        "direct-tcp connection request to %(dst_ip)s:%(dst_port)s from %(src_ip)s:%(src_port)s",
         dst_ip=remoteHP[0],
         dst_port=remoteHP[1],
         src_ip=origHP[0],
@@ -50,9 +51,9 @@ def cowrieOpenConnectForwardingClient(remoteWindow, remoteMaxPacket, data, avata
                 redirects[int(destPort)] = (redirectHP[0], int(redirectHP[1]))
         if remoteHP[1] in redirects:
             remoteHPNew = redirects[remoteHP[1]]
-            log.msg(
-                eventid="cowrie.direct-tcpip.redirect",
-                format="redirected direct-tcp connection request from %(src_ip)s:%(src_port)"
+            events.dispatch(
+                "cowrie.direct-tcpip.redirect",
+                "redirected direct-tcp connection request from %(src_ip)s:%(src_port)"
                 + "d to %(dst_ip)s:%(dst_port)d to %(new_ip)s:%(new_port)d",
                 new_ip=remoteHPNew[0],
                 new_port=remoteHPNew[1],
@@ -79,9 +80,9 @@ def cowrieOpenConnectForwardingClient(remoteWindow, remoteMaxPacket, data, avata
                 tunnels[int(destPort)] = (tunnelHP[0], int(tunnelHP[1]))
         if remoteHP[1] in tunnels:
             remoteHPNew = tunnels[remoteHP[1]]
-            log.msg(
-                eventid="cowrie.direct-tcpip.tunnel",
-                format="tunneled direct-tcp connection request %(src_ip)s:%(src_port)"
+            events.dispatch(
+                "cowrie.direct-tcpip.tunnel",
+                "tunneled direct-tcp connection request %(src_ip)s:%(src_port)"
                 + "d->%(dst_ip)s:%(dst_port)d to %(new_ip)s:%(new_port)d",
                 new_ip=remoteHPNew[0],
                 new_port=remoteHPNew[1],
@@ -137,20 +138,24 @@ class FakeForwardingChannel(forwarding.SSHConnectForwardingChannel):
                         extensions=tls_info["extensions"],
                         has_sni=tls_info["has_sni"],
                         alpn=tls_info["alpn"],
-                        signature_algorithms=tls_info["signature_algorithms"]
+                        signature_algorithms=tls_info["signature_algorithms"],
                     )
-                    log.msg(
-                        eventid="cowrie.direct-tcpip.ja4",
-                        format="JA4 fingerprint for forwarded TLS to %(dst_ip)s:%(dst_port)s: %(ja4)s",
+                    self.conn.transport.events.dispatch(
+                        "cowrie.direct-tcpip.ja4",
+                        "JA4 fingerprint for forwarded TLS to %(dst_ip)s:%(dst_port)s: %(ja4)s",
                         dst_ip=self.hostport[0],
                         dst_port=self.hostport[1],
-                        ja4=ja4
+                        ja4=ja4,
                     )
                 except Exception as e:
                     log.msg(f"Error generating JA4 fingerprint: {e}")
 
         # Check for HTTP request
-        elif data.startswith(b"GET ") or data.startswith(b"POST ") or data.startswith(b"HEAD "):
+        elif (
+            data.startswith(b"GET ")
+            or data.startswith(b"POST ")
+            or data.startswith(b"HEAD ")
+        ):
             http_info = parse_http_request(data)
             if http_info:
                 try:
@@ -160,21 +165,21 @@ class FakeForwardingChannel(forwarding.SSHConnectForwardingChannel):
                         headers=http_info["headers"],
                         cookies=http_info["cookies"],
                         referer=http_info["referer"],
-                        accept_language=http_info["accept_language"]
+                        accept_language=http_info["accept_language"],
                     )
-                    log.msg(
-                        eventid="cowrie.direct-tcpip.ja4h",
-                        format="JA4H fingerprint for forwarded HTTP to %(dst_ip)s:%(dst_port)s: %(ja4h)s",
+                    self.conn.transport.events.dispatch(
+                        "cowrie.direct-tcpip.ja4h",
+                        "JA4H fingerprint for forwarded HTTP to %(dst_ip)s:%(dst_port)s: %(ja4h)s",
                         dst_ip=self.hostport[0],
                         dst_port=self.hostport[1],
-                        ja4h=ja4h
+                        ja4h=ja4h,
                     )
                 except Exception as e:
                     log.msg(f"Error generating JA4H fingerprint: {e}")
 
-        log.msg(
-            eventid="cowrie.direct-tcpip.data",
-            format="discarded direct-tcp forward request %(id)s to %(dst_ip)s:%(dst_port)s with data %(data)s",
+        self.conn.transport.events.dispatch(
+            "cowrie.direct-tcpip.data",
+            "discarded direct-tcp forward request %(id)s to %(dst_ip)s:%(dst_port)s with data %(data)s",
             dst_ip=self.hostport[0],
             dst_port=self.hostport[1],
             data=repr(data),
@@ -221,20 +226,24 @@ class TCPTunnelForwardingChannel(forwarding.SSHConnectForwardingChannel):
                         extensions=tls_info["extensions"],
                         has_sni=tls_info["has_sni"],
                         alpn=tls_info["alpn"],
-                        signature_algorithms=tls_info["signature_algorithms"]
+                        signature_algorithms=tls_info["signature_algorithms"],
                     )
-                    log.msg(
-                        eventid="cowrie.direct-tcpip.ja4",
-                        format="JA4 fingerprint for tunneled TLS to %(dst_ip)s:%(dst_port)s: %(ja4)s",
+                    self.conn.transport.events.dispatch(
+                        "cowrie.direct-tcpip.ja4",
+                        "JA4 fingerprint for tunneled TLS to %(dst_ip)s:%(dst_port)s: %(ja4)s",
                         dst_ip=self.dstport[0],
                         dst_port=self.dstport[1],
-                        ja4=ja4
+                        ja4=ja4,
                     )
                 except Exception as e:
                     log.msg(f"Error generating JA4 fingerprint in tunnel: {e}")
 
         # Check for HTTP request
-        elif data.startswith(b"GET ") or data.startswith(b"POST ") or data.startswith(b"HEAD "):
+        elif (
+            data.startswith(b"GET ")
+            or data.startswith(b"POST ")
+            or data.startswith(b"HEAD ")
+        ):
             http_info = parse_http_request(data)
             if http_info:
                 try:
@@ -244,21 +253,21 @@ class TCPTunnelForwardingChannel(forwarding.SSHConnectForwardingChannel):
                         headers=http_info["headers"],
                         cookies=http_info["cookies"],
                         referer=http_info["referer"],
-                        accept_language=http_info["accept_language"]
+                        accept_language=http_info["accept_language"],
                     )
-                    log.msg(
-                        eventid="cowrie.direct-tcpip.ja4h",
-                        format="JA4H fingerprint for tunneled HTTP to %(dst_ip)s:%(dst_port)s: %(ja4h)s",
+                    self.conn.transport.events.dispatch(
+                        "cowrie.direct-tcpip.ja4h",
+                        "JA4H fingerprint for tunneled HTTP to %(dst_ip)s:%(dst_port)s: %(ja4h)s",
                         dst_ip=self.dstport[0],
                         dst_port=self.dstport[1],
-                        ja4h=ja4h
+                        ja4h=ja4h,
                     )
                 except Exception as e:
                     log.msg(f"Error generating JA4H fingerprint in tunnel: {e}")
 
-        log.msg(
-            eventid="cowrie.tunnelproxy-tcpip.data",
-            format="sending via tunnel proxy %(data)s",
+        self.conn.transport.events.dispatch(
+            "cowrie.tunnelproxy-tcpip.data",
+            "sending via tunnel proxy %(data)s",
             data=repr(data),
         )
         forwarding.SSHConnectForwardingChannel.dataReceived(self, data)

--- a/src/cowrie/ssh/session.py
+++ b/src/cowrie/ssh/session.py
@@ -32,9 +32,9 @@ class HoneyPotSSHSession(session.SSHSession):
             log.msg(f"Extra data in request_env: {rest!r}")
             return 1
 
-        log.msg(
-            eventid="cowrie.client.var",
-            format="request_env: %(name)s=%(value)s",
+        self.conn.transport.events.dispatch(
+            "cowrie.client.var",
+            "request_env: %(name)s=%(value)s",
             name=name.decode("utf-8"),
             value=value.decode("utf-8"),
         )

--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -141,11 +141,12 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             if b"\n" not in self.buf:
                 return
             self.otherVersionString: bytes = self.buf.split(b"\n")[0].strip()
-            log.msg(
-                eventid="cowrie.client.version",
-                version=escape_nonprintable(self.otherVersionString),
-                format="Remote SSH version: %(version)s",
-            )
+            if self.events:
+                self.events.dispatch(
+                    "cowrie.client.version",
+                    "Remote SSH version: %(version)s",
+                    version=escape_nonprintable(self.otherVersionString),
+                )
             m = re.match(rb"SSH-(\d+\.\d+)-(.*)", self.otherVersionString)
             if m is None:
                 log.msg(
@@ -180,13 +181,14 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             # without a SSH_MSG_DISCONNECT; match that (which also avoids a
             # cowrie-specific disconnect string), and record the probe -- these
             # malformed pre-auth packets are a common exploit/scanner signal.
-            log.msg(
-                eventid="cowrie.client.malformed_packet",
-                format="Malformed SSH packet (message %(messagenum)d, %(datalen)d bytes); disconnecting",
-                messagenum=messageNum,
-                datalen=len(payload),
-                data=payload[:256].hex(),
-            )
+            if self.events:
+                self.events.dispatch(
+                    "cowrie.client.malformed_packet",
+                    "Malformed SSH packet (message %(messagenum)d, %(datalen)d bytes); disconnecting",
+                    messagenum=messageNum,
+                    datalen=len(payload),
+                    data=payload[:256].hex(),
+                )
             self.transport.loseConnection()
 
     def sendPacket(self, messageType: int, payload: bytes) -> None:
@@ -244,18 +246,19 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         hasshAlgorithms = f"{ckexAlgs};{cencCS};{cmacCS};{ccompCS}"
         hassh = md5(hasshAlgorithms.encode("utf-8")).hexdigest()
 
-        log.msg(
-            eventid="cowrie.client.kex",
-            format="SSH client hassh fingerprint: %(hassh)s",
-            hassh=hassh,
-            hasshAlgorithms=hasshAlgorithms,
-            kexAlgs=kexAlgs,
-            keyAlgs=keyAlgs,
-            encCS=encCS,
-            macCS=macCS,
-            compCS=compCS,
-            langCS=langCS,
-        )
+        if self.events:
+            self.events.dispatch(
+                "cowrie.client.kex",
+                "SSH client hassh fingerprint: %(hassh)s",
+                hassh=hassh,
+                hasshAlgorithms=hasshAlgorithms,
+                kexAlgs=kexAlgs,
+                keyAlgs=keyAlgs,
+                encCS=encCS,
+                macCS=macCS,
+                compCS=compCS,
+                langCS=langCS,
+            )
 
         return transport.SSHServerTransport.ssh_KEXINIT(self, packet)
 

--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -81,17 +81,11 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             src_ip=src_ip,
         )
 
-        log.msg(
-            eventid="cowrie.session.connect",
-            format="New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: %(session)s]",
-            src_ip=src_ip,
-            src_port=self.transport.getPeer().port,
-            dst_ip=self.transport.getHost().host,
-            dst_port=self.transport.getHost().port,
-            session=self.transportId,
-            sessionno=f"S{self.transport.sessionno}",
-            protocol="ssh",
-        )
+        if self.events:
+            self.events.dispatch(
+                "cowrie.session.connect",
+                "New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: %(session)s]",
+            )
 
         self.transport.write(self.ourVersionString + b"\r\n")
         self.currentEncryptions = transport.SSHCiphers(
@@ -293,12 +287,12 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         self.transport.connectionLost(reason)
         self.transport = None
         duration_ms = round((time.time() - self.startTime) * 1000)
-        log.msg(
-            eventid="cowrie.session.closed",
-            format="Connection lost after %(duration_ms)d milliseconds",
-            duration_ms=duration_ms,
-        )
         if self.events is not None:
+            self.events.dispatch(
+                "cowrie.session.closed",
+                "Connection lost after %(duration_ms)d milliseconds",
+                duration_ms=duration_ms,
+            )
             self.events.close()
 
     def sendDisconnect(self, reason, desc):

--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -26,7 +26,7 @@ from twisted.protocols.policies import TimeoutMixin
 from twisted.python import failure, log, randbytes
 
 from cowrie.core.config import CowrieConfig
-from cowrie.core.events import EventLog
+from cowrie.core.events import EventLog, transport_events
 from cowrie.core.utils import escape_nonprintable
 
 
@@ -73,17 +73,13 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         if ipv4_search is not None:
             src_ip = ipv4_search.group(1)
 
-        dispatcher = getattr(getattr(self.factory, "tac", None), "dispatcher", None)
-        if dispatcher is not None:
-            self.events = EventLog(
-                dispatcher,
-                session=self.transportId,
-                protocol="ssh",
-                src_ip=src_ip,
-                src_port=self.transport.getPeer().port,
-                dst_ip=self.transport.getHost().host,
-                dst_port=self.transport.getHost().port,
-            )
+        self.events = transport_events(
+            self.factory,
+            self.transport,
+            session=self.transportId,
+            protocol="ssh",
+            src_ip=src_ip,
+        )
 
         log.msg(
             eventid="cowrie.session.connect",

--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -81,12 +81,6 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             src_ip=src_ip,
         )
 
-        if self.events:
-            self.events.dispatch(
-                "cowrie.session.connect",
-                "New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: %(session)s]",
-            )
-
         self.transport.write(self.ourVersionString + b"\r\n")
         self.currentEncryptions = transport.SSHCiphers(
             b"none", b"none", b"none", b"none"
@@ -288,12 +282,7 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         self.transport = None
         duration_ms = round((time.time() - self.startTime) * 1000)
         if self.events is not None:
-            self.events.dispatch(
-                "cowrie.session.closed",
-                "Connection lost after %(duration_ms)d milliseconds",
-                duration_ms=duration_ms,
-            )
-            self.events.close()
+            self.events.session_closed(duration_ms)
 
     def sendDisconnect(self, reason, desc):
         """

--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -26,6 +26,7 @@ from twisted.protocols.policies import TimeoutMixin
 from twisted.python import failure, log, randbytes
 
 from cowrie.core.config import CowrieConfig
+from cowrie.core.events import EventLog
 from cowrie.core.utils import escape_nonprintable
 
 
@@ -34,6 +35,9 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
     gotVersion: bool = False
     buf: bytes
     transportId: str
+    # The session's event emitter, bound in connectionMade when the running
+    # application provides a dispatcher.
+    events: EventLog | None = None
     ipv4rex = re.compile(r"^::ffff:(\d+\.\d+\.\d+\.\d+)$")
     auth_timeout: int = CowrieConfig.getint(
         "honeypot", "authentication_timeout", fallback=120
@@ -68,6 +72,18 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         ipv4_search = self.ipv4rex.search(src_ip)
         if ipv4_search is not None:
             src_ip = ipv4_search.group(1)
+
+        dispatcher = getattr(getattr(self.factory, "tac", None), "dispatcher", None)
+        if dispatcher is not None:
+            self.events = EventLog(
+                dispatcher,
+                session=self.transportId,
+                protocol="ssh",
+                src_ip=src_ip,
+                src_port=self.transport.getPeer().port,
+                dst_ip=self.transport.getHost().host,
+                dst_port=self.transport.getHost().port,
+            )
 
         log.msg(
             eventid="cowrie.session.connect",
@@ -283,6 +299,8 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             format="Connection lost after %(duration_ms)d milliseconds",
             duration_ms=duration_ms,
         )
+        if self.events is not None:
+            self.events.close()
 
     def sendDisconnect(self, reason, desc):
         """

--- a/src/cowrie/ssh/userauth.py
+++ b/src/cowrie/ssh/userauth.py
@@ -96,8 +96,8 @@ class HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer):
         """
         Allow every login
         """
-        c = credentials.Username(self.user)
         srcIp: str = self.transport.transport.getPeer().host  # type: ignore
+        c = credentials.Username(self.user, events=self.transport.events)  # type: ignore[union-attr]
         return self.portal.login(c, srcIp, IConchUser)
 
     def auth_password(self, packet: bytes) -> Any:
@@ -108,7 +108,12 @@ class HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer):
         if password == b"\x00":
             return None  # sshamble
         srcIp = self.transport.transport.getPeer().host  # type: ignore
-        c = credentials.UsernamePasswordIP(self.user, password, srcIp)
+        c = credentials.UsernamePasswordIP(
+            self.user,
+            password,
+            srcIp,
+            events=self.transport.events,  # type: ignore[union-attr]
+        )
         return self.portal.login(c, srcIp, IConchUser).addErrback(self._ebPassword)
 
     def auth_keyboard_interactive(self, _packet: bytes) -> Any:
@@ -128,7 +133,10 @@ class HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer):
             return defer.fail(error.IgnoreAuthentication())
         src_ip = self.transport.transport.getPeer().host  # type: ignore
         c = credentials.PluggableAuthenticationModulesIP(
-            self.user, self._pamConv, src_ip
+            self.user,
+            self._pamConv,
+            src_ip,
+            events=self.transport.events,  # type: ignore[union-attr]
         )
         return self.portal.login(c, src_ip, IConchUser).addErrback(self._ebPassword)
 

--- a/src/cowrie/ssh/userauth.py
+++ b/src/cowrie/ssh/userauth.py
@@ -23,6 +23,20 @@ from cowrie.core.config import CowrieConfig
 from cowrie.shell.honeyfs import read_honeyfs_bytes
 
 
+class EventsAttachingPortal:
+    """Attaches a session's EventLog to credentials before delegating to the
+    real portal, for the credential objects Twisted builds internally
+    (public key auth) that cannot carry the emitter from construction."""
+
+    def __init__(self, portal: Any, events: Any) -> None:
+        self.portal = portal
+        self.events = events
+
+    def login(self, credentials: Any, mind: Any, *interfaces: Any) -> Any:
+        credentials.events = self.events
+        return self.portal.login(credentials, mind, *interfaces)
+
+
 class HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer):
     """
     This contains modifications to the authentication system to do:
@@ -91,6 +105,22 @@ class HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer):
     #                           with {} algorithm".format(algName))
     #         return defer.fail(error.ConchError("Incorrect signature"))
     #     return userauth.SSHUserAuthServer.auth_publickey(self, packet)
+
+    def auth_publickey(self, packet: bytes) -> Any:
+        """
+        Overridden to attach the session's EventLog to the credential that
+        the base implementation constructs, so the public-key checker can
+        dispatch attributed events.
+        """
+        original = self.portal
+        self.portal = EventsAttachingPortal(
+            original,
+            self.transport.events,  # type: ignore[union-attr]
+        )
+        try:
+            return userauth.SSHUserAuthServer.auth_publickey(self, packet)
+        finally:
+            self.portal = original
 
     def auth_none(self, _packet: bytes) -> Any:
         """

--- a/src/cowrie/ssh_proxy/client_transport.py
+++ b/src/cowrie/ssh_proxy/client_transport.py
@@ -112,21 +112,21 @@ class BackendSSHTransport(transport.SSHClientTransport, TimeoutMixin):
         self.authDone = True
 
     def connectionLost(self, reason=None):
-        if self.factory.server.pool_interface:
-            log.msg(
-                eventid="cowrie.proxy.client_disconnect",
-                format="Lost connection with the pool backend: id %(vm_id)s",
-                vm_id=self.factory.server.pool_interface.vm_id,
-                protocol="ssh",
-            )
-        else:
-            log.msg(
-                eventid="cowrie.proxy.client_disconnect",
-                format="Lost connection with the proxy's backend: %(honey_ip)s:%(honey_port)s",
-                honey_ip=self.factory.server.backend_ip,
-                honey_port=self.factory.server.backend_port,
-                protocol="ssh",
-            )
+        events = self.factory.server.events
+        if events:
+            if self.factory.server.pool_interface:
+                events.dispatch(
+                    "cowrie.proxy.client_disconnect",
+                    "Lost connection with the pool backend: id %(vm_id)s",
+                    vm_id=self.factory.server.pool_interface.vm_id,
+                )
+            else:
+                events.dispatch(
+                    "cowrie.proxy.client_disconnect",
+                    "Lost connection with the proxy's backend: %(honey_ip)s:%(honey_port)s",
+                    honey_ip=self.factory.server.backend_ip,
+                    honey_port=self.factory.server.backend_port,
+                )
 
         self.transport.connectionLost(reason)
         self.transport = None

--- a/src/cowrie/ssh_proxy/protocols/exec_term.py
+++ b/src/cowrie/ssh_proxy/protocols/exec_term.py
@@ -20,12 +20,14 @@ class ExecTerm(base_protocol.BaseProtocol):
     def __init__(self, uuid, channelName, ssh, channelId, command):
         super().__init__(uuid, channelName, ssh)
 
+        self.events = ssh.server.events
         try:
-            log.msg(
-                eventid="cowrie.command.input",
-                input=command.decode("utf8"),
-                format="CMD: %(input)s",
-            )
+            if self.events:
+                self.events.dispatch(
+                    "cowrie.command.input",
+                    "CMD: %(input)s",
+                    input=command.decode("utf8"),
+                )
         except UnicodeDecodeError:
             log.err(f"Unusual execcmd: {command!r}")
 
@@ -71,12 +73,13 @@ class ExecTerm(base_protocol.BaseProtocol):
                 os.umask(umask)
                 os.chmod(shasumfile, 0o666 & ~umask)
 
-            log.msg(
-                eventid="cowrie.log.closed",
-                format="Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
-                ttylog=shasumfile,
-                size=self.ttylogSize,
-                shasum=shasum,
-                duplicate=duplicate,
-                duration_ms=round((time.time() - self.startTime) * 1000),
-            )
+            if self.events:
+                self.events.dispatch(
+                    "cowrie.log.closed",
+                    "Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
+                    ttylog=shasumfile,
+                    size=self.ttylogSize,
+                    shasum=shasum,
+                    duplicate=duplicate,
+                    duration_ms=round((time.time() - self.startTime) * 1000),
+                )

--- a/src/cowrie/ssh_proxy/protocols/port_forward.py
+++ b/src/cowrie/ssh_proxy/protocols/port_forward.py
@@ -22,6 +22,7 @@ from cowrie.ssh_proxy.protocols import base_protocol
 class PortForward(base_protocol.BaseProtocol):
     def __init__(self, uuid, chan_name, ssh):
         super().__init__(uuid, chan_name, ssh)
+        self.events = ssh.server.events
 
     def parse_packet(self, parent: str, data: bytes) -> None:
         """
@@ -40,18 +41,23 @@ class PortForward(base_protocol.BaseProtocol):
                         extensions=tls_info["extensions"],
                         has_sni=tls_info["has_sni"],
                         alpn=tls_info["alpn"],
-                        signature_algorithms=tls_info["signature_algorithms"]
+                        signature_algorithms=tls_info["signature_algorithms"],
                     )
-                    log.msg(
-                        eventid="cowrie.direct-tcpip.ja4",
-                        format="JA4 fingerprint for SSH proxy forwarded TLS: %(ja4)s",
-                        ja4=ja4
-                    )
+                    if self.events:
+                        self.events.dispatch(
+                            "cowrie.direct-tcpip.ja4",
+                            "JA4 fingerprint for SSH proxy forwarded TLS: %(ja4)s",
+                            ja4=ja4,
+                        )
                 except Exception as e:
                     log.msg(f"Error generating JA4 fingerprint in SSH proxy: {e}")
 
         # Check for HTTP request
-        elif data.startswith(b"GET ") or data.startswith(b"POST ") or data.startswith(b"HEAD "):
+        elif (
+            data.startswith(b"GET ")
+            or data.startswith(b"POST ")
+            or data.startswith(b"HEAD ")
+        ):
             http_info = parse_http_request(data)
             if http_info:
                 try:
@@ -61,12 +67,13 @@ class PortForward(base_protocol.BaseProtocol):
                         headers=http_info["headers"],
                         cookies=http_info["cookies"],
                         referer=http_info["referer"],
-                        accept_language=http_info["accept_language"]
+                        accept_language=http_info["accept_language"],
                     )
-                    log.msg(
-                        eventid="cowrie.direct-tcpip.ja4h",
-                        format="JA4H fingerprint for SSH proxy forwarded HTTP: %(ja4h)s",
-                        ja4h=ja4h
-                    )
+                    if self.events:
+                        self.events.dispatch(
+                            "cowrie.direct-tcpip.ja4h",
+                            "JA4H fingerprint for SSH proxy forwarded HTTP: %(ja4h)s",
+                            ja4h=ja4h,
+                        )
                 except Exception as e:
                     log.msg(f"Error generating JA4H fingerprint in SSH proxy: {e}")

--- a/src/cowrie/ssh_proxy/protocols/sftp.py
+++ b/src/cowrie/ssh_proxy/protocols/sftp.py
@@ -67,6 +67,7 @@ class SFTP(base_protocol.BaseProtocol):
     def __init__(self, uuid, chan_name, ssh):
         super().__init__(uuid, chan_name, ssh)
 
+        self.events = ssh.server.events
         self.downloadPath: str = CowrieConfig.get("honeypot", "download_path")
 
         self.clientPacket = base_protocol.BaseProtocol()
@@ -220,16 +221,17 @@ class SFTP(base_protocol.BaseProtocol):
                         f.write(self.theFile)
                         f.close()
 
-                    log.msg(
-                        format='SFTP Uploaded file "%(filename)s" to %(outfile)s',
-                        eventid="cowrie.session.file_upload",
-                        filename=fname,
-                        duplicate=duplicate,
-                        url=fname,
-                        outfile=outfile,
-                        shasum=shasum,
-                        destfile=fname,
-                    )
+                    if self.events:
+                        self.events.dispatch(
+                            "cowrie.session.file_upload",
+                            'SFTP Uploaded file "%(filename)s" to %(outfile)s',
+                            filename=fname,
+                            duplicate=duplicate,
+                            url=fname,
+                            outfile=outfile,
+                            shasum=shasum,
+                            destfile=fname,
+                        )
 
                     # if self.out.cfg.getboolean(['download', 'passive']):
                     #     # self.out.make_downloads_folder()

--- a/src/cowrie/ssh_proxy/protocols/ssh.py
+++ b/src/cowrie/ssh_proxy/protocols/ssh.py
@@ -204,11 +204,11 @@ class SSH(base_protocol.BaseProtocol):
                         self.server.events.dispatch(
                             "cowrie.direct-tcpip.request",
                             "direct-tcp connection request to %(dst_ip)s:%(dst_port)s "
-                            "from %(src_ip)s:%(src_port)s",
+                            "from %(orig_ip)s:%(orig_port)s",
                             dst_ip=dst_ip,
                             dst_port=dst_port,
-                            src_ip=src_ip,
-                            src_port=src_port,
+                            orig_ip=src_ip,
+                            orig_port=src_port,
                         )
 
                     the_uuid = uuid.uuid4().hex

--- a/src/cowrie/ssh_proxy/protocols/ssh.py
+++ b/src/cowrie/ssh_proxy/protocols/ssh.py
@@ -98,14 +98,13 @@ class SSH(base_protocol.BaseProtocol):
         else:
             direction = "BACKEND -> PROXY"
 
-        if self.log_raw:
-            log.msg(
-                eventid="cowrie.proxy.ssh",
-                format="%(direction)s - %(packet)s - %(payload)s",
+        if self.log_raw and self.server.events:
+            self.server.events.dispatch(
+                "cowrie.proxy.ssh",
+                "%(direction)s - %(packet)s - %(payload)s",
                 direction=direction,
                 packet=PACKETLAYOUT[message_num].ljust(37),
                 payload=repr(payload),
-                protocol="ssh",
             )
 
         if message_num == transport.MSG_SERVICE_REQUEST:
@@ -201,15 +200,16 @@ class SSH(base_protocol.BaseProtocol):
                 src_port = self.extract_int(4)
 
                 if CowrieConfig.getboolean("ssh", "forwarding"):
-                    log.msg(
-                        eventid="cowrie.direct-tcpip.request",
-                        format="direct-tcp connection request to %(dst_ip)s:%(dst_port)s "
-                        "from %(src_ip)s:%(src_port)s",
-                        dst_ip=dst_ip,
-                        dst_port=dst_port,
-                        src_ip=src_ip,
-                        src_port=src_port,
-                    )
+                    if self.server.events:
+                        self.server.events.dispatch(
+                            "cowrie.direct-tcpip.request",
+                            "direct-tcp connection request to %(dst_ip)s:%(dst_port)s "
+                            "from %(src_ip)s:%(src_port)s",
+                            dst_ip=dst_ip,
+                            dst_port=dst_port,
+                            src_ip=src_ip,
+                            src_port=src_port,
+                        )
 
                     the_uuid = uuid.uuid4().hex
                     self.create_channel(parent, channel_id, channel_type)
@@ -229,12 +229,13 @@ class SSH(base_protocol.BaseProtocol):
 
                 else:
                     log.msg("[SSH] Detected Port Forwarding Channel - Disabling!")
-                    log.msg(
-                        eventid="cowrie.direct-tcpip.data",
-                        format="discarded direct-tcp forward request %(id)s to %(dst_ip)s:%(dst_port)s ",
-                        dst_ip=dst_ip,
-                        dst_port=dst_port,
-                    )
+                    if self.server.events:
+                        self.server.events.dispatch(
+                            "cowrie.direct-tcpip.data",
+                            "discarded direct-tcp forward request %(id)s to %(dst_ip)s:%(dst_port)s ",
+                            dst_ip=dst_ip,
+                            dst_port=dst_port,
+                        )
 
                     self.sendOn = False
                     self.send_back(
@@ -379,14 +380,14 @@ class SSH(base_protocol.BaseProtocol):
         else:
             direction = "PROXY -> BACKEND"
 
-            log.msg(
-                eventid="cowrie.proxy.ssh",
-                format="%(direction)s - %(packet)s - %(payload)s",
-                direction=direction,
-                packet=PACKETLAYOUT[message_num].ljust(37),
-                payload=repr(payload),
-                protocol="ssh",
-            )
+            if self.server.events:
+                self.server.events.dispatch(
+                    "cowrie.proxy.ssh",
+                    "%(direction)s - %(packet)s - %(payload)s",
+                    direction=direction,
+                    packet=PACKETLAYOUT[message_num].ljust(37),
+                    payload=repr(payload),
+                )
 
         if parent == "[SERVER]":
             self.server.sendPacket(message_num, payload)

--- a/src/cowrie/ssh_proxy/protocols/term.py
+++ b/src/cowrie/ssh_proxy/protocols/term.py
@@ -27,6 +27,7 @@ class Term(base_protocol.BaseProtocol):
 
         self.transportId: int = ssh.server.transportId
         self.channelId: int = channelId
+        self.events = ssh.server.events
 
         self.startTime: float = time.time()
         self.ttylogPath: str = CowrieConfig.get("honeypot", "ttylog_path")
@@ -57,15 +58,16 @@ class Term(base_protocol.BaseProtocol):
                 os.umask(umask)
                 os.chmod(shasumfile, 0o666 & ~umask)
 
-            log.msg(
-                eventid="cowrie.log.closed",
-                format="Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
-                ttylog=shasumfile,
-                size=self.ttylogSize,
-                shasum=shasum,
-                duplicate=duplicate,
-                duration_ms=round((time.time() - self.startTime) * 1000),
-            )
+            if self.events:
+                self.events.dispatch(
+                    "cowrie.log.closed",
+                    "Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
+                    ttylog=shasumfile,
+                    size=self.ttylogSize,
+                    shasum=shasum,
+                    duplicate=duplicate,
+                    duration_ms=round((time.time() - self.startTime) * 1000),
+                )
 
     def parse_packet(self, parent: str, data: bytes) -> None:
         self.data: bytes = data
@@ -97,11 +99,11 @@ class Term(base_protocol.BaseProtocol):
                     self.data = self.data[1:]
 
                     try:
-                        if self.command != b"":
-                            log.msg(
-                                eventid="cowrie.command.input",
+                        if self.command != b"" and self.events:
+                            self.events.dispatch(
+                                "cowrie.command.input",
+                                "CMD: %(input)s",
                                 input=self.command.decode("utf8"),
-                                format="CMD: %(input)s",
                             )
                     except UnicodeDecodeError:
                         log.err(f"Unusual execcmd: {self.command!r}")

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -154,16 +154,14 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             self.connect_to_backend(honey_ip, ssh_port)
 
     def backend_connection_error(self, reason: failure.Failure) -> None:
-        log.msg(
-            eventid="cowrie.proxy.backend_connect_error",
-            format="Connection to honeypot backend %(backend_ip)s:%(backend_port)s refused: %(error)s",
-            backend_ip=self.backend_ip,
-            backend_port=self.backend_port,
-            error=reason.getErrorMessage(),
-            session=self.transportId,
-            sessionno=self.sessionno,
-            protocol="ssh",
-        )
+        if self.events:
+            self.events.dispatch(
+                "cowrie.proxy.backend_connect_error",
+                "Connection to honeypot backend %(backend_ip)s:%(backend_port)s refused: %(error)s",
+                backend_ip=self.backend_ip,
+                backend_port=self.backend_port,
+                error=reason.getErrorMessage(),
+            )
         if self.transport:
             self.transport.loseConnection()
 
@@ -179,17 +177,15 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         )  # Sets backend_ip to its IP if backend_ip was a hostname
         self.backend_port = backend_peer.port
 
-        log.msg(
-            eventid="cowrie.proxy.backend_connected",
-            format="Connected to honeypot backend %(backend_ip)s:%(backend_port)s from %(local_ip)s:%(local_port)s",
-            backend_ip=backend_peer.host,
-            backend_port=backend_peer.port,
-            local_ip=backend_host.host,
-            local_port=backend_host.port,
-            session=self.transportId,
-            sessionno=self.sessionno,
-            protocol="ssh",
-        )
+        if self.events:
+            self.events.dispatch(
+                "cowrie.proxy.backend_connected",
+                "Connected to honeypot backend %(backend_ip)s:%(backend_port)s from %(local_ip)s:%(local_port)s",
+                backend_ip=backend_peer.host,
+                backend_port=backend_peer.port,
+                local_ip=backend_host.host,
+                local_port=backend_host.port,
+            )
 
         self.startTime = time.time()
 
@@ -242,11 +238,12 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             if b"\n" not in self.buf:
                 return
             self.otherVersionString = self.buf.split(b"\n")[0].strip()
-            log.msg(
-                eventid="cowrie.client.version",
-                version=escape_nonprintable(self.otherVersionString),
-                format="Remote SSH version: %(version)s",
-            )
+            if self.events:
+                self.events.dispatch(
+                    "cowrie.client.version",
+                    "Remote SSH version: %(version)s",
+                    version=escape_nonprintable(self.otherVersionString),
+                )
             m = re.match(rb"SSH-(\d+.\d+)-(.*)", self.otherVersionString)
             if m is None:
                 log.msg(
@@ -337,18 +334,19 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         hasshAlgorithms = f"{ckexAlgs};{cencCS};{cmacCS};{ccompCS}"
         hassh = md5(hasshAlgorithms.encode("utf-8")).hexdigest()
 
-        log.msg(
-            eventid="cowrie.client.kex",
-            format="SSH client hassh fingerprint: %(hassh)s",
-            hassh=hassh,
-            hasshAlgorithms=hasshAlgorithms,
-            kexAlgs=kexAlgs,
-            keyAlgs=keyAlgs,
-            encCS=encCS,
-            macCS=macCS,
-            compCS=compCS,
-            langCS=langCS,
-        )
+        if self.events:
+            self.events.dispatch(
+                "cowrie.client.kex",
+                "SSH client hassh fingerprint: %(hassh)s",
+                hassh=hassh,
+                hasshAlgorithms=hasshAlgorithms,
+                kexAlgs=kexAlgs,
+                keyAlgs=keyAlgs,
+                encCS=encCS,
+                macCS=macCS,
+                compCS=compCS,
+                langCS=langCS,
+            )
 
         return transport.SSHServerTransport.ssh_KEXINIT(self, packet)
 
@@ -383,17 +381,14 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         """
         This seems to be the only reliable place of catching lost connection
         """
-        if self.backend_ip and self.backend_local_ip:
-            log.msg(
-                eventid="cowrie.proxy.backend_disconnected",
-                format="Disconnected from honeypot backend %(backend_ip)s:%(backend_port)s (local %(local_ip)s:%(local_port)s)",
+        if self.backend_ip and self.backend_local_ip and self.events:
+            self.events.dispatch(
+                "cowrie.proxy.backend_disconnected",
+                "Disconnected from honeypot backend %(backend_ip)s:%(backend_port)s (local %(local_ip)s:%(local_port)s)",
                 backend_ip=self.backend_ip,
                 backend_port=self.backend_port,
                 local_ip=self.backend_local_ip,
                 local_port=self.backend_local_port,
-                session=self.transportId,
-                sessionno=self.sessionno,
-                protocol="ssh",
             )
 
         self.setTimeout(None)

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -20,7 +20,7 @@ from twisted.protocols.policies import TimeoutMixin
 from twisted.python import failure, log, randbytes
 
 from cowrie.core.config import CowrieConfig
-from cowrie.core.events import EventLog
+from cowrie.core.events import EventLog, transport_events
 from cowrie.core.utils import escape_nonprintable
 from cowrie.ssh_proxy import client_transport
 from cowrie.ssh_proxy.protocols import ssh
@@ -83,17 +83,12 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         self.local_ip = self.transport.getHost().host
         self.local_port = self.transport.getHost().port
 
-        dispatcher = getattr(getattr(self.factory, "tac", None), "dispatcher", None)
-        if dispatcher is not None:
-            self.events = EventLog(
-                dispatcher,
-                session=self.transportId,
-                protocol="ssh",
-                src_ip=self.peer_ip,
-                src_port=self.transport.getPeer().port,
-                dst_ip=self.local_ip,
-                dst_port=self.transport.getHost().port,
-            )
+        self.events = transport_events(
+            self.factory,
+            self.transport,
+            session=self.transportId,
+            protocol="ssh",
+        )
 
         self.transport.write(self.ourVersionString + b"\r\n")
         self.currentEncryptions = transport.SSHCiphers(

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -20,6 +20,7 @@ from twisted.protocols.policies import TimeoutMixin
 from twisted.python import failure, log, randbytes
 
 from cowrie.core.config import CowrieConfig
+from cowrie.core.events import EventLog
 from cowrie.core.utils import escape_nonprintable
 from cowrie.ssh_proxy import client_transport
 from cowrie.ssh_proxy.protocols import ssh
@@ -36,6 +37,9 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
     buf: bytes
     ourVersionString: bytes
     gotVersion: bool
+    # The session's event emitter, bound in connectionMade when the running
+    # application provides a dispatcher.
+    events: EventLog | None = None
 
     # TODO merge this with HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin)
     # maybe create a parent class with common methods for the two
@@ -78,6 +82,18 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         self.peer_port = self.transport.getPeer().port + 1
         self.local_ip = self.transport.getHost().host
         self.local_port = self.transport.getHost().port
+
+        dispatcher = getattr(getattr(self.factory, "tac", None), "dispatcher", None)
+        if dispatcher is not None:
+            self.events = EventLog(
+                dispatcher,
+                session=self.transportId,
+                protocol="ssh",
+                src_ip=self.peer_ip,
+                src_port=self.transport.getPeer().port,
+                dst_ip=self.local_ip,
+                dst_port=self.transport.getHost().port,
+            )
 
         self.transport.write(self.ourVersionString + b"\r\n")
         self.currentEncryptions = transport.SSHCiphers(
@@ -411,6 +427,8 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
                 format="Connection lost after %(duration_ms)d milliseconds",
                 duration_ms=duration_ms,
             )
+        if self.events is not None:
+            self.events.close()
 
     def sendDisconnect(self, reason, desc):
         """

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -96,17 +96,11 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         )
         self.currentEncryptions.setKeys(b"", b"", b"", b"", b"", b"")
 
-        log.msg(
-            eventid="cowrie.session.connect",
-            format="New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: %(session)s]",
-            src_ip=self.peer_ip,
-            src_port=self.transport.getPeer().port,
-            dst_ip=self.local_ip,
-            dst_port=self.transport.getHost().port,
-            session=self.transportId,
-            sessionno=self.sessionno,
-            protocol="ssh",
-        )
+        if self.events:
+            self.events.dispatch(
+                "cowrie.session.connect",
+                "New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: %(session)s]",
+            )
 
         # if we have a pool connect to it and later request a backend, else just connect to a simple backend
         # when pool is set we can just test self.pool_interface to the same effect of getting the CowrieConfig
@@ -412,11 +406,12 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
 
         if self.startTime is not None:  # startTime is not set when auth fails
             duration_ms = round((time.time() - self.startTime) * 1000)
-            log.msg(
-                eventid="cowrie.session.closed",
-                format="Connection lost after %(duration_ms)d milliseconds",
-                duration_ms=duration_ms,
-            )
+            if self.events is not None:
+                self.events.dispatch(
+                    "cowrie.session.closed",
+                    "Connection lost after %(duration_ms)d milliseconds",
+                    duration_ms=duration_ms,
+                )
         if self.events is not None:
             self.events.close()
 

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -96,12 +96,6 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         )
         self.currentEncryptions.setKeys(b"", b"", b"", b"", b"", b"")
 
-        if self.events:
-            self.events.dispatch(
-                "cowrie.session.connect",
-                "New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: %(session)s]",
-            )
-
         # if we have a pool connect to it and later request a backend, else just connect to a simple backend
         # when pool is set we can just test self.pool_interface to the same effect of getting the CowrieConfig
         proxy_backend = CowrieConfig.get("proxy", "backend", fallback="simple")
@@ -407,11 +401,7 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         if self.startTime is not None:  # startTime is not set when auth fails
             duration_ms = round((time.time() - self.startTime) * 1000)
             if self.events is not None:
-                self.events.dispatch(
-                    "cowrie.session.closed",
-                    "Connection lost after %(duration_ms)d milliseconds",
-                    duration_ms=duration_ms,
-                )
+                self.events.session_closed(duration_ms)
         if self.events is not None:
             self.events.close()
 

--- a/src/cowrie/telnet/factory.py
+++ b/src/cowrie/telnet/factory.py
@@ -43,7 +43,6 @@ class HoneyPotTelnetFactory(protocol.ServerFactory):
         self.pool_handler = pool_handler
         super().__init__()
 
-
     def startFactory(self) -> None:
         """ """
         try:

--- a/src/cowrie/telnet/factory.py
+++ b/src/cowrie/telnet/factory.py
@@ -43,14 +43,6 @@ class HoneyPotTelnetFactory(protocol.ServerFactory):
         self.pool_handler = pool_handler
         super().__init__()
 
-    # TODO logging clarity can be improved: see what SSH does
-    def logDispatch(self, **args):
-        """
-        Special delivery to the loggers to avoid scope problems
-        """
-        args["sessionno"] = f"T{args['sessionno']}"
-        for output in self.tac.output_plugins:
-            output.logDispatch(**args)
 
     def startFactory(self) -> None:
         """ """

--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -121,11 +121,12 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         try:
             TelnetTransport.dataReceived(self, data)
         except ValueError as e:
-            log.msg(
-                eventid="cowrie.telnet.error",
-                format="Telnet protocol error %(error)s; dropping connection",
-                error=str(e),
-            )
+            if self.events:
+                self.events.dispatch(
+                    "cowrie.telnet.error",
+                    "Telnet protocol error %(error)s; dropping connection",
+                    error=str(e),
+                )
             log.err()
             if self.transport:
                 self.transport.loseConnection()
@@ -224,13 +225,14 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         if key in self._logged_options:
             return
         self._logged_options.add(key)
-        log.msg(
-            eventid="cowrie.telnet.option",
-            format=f"Telnet {command} %(option_name)s",
-            command=command,
-            option_name=self._get_option_name(option),
-            option_byte=option_byte,
-        )
+        if self.events:
+            self.events.dispatch(
+                "cowrie.telnet.option",
+                f"Telnet {command} %(option_name)s",
+                command=command,
+                option_name=self._get_option_name(option),
+                option_byte=option_byte,
+            )
 
     def telnet_WILL(self, option: bytes) -> None:
         """Client indicates willingness to enable an option."""

--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -20,6 +20,7 @@ from twisted.protocols.policies import TimeoutMixin
 from twisted.python import failure, log
 
 from cowrie.core.config import CowrieConfig
+from cowrie.core.events import EventLog
 
 # Telnet option names for logging (RFC 854, RFC 855, RFC 1572, etc.)
 TELNET_OPTIONS: dict[int, str] = {
@@ -45,6 +46,10 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
     CowrieTelnetTransport
     """
 
+    # The session's event emitter, bound in connectionMade when the running
+    # application provides a dispatcher.
+    events: EventLog | None = None
+
     # Set while the connection is being torn down. Telnet.connectionLost()
     # iterates self.options and errbacks pending negotiations; our retry
     # machinery must not re-enter negotiation during that iteration, since
@@ -61,6 +66,18 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         self.setTimeout(
             CowrieConfig.getint("honeypot", "authentication_timeout", fallback=120)
         )
+
+        dispatcher = getattr(getattr(self.factory, "tac", None), "dispatcher", None)
+        if dispatcher is not None:
+            self.events = EventLog(
+                dispatcher,
+                session=self.transportId,
+                protocol="telnet",
+                src_ip=self.transport.getPeer().host,
+                src_port=self.transport.getPeer().port,
+                dst_ip=self.transport.getHost().host,
+                dst_port=self.transport.getHost().port,
+            )
 
         log.msg(
             eventid="cowrie.session.connect",
@@ -135,6 +152,8 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
             format="Connection lost after %(duration_ms)d milliseconds",
             duration_ms=duration_ms,
         )
+        if self.events is not None:
+            self.events.close()
 
     def willChain(self, option):
         return self._chainNegotiation(None, self.will, option)

--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -73,11 +73,6 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
             protocol="telnet",
         )
 
-        if self.events:
-            self.events.dispatch(
-                "cowrie.session.connect",
-                "New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: %(session)s]",
-            )
         TelnetTransport.connectionMade(self)
 
     def write(self, data):
@@ -137,12 +132,7 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         TelnetTransport.connectionLost(self, reason)
         duration_ms = round((time.time() - self.startTime) * 1000)
         if self.events is not None:
-            self.events.dispatch(
-                "cowrie.session.closed",
-                "Connection lost after %(duration_ms)d milliseconds",
-                duration_ms=duration_ms,
-            )
-            self.events.close()
+            self.events.session_closed(duration_ms)
 
     def willChain(self, option):
         return self._chainNegotiation(None, self.will, option)

--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -61,7 +61,6 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         # (command, option_byte) pairs already logged, to suppress a scanner
         # flooding the same option negotiation (see _log_negotiation).
         self._logged_options: set[tuple[str, int]] = set()
-        sessionno = self.transport.sessionno
         self.startTime = time.time()
         self.setTimeout(
             CowrieConfig.getint("honeypot", "authentication_timeout", fallback=120)
@@ -74,17 +73,11 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
             protocol="telnet",
         )
 
-        log.msg(
-            eventid="cowrie.session.connect",
-            format="New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: %(session)s]",
-            src_ip=self.transport.getPeer().host,
-            src_port=self.transport.getPeer().port,
-            dst_ip=self.transport.getHost().host,
-            dst_port=self.transport.getHost().port,
-            session=self.transportId,
-            sessionno=f"T{sessionno!s}",
-            protocol="telnet",
-        )
+        if self.events:
+            self.events.dispatch(
+                "cowrie.session.connect",
+                "New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: %(session)s]",
+            )
         TelnetTransport.connectionMade(self)
 
     def write(self, data):
@@ -143,12 +136,12 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         self.setTimeout(None)
         TelnetTransport.connectionLost(self, reason)
         duration_ms = round((time.time() - self.startTime) * 1000)
-        log.msg(
-            eventid="cowrie.session.closed",
-            format="Connection lost after %(duration_ms)d milliseconds",
-            duration_ms=duration_ms,
-        )
         if self.events is not None:
+            self.events.dispatch(
+                "cowrie.session.closed",
+                "Connection lost after %(duration_ms)d milliseconds",
+                duration_ms=duration_ms,
+            )
             self.events.close()
 
     def willChain(self, option):

--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -20,7 +20,7 @@ from twisted.protocols.policies import TimeoutMixin
 from twisted.python import failure, log
 
 from cowrie.core.config import CowrieConfig
-from cowrie.core.events import EventLog
+from cowrie.core.events import EventLog, transport_events
 
 # Telnet option names for logging (RFC 854, RFC 855, RFC 1572, etc.)
 TELNET_OPTIONS: dict[int, str] = {
@@ -67,17 +67,12 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
             CowrieConfig.getint("honeypot", "authentication_timeout", fallback=120)
         )
 
-        dispatcher = getattr(getattr(self.factory, "tac", None), "dispatcher", None)
-        if dispatcher is not None:
-            self.events = EventLog(
-                dispatcher,
-                session=self.transportId,
-                protocol="telnet",
-                src_ip=self.transport.getPeer().host,
-                src_port=self.transport.getPeer().port,
-                dst_ip=self.transport.getHost().host,
-                dst_port=self.transport.getHost().port,
-            )
+        self.events = transport_events(
+            self.factory,
+            self.transport,
+            session=self.transportId,
+            protocol="telnet",
+        )
 
         log.msg(
             eventid="cowrie.session.connect",

--- a/src/cowrie/telnet/userauth.py
+++ b/src/cowrie/telnet/userauth.py
@@ -12,6 +12,7 @@ Telnet Transport and Authentication for the Honeypot
 from __future__ import annotations
 
 import struct
+from typing import TYPE_CHECKING, cast
 
 from twisted.conch.telnet import (
     ECHO,
@@ -26,6 +27,9 @@ from twisted.python import failure, log
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.credentials import UsernamePasswordIP
+
+if TYPE_CHECKING:
+    from cowrie.telnet.transport import CowrieTelnetTransport
 
 # NEW-ENVIRON telnet option (RFC 1572)
 # Used for environment variable exchange and targeted by CVE-2026-24061
@@ -97,19 +101,23 @@ class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
         # CVE-2026-24061 exploit bypass: use the extracted username if set
         if self.cve_2026_24061_user is not None:
             exploit_user = self.cve_2026_24061_user
-            log.msg(
-                eventid="cowrie.telnet.exploit_success",
-                format="CVE-2026-24061 exploit successful: logging in as %(username)s",
-                cve="CVE-2026-24061",
-                username=exploit_user,
-                original_username=username.decode("utf-8", errors="replace")
-                if isinstance(username, bytes)
-                else username,
-                attempted_command=password.decode("utf-8", errors="replace")
-                if isinstance(password, bytes)
-                else password,
+            events = cast("CowrieTelnetTransport", self.transport).events
+            if events:
+                events.dispatch(
+                    "cowrie.telnet.exploit_success",
+                    "CVE-2026-24061 exploit successful: logging in as %(username)s",
+                    cve="CVE-2026-24061",
+                    username=exploit_user,
+                    original_username=username.decode("utf-8", errors="replace")
+                    if isinstance(username, bytes)
+                    else username,
+                    attempted_command=password.decode("utf-8", errors="replace")
+                    if isinstance(password, bytes)
+                    else password,
+                )
+            username = (
+                exploit_user.encode() if isinstance(exploit_user, str) else exploit_user
             )
-            username = exploit_user.encode() if isinstance(exploit_user, str) else exploit_user
             password = b""  # Exploit bypasses password
             self.cve_2026_24061_user = None  # Clear the flag
 
@@ -202,6 +210,7 @@ class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
 
         # Parse the environment variables
         env_vars = self._parse_new_environ_data(raw_data[1:])
+        events = cast("CowrieTelnetTransport", self.transport).events
 
         # Log each environment variable
         for name, value in env_vars.items():
@@ -209,23 +218,25 @@ class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
             self.environ_received[name] = value
 
             # Log the environment variable (matches SSH cowrie.client.var pattern)
-            log.msg(
-                eventid="cowrie.client.var",
-                format="Telnet NEW-ENVIRON: %(name)s=%(value)s",
-                name=name,
-                value=value,
-            )
+            if events:
+                events.dispatch(
+                    "cowrie.client.var",
+                    "Telnet NEW-ENVIRON: %(name)s=%(value)s",
+                    name=name,
+                    value=value,
+                )
 
             # CVE-2026-24061 detection: USER environment variable with -f flag
             # This exploit bypasses authentication in GNU inetutils telnetd <= 2.7
             if name.upper() == "USER" and value.startswith("-f"):
-                log.msg(
-                    eventid="cowrie.telnet.exploit_attempt",
-                    format="CVE-2026-24061 exploit attempt detected: USER=%(value)s",
-                    cve="CVE-2026-24061",
-                    name=name,
-                    value=value,
-                )
+                if events:
+                    events.dispatch(
+                        "cowrie.telnet.exploit_attempt",
+                        "CVE-2026-24061 exploit attempt detected: USER=%(value)s",
+                        cve="CVE-2026-24061",
+                        name=name,
+                        value=value,
+                    )
                 # If vulnerability emulation is enabled, set up auth bypass
                 if CowrieConfig.getboolean(
                     "telnet", "cve_2026_24061_vulnerable", fallback=False

--- a/src/cowrie/telnet/userauth.py
+++ b/src/cowrie/telnet/userauth.py
@@ -123,7 +123,9 @@ class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
 
         def login(ignored):
             self.src_ip = self.transport.getPeer().host
-            creds = UsernamePasswordIP(username, password, self.src_ip)
+            creds = UsernamePasswordIP(
+                username, password, self.src_ip, events=self.transport.events
+            )
             d = self.portal.login(creds, self.src_ip, ITelnetProtocol)
             d.addCallback(self._cbLogin)
             d.addErrback(self._ebLogin)

--- a/src/cowrie/telnet_proxy/handler.py
+++ b/src/cowrie/telnet_proxy/handler.py
@@ -128,15 +128,16 @@ class TelnetHandler:
                 False  # do not close again if function called after closing
             )
 
-            log.msg(
-                eventid="cowrie.log.closed",
-                format="Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
-                ttylog=shasumfile,
-                size=self.ttylogSize,
-                shasum=shasum,
-                duplicate=duplicate,
-                duration_ms=round((time.time() - self.startTime) * 1000),
-            )
+            if self.server.events:
+                self.server.events.dispatch(
+                    "cowrie.log.closed",
+                    "Closing TTY Log: %(ttylog)s after %(duration_ms)d milliseconds",
+                    ttylog=shasumfile,
+                    size=self.ttylogSize,
+                    shasum=shasum,
+                    duplicate=duplicate,
+                    duration_ms=round((time.time() - self.startTime) * 1000),
+                )
 
     def sendBackend(self, data: bytes) -> None:
         self.backend_buffer.append(data)
@@ -212,11 +213,11 @@ class TelnetHandler:
 
             # check if a command has terminated
             if b"\r" in data:
-                if len(self.currentCommand) > 0:
-                    log.msg(
-                        eventid="cowrie.command.input",
+                if len(self.currentCommand) > 0 and self.server.events:
+                    self.server.events.dispatch(
+                        "cowrie.command.input",
+                        "CMD: %(input)s",
                         input=self.currentCommand,
-                        format="CMD: %(input)s",
                     )
                 self.currentCommand = b""
 
@@ -342,19 +343,20 @@ class TelnetHandler:
             )
 
             # Log the environment variable for consistency with shell mode
-            log.msg(
-                eventid="cowrie.client.var",
-                format="Telnet NEW-ENVIRON: %(name)s=%(value)s",
-                name="USER",
-                value=username_str,
-            )
+            if self.server.events:
+                self.server.events.dispatch(
+                    "cowrie.client.var",
+                    "Telnet NEW-ENVIRON: %(name)s=%(value)s",
+                    name="USER",
+                    value=username_str,
+                )
 
             # CVE-2026-24061 detection: USER environment variable with -f flag
             # This exploit bypasses authentication in GNU inetutils telnetd <= 2.7
-            if username_str.startswith("-f"):
-                log.msg(
-                    eventid="cowrie.telnet.exploit_attempt",
-                    format="CVE-2026-24061 exploit attempt detected: USER=%(value)s",
+            if username_str.startswith("-f") and self.server.events:
+                self.server.events.dispatch(
+                    "cowrie.telnet.exploit_attempt",
+                    "CVE-2026-24061 exploit attempt detected: USER=%(value)s",
                     cve="CVE-2026-24061",
                     name="USER",
                     value=username_str,

--- a/src/cowrie/telnet_proxy/handler.py
+++ b/src/cowrie/telnet_proxy/handler.py
@@ -290,7 +290,7 @@ class TelnetHandler:
             # the login failed prompt
             src_ip = self.server.transport.getPeer().host
             if HoneypotPasswordChecker().checkUserPass(
-                self.usernameState, self.passwordState, src_ip
+                self.usernameState, self.passwordState, src_ip, self.server.events
             ):
                 passwordToSend = self.backendPassword
                 self.authDone = True

--- a/src/cowrie/telnet_proxy/server_transport.py
+++ b/src/cowrie/telnet_proxy/server_transport.py
@@ -21,12 +21,17 @@ from twisted.protocols.policies import TimeoutMixin
 from twisted.python import failure, log
 
 from cowrie.core.config import CowrieConfig
+from cowrie.core.events import EventLog
 from cowrie.telnet_proxy import client_transport
 from cowrie.telnet_proxy.handler import TelnetHandler
 
 
 # object is added for Python 2.7 compatibility (#1198) - as is super with args
 class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
+    # The session's event emitter, bound in connectionMade when the running
+    # application provides a dispatcher.
+    events: EventLog | None = None
+
     def __init__(self):
         super().__init__()
 
@@ -63,6 +68,18 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
         self.peer_port = self.transport.getPeer().port + 1
         self.local_ip = self.transport.getHost().host
         self.local_port = self.transport.getHost().port
+
+        dispatcher = getattr(getattr(self.factory, "tac", None), "dispatcher", None)
+        if dispatcher is not None:
+            self.events = EventLog(
+                dispatcher,
+                session=self.transportId,
+                protocol="telnet",
+                src_ip=self.transport.getPeer().host,
+                src_port=self.transport.getPeer().port,
+                dst_ip=self.transport.getHost().host,
+                dst_port=self.transport.getHost().port,
+            )
 
         log.msg(
             eventid="cowrie.session.connect",
@@ -236,6 +253,8 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
                 format="Connection lost after %(duration_ms)d milliseconds",
                 duration_ms=duration_ms,
             )
+        if self.events is not None:
+            self.events.close()
 
     def packet_buffer(self, payload):
         """

--- a/src/cowrie/telnet_proxy/server_transport.py
+++ b/src/cowrie/telnet_proxy/server_transport.py
@@ -21,7 +21,7 @@ from twisted.protocols.policies import TimeoutMixin
 from twisted.python import failure, log
 
 from cowrie.core.config import CowrieConfig
-from cowrie.core.events import EventLog
+from cowrie.core.events import EventLog, transport_events
 from cowrie.telnet_proxy import client_transport
 from cowrie.telnet_proxy.handler import TelnetHandler
 
@@ -69,17 +69,12 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
         self.local_ip = self.transport.getHost().host
         self.local_port = self.transport.getHost().port
 
-        dispatcher = getattr(getattr(self.factory, "tac", None), "dispatcher", None)
-        if dispatcher is not None:
-            self.events = EventLog(
-                dispatcher,
-                session=self.transportId,
-                protocol="telnet",
-                src_ip=self.transport.getPeer().host,
-                src_port=self.transport.getPeer().port,
-                dst_ip=self.transport.getHost().host,
-                dst_port=self.transport.getHost().port,
-            )
+        self.events = transport_events(
+            self.factory,
+            self.transport,
+            session=self.transportId,
+            protocol="telnet",
+        )
 
         log.msg(
             eventid="cowrie.session.connect",

--- a/src/cowrie/telnet_proxy/server_transport.py
+++ b/src/cowrie/telnet_proxy/server_transport.py
@@ -76,17 +76,11 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
             protocol="telnet",
         )
 
-        log.msg(
-            eventid="cowrie.session.connect",
-            format="New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: %(session)s]",
-            src_ip=self.transport.getPeer().host,
-            src_port=self.transport.getPeer().port,
-            dst_ip=self.transport.getHost().host,
-            dst_port=self.transport.getHost().port,
-            session=self.transportId,
-            sessionno=self.sessionno,
-            protocol="telnet",
-        )
+        if self.events:
+            self.events.dispatch(
+                "cowrie.session.connect",
+                "New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: %(session)s]",
+            )
 
         TelnetTransport.connectionMade(self)
 
@@ -236,11 +230,12 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
 
         if self.startTime is not None:  # startTime is not set when auth fails
             duration_ms = round((time.time() - self.startTime) * 1000)
-            log.msg(
-                eventid="cowrie.session.closed",
-                format="Connection lost after %(duration_ms)d milliseconds",
-                duration_ms=duration_ms,
-            )
+            if self.events is not None:
+                self.events.dispatch(
+                    "cowrie.session.closed",
+                    "Connection lost after %(duration_ms)d milliseconds",
+                    duration_ms=duration_ms,
+                )
         if self.events is not None:
             self.events.close()
 

--- a/src/cowrie/telnet_proxy/server_transport.py
+++ b/src/cowrie/telnet_proxy/server_transport.py
@@ -76,12 +76,6 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
             protocol="telnet",
         )
 
-        if self.events:
-            self.events.dispatch(
-                "cowrie.session.connect",
-                "New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: %(session)s]",
-            )
-
         TelnetTransport.connectionMade(self)
 
         # if we have a pool connect to it and later request a backend, else just connect to a simple backend
@@ -231,11 +225,7 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
         if self.startTime is not None:  # startTime is not set when auth fails
             duration_ms = round((time.time() - self.startTime) * 1000)
             if self.events is not None:
-                self.events.dispatch(
-                    "cowrie.session.closed",
-                    "Connection lost after %(duration_ms)d milliseconds",
-                    duration_ms=duration_ms,
-                )
+                self.events.session_closed(duration_ms)
         if self.events is not None:
             self.events.close()
 

--- a/src/cowrie/telnet_proxy/server_transport.py
+++ b/src/cowrie/telnet_proxy/server_transport.py
@@ -137,16 +137,14 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
             self.connect_to_backend(honey_ip, telnet_port)
 
     def backend_connection_error(self, reason: failure.Failure) -> None:
-        log.msg(
-            eventid="cowrie.proxy.backend_connect_error",
-            format="Connection to honeypot backend %(backend_ip)s:%(backend_port)s refused: %(error)s",
-            backend_ip=self.backend_ip,
-            backend_port=self.backend_port,
-            error=reason.getErrorMessage(),
-            session=self.transportId,
-            sessionno=self.sessionno,
-            protocol="telnet",
-        )
+        if self.events:
+            self.events.dispatch(
+                "cowrie.proxy.backend_connect_error",
+                "Connection to honeypot backend %(backend_ip)s:%(backend_port)s refused: %(error)s",
+                backend_ip=self.backend_ip,
+                backend_port=self.backend_port,
+                error=reason.getErrorMessage(),
+            )
         if self.transport:
             self.transport.loseConnection()
 
@@ -158,17 +156,15 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
         self.backend_local_ip = backend_host.host
         self.backend_local_port = backend_host.port
 
-        log.msg(
-            eventid="cowrie.proxy.backend_connected",
-            format="Connected to honeypot backend %(backend_ip)s:%(backend_port)s from %(local_ip)s:%(local_port)s",
-            backend_ip=backend_peer.host,
-            backend_port=backend_peer.port,
-            local_ip=backend_host.host,
-            local_port=backend_host.port,
-            session=self.transportId,
-            sessionno=self.sessionno,
-            protocol="telnet",
-        )
+        if self.events:
+            self.events.dispatch(
+                "cowrie.proxy.backend_connected",
+                "Connected to honeypot backend %(backend_ip)s:%(backend_port)s from %(local_ip)s:%(local_port)s",
+                backend_ip=backend_peer.host,
+                backend_port=backend_peer.port,
+                local_ip=backend_host.host,
+                local_port=backend_host.port,
+            )
 
         self.startTime = time.time()
         self.setTimeout(
@@ -216,17 +212,14 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
         """
         Fires on pre-authentication disconnects
         """
-        if self.backend_ip and self.backend_local_ip:
-            log.msg(
-                eventid="cowrie.proxy.backend_disconnected",
-                format="Disconnected from honeypot backend %(backend_ip)s:%(backend_port)s (local %(local_ip)s:%(local_port)s)",
+        if self.backend_ip and self.backend_local_ip and self.events:
+            self.events.dispatch(
+                "cowrie.proxy.backend_disconnected",
+                "Disconnected from honeypot backend %(backend_ip)s:%(backend_port)s (local %(local_ip)s:%(local_port)s)",
                 backend_ip=self.backend_ip,
                 backend_port=self.backend_port,
                 local_ip=self.backend_local_ip,
                 local_port=self.backend_local_port,
-                session=self.transportId,
-                sessionno=self.sessionno,
-                protocol="telnet",
             )
 
         self.setTimeout(None)

--- a/src/cowrie/test/eventcapture.py
+++ b/src/cowrie/test/eventcapture.py
@@ -23,24 +23,26 @@ class CaptureSink:
         self.events.append(event)
 
 
+def _capture_pipeline(sink: CaptureSink, **identity: Any) -> EventLog:
+    """An EventLog delivering only to ``sink``, with test identity defaults."""
+    bound = {"session": "test0000", "protocol": "test", "src_ip": "1.2.3.4"}
+    bound.update(identity)
+    return EventLog(
+        EventDispatcher([sink], logmsg=lambda *args, **kwargs: None), **bound
+    )
+
+
 def capture_eventlog(**identity: Any) -> tuple[EventLog, list[dict[str, Any]]]:
     """An EventLog whose dispatched events land in the returned list."""
     sink = CaptureSink()
-    bound = {"session": "test0000", "protocol": "test", "src_ip": "1.2.3.4"}
-    bound.update(identity)
-    events = EventLog(
-        EventDispatcher([sink], logmsg=lambda *args, **kwargs: None), **bound
-    )
-    return events, sink.events
+    return _capture_pipeline(sink, **identity), sink.events
 
 
 def capture_events(protocol: Any, **identity: Any) -> list[dict[str, Any]]:
     """Install a capturing EventLog on ``protocol`` and return the list its
     events land in. The console renderer is omitted so nothing reaches the
     Twisted log during tests."""
-    bound = {"session": "test0000", "protocol": "test", "src_ip": "203.0.113.1"}
-    bound.update(identity)
-    events, dispatched = capture_eventlog(**bound)
+    events, dispatched = capture_eventlog(**identity)
     protocol.events = events
     return dispatched
 
@@ -55,11 +57,8 @@ def make_exec_transport(sink: CaptureSink, processEnded: Any = None) -> SimpleNa
     peer = SimpleNamespace(host="1.1.1.1", port=2222)
     inner = SimpleNamespace(sessionno=1, getPeer=lambda: peer)
     factory = SimpleNamespace(starttime=0)
-    events = EventLog(
-        EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
-        session="testexec",
-        protocol="ssh",
-        src_ip="1.1.1.1",
+    events = _capture_pipeline(
+        sink, session="testexec", protocol="ssh", src_ip="1.1.1.1"
     )
     conn_transport = SimpleNamespace(
         transportId="testexec", factory=factory, transport=inner, events=events

--- a/src/cowrie/test/eventcapture.py
+++ b/src/cowrie/test/eventcapture.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# ABOUTME: Test helper that wires a capturing event pipeline onto a protocol.
-# ABOUTME: Lets command tests assert on dispatched events instead of log calls.
+# ABOUTME: Test helpers that wire a capturing event pipeline onto protocols,
+# ABOUTME: transports, and fake exec channels for asserting dispatched events.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 from cowrie.core.events import EventDispatcher, EventLog
@@ -22,13 +23,53 @@ class CaptureSink:
         self.events.append(event)
 
 
+def capture_eventlog(**identity: Any) -> tuple[EventLog, list[dict[str, Any]]]:
+    """An EventLog whose dispatched events land in the returned list."""
+    sink = CaptureSink()
+    bound = {"session": "test0000", "protocol": "test", "src_ip": "1.2.3.4"}
+    bound.update(identity)
+    events = EventLog(
+        EventDispatcher([sink], logmsg=lambda *args, **kwargs: None), **bound
+    )
+    return events, sink.events
+
+
 def capture_events(protocol: Any, **identity: Any) -> list[dict[str, Any]]:
     """Install a capturing EventLog on ``protocol`` and return the list its
     events land in. The console renderer is omitted so nothing reaches the
     Twisted log during tests."""
-    sink = CaptureSink()
-    dispatcher = EventDispatcher([sink], logmsg=lambda *a, **kw: None)
-    base = {"session": "test0000", "protocol": "test", "src_ip": "203.0.113.1"}
-    base.update(identity)
-    protocol.events = EventLog(dispatcher, **base)
-    return sink.events
+    bound = {"session": "test0000", "protocol": "test", "src_ip": "203.0.113.1"}
+    bound.update(identity)
+    events, dispatched = capture_eventlog(**bound)
+    protocol.events = events
+    return dispatched
+
+
+def events_of(events: list[dict[str, Any]], eventid: str) -> list[dict[str, Any]]:
+    return [e for e in events if e["eventid"] == eventid]
+
+
+def make_exec_transport(sink: CaptureSink, processEnded: Any = None) -> SimpleNamespace:
+    """The transport.session.conn.transport chain insults expects for an SSH
+    exec channel, with an EventLog whose events land in ``sink``."""
+    peer = SimpleNamespace(host="1.1.1.1", port=2222)
+    inner = SimpleNamespace(sessionno=1, getPeer=lambda: peer)
+    factory = SimpleNamespace(starttime=0)
+    events = EventLog(
+        EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
+        session="testexec",
+        protocol="ssh",
+        src_ip="1.1.1.1",
+    )
+    conn_transport = SimpleNamespace(
+        transportId="testexec", factory=factory, transport=inner, events=events
+    )
+    conn = SimpleNamespace(transport=conn_transport)
+    session = SimpleNamespace(id="chan0", conn=conn)
+    return SimpleNamespace(
+        session=session,
+        write=lambda data: None,
+        processEnded=processEnded
+        if processEnded is not None
+        else lambda reason=None: None,
+    )

--- a/src/cowrie/test/eventcapture.py
+++ b/src/cowrie/test/eventcapture.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Test helper that wires a capturing event pipeline onto a protocol.
+# ABOUTME: Lets command tests assert on dispatched events instead of log calls.
+
+from __future__ import annotations
+
+from typing import Any
+
+from cowrie.core.events import EventDispatcher, EventLog
+
+
+class CaptureSink:
+    """An event sink that records every event it receives."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def write(self, event: dict[str, Any]) -> None:
+        self.events.append(event)
+
+
+def capture_events(protocol: Any, **identity: Any) -> list[dict[str, Any]]:
+    """Install a capturing EventLog on ``protocol`` and return the list its
+    events land in. The console renderer is omitted so nothing reaches the
+    Twisted log during tests."""
+    sink = CaptureSink()
+    dispatcher = EventDispatcher([sink], logmsg=lambda *a, **kw: None)
+    base = {"session": "test0000", "protocol": "test", "src_ip": "203.0.113.1"}
+    base.update(identity)
+    protocol.events = EventLog(dispatcher, **base)
+    return sink.events

--- a/src/cowrie/test/fake_server.py
+++ b/src/cowrie/test/fake_server.py
@@ -22,6 +22,10 @@ class FakeServer:
         self.fs = fs.HoneyPotFilesystem("arch", "/root")
         self.process = None
 
+    def initFileSystem(self, home: str) -> None:
+        """The filesystem is already created in __init__; sessions call this
+        before use."""
+
 
 class FakeAvatar:
     """FakeAvatar class.

--- a/src/cowrie/test/fake_transport.py
+++ b/src/cowrie/test/fake_transport.py
@@ -10,6 +10,9 @@ from typing import TYPE_CHECKING, ClassVar
 from twisted.conch.insults import insults
 from twisted.test import proto_helpers
 
+from cowrie.core.events import EventDispatcher, EventLog
+from cowrie.test.eventcapture import CaptureSink
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -87,6 +90,19 @@ class FakeTransport(proto_helpers.StringTransport):
 
     modes: ClassVar[dict[str, Callable]] = {}
 
+    def __init__(self, hostAddress=None, peerAddress=None):
+        # The event pipeline a protocol picks up in connectionMade; events
+        # dispatched by commands land in dispatchedEvents for assertions.
+        sink = CaptureSink()
+        self.dispatchedEvents = sink.events
+        self.events = EventLog(
+            EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
+            session="test-suite",
+            protocol="test",
+            src_ip="1.1.1.1",
+        )
+        super().__init__(hostAddress, peerAddress)
+
     # '\x01':     self.handle_HOME,	# CTRL-A
     # '\x02':     self.handle_LEFT,	# CTRL-B
     # '\x03':     self.handle_CTRL_C,	# CTRL-C
@@ -157,12 +173,14 @@ class FakeTransport(proto_helpers.StringTransport):
 
     def clear(self):
         proto_helpers.StringTransport.clear(self)
+        self.dispatchedEvents.clear()
         self.transport = Container()
         self.transport.session = Container()
         self.transport.session.conn = Container()
         self.transport.session.conn.transport = Container()
         self.transport.session.conn.transport.transport = Container()
         self.transport.session.conn.transport.transport.sessionno = 1
+        self.transport.session.conn.transport.events = self.events
         self.transport.session.conn.transport.factory = Container()
         self.transport.session.conn.transport.factory.sessions = {}
         self.transport.session.conn.transport.factory.starttime = 0

--- a/src/cowrie/test/test_cat_exec.py
+++ b/src/cowrie/test/test_cat_exec.py
@@ -10,13 +10,12 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
-from types import SimpleNamespace
 
 from twisted.internet.protocol import connectionDone
 
-from cowrie.core.events import EventDispatcher, EventLog
 from cowrie.insults import insults
 from cowrie.shell import protocol
+from cowrie.test.eventcapture import CaptureSink, make_exec_transport
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 
 _DOWNLOAD_DIR = tempfile.mkdtemp(prefix="cowrie_cat_exec_")
@@ -25,29 +24,6 @@ os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = _DOWNLOAD_DIR
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 insults.LoggingServerProtocol.downloadPath = _DOWNLOAD_DIR
-
-
-def _make_exec_transport() -> SimpleNamespace:
-    """Build the transport.session.conn.transport chain insults expects."""
-    peer = SimpleNamespace(host="1.1.1.1", port=2222)
-    inner = SimpleNamespace(sessionno=1, getPeer=lambda: peer)
-    factory = SimpleNamespace(starttime=0)
-    events = EventLog(
-        EventDispatcher([], logmsg=lambda *args, **kwargs: None),
-        session="testexec",
-        protocol="ssh",
-        src_ip="1.1.1.1",
-    )
-    conn_transport = SimpleNamespace(
-        transportId="testexec", factory=factory, transport=inner, events=events
-    )
-    conn = SimpleNamespace(transport=conn_transport)
-    session = SimpleNamespace(id="chan0", conn=conn)
-    return SimpleNamespace(
-        session=session,
-        write=lambda data: None,
-        processEnded=lambda reason=None: None,
-    )
 
 
 def run_exec_cat_redirect(payload: bytes) -> bytes:
@@ -62,7 +38,7 @@ def run_exec_cat_redirect(payload: bytes) -> bytes:
     lsp = insults.LoggingServerProtocol(
         protocol.HoneyPotExecProtocol, avatar, b"cat > /tmp/cowrietest"
     )
-    lsp.makeConnection(_make_exec_transport())
+    lsp.makeConnection(make_exec_transport(CaptureSink()))
 
     lsp.dataReceived(payload)
     lsp.eofReceived()

--- a/src/cowrie/test/test_cat_exec.py
+++ b/src/cowrie/test/test_cat_exec.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 
 from twisted.internet.protocol import connectionDone
 
+from cowrie.core.events import EventDispatcher, EventLog
 from cowrie.insults import insults
 from cowrie.shell import protocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
@@ -30,9 +31,15 @@ def _make_exec_transport() -> SimpleNamespace:
     """Build the transport.session.conn.transport chain insults expects."""
     peer = SimpleNamespace(host="1.1.1.1", port=2222)
     inner = SimpleNamespace(sessionno=1, getPeer=lambda: peer)
-    factory = SimpleNamespace(starttime=0, logDispatch=lambda **kw: None)
+    factory = SimpleNamespace(starttime=0)
+    events = EventLog(
+        EventDispatcher([], logmsg=lambda *args, **kwargs: None),
+        session="testexec",
+        protocol="ssh",
+        src_ip="1.1.1.1",
+    )
     conn_transport = SimpleNamespace(
-        transportId="testexec", factory=factory, transport=inner
+        transportId="testexec", factory=factory, transport=inner, events=events
     )
     conn = SimpleNamespace(transport=conn_transport)
     session = SimpleNamespace(id="chan0", conn=conn)

--- a/src/cowrie/test/test_cat_exec.py
+++ b/src/cowrie/test/test_cat_exec.py
@@ -33,7 +33,6 @@ def run_exec_cat_redirect(payload: bytes) -> bytes:
     the session teardown finalizes it.
     """
     avatar = FakeAvatar(FakeServer())
-    avatar.server.initFileSystem = lambda home: None
 
     lsp = insults.LoggingServerProtocol(
         protocol.HoneyPotExecProtocol, avatar, b"cat > /tmp/cowrietest"

--- a/src/cowrie/test/test_checkers.py
+++ b/src/cowrie/test/test_checkers.py
@@ -8,17 +8,34 @@
 from __future__ import annotations
 
 import unittest
-from typing import TYPE_CHECKING
+from typing import Any
 from unittest.mock import patch
 
-from twisted.python import log
-
 from cowrie.core import auth
-from cowrie.core.checkers import HoneypotPasswordChecker
+from cowrie.core.checkers import HoneypotNoneChecker, HoneypotPasswordChecker
 from cowrie.core.config import CowrieConfig
+from cowrie.core.credentials import Username, UsernamePasswordIP
+from cowrie.core.events import EventDispatcher, EventLog
+from cowrie.test.eventcapture import CaptureSink
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
+
+def capture_eventlog() -> tuple[EventLog, list[dict[str, Any]]]:
+    sink = CaptureSink()
+    events = EventLog(
+        EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
+        session="test0000",
+        protocol="ssh",
+        src_ip="1.2.3.4",
+    )
+    return events, sink.events
+
+
+def login_events(dispatched: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        e
+        for e in dispatched
+        if e.get("eventid") in ("cowrie.login.success", "cowrie.login.failed")
+    ]
 
 
 class TestHoneypotPasswordChecker(unittest.TestCase):
@@ -29,6 +46,7 @@ class TestHoneypotPasswordChecker(unittest.TestCase):
         self._old = (
             CowrieConfig.get("honeypot", "auth_class") if self._had_option else None
         )
+        self.events, self.dispatched = capture_eventlog()
 
     def tearDown(self) -> None:
         if self._had_option:
@@ -41,35 +59,48 @@ class TestHoneypotPasswordChecker(unittest.TestCase):
         checker = HoneypotPasswordChecker()
         with patch.object(auth, "UserDB") as mock_userdb:
             mock_userdb.return_value.checklogin.return_value = False
-            result = checker.checkUserPass(b"root", b"toor", "1.2.3.4")
+            result = checker.checkUserPass(b"root", b"toor", "1.2.3.4", self.events)
         self.assertFalse(result)
         mock_userdb.assert_called_once()
-
-    def _capture_login(self, run: Callable[[], object]) -> list[dict]:
-        events: list[dict] = []
-        log.addObserver(events.append)
-        try:
-            run()
-        finally:
-            log.removeObserver(events.append)
-        return [
-            e
-            for e in events
-            if e.get("eventid") in ("cowrie.login.success", "cowrie.login.failed")
-        ]
 
     def test_credentials_with_control_bytes_are_escaped(self) -> None:
         """Attacker-controlled username/password must not log raw control bytes."""
         checker = HoneypotPasswordChecker()
         with patch.object(auth, "UserDB") as mock_userdb:
             mock_userdb.return_value.checklogin.return_value = False
-            events = self._capture_login(
-                lambda: checker.checkUserPass(b"ro\x00ot", b"pa\r\nss", "1.2.3.4")
-            )
+            checker.checkUserPass(b"ro\x00ot", b"pa\r\nss", "1.2.3.4", self.events)
 
+        events = login_events(self.dispatched)
         self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["eventid"], "cowrie.login.failed")
         self.assertEqual(events[0]["username"], "ro\\x00ot")
         self.assertEqual(events[0]["password"], "pa\\x0d\\x0ass")
+
+    def test_login_event_carries_session_identity(self) -> None:
+        """Login events must arrive attributed through the credentials'
+        EventLog, not reconstructed from the log context."""
+        checker = HoneypotPasswordChecker()
+        creds = UsernamePasswordIP(b"root", b"toor", "1.2.3.4", events=self.events)
+        with patch.object(auth, "UserDB") as mock_userdb:
+            mock_userdb.return_value.checklogin.return_value = True
+            checker.requestAvatarId(creds)
+
+        events = login_events(self.dispatched)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["eventid"], "cowrie.login.success")
+        self.assertEqual(events[0]["session"], "test0000")
+
+
+class TestHoneypotNoneChecker(unittest.TestCase):
+    def test_none_auth_dispatches_login_success(self) -> None:
+        events, dispatched = capture_eventlog()
+        checker = HoneypotNoneChecker()
+        checker.requestAvatarId(Username(b"root", events=events))
+
+        captured = login_events(dispatched)
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(captured[0]["eventid"], "cowrie.login.success")
+        self.assertEqual(captured[0]["session"], "test0000")
 
 
 if __name__ == "__main__":

--- a/src/cowrie/test/test_checkers.py
+++ b/src/cowrie/test/test_checkers.py
@@ -15,19 +15,7 @@ from cowrie.core import auth
 from cowrie.core.checkers import HoneypotNoneChecker, HoneypotPasswordChecker
 from cowrie.core.config import CowrieConfig
 from cowrie.core.credentials import Username, UsernamePasswordIP
-from cowrie.core.events import EventDispatcher, EventLog
-from cowrie.test.eventcapture import CaptureSink
-
-
-def capture_eventlog() -> tuple[EventLog, list[dict[str, Any]]]:
-    sink = CaptureSink()
-    events = EventLog(
-        EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
-        session="test0000",
-        protocol="ssh",
-        src_ip="1.2.3.4",
-    )
-    return events, sink.events
+from cowrie.test.eventcapture import capture_eventlog
 
 
 def login_events(dispatched: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -46,7 +34,7 @@ class TestHoneypotPasswordChecker(unittest.TestCase):
         self._old = (
             CowrieConfig.get("honeypot", "auth_class") if self._had_option else None
         )
-        self.events, self.dispatched = capture_eventlog()
+        self.events, self.dispatched = capture_eventlog(protocol="ssh")
 
     def tearDown(self) -> None:
         if self._had_option:
@@ -93,7 +81,7 @@ class TestHoneypotPasswordChecker(unittest.TestCase):
 
 class TestHoneypotNoneChecker(unittest.TestCase):
     def test_none_auth_dispatches_login_success(self) -> None:
-        events, dispatched = capture_eventlog()
+        events, dispatched = capture_eventlog(protocol="ssh")
         checker = HoneypotNoneChecker()
         checker.requestAvatarId(Username(b"root", events=events))
 

--- a/src/cowrie/test/test_checkers.py
+++ b/src/cowrie/test/test_checkers.py
@@ -79,6 +79,49 @@ class TestHoneypotPasswordChecker(unittest.TestCase):
         self.assertEqual(events[0]["session"], "test0000")
 
 
+class TestHoneypotPublicKeyChecker(unittest.TestCase):
+    def test_pubkey_attempt_dispatches_fingerprint_and_login_failed(self) -> None:
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+        from twisted.conch.ssh import keys
+        from twisted.cred.credentials import SSHPrivateKey
+
+        from cowrie.core.checkers import HoneypotPublicKeyChecker
+
+        events, dispatched = capture_eventlog(protocol="ssh")
+        blob = keys.Key(ed25519.Ed25519PrivateKey.generate()).public().blob()
+        creds = SSHPrivateKey(b"root", b"ssh-ed25519", blob, None, None)
+        creds.events = events  # type: ignore[attr-defined]
+
+        HoneypotPublicKeyChecker().requestAvatarId(creds)
+
+        fingerprints = [
+            e for e in dispatched if e["eventid"] == "cowrie.client.fingerprint"
+        ]
+        self.assertEqual(len(fingerprints), 1)
+        self.assertEqual(fingerprints[0]["username"], "root")
+        self.assertEqual(fingerprints[0]["session"], "test0000")
+        failed = login_events(dispatched)
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0]["eventid"], "cowrie.login.failed")
+
+
+class TestEventsAttachingPortal(unittest.TestCase):
+    def test_login_attaches_events_to_credentials(self) -> None:
+        from types import SimpleNamespace
+
+        from cowrie.ssh.userauth import EventsAttachingPortal
+
+        seen: list[Any] = []
+        inner = SimpleNamespace(
+            login=lambda creds, mind, *interfaces: seen.append(creds)
+        )
+        events, _ = capture_eventlog(protocol="ssh")
+        creds = SimpleNamespace()
+        EventsAttachingPortal(inner, events).login(creds, None, object)
+        self.assertEqual(seen, [creds])
+        self.assertIs(creds.events, events)
+
+
 class TestHoneypotNoneChecker(unittest.TestCase):
     def test_none_auth_dispatches_login_success(self) -> None:
         events, dispatched = capture_eventlog(protocol="ssh")

--- a/src/cowrie/test/test_command_input_events.py
+++ b/src/cowrie/test/test_command_input_events.py
@@ -45,18 +45,25 @@ class CommandInputEventTests(unittest.TestCase):
     def assert_input_event(
         self, command: bytes, eventid: str, realm: str, line: bytes = b"stdin line"
     ) -> None:
-        self.proto.lineReceived(command + b"\n")
-        self.proto.lineReceived(line)
-        events = [e for e in self.tr.dispatchedEvents if e["eventid"] == eventid]
-        self.assertEqual(
-            len(events), 1, f"expected one {eventid} event, got {events!r}"
-        )
-        ev = events[0]
-        self.assertEqual(ev["realm"], realm)
-        self.assertEqual(ev["input"], line.decode())
-        self.assertEqual(ev["session"], "test-suite")
-        self.proto.handle_CTRL_C()
-        self.tr.clear()
+        # The realm filter separates the command's stdin event from the
+        # shell's own CMD event, which shares the cowrie.command.input id.
+        try:
+            self.proto.lineReceived(command + b"\n")
+            self.proto.lineReceived(line)
+            events = [
+                e
+                for e in self.tr.dispatchedEvents
+                if e["eventid"] == eventid and e.get("realm") == realm
+            ]
+            self.assertEqual(
+                len(events), 1, f"expected one {eventid} event, got {events!r}"
+            )
+            ev = events[0]
+            self.assertEqual(ev["input"], line.decode())
+            self.assertEqual(ev["session"], "test-suite")
+        finally:
+            self.proto.handle_CTRL_C()
+            self.tr.clear()
 
     def make_command(self, cmdclass: type[T], *args: str) -> T:
         """Instantiate a command outside the shell; commands need the
@@ -99,18 +106,20 @@ class CommandInputEventTests(unittest.TestCase):
         )
 
     def test_chpasswd_password_change_event(self) -> None:
-        self.proto.lineReceived(b"chpasswd\n")
-        self.proto.lineReceived(b"root:hunter2\n")
-        events = [
-            e
-            for e in self.tr.dispatchedEvents
-            if e["eventid"] == "cowrie.command.chpasswd"
-        ]
-        self.assertEqual(len(events), 1)
-        self.assertEqual(events[0]["username"], "root")
-        self.assertEqual(events[0]["session"], "test-suite")
-        self.proto.handle_CTRL_C()
-        self.tr.clear()
+        try:
+            self.proto.lineReceived(b"chpasswd\n")
+            self.proto.lineReceived(b"root:hunter2\n")
+            events = [
+                e
+                for e in self.tr.dispatchedEvents
+                if e["eventid"] == "cowrie.command.chpasswd"
+            ]
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0]["username"], "root")
+            self.assertEqual(events[0]["session"], "test-suite")
+        finally:
+            self.proto.handle_CTRL_C()
+            self.tr.clear()
 
     def test_crontab_input_event(self) -> None:
         self.assert_input_event(b"crontab -", "cowrie.command.input", "crontab")

--- a/src/cowrie/test/test_command_input_events.py
+++ b/src/cowrie/test/test_command_input_events.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Asserts that commands reading attacker stdin dispatch their input
+# ABOUTME: events through the session EventLog with bound identity.
+
+from __future__ import annotations
+
+import os
+import unittest
+from typing import TypeVar
+
+from cowrie.shell.command import HoneyPotCommand
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+T = TypeVar("T", bound=HoneyPotCommand)
+
+
+class CommandInputEventTests(unittest.TestCase):
+    """Each interactive command that consumes stdin must dispatch its input
+    event through the session EventLog, so the event carries the session
+    identity from any execution context."""
+
+    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+    tr = FakeTransport("", "31337")
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.proto.makeConnection(cls.tr)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proto.connectionLost()
+
+    def setUp(self) -> None:
+        self.tr.clear()
+
+    def assert_input_event(
+        self, command: bytes, eventid: str, realm: str, line: bytes = b"stdin line"
+    ) -> None:
+        self.proto.lineReceived(command + b"\n")
+        self.proto.lineReceived(line)
+        events = [e for e in self.tr.dispatchedEvents if e["eventid"] == eventid]
+        self.assertEqual(
+            len(events), 1, f"expected one {eventid} event, got {events!r}"
+        )
+        ev = events[0]
+        self.assertEqual(ev["realm"], realm)
+        self.assertEqual(ev["input"], line.decode())
+        self.assertEqual(ev["session"], "test-suite")
+        self.proto.handle_CTRL_C()
+        self.tr.clear()
+
+    def make_command(self, cmdclass: type[T], *args: str) -> T:
+        """Instantiate a command outside the shell; commands need the
+        protocol's process protocol, which exists once any command has run."""
+        self.proto.lineReceived(b"echo\n")
+        self.tr.clear()
+        return cmdclass(self.proto, *args)
+
+    def assert_direct_input_event(
+        self, command: HoneyPotCommand, eventid: str, realm: str
+    ) -> None:
+        """For commands whose start() always exits, so the shell never routes
+        stdin to them: dispatch must still work when lineReceived is driven
+        directly (e.g. from a pipe)."""
+        command.lineReceived("stdin line")
+        events = [e for e in self.tr.dispatchedEvents if e["eventid"] == eventid]
+        self.assertEqual(
+            len(events), 1, f"expected one {eventid} event, got {events!r}"
+        )
+        self.assertEqual(events[0]["realm"], realm)
+        self.assertEqual(events[0]["input"], "stdin line")
+        self.assertEqual(events[0]["session"], "test-suite")
+
+    def test_awk_input_event(self) -> None:
+        from cowrie.commands.awk import Command_awk
+
+        cmd = self.make_command(Command_awk, "awk", "{ print }")
+        cmd.code = []
+        self.assert_direct_input_event(cmd, "cowrie.session.input", "awk")
+
+    def test_base64_input_event(self) -> None:
+        self.assert_input_event(b"base64", "cowrie.session.input", "base64")
+
+    def test_cat_input_event(self) -> None:
+        self.assert_input_event(b"cat", "cowrie.session.input", "cat")
+
+    def test_chpasswd_input_event(self) -> None:
+        self.assert_input_event(
+            b"chpasswd", "cowrie.command.input", "chpasswd", line=b"root:hunter2"
+        )
+
+    def test_chpasswd_password_change_event(self) -> None:
+        self.proto.lineReceived(b"chpasswd\n")
+        self.proto.lineReceived(b"root:hunter2\n")
+        events = [
+            e
+            for e in self.tr.dispatchedEvents
+            if e["eventid"] == "cowrie.command.chpasswd"
+        ]
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["username"], "root")
+        self.assertEqual(events[0]["session"], "test-suite")
+        self.proto.handle_CTRL_C()
+        self.tr.clear()
+
+    def test_crontab_input_event(self) -> None:
+        self.assert_input_event(b"crontab -", "cowrie.command.input", "crontab")
+
+    def test_cut_input_event(self) -> None:
+        self.assert_input_event(b"cut -c1", "cowrie.command.input", "cut")
+
+    def test_dd_input_event(self) -> None:
+        self.assert_input_event(b"dd", "cowrie.session.input", "dd")
+
+    def test_grep_input_event(self) -> None:
+        from cowrie.commands.fs import Command_grep
+
+        cmd = self.make_command(Command_grep, "grep", "stdin")
+        self.assert_direct_input_event(cmd, "cowrie.command.input", "grep")
+
+    def test_tail_input_event(self) -> None:
+        self.assert_input_event(b"tail", "cowrie.command.input", "tail")
+
+    def test_head_input_event(self) -> None:
+        self.assert_input_event(b"head", "cowrie.command.input", "head")
+
+    def test_passwd_input_event(self) -> None:
+        self.assert_input_event(b"passwd", "cowrie.command.success", "passwd")
+
+    def test_php_input_event(self) -> None:
+        self.assert_input_event(b"php", "cowrie.command.success", "php")
+
+    def test_perl_input_event(self) -> None:
+        self.assert_input_event(b"perl", "cowrie.command.input", "perl")
+
+    def test_python_input_event(self) -> None:
+        self.assert_input_event(b"python", "cowrie.command.input", "python")
+
+    def test_tee_input_event(self) -> None:
+        self.assert_input_event(b"tee", "cowrie.session.input", "tee")
+
+    def test_uniq_input_event(self) -> None:
+        self.assert_input_event(b"uniq", "cowrie.command.input", "uniq")
+
+    def test_wc_input_event(self) -> None:
+        from cowrie.commands.wc import Command_wc
+
+        cmd = self.make_command(Command_wc, "wc")
+        self.assert_direct_input_event(cmd, "cowrie.command.input", "wc")
+
+    def test_busybox_command_found_event(self) -> None:
+        self.proto.lineReceived(b"busybox ls\n")
+        events = [
+            e
+            for e in self.tr.dispatchedEvents
+            if e["eventid"] == "cowrie.command.success"
+        ]
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["input"], "ls")
+        self.assertEqual(events[0]["session"], "test-suite")

--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -19,6 +19,7 @@ from cowrie.commands.curl import Command_curl
 from cowrie.core.artifact import Artifact
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.eventcapture import capture_events
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
@@ -34,8 +35,7 @@ class CurlArtifactCleanupTests(unittest.TestCase):
         self.tr = FakeTransport("", "31337")
         self.proto.makeConnection(self.tr)
         self.tr.clear()
-        # The fake factory has no logDispatch; error() dispatches a log event.
-        self.proto.logDispatch = lambda **_kw: None  # type: ignore[method-assign]
+        self.events = capture_events(self.proto)
 
         self.tmpdir = tempfile.mkdtemp()
         self._orig_artifact_dir = Artifact.artifactDir

--- a/src/cowrie/test/test_events.py
+++ b/src/cowrie/test/test_events.py
@@ -126,6 +126,29 @@ class EventDispatcherTests(unittest.TestCase):
             "a mutating sink corrupted the event for the next sink",
         )
 
+    def test_sinks_do_not_share_nested_containers(self) -> None:
+        class NestedMutatingSink:
+            def write(self, event: dict[str, Any]) -> None:
+                event["algs"].append("mutated")
+
+        after = CapturingSink()
+        dispatcher = EventDispatcher(
+            [NestedMutatingSink(), after], logmsg=lambda msg, **kw: None
+        )
+        dispatcher.dispatch(
+            {
+                "eventid": "cowrie.client.kex",
+                "format": "kex",
+                "algs": ["curve25519-sha256"],
+                "session": "s",
+            }
+        )
+        self.assertEqual(
+            after.events[0]["algs"],
+            ["curve25519-sha256"],
+            "a sink mutating a nested list corrupted the next sink's event",
+        )
+
     def test_timestamp_format_follows_timezone_convention(self) -> None:
         # Same convention as Output: the Z suffix only when TZ is UTC,
         # otherwise a numeric offset -- a non-UTC time must not claim Zulu.
@@ -160,6 +183,22 @@ class EventLogTests(unittest.TestCase):
         self.assertEqual(ev["src_ip"], "192.0.2.1")
         self.assertEqual(ev["message"], "CMD: uname -a")
         self.assertNotIn("late", ev)
+
+    def test_fields_cannot_override_bound_attribution(self) -> None:
+        # Emitter fields may carry protocol-supplied values named like the
+        # identity (a direct-tcpip request's claimed originator); attribution
+        # must stay the connection's own.
+        self.events.dispatch(
+            "cowrie.direct-tcpip.request",
+            "request from %(src_ip)s",
+            src_ip="6.6.6.6",
+            session="spoofed",
+            protocol="fake",
+        )
+        ev = self.sink.events[0]
+        self.assertEqual(ev["src_ip"], "192.0.2.1")
+        self.assertEqual(ev["session"], "abcd0123")
+        self.assertEqual(ev["protocol"], "ssh")
 
     def test_late_after_close(self) -> None:
         self.events.close()
@@ -237,3 +276,17 @@ class ConsoleRendererTests(unittest.TestCase):
             }
         )
         self.assertEqual(lines, [("CMD: ls", "telnet,abcd0123,192.0.2.1")])
+
+    def test_skips_events_without_message(self) -> None:
+        lines: list[tuple[str, str]] = []
+        renderer = ConsoleRenderer(
+            logmsg=lambda msg, system: lines.append((msg, system))
+        )
+        renderer.write(
+            {
+                "eventid": "cowrie.session.params",
+                "message": "",
+                "session": "abcd0123",
+            }
+        )
+        self.assertEqual(lines, [])

--- a/src/cowrie/test/test_events.py
+++ b/src/cowrie/test/test_events.py
@@ -13,17 +13,10 @@ from types import SimpleNamespace
 from typing import Any
 
 from cowrie.core.events import ConsoleRenderer, EventDispatcher, EventLog
+from cowrie.test.eventcapture import CaptureSink
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
-
-
-class CapturingSink:
-    def __init__(self) -> None:
-        self.events: list[dict[str, Any]] = []
-
-    def write(self, event: dict[str, Any]) -> None:
-        self.events.append(event)
 
 
 class SinkFailure(Exception):
@@ -38,7 +31,7 @@ class RaisingSink:
 
 class EventDispatcherTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.sink = CapturingSink()
+        self.sink = CaptureSink()
         self.logged: list[str] = []
         self.dispatcher = EventDispatcher(
             [self.sink], logmsg=lambda msg, **kw: self.logged.append(msg)
@@ -69,7 +62,7 @@ class EventDispatcherTests(unittest.TestCase):
         self.assertEqual(ev["session"], "abcd0123")
 
     def test_sink_failure_is_isolated(self) -> None:
-        good = CapturingSink()
+        good = CaptureSink()
         dispatcher = EventDispatcher(
             [RaisingSink(), good], logmsg=lambda msg, **kw: self.logged.append(msg)
         )
@@ -108,7 +101,7 @@ class EventDispatcherTests(unittest.TestCase):
             def write(self, event: dict[str, Any]) -> None:
                 del event["input"]
 
-        after = CapturingSink()
+        after = CaptureSink()
         dispatcher = EventDispatcher(
             [MutatingSink(), after], logmsg=lambda msg, **kw: None
         )
@@ -131,7 +124,7 @@ class EventDispatcherTests(unittest.TestCase):
             def write(self, event: dict[str, Any]) -> None:
                 event["algs"].append("mutated")
 
-        after = CapturingSink()
+        after = CaptureSink()
         dispatcher = EventDispatcher(
             [NestedMutatingSink(), after], logmsg=lambda msg, **kw: None
         )
@@ -162,7 +155,7 @@ class EventDispatcherTests(unittest.TestCase):
 
 class EventLogTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.sink = CapturingSink()
+        self.sink = CaptureSink()
         self.dispatcher = EventDispatcher([self.sink], logmsg=lambda msg, **kw: None)
         self.events = EventLog(
             self.dispatcher,
@@ -224,12 +217,12 @@ class EventLogTests(unittest.TestCase):
 class TelnetTransportEventLogTests(unittest.TestCase):
     """The telnet transport binds an EventLog for the connection's lifetime."""
 
-    def make_transport(self) -> tuple[Any, CapturingSink]:
+    def make_transport(self) -> tuple[Any, CaptureSink]:
         from twisted.test.proto_helpers import StringTransport
 
         from cowrie.telnet.transport import CowrieTelnetTransport
 
-        sink = CapturingSink()
+        sink = CaptureSink()
         dispatcher = EventDispatcher([sink], logmsg=lambda msg, **kw: None)
         transport = CowrieTelnetTransport()
         transport.factory = SimpleNamespace(tac=SimpleNamespace(dispatcher=dispatcher))

--- a/src/cowrie/test/test_events.py
+++ b/src/cowrie/test/test_events.py
@@ -253,6 +253,55 @@ class TelnetTransportEventLogTests(unittest.TestCase):
         )
 
 
+class OutputDispatchTests(unittest.TestCase):
+    """Output plugins emit enrichment events through the dispatcher they are
+    handed, into the same fan-out as every other event."""
+
+    def test_plugin_dispatch_reaches_sinks(self) -> None:
+        from cowrie.core.output import Output
+
+        class EnrichingPlugin(Output):
+            def start(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                pass
+
+            def write(self, event: dict[str, Any]) -> None:
+                pass
+
+        plugin = EnrichingPlugin()
+        sink = CaptureSink()
+        plugin.dispatcher = EventDispatcher([sink], logmsg=lambda msg, **kw: None)
+        plugin.dispatch(
+            eventid="cowrie.virustotal.scanfile",
+            format="VT: New file %(sha256)s",
+            session="abcd0123",
+            src_ip="192.0.2.1",
+            sha256="cafe",
+        )
+        self.assertEqual(len(sink.events), 1)
+        ev = sink.events[0]
+        self.assertEqual(ev["eventid"], "cowrie.virustotal.scanfile")
+        self.assertEqual(ev["message"], "VT: New file cafe")
+        self.assertEqual(ev["session"], "abcd0123")
+
+    def test_plugin_dispatch_without_dispatcher_is_dropped(self) -> None:
+        from cowrie.core.output import Output
+
+        class EnrichingPlugin(Output):
+            def start(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                pass
+
+            def write(self, event: dict[str, Any]) -> None:
+                pass
+
+        EnrichingPlugin().dispatch(eventid="cowrie.test", format="no pipeline")
+
+
 class ConsoleRendererTests(unittest.TestCase):
     def test_renders_with_session_prefix(self) -> None:
         lines: list[tuple[str, str]] = []

--- a/src/cowrie/test/test_events.py
+++ b/src/cowrie/test/test_events.py
@@ -100,6 +100,42 @@ class EventDispatcherTests(unittest.TestCase):
         self.dispatch_one()
         self.assertEqual(self.sink.events, [])
 
+    def test_sinks_do_not_share_a_mutable_event(self) -> None:
+        # Several output plugins mutate the event they receive (jsonlog,
+        # mongodb, graylog... all `del event[i]`); one sink's mutation must
+        # not corrupt what later sinks see.
+        class MutatingSink:
+            def write(self, event: dict[str, Any]) -> None:
+                del event["input"]
+
+        after = CapturingSink()
+        dispatcher = EventDispatcher(
+            [MutatingSink(), after], logmsg=lambda msg, **kw: None
+        )
+        dispatcher.dispatch(
+            {
+                "eventid": "cowrie.command.input",
+                "format": "CMD: %(input)s",
+                "input": "ls",
+                "session": "s",
+            }
+        )
+        self.assertEqual(
+            after.events[0]["input"],
+            "ls",
+            "a mutating sink corrupted the event for the next sink",
+        )
+
+    def test_timestamp_format_follows_timezone_convention(self) -> None:
+        # Same convention as Output: the Z suffix only when TZ is UTC,
+        # otherwise a numeric offset -- a non-UTC time must not claim Zulu.
+        from unittest import mock
+
+        with mock.patch.dict(os.environ, {"TZ": "UTC"}):
+            self.assertTrue(EventDispatcher([]).timeFormat.endswith("Z"))
+        with mock.patch.dict(os.environ, {"TZ": "Europe/Amsterdam"}):
+            self.assertTrue(EventDispatcher([]).timeFormat.endswith("%z"))
+
 
 class EventLogTests(unittest.TestCase):
     def setUp(self) -> None:

--- a/src/cowrie/test/test_events.py
+++ b/src/cowrie/test/test_events.py
@@ -142,6 +142,34 @@ class EventDispatcherTests(unittest.TestCase):
             "a sink mutating a nested list corrupted the next sink's event",
         )
 
+    def test_sessionless_events_skip_plugin_sinks(self) -> None:
+        # Output plugins' write() assumes session attribution (the OUTPUT
+        # schema); an operational event without a session must not reach
+        # them, only sinks that declare they accept everything.
+        plugin = CaptureSink()
+        renderer = CaptureSink()
+        renderer.accepts_sessionless = True  # type: ignore[attr-defined]
+        dispatcher = EventDispatcher([plugin, renderer], logmsg=lambda msg, **kw: None)
+        dispatcher.dispatch(
+            {
+                "eventid": "cowrie.abuseipdb.reportedip",
+                "format": "reported %(IP)s",
+                "IP": "192.0.2.1",
+            }
+        )
+        self.assertEqual(plugin.events, [])
+        self.assertEqual(len(renderer.events), 1)
+
+    def test_shutdown_registration_is_after_reactor_teardown(self) -> None:
+        # Events emitted while connections are torn down (during shutdown)
+        # must still deliver; the dispatcher stops only afterwards.
+        calls: list[tuple[str, str]] = []
+        reactor = SimpleNamespace(
+            addSystemEventTrigger=lambda phase, event, f: calls.append((phase, event))
+        )
+        self.dispatcher.registerShutdown(reactor)
+        self.assertEqual(calls, [("after", "shutdown")])
+
     def test_timestamp_format_follows_timezone_convention(self) -> None:
         # Same convention as Output: the Z suffix only when TZ is UTC,
         # otherwise a numeric offset -- a non-UTC time must not claim Zulu.
@@ -285,6 +313,63 @@ class OutputDispatchTests(unittest.TestCase):
         self.assertEqual(ev["eventid"], "cowrie.virustotal.scanfile")
         self.assertEqual(ev["message"], "VT: New file cafe")
         self.assertEqual(ev["session"], "abcd0123")
+
+    def test_plugin_dispatch_from_start_reaches_sinks(self) -> None:
+        # Plugins dispatch from start(), which runs during construction --
+        # the dispatcher must already be reachable then (it is installed as
+        # a class attribute before the plugins are instantiated). The started
+        # notice is session-less, so it lands in the console renderer's kind
+        # of sink.
+        from cowrie.core.output import Output
+
+        sink = CaptureSink()
+        sink.accepts_sessionless = True  # type: ignore[attr-defined]
+        dispatcher = EventDispatcher([sink], logmsg=lambda msg, **kw: None)
+
+        class AnnouncingPlugin(Output):
+            def start(self) -> None:
+                self.dispatch(
+                    eventid="cowrie.abuseipdb.started",
+                    format="plugin started",
+                )
+
+            def stop(self) -> None:
+                pass
+
+            def write(self, event: dict[str, Any]) -> None:
+                pass
+
+        old = Output.dispatcher
+        Output.dispatcher = dispatcher
+        try:
+            AnnouncingPlugin()
+        finally:
+            Output.dispatcher = old
+        self.assertEqual(len(sink.events), 1)
+        self.assertEqual(sink.events[0]["eventid"], "cowrie.abuseipdb.started")
+
+    def test_plugin_stop_runs_after_reactor_teardown(self) -> None:
+        # A plugin's stop() must not close its resources before the final
+        # events of in-flight sessions (emitted during teardown) deliver.
+        from unittest.mock import patch
+
+        from cowrie.core import output
+
+        class QuietPlugin(output.Output):
+            def start(self) -> None:
+                pass
+
+            def stop(self) -> None:
+                pass
+
+            def write(self, event: dict[str, Any]) -> None:
+                pass
+
+        with patch.object(output, "reactor") as reactor:
+            plugin = QuietPlugin()
+        reactor.addSystemEventTrigger.assert_called_once_with(
+            "after", "shutdown", plugin.stop
+        )
 
     def test_plugin_dispatch_without_dispatcher_is_dropped(self) -> None:
         from cowrie.core.output import Output

--- a/src/cowrie/test/test_events.py
+++ b/src/cowrie/test/test_events.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for cowrie/core/events.py, the session-scoped event pipeline.
+# ABOUTME: Covers dispatcher enrichment/isolation, EventLog identity, and rendering.
+
+from __future__ import annotations
+
+import os
+import unittest
+from types import SimpleNamespace
+from typing import Any
+
+from cowrie.core.events import ConsoleRenderer, EventDispatcher, EventLog
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class CapturingSink:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def write(self, event: dict[str, Any]) -> None:
+        self.events.append(event)
+
+
+class SinkFailure(Exception):
+    def __init__(self) -> None:
+        super().__init__("sink is broken")
+
+
+class RaisingSink:
+    def write(self, event: dict[str, Any]) -> None:
+        raise SinkFailure
+
+
+class EventDispatcherTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sink = CapturingSink()
+        self.logged: list[str] = []
+        self.dispatcher = EventDispatcher(
+            [self.sink], logmsg=lambda msg, **kw: self.logged.append(msg)
+        )
+
+    def dispatch_one(self, **extra: Any) -> None:
+        event: dict[str, Any] = {
+            "eventid": "cowrie.command.input",
+            "format": "CMD: %(input)s",
+            "input": b"ls",
+            "session": "abcd0123",
+            "protocol": "telnet",
+            "src_ip": "192.0.2.1",
+        }
+        event.update(extra)
+        self.dispatcher.dispatch(event)
+
+    def test_enriches_once_and_delivers(self) -> None:
+        self.dispatch_one()
+        self.assertEqual(len(self.sink.events), 1)
+        ev = self.sink.events[0]
+        self.assertEqual(ev["message"], "CMD: ls")
+        self.assertNotIn("format", ev)
+        self.assertEqual(ev["input"], "ls")  # bytes converted
+        self.assertIn("sensor", ev)
+        self.assertIn("time", ev)
+        self.assertIn("timestamp", ev)
+        self.assertEqual(ev["session"], "abcd0123")
+
+    def test_sink_failure_is_isolated(self) -> None:
+        good = CapturingSink()
+        dispatcher = EventDispatcher(
+            [RaisingSink(), good], logmsg=lambda msg, **kw: self.logged.append(msg)
+        )
+        event = {
+            "eventid": "cowrie.command.input",
+            "format": "CMD",
+            "session": "s",
+        }
+        dispatcher.dispatch(dict(event))
+        dispatcher.dispatch(dict(event))
+        self.assertEqual(len(good.events), 2, "healthy sink must keep receiving")
+
+    def test_sink_failure_logging_is_rate_limited(self) -> None:
+        dispatcher = EventDispatcher(
+            [RaisingSink()], logmsg=lambda msg, **kw: self.logged.append(msg)
+        )
+        for _ in range(10):
+            dispatcher.dispatch(
+                {"eventid": "cowrie.command.input", "format": "CMD", "session": "s"}
+            )
+        failure_logs = [m for m in self.logged if "sink is broken" in m]
+        self.assertEqual(
+            len(failure_logs), 1, "only the first failure is logged verbatim"
+        )
+
+    def test_dispatch_after_stop_is_dropped(self) -> None:
+        self.dispatcher.stop()
+        self.dispatch_one()
+        self.assertEqual(self.sink.events, [])
+
+
+class EventLogTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sink = CapturingSink()
+        self.dispatcher = EventDispatcher([self.sink], logmsg=lambda msg, **kw: None)
+        self.events = EventLog(
+            self.dispatcher,
+            session="abcd0123",
+            protocol="ssh",
+            src_ip="192.0.2.1",
+            src_port=4711,
+            dst_ip="198.51.100.9",
+            dst_port=22,
+        )
+
+    def test_identity_is_bound(self) -> None:
+        self.events.dispatch("cowrie.command.input", "CMD: %(input)s", input="uname -a")
+        ev = self.sink.events[0]
+        self.assertEqual(ev["eventid"], "cowrie.command.input")
+        self.assertEqual(ev["session"], "abcd0123")
+        self.assertEqual(ev["protocol"], "ssh")
+        self.assertEqual(ev["src_ip"], "192.0.2.1")
+        self.assertEqual(ev["message"], "CMD: uname -a")
+        self.assertNotIn("late", ev)
+
+    def test_late_after_close(self) -> None:
+        self.events.close()
+        self.events.dispatch("cowrie.session.file_download", "late download")
+        self.assertTrue(self.sink.events[0]["late"])
+
+    def test_child_overlays_and_shares_close(self) -> None:
+        channel_events = self.events.child(channel=3)
+        channel_events.dispatch("cowrie.command.input", "CMD")
+        ev = self.sink.events[0]
+        self.assertEqual(ev["channel"], 3)
+        self.assertEqual(ev["session"], "abcd0123")
+        self.assertNotIn("late", ev)
+
+        self.events.close()
+        channel_events.dispatch("cowrie.command.input", "CMD")
+        self.assertTrue(
+            self.sink.events[1]["late"],
+            "a child emitter follows the connection's closed state",
+        )
+
+
+class TelnetTransportEventLogTests(unittest.TestCase):
+    """The telnet transport binds an EventLog for the connection's lifetime."""
+
+    def make_transport(self) -> tuple[Any, CapturingSink]:
+        from twisted.test.proto_helpers import StringTransport
+
+        from cowrie.telnet.transport import CowrieTelnetTransport
+
+        sink = CapturingSink()
+        dispatcher = EventDispatcher([sink], logmsg=lambda msg, **kw: None)
+        transport = CowrieTelnetTransport()
+        transport.factory = SimpleNamespace(tac=SimpleNamespace(dispatcher=dispatcher))
+        tcp = StringTransport()
+        tcp.sessionno = 7  # type: ignore[attr-defined]  # the transport logs it
+        transport.transport = tcp
+        return transport, sink
+
+    def test_eventlog_bound_and_closed_with_connection(self) -> None:
+        transport, sink = self.make_transport()
+        transport.makeConnection(transport.transport)
+        try:
+            self.assertIsNotNone(transport.events)
+            self.assertEqual(
+                transport.events.identity["session"], transport.transportId
+            )
+            self.assertEqual(transport.events.identity["protocol"], "telnet")
+
+            transport.events.dispatch("cowrie.test", "before close")
+            self.assertNotIn("late", sink.events[-1])
+        finally:
+            transport.connectionLost(None)
+
+        transport.events.dispatch("cowrie.test", "after close")
+        self.assertTrue(
+            sink.events[-1]["late"],
+            "events after connectionLost must be flagged late",
+        )
+
+
+class ConsoleRendererTests(unittest.TestCase):
+    def test_renders_with_session_prefix(self) -> None:
+        lines: list[tuple[str, str]] = []
+        renderer = ConsoleRenderer(
+            logmsg=lambda msg, system: lines.append((msg, system))
+        )
+        renderer.write(
+            {
+                "eventid": "cowrie.command.input",
+                "message": "CMD: ls",
+                "session": "abcd0123",
+                "protocol": "telnet",
+                "src_ip": "192.0.2.1",
+            }
+        )
+        self.assertEqual(lines, [("CMD: ls", "telnet,abcd0123,192.0.2.1")])

--- a/src/cowrie/test/test_exit_status.py
+++ b/src/cowrie/test/test_exit_status.py
@@ -11,6 +11,7 @@ import os
 import unittest
 from types import SimpleNamespace
 
+from cowrie.core.events import EventDispatcher, EventLog
 from cowrie.insults import insults
 from cowrie.shell import protocol
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -210,8 +211,16 @@ def run_exec(cmd: bytes) -> int:
 
     peer = SimpleNamespace(host="1.1.1.1", port=2222)
     inner = SimpleNamespace(sessionno=1, getPeer=lambda: peer)
-    factory = SimpleNamespace(starttime=0, logDispatch=lambda **kw: None)
-    conn_transport = SimpleNamespace(transportId="t", factory=factory, transport=inner)
+    factory = SimpleNamespace(starttime=0)
+    events = EventLog(
+        EventDispatcher([], logmsg=lambda *args, **kwargs: None),
+        session="t",
+        protocol="ssh",
+        src_ip="1.1.1.1",
+    )
+    conn_transport = SimpleNamespace(
+        transportId="t", factory=factory, transport=inner, events=events
+    )
     session = SimpleNamespace(
         id="chan0", conn=SimpleNamespace(transport=conn_transport)
     )

--- a/src/cowrie/test/test_exit_status.py
+++ b/src/cowrie/test/test_exit_status.py
@@ -9,12 +9,11 @@ from __future__ import annotations
 
 import os
 import unittest
-from types import SimpleNamespace
 
-from cowrie.core.events import EventDispatcher, EventLog
 from cowrie.insults import insults
 from cowrie.shell import protocol
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.eventcapture import CaptureSink, make_exec_transport
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
@@ -209,24 +208,7 @@ def run_exec(cmd: bytes) -> int:
         value = getattr(reason, "value", None)
         captured["code"] = getattr(value, "exitCode", 0) if value is not None else 0
 
-    peer = SimpleNamespace(host="1.1.1.1", port=2222)
-    inner = SimpleNamespace(sessionno=1, getPeer=lambda: peer)
-    factory = SimpleNamespace(starttime=0)
-    events = EventLog(
-        EventDispatcher([], logmsg=lambda *args, **kwargs: None),
-        session="t",
-        protocol="ssh",
-        src_ip="1.1.1.1",
-    )
-    conn_transport = SimpleNamespace(
-        transportId="t", factory=factory, transport=inner, events=events
-    )
-    session = SimpleNamespace(
-        id="chan0", conn=SimpleNamespace(transport=conn_transport)
-    )
-    transport = SimpleNamespace(
-        session=session, write=lambda data: None, processEnded=process_ended
-    )
+    transport = make_exec_transport(CaptureSink(), processEnded=process_ended)
 
     avatar = FakeAvatar(FakeServer())
     avatar.server.initFileSystem = lambda home: None

--- a/src/cowrie/test/test_exit_status.py
+++ b/src/cowrie/test/test_exit_status.py
@@ -211,7 +211,6 @@ def run_exec(cmd: bytes) -> int:
     transport = make_exec_transport(CaptureSink(), processEnded=process_ended)
 
     avatar = FakeAvatar(FakeServer())
-    avatar.server.initFileSystem = lambda home: None
     lsp = insults.LoggingServerProtocol(protocol.HoneyPotExecProtocol, avatar, cmd)
     lsp.makeConnection(transport)
     return captured.get("code", 0)

--- a/src/cowrie/test/test_forwarding_events.py
+++ b/src/cowrie/test/test_forwarding_events.py
@@ -57,6 +57,11 @@ class ForwardingEventTests(unittest.TestCase):
         self.assertEqual(requests[0]["dst_ip"], "198.51.100.7")
         self.assertEqual(requests[0]["dst_port"], 443)
         self.assertEqual(requests[0]["session"], "test0000")
+        # The originator in the packet is attacker-controlled; it must not
+        # replace the connection's source address.
+        self.assertEqual(requests[0]["src_ip"], "1.2.3.4")
+        self.assertEqual(requests[0]["orig_ip"], "10.0.0.1")
+        self.assertEqual(requests[0]["orig_port"], 50000)
 
     def test_discarded_data_dispatches_with_session_identity(self) -> None:
         events, dispatched = capture_eventlog()

--- a/src/cowrie/test/test_forwarding_events.py
+++ b/src/cowrie/test/test_forwarding_events.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Asserts direct-tcpip forwarding requests and discarded data
+# ABOUTME: dispatch events through the session EventLog.
+
+from __future__ import annotations
+
+import os
+import unittest
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+from twisted.conch.ssh import forwarding as conchforwarding
+
+from cowrie.core.events import EventDispatcher, EventLog
+from cowrie.ssh import forwarding
+from cowrie.test.eventcapture import CaptureSink
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+def capture_eventlog() -> tuple[EventLog, list[dict[str, Any]]]:
+    sink = CaptureSink()
+    events = EventLog(
+        EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
+        session="test0000",
+        protocol="ssh",
+        src_ip="1.2.3.4",
+    )
+    return events, sink.events
+
+
+def events_of(events: list[dict[str, Any]], eventid: str) -> list[dict[str, Any]]:
+    return [e for e in events if e["eventid"] == eventid]
+
+
+class ForwardingEventTests(unittest.TestCase):
+    def test_request_dispatches_with_session_identity(self) -> None:
+        events, dispatched = capture_eventlog()
+        avatar = SimpleNamespace(
+            conn=SimpleNamespace(transport=SimpleNamespace(events=events))
+        )
+        data = conchforwarding.packOpen_direct_tcpip(
+            ("198.51.100.7", 443), ("10.0.0.1", 50000)
+        )
+        channel = forwarding.cowrieOpenConnectForwardingClient(
+            262144, 32768, data, avatar
+        )
+        self.assertIsInstance(channel, forwarding.FakeForwardingChannel)
+
+        requests = events_of(dispatched, "cowrie.direct-tcpip.request")
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0]["dst_ip"], "198.51.100.7")
+        self.assertEqual(requests[0]["dst_port"], 443)
+        self.assertEqual(requests[0]["session"], "test0000")
+
+    def test_discarded_data_dispatches_with_session_identity(self) -> None:
+        events, dispatched = capture_eventlog()
+        channel = forwarding.FakeForwardingChannel(("198.51.100.7", 80))
+        channel.conn = SimpleNamespace(transport=SimpleNamespace(events=events))
+        channel.id = 0
+        with patch.object(channel, "_close"):
+            channel.dataReceived(b"GET / HTTP/1.0\r\n\r\n")
+
+        data_events = events_of(dispatched, "cowrie.direct-tcpip.data")
+        self.assertEqual(len(data_events), 1)
+        self.assertEqual(data_events[0]["dst_port"], 80)
+        self.assertEqual(data_events[0]["session"], "test0000")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_forwarding_events.py
+++ b/src/cowrie/test/test_forwarding_events.py
@@ -10,37 +10,20 @@ from __future__ import annotations
 import os
 import unittest
 from types import SimpleNamespace
-from typing import Any
 from unittest.mock import patch
 
 from twisted.conch.ssh import forwarding as conchforwarding
 
-from cowrie.core.events import EventDispatcher, EventLog
 from cowrie.ssh import forwarding
-from cowrie.test.eventcapture import CaptureSink
+from cowrie.test.eventcapture import capture_eventlog, events_of
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 
-def capture_eventlog() -> tuple[EventLog, list[dict[str, Any]]]:
-    sink = CaptureSink()
-    events = EventLog(
-        EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
-        session="test0000",
-        protocol="ssh",
-        src_ip="1.2.3.4",
-    )
-    return events, sink.events
-
-
-def events_of(events: list[dict[str, Any]], eventid: str) -> list[dict[str, Any]]:
-    return [e for e in events if e["eventid"] == eventid]
-
-
 class ForwardingEventTests(unittest.TestCase):
     def test_request_dispatches_with_session_identity(self) -> None:
-        events, dispatched = capture_eventlog()
+        events, dispatched = capture_eventlog(protocol="ssh")
         avatar = SimpleNamespace(
             conn=SimpleNamespace(transport=SimpleNamespace(events=events))
         )
@@ -64,7 +47,7 @@ class ForwardingEventTests(unittest.TestCase):
         self.assertEqual(requests[0]["orig_port"], 50000)
 
     def test_discarded_data_dispatches_with_session_identity(self) -> None:
-        events, dispatched = capture_eventlog()
+        events, dispatched = capture_eventlog(protocol="ssh")
         channel = forwarding.FakeForwardingChannel(("198.51.100.7", 80))
         channel.conn = SimpleNamespace(transport=SimpleNamespace(events=events))
         channel.id = 0

--- a/src/cowrie/test/test_insults_events.py
+++ b/src/cowrie/test/test_insults_events.py
@@ -16,10 +16,14 @@ from typing import Any
 from twisted.conch.ssh.common import NS
 from twisted.internet.protocol import connectionDone
 
-from cowrie.core.events import EventDispatcher, EventLog
 from cowrie.insults import insults
 from cowrie.shell import protocol
-from cowrie.test.eventcapture import CaptureSink
+from cowrie.test.eventcapture import (
+    CaptureSink,
+    capture_eventlog,
+    events_of,
+    make_exec_transport,
+)
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 
 _DOWNLOAD_DIR = tempfile.mkdtemp(prefix="cowrie_insults_events_")
@@ -31,41 +35,13 @@ os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 insults.LoggingServerProtocol.downloadPath = _DOWNLOAD_DIR
 
 
-def _make_exec_transport(sink: CaptureSink) -> SimpleNamespace:
-    """The transport.session.conn.transport chain insults expects, with an
-    EventLog whose events land in ``sink``."""
-    peer = SimpleNamespace(host="1.1.1.1", port=2222)
-    inner = SimpleNamespace(sessionno=1, getPeer=lambda: peer)
-    factory = SimpleNamespace(starttime=0)
-    events = EventLog(
-        EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
-        session="testexec",
-        protocol="ssh",
-        src_ip="1.1.1.1",
-    )
-    conn_transport = SimpleNamespace(
-        transportId="testexec", factory=factory, transport=inner, events=events
-    )
-    conn = SimpleNamespace(transport=conn_transport)
-    session = SimpleNamespace(id="chan0", conn=conn)
-    return SimpleNamespace(
-        session=session,
-        write=lambda data: None,
-        processEnded=lambda reason=None: None,
-    )
-
-
-def events_of(events: list[dict[str, Any]], eventid: str) -> list[dict[str, Any]]:
-    return [e for e in events if e["eventid"] == eventid]
-
-
 class StdinCaptureEventTests(unittest.TestCase):
     def run_exec(self, cmd: bytes, payload: bytes) -> list[dict[str, Any]]:
         sink = CaptureSink()
         avatar = FakeAvatar(FakeServer())
         avatar.server.initFileSystem = lambda home: None
         lsp = insults.LoggingServerProtocol(protocol.HoneyPotExecProtocol, avatar, cmd)
-        lsp.makeConnection(_make_exec_transport(sink))
+        lsp.makeConnection(make_exec_transport(sink))
         lsp.dataReceived(payload)
         lsp.eofReceived()
         lsp.connectionLost(connectionDone)
@@ -105,23 +81,17 @@ class TelnetInsultsEventLogTests(unittest.TestCase):
             TelnetSessionProcessProtocol,
         )
 
-        sink = CaptureSink()
-        events = EventLog(
-            EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
-            session="telnet01",
-            protocol="telnet",
-            src_ip="1.1.1.1",
+        events, _dispatched = capture_eventlog(
+            session="telnet01", protocol="telnet", src_ip="1.1.1.1"
         )
         server = FakeServer()
-        server.initFileSystem = lambda home: None
-        server.fs = FakeServer().fs
 
         session = HoneyPotTelnetSession(b"root", server)
         session.transportId = "telnet01"
         peer = SimpleNamespace(host="1.1.1.1", port=2323)
         # The telnet transport as HoneyPotInteractiveTelnetProtocol and the
         # insults wrapper reach it: session.transport is CowrieTelnetTransport.
-        session.transport = SimpleNamespace(
+        session.transport = SimpleNamespace(  # type: ignore[assignment]
             events=events,
             transportId="telnet01",
             factory=SimpleNamespace(starttime=0),
@@ -148,18 +118,14 @@ class SshRequestEnvEventTests(unittest.TestCase):
     def test_request_env_dispatches_client_var(self) -> None:
         from cowrie.ssh.session import HoneyPotSSHSession
 
-        sink = CaptureSink()
-        events = EventLog(
-            EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
-            session="testexec",
-            protocol="ssh",
-            src_ip="1.1.1.1",
+        events, dispatched = capture_eventlog(
+            session="testexec", protocol="ssh", src_ip="1.1.1.1"
         )
         conn = SimpleNamespace(transport=SimpleNamespace(events=events))
         channel = HoneyPotSSHSession(conn=conn)
         result = channel.request_env(NS(b"LANG") + NS(b"en_US.UTF-8"))
         self.assertEqual(result, 0)
-        client_vars = events_of(sink.events, "cowrie.client.var")
+        client_vars = events_of(dispatched, "cowrie.client.var")
         self.assertEqual(len(client_vars), 1)
         self.assertEqual(client_vars[0]["name"], "LANG")
         self.assertEqual(client_vars[0]["value"], "en_US.UTF-8")

--- a/src/cowrie/test/test_insults_events.py
+++ b/src/cowrie/test/test_insults_events.py
@@ -95,6 +95,55 @@ class StdinCaptureEventTests(unittest.TestCase):
             insults.LoggingServerProtocol.ttylogPath = old_path
 
 
+class TelnetInsultsEventLogTests(unittest.TestCase):
+    """The telnet insults wrapper must find the EventLog on the telnet
+    transport (session.transport), wiring the real telnet session chain."""
+
+    def test_telnet_session_chain_binds_eventlog(self) -> None:
+        from cowrie.telnet.session import (
+            HoneyPotTelnetSession,
+            TelnetSessionProcessProtocol,
+        )
+
+        sink = CaptureSink()
+        events = EventLog(
+            EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
+            session="telnet01",
+            protocol="telnet",
+            src_ip="1.1.1.1",
+        )
+        server = FakeServer()
+        server.initFileSystem = lambda home: None
+        server.fs = FakeServer().fs
+
+        session = HoneyPotTelnetSession(b"root", server)
+        session.transportId = "telnet01"
+        peer = SimpleNamespace(host="1.1.1.1", port=2323)
+        # The telnet transport as HoneyPotInteractiveTelnetProtocol and the
+        # insults wrapper reach it: session.transport is CowrieTelnetTransport.
+        session.transport = SimpleNamespace(
+            events=events,
+            transportId="telnet01",
+            factory=SimpleNamespace(starttime=0),
+            transport=SimpleNamespace(sessionno=1, getPeer=lambda: peer),
+            options={},
+            write=lambda data: None,
+        )
+
+        from cowrie.shell.protocol import HoneyPotInteractiveTelnetProtocol
+
+        lsp = insults.LoggingTelnetServerProtocol(
+            HoneyPotInteractiveTelnetProtocol, session
+        )
+        pp = TelnetSessionProcessProtocol(session)
+        lsp.makeConnection(pp)
+        try:
+            self.assertIs(lsp.events, events)
+            self.assertIs(lsp.terminalProtocol.events, events)
+        finally:
+            lsp.connectionLost(connectionDone)
+
+
 class SshRequestEnvEventTests(unittest.TestCase):
     def test_request_env_dispatches_client_var(self) -> None:
         from cowrie.ssh.session import HoneyPotSSHSession

--- a/src/cowrie/test/test_insults_events.py
+++ b/src/cowrie/test/test_insults_events.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Asserts the insults terminal wrapper and SSH session channel
+# ABOUTME: dispatch their events through the session EventLog.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from typing import Any
+
+from twisted.conch.ssh.common import NS
+from twisted.internet.protocol import connectionDone
+
+from cowrie.core.events import EventDispatcher, EventLog
+from cowrie.insults import insults
+from cowrie.shell import protocol
+from cowrie.test.eventcapture import CaptureSink
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+
+_DOWNLOAD_DIR = tempfile.mkdtemp(prefix="cowrie_insults_events_")
+_TTYLOG_DIR = tempfile.mkdtemp(prefix="cowrie_insults_ttylog_")
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = _DOWNLOAD_DIR
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+insults.LoggingServerProtocol.downloadPath = _DOWNLOAD_DIR
+
+
+def _make_exec_transport(sink: CaptureSink) -> SimpleNamespace:
+    """The transport.session.conn.transport chain insults expects, with an
+    EventLog whose events land in ``sink``."""
+    peer = SimpleNamespace(host="1.1.1.1", port=2222)
+    inner = SimpleNamespace(sessionno=1, getPeer=lambda: peer)
+    factory = SimpleNamespace(starttime=0)
+    events = EventLog(
+        EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
+        session="testexec",
+        protocol="ssh",
+        src_ip="1.1.1.1",
+    )
+    conn_transport = SimpleNamespace(
+        transportId="testexec", factory=factory, transport=inner, events=events
+    )
+    conn = SimpleNamespace(transport=conn_transport)
+    session = SimpleNamespace(id="chan0", conn=conn)
+    return SimpleNamespace(
+        session=session,
+        write=lambda data: None,
+        processEnded=lambda reason=None: None,
+    )
+
+
+def events_of(events: list[dict[str, Any]], eventid: str) -> list[dict[str, Any]]:
+    return [e for e in events if e["eventid"] == eventid]
+
+
+class StdinCaptureEventTests(unittest.TestCase):
+    def run_exec(self, cmd: bytes, payload: bytes) -> list[dict[str, Any]]:
+        sink = CaptureSink()
+        avatar = FakeAvatar(FakeServer())
+        avatar.server.initFileSystem = lambda home: None
+        lsp = insults.LoggingServerProtocol(protocol.HoneyPotExecProtocol, avatar, cmd)
+        lsp.makeConnection(_make_exec_transport(sink))
+        lsp.dataReceived(payload)
+        lsp.eofReceived()
+        lsp.connectionLost(connectionDone)
+        return sink.events
+
+    def test_stdin_capture_dispatches_file_download(self) -> None:
+        dispatched = self.run_exec(b"cat", b"captured stdin payload")
+        downloads = events_of(dispatched, "cowrie.session.file_download")
+        self.assertEqual(len(downloads), 1)
+        self.assertEqual(downloads[0]["session"], "testexec")
+        self.assertEqual(downloads[0]["destfile"], "")
+        self.assertIn("shasum", downloads[0])
+
+    def test_ttylog_closed_dispatches_log_closed(self) -> None:
+        old_enabled = insults.LoggingServerProtocol.ttylogEnabled
+        old_path = insults.LoggingServerProtocol.ttylogPath
+        insults.LoggingServerProtocol.ttylogEnabled = True
+        insults.LoggingServerProtocol.ttylogPath = _TTYLOG_DIR
+        try:
+            dispatched = self.run_exec(b"echo hi", b"")
+            closed = events_of(dispatched, "cowrie.log.closed")
+            self.assertEqual(len(closed), 1)
+            self.assertEqual(closed[0]["session"], "testexec")
+            self.assertIsInstance(closed[0]["duration_ms"], int)
+        finally:
+            insults.LoggingServerProtocol.ttylogEnabled = old_enabled
+            insults.LoggingServerProtocol.ttylogPath = old_path
+
+
+class SshRequestEnvEventTests(unittest.TestCase):
+    def test_request_env_dispatches_client_var(self) -> None:
+        from cowrie.ssh.session import HoneyPotSSHSession
+
+        sink = CaptureSink()
+        events = EventLog(
+            EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
+            session="testexec",
+            protocol="ssh",
+            src_ip="1.1.1.1",
+        )
+        conn = SimpleNamespace(transport=SimpleNamespace(events=events))
+        channel = HoneyPotSSHSession(conn=conn)
+        result = channel.request_env(NS(b"LANG") + NS(b"en_US.UTF-8"))
+        self.assertEqual(result, 0)
+        client_vars = events_of(sink.events, "cowrie.client.var")
+        self.assertEqual(len(client_vars), 1)
+        self.assertEqual(client_vars[0]["name"], "LANG")
+        self.assertEqual(client_vars[0]["value"], "en_US.UTF-8")
+        self.assertEqual(client_vars[0]["session"], "testexec")

--- a/src/cowrie/test/test_insults_events.py
+++ b/src/cowrie/test/test_insults_events.py
@@ -39,7 +39,6 @@ class StdinCaptureEventTests(unittest.TestCase):
     def run_exec(self, cmd: bytes, payload: bytes) -> list[dict[str, Any]]:
         sink = CaptureSink()
         avatar = FakeAvatar(FakeServer())
-        avatar.server.initFileSystem = lambda home: None
         lsp = insults.LoggingServerProtocol(protocol.HoneyPotExecProtocol, avatar, cmd)
         lsp.makeConnection(make_exec_transport(sink))
         lsp.dataReceived(payload)

--- a/src/cowrie/test/test_scp_exec.py
+++ b/src/cowrie/test/test_scp_exec.py
@@ -45,7 +45,6 @@ def run_exec_scp_push(
     """
     sink = CaptureSink()
     avatar = FakeAvatar(FakeServer())
-    avatar.server.initFileSystem = lambda home: None
     if fs_newcount is not None:
         avatar.server.fs.newcount = fs_newcount
 

--- a/src/cowrie/test/test_scp_exec.py
+++ b/src/cowrie/test/test_scp_exec.py
@@ -13,11 +13,12 @@ import unittest
 from types import SimpleNamespace
 
 from twisted.internet.protocol import connectionDone
-from twisted.python import log
 
 from cowrie.commands import scp
+from cowrie.core.events import EventDispatcher, EventLog
 from cowrie.insults import insults
 from cowrie.shell import protocol
+from cowrie.test.eventcapture import CaptureSink
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
@@ -32,13 +33,20 @@ scp.Command_scp.download_path = _DOWNLOAD_DIR
 scp.Command_scp.download_path_uniq = _DOWNLOAD_DIR
 
 
-def _make_exec_transport() -> SimpleNamespace:
-    """Build the transport.session.conn.transport chain insults expects."""
+def _make_exec_transport(sink: CaptureSink) -> SimpleNamespace:
+    """Build the transport.session.conn.transport chain insults expects, with
+    an EventLog whose events land in ``sink``."""
     peer = SimpleNamespace(host="1.1.1.1", port=2222)
     inner = SimpleNamespace(sessionno=1, getPeer=lambda: peer)
     factory = SimpleNamespace(starttime=0, logDispatch=lambda **kw: None)
+    events = EventLog(
+        EventDispatcher([sink], logmsg=lambda *a, **kw: None),
+        session="testexec",
+        protocol="ssh",
+        src_ip="1.1.1.1",
+    )
     conn_transport = SimpleNamespace(
-        transportId="testexec", factory=factory, transport=inner
+        transportId="testexec", factory=factory, transport=inner, events=events
     )
     conn = SimpleNamespace(transport=conn_transport)
     session = SimpleNamespace(id="chan0", conn=conn)
@@ -59,31 +67,28 @@ def run_exec_scp_push(
     non-zero chunk_size splits the stdin across multiple dataReceived calls, as
     happens for a large transfer. fs_newcount pre-loads the filesystem's
     new-file counter to drive it over its quota. Returns the contents of every
-    saved download file and the captured log events.
+    saved download file and the captured events.
     """
-    events: list[dict] = []
-    log.addObserver(events.append)
-    try:
-        avatar = FakeAvatar(FakeServer())
-        avatar.server.initFileSystem = lambda home: None
-        if fs_newcount is not None:
-            avatar.server.fs.newcount = fs_newcount
+    sink = CaptureSink()
+    avatar = FakeAvatar(FakeServer())
+    avatar.server.initFileSystem = lambda home: None
+    if fs_newcount is not None:
+        avatar.server.fs.newcount = fs_newcount
 
-        lsp = insults.LoggingServerProtocol(
-            protocol.HoneyPotExecProtocol, avatar, b"scp -t /tmp"
-        )
-        lsp.makeConnection(_make_exec_transport())
+    lsp = insults.LoggingServerProtocol(
+        protocol.HoneyPotExecProtocol, avatar, b"scp -t /tmp"
+    )
+    lsp.makeConnection(_make_exec_transport(sink))
 
-        live_stdinlog = lsp.stdinlogFile
-        if chunk_size:
-            for i in range(0, len(framed_stdin), chunk_size):
-                lsp.dataReceived(framed_stdin[i : i + chunk_size])
-        else:
-            lsp.dataReceived(framed_stdin)
-        lsp.eofReceived()
-        lsp.connectionLost(connectionDone)
-    finally:
-        log.removeObserver(events.append)
+    live_stdinlog = lsp.stdinlogFile
+    if chunk_size:
+        for i in range(0, len(framed_stdin), chunk_size):
+            lsp.dataReceived(framed_stdin[i : i + chunk_size])
+    else:
+        lsp.dataReceived(framed_stdin)
+    lsp.eofReceived()
+    lsp.connectionLost(connectionDone)
+    events = sink.events
 
     saved = []
     for name in os.listdir(_DOWNLOAD_DIR):

--- a/src/cowrie/test/test_scp_exec.py
+++ b/src/cowrie/test/test_scp_exec.py
@@ -10,15 +10,13 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
-from types import SimpleNamespace
 
 from twisted.internet.protocol import connectionDone
 
 from cowrie.commands import scp
-from cowrie.core.events import EventDispatcher, EventLog
 from cowrie.insults import insults
 from cowrie.shell import protocol
-from cowrie.test.eventcapture import CaptureSink
+from cowrie.test.eventcapture import CaptureSink, make_exec_transport
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
@@ -31,30 +29,6 @@ _DOWNLOAD_DIR = tempfile.mkdtemp(prefix="cowrie_scp_exec_")
 insults.LoggingServerProtocol.downloadPath = _DOWNLOAD_DIR
 scp.Command_scp.download_path = _DOWNLOAD_DIR
 scp.Command_scp.download_path_uniq = _DOWNLOAD_DIR
-
-
-def _make_exec_transport(sink: CaptureSink) -> SimpleNamespace:
-    """Build the transport.session.conn.transport chain insults expects, with
-    an EventLog whose events land in ``sink``."""
-    peer = SimpleNamespace(host="1.1.1.1", port=2222)
-    inner = SimpleNamespace(sessionno=1, getPeer=lambda: peer)
-    factory = SimpleNamespace(starttime=0, logDispatch=lambda **kw: None)
-    events = EventLog(
-        EventDispatcher([sink], logmsg=lambda *a, **kw: None),
-        session="testexec",
-        protocol="ssh",
-        src_ip="1.1.1.1",
-    )
-    conn_transport = SimpleNamespace(
-        transportId="testexec", factory=factory, transport=inner, events=events
-    )
-    conn = SimpleNamespace(transport=conn_transport)
-    session = SimpleNamespace(id="chan0", conn=conn)
-    return SimpleNamespace(
-        session=session,
-        write=lambda data: None,
-        processEnded=lambda reason=None: None,
-    )
 
 
 def run_exec_scp_push(
@@ -78,7 +52,7 @@ def run_exec_scp_push(
     lsp = insults.LoggingServerProtocol(
         protocol.HoneyPotExecProtocol, avatar, b"scp -t /tmp"
     )
-    lsp.makeConnection(_make_exec_transport(sink))
+    lsp.makeConnection(make_exec_transport(sink))
 
     live_stdinlog = lsp.stdinlogFile
     if chunk_size:

--- a/src/cowrie/test/test_session_duration.py
+++ b/src/cowrie/test/test_session_duration.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 from cowrie.ssh import channel as ssh_channel
 from cowrie.ssh import transport as ssh_transport
 from cowrie.telnet import transport as telnet_transport
+from cowrie.test.eventcapture import capture_events
 
 
 class TestSessionDuration(unittest.TestCase):
@@ -67,15 +68,19 @@ class TestSessionDuration(unittest.TestCase):
         ch = ssh_channel.CowrieSSHChannel()
         ch.ttylogFile = "/dev/null"
         ch.startTime = time.time() - 5
+        dispatched = capture_events(ch)
 
         with (
-            patch("cowrie.ssh.channel.log.msg") as mock_msg,
             patch("cowrie.ssh.channel.ttylog.ttylog_close"),
             patch("twisted.conch.ssh.channel.SSHChannel.closed"),
         ):
             ch.closed()
 
-        event = self._event(mock_msg, "cowrie.log.closed")
+        event = next(
+            (e for e in dispatched if e.get("eventid") == "cowrie.log.closed"), None
+        )
+        self.assertIsNotNone(event, "no cowrie.log.closed event was dispatched")
+        assert event is not None
         ms = event["duration_ms"]
         assert isinstance(ms, int)
         self.assertNotIn("duration", event)

--- a/src/cowrie/test/test_session_duration.py
+++ b/src/cowrie/test/test_session_duration.py
@@ -20,49 +20,47 @@ from cowrie.test.eventcapture import capture_events
 class TestSessionDuration(unittest.TestCase):
     """Session events must report duration as an integer duration_ms field."""
 
-    def _event(self, mock_msg: MagicMock, eventid: str) -> dict[str, object]:
-        for call in mock_msg.call_args_list:
-            if call.kwargs.get("eventid") == eventid:
-                return dict(call.kwargs)
+    def _event(
+        self, dispatched: list[dict[str, object]], eventid: str
+    ) -> dict[str, object]:
+        for event in dispatched:
+            if event.get("eventid") == eventid:
+                return event
         self.fail(f"no {eventid} event was emitted")
 
-    def _closed_event(self, mock_msg: MagicMock) -> dict[str, object]:
-        return self._event(mock_msg, "cowrie.session.closed")
+    def _assert_closed_duration(self, dispatched: list[dict[str, object]]) -> None:
+        event = self._event(dispatched, "cowrie.session.closed")
+        ms = event["duration_ms"]
+        assert isinstance(ms, int)
+        self.assertNotIn("duration", event)
+        self.assertGreaterEqual(ms, 5000)
 
     def test_ssh_duration_ms_is_int(self) -> None:
         t = ssh_transport.HoneyPotSSHTransport()
         t.transport = MagicMock()
         t.startTime = time.time() - 5
+        dispatched = capture_events(t)
 
         with (
-            patch("cowrie.ssh.transport.log.msg") as mock_msg,
             patch.object(ssh_transport.HoneyPotSSHTransport, "setTimeout"),
             patch("twisted.conch.ssh.transport.SSHServerTransport.connectionLost"),
         ):
             t.connectionLost()
 
-        event = self._closed_event(mock_msg)
-        ms = event["duration_ms"]
-        assert isinstance(ms, int)
-        self.assertNotIn("duration", event)
-        self.assertGreaterEqual(ms, 5000)
+        self._assert_closed_duration(dispatched)
 
     def test_telnet_duration_ms_is_int(self) -> None:
         t = telnet_transport.CowrieTelnetTransport()
         t.startTime = time.time() - 5
+        dispatched = capture_events(t)
 
         with (
-            patch("cowrie.telnet.transport.log.msg") as mock_msg,
             patch.object(telnet_transport.CowrieTelnetTransport, "setTimeout"),
             patch("twisted.conch.telnet.TelnetTransport.connectionLost"),
         ):
             t.connectionLost()
 
-        event = self._closed_event(mock_msg)
-        ms = event["duration_ms"]
-        assert isinstance(ms, int)
-        self.assertNotIn("duration", event)
-        self.assertGreaterEqual(ms, 5000)
+        self._assert_closed_duration(dispatched)
 
     def test_log_closed_duration_ms_is_int(self) -> None:
         ch = ssh_channel.CowrieSSHChannel()

--- a/src/cowrie/test/test_shell_events.py
+++ b/src/cowrie/test/test_shell_events.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Asserts that the shell, session, SFTP, and LLM layers dispatch
+# ABOUTME: their events through the session EventLog with bound identity.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from typing import Any
+
+from twisted.conch.ssh.filetransfer import FXF_CREAT, FXF_WRITE
+
+from cowrie.core.events import EventDispatcher, EventLog
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.eventcapture import CaptureSink
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.mkdtemp(
+    prefix="cowrie_shell_events_"
+)
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+def capture_eventlog() -> tuple[EventLog, list[dict[str, Any]]]:
+    sink = CaptureSink()
+    events = EventLog(
+        EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
+        session="test-suite",
+        protocol="test",
+        src_ip="1.1.1.1",
+    )
+    return events, sink.events
+
+
+def events_of(events: list[dict[str, Any]], eventid: str) -> list[dict[str, Any]]:
+    return [e for e in events if e["eventid"] == eventid]
+
+
+class ShellEventTests(unittest.TestCase):
+    """The interactive shell's command events carry the bound identity."""
+
+    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+    tr = FakeTransport("", "31337")
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.proto.makeConnection(cls.tr)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proto.connectionLost()
+
+    def setUp(self) -> None:
+        self.tr.clear()
+
+    def test_command_input_event(self) -> None:
+        self.proto.lineReceived(b"echo hello")
+        events = events_of(self.tr.dispatchedEvents, "cowrie.command.input")
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["input"], "echo hello")
+        self.assertEqual(events[0]["message"], "CMD: echo hello")
+        self.assertEqual(events[0]["session"], "test-suite")
+
+    def test_command_failed_event(self) -> None:
+        self.proto.lineReceived(b"nosuchcommand --foo")
+        events = events_of(self.tr.dispatchedEvents, "cowrie.command.failed")
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["input"], "nosuchcommand --foo")
+        self.assertEqual(events[0]["session"], "test-suite")
+
+
+class SessionParamsEventTests(unittest.TestCase):
+    def test_session_params_dispatched_on_connection(self) -> None:
+        proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        tr = FakeTransport("", "31337")
+        proto.makeConnection(tr)
+        try:
+            events = events_of(tr.dispatchedEvents, "cowrie.session.params")
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0]["arch"], "linux-x64-lsb")
+            self.assertEqual(events[0]["session"], "test-suite")
+        finally:
+            proto.connectionLost()
+
+
+class ClientSizeEventTests(unittest.TestCase):
+    """getPty dispatches the client's terminal size on both session types."""
+    def make_session(self, sessionclass: type) -> tuple[Any, list[dict[str, Any]]]:
+        events, dispatched = capture_eventlog()
+        server = FakeServer()
+        server.initFileSystem = lambda home: None
+        avatar = SimpleNamespace(
+            server=server,
+            uid=0,
+            gid=0,
+            username="root",
+            home="/root",
+            temporary=False,
+            conn=SimpleNamespace(transport=SimpleNamespace(events=events)),
+        )
+        return sessionclass(avatar), dispatched
+
+    def assert_client_size_event(self, session: Any, dispatched: list) -> None:
+        session.getPty(b"xterm", (24, 80, 0, 0), None)
+        events = events_of(dispatched, "cowrie.client.size")
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["width"], 80)
+        self.assertEqual(events[0]["height"], 24)
+        self.assertEqual(events[0]["session"], "test-suite")
+
+    def test_shell_session_client_size_event(self) -> None:
+        from cowrie.shell.session import SSHSessionForCowrieUser
+
+        session, dispatched = self.make_session(SSHSessionForCowrieUser)
+        self.assert_client_size_event(session, dispatched)
+
+    def test_llm_session_client_size_event(self) -> None:
+        from cowrie.llm.session import SSHSessionForCowrieUser
+
+        session, dispatched = self.make_session(SSHSessionForCowrieUser)
+        self.assert_client_size_event(session, dispatched)
+
+
+class SftpUploadEventTests(unittest.TestCase):
+    def test_sftp_upload_dispatches_file_upload(self) -> None:
+        from cowrie.shell import fs
+        from cowrie.shell.filetransfer import SFTPServerForCowrieUser
+
+        events, dispatched = capture_eventlog()
+        server = SFTPServerForCowrieUser.__new__(SFTPServerForCowrieUser)
+        server.fs = fs.HoneyPotFilesystem("linux-x64-lsb", "/root")
+        server.fs.events = events
+        server.avatar = SimpleNamespace(home="/root")
+
+        handle = server.openFile("/root/payload.bin", FXF_WRITE | FXF_CREAT, {})
+        handle.writeChunk(0, b"malicious payload")
+        handle.close()
+
+        uploads = events_of(dispatched, "cowrie.session.file_upload")
+        self.assertEqual(len(uploads), 1)
+        self.assertEqual(uploads[0]["filename"], "payload.bin")
+        self.assertEqual(uploads[0]["session"], "test-suite")
+        self.assertIn("shasum", uploads[0])
+
+
+class LlmCommandInputEventTests(unittest.TestCase):
+    def test_llm_command_input_event(self) -> None:
+        from cowrie.llm import protocol as llmprotocol
+
+        proto = llmprotocol.HoneyPotBaseProtocol(FakeAvatar(FakeServer()))
+        proto._process_command_with_llm = lambda command: None  # type: ignore[method-assign]
+        tr = FakeTransport("", "31337")
+        proto.makeConnection(tr)
+        try:
+            tr.clear()
+            proto.lineReceived(b"uname -a")
+            events = events_of(tr.dispatchedEvents, "cowrie.command.input")
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0]["input"], "uname -a")
+            self.assertEqual(events[0]["session"], "test-suite")
+        finally:
+            proto.connectionLost(None)

--- a/src/cowrie/test/test_shell_events.py
+++ b/src/cowrie/test/test_shell_events.py
@@ -15,9 +15,8 @@ from typing import Any
 
 from twisted.conch.ssh.filetransfer import FXF_CREAT, FXF_WRITE
 
-from cowrie.core.events import EventDispatcher, EventLog
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
-from cowrie.test.eventcapture import CaptureSink
+from cowrie.test.eventcapture import capture_eventlog, events_of
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
@@ -26,21 +25,6 @@ os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.mkdtemp(
     prefix="cowrie_shell_events_"
 )
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
-
-
-def capture_eventlog() -> tuple[EventLog, list[dict[str, Any]]]:
-    sink = CaptureSink()
-    events = EventLog(
-        EventDispatcher([sink], logmsg=lambda *args, **kwargs: None),
-        session="test-suite",
-        protocol="test",
-        src_ip="1.1.1.1",
-    )
-    return events, sink.events
-
-
-def events_of(events: list[dict[str, Any]], eventid: str) -> list[dict[str, Any]]:
-    return [e for e in events if e["eventid"] == eventid]
 
 
 class ShellEventTests(unittest.TestCase):
@@ -94,7 +78,7 @@ class ClientSizeEventTests(unittest.TestCase):
     """getPty dispatches the client's terminal size on both session types."""
 
     def make_session(self, sessionclass: type) -> tuple[Any, list[dict[str, Any]]]:
-        events, dispatched = capture_eventlog()
+        events, dispatched = capture_eventlog(session="test-suite", src_ip="1.1.1.1")
         server = FakeServer()
         avatar = SimpleNamespace(
             server=server,
@@ -133,7 +117,7 @@ class SftpUploadEventTests(unittest.TestCase):
         from cowrie.shell import fs
         from cowrie.shell.filetransfer import SFTPServerForCowrieUser
 
-        events, dispatched = capture_eventlog()
+        events, dispatched = capture_eventlog(session="test-suite", src_ip="1.1.1.1")
         server = SFTPServerForCowrieUser.__new__(SFTPServerForCowrieUser)
         server.fs = fs.HoneyPotFilesystem("linux-x64-lsb", "/root")
         server.fs.events = events

--- a/src/cowrie/test/test_shell_events.py
+++ b/src/cowrie/test/test_shell_events.py
@@ -92,10 +92,10 @@ class SessionParamsEventTests(unittest.TestCase):
 
 class ClientSizeEventTests(unittest.TestCase):
     """getPty dispatches the client's terminal size on both session types."""
+
     def make_session(self, sessionclass: type) -> tuple[Any, list[dict[str, Any]]]:
         events, dispatched = capture_eventlog()
         server = FakeServer()
-        server.initFileSystem = lambda home: None
         avatar = SimpleNamespace(
             server=server,
             uid=0,

--- a/src/cowrie/test/test_ssh_transport.py
+++ b/src/cowrie/test/test_ssh_transport.py
@@ -15,6 +15,7 @@ from twisted.conch.ssh.common import NS
 from twisted.conch.ssh.transport import MSG_SERVICE_REQUEST
 
 from cowrie.ssh import transport as ssh_transport
+from cowrie.test.eventcapture import capture_events
 
 
 def _kexinit_payload(kex_algs: list[bytes]) -> bytes:
@@ -45,14 +46,12 @@ class TestKexInitEscaping(unittest.TestCase):
     def _kex_event(self, packet: bytes) -> dict:
         t = ssh_transport.HoneyPotSSHTransport()
         t.transport = MagicMock()
-        with (
-            patch("cowrie.ssh.transport.log.msg") as mock_msg,
-            patch("twisted.conch.ssh.transport.SSHServerTransport.ssh_KEXINIT"),
-        ):
+        dispatched = capture_events(t)
+        with patch("twisted.conch.ssh.transport.SSHServerTransport.ssh_KEXINIT"):
             t.ssh_KEXINIT(packet)
-        for call in mock_msg.call_args_list:
-            if call.kwargs.get("eventid") == "cowrie.client.kex":
-                return dict(call.kwargs)
+        for event in dispatched:
+            if event.get("eventid") == "cowrie.client.kex":
+                return event
         self.fail("no cowrie.client.kex event was emitted")
 
     def test_invalid_utf8_algorithm_name_does_not_crash(self) -> None:
@@ -85,17 +84,17 @@ class TestMalformedPacket(unittest.TestCase):
         # connection (as OpenSSH does) rather than letting it escape.
         t = ssh_transport.HoneyPotSSHTransport()
         t.transport = MagicMock()
+        dispatched = capture_events(t)
 
-        with patch("cowrie.ssh.transport.log.msg") as mock_msg:
-            t.dispatchMessage(MSG_SERVICE_REQUEST, b"\x00\x00\x00")
+        t.dispatchMessage(MSG_SERVICE_REQUEST, b"\x00\x00\x00")
 
         t.transport.loseConnection.assert_called_once()
 
         event = next(
             (
-                dict(c.kwargs)
-                for c in mock_msg.call_args_list
-                if c.kwargs.get("eventid") == "cowrie.client.malformed_packet"
+                e
+                for e in dispatched
+                if e.get("eventid") == "cowrie.client.malformed_packet"
             ),
             None,
         )

--- a/src/cowrie/test/test_telnet_new_environ.py
+++ b/src/cowrie/test/test_telnet_new_environ.py
@@ -25,6 +25,7 @@ from cowrie.telnet.userauth import (
     NEW_ENVIRON_VAR,
     HoneyPotTelnetAuthProtocol,
 )
+from cowrie.test.eventcapture import capture_events
 
 if TYPE_CHECKING:
     from cowrie.core.credentials import UsernamePasswordIP
@@ -106,10 +107,7 @@ class TestNewEnvironParser(unittest.TestCase):
         """Test parsing the exact CVE-2026-24061 exploit payload."""
         # VAR USER VALUE -f root
         data = (
-            bytes([NEW_ENVIRON_VAR])
-            + b"USER"
-            + bytes([NEW_ENVIRON_VALUE])
-            + b"-f root"
+            bytes([NEW_ENVIRON_VAR]) + b"USER" + bytes([NEW_ENVIRON_VALUE]) + b"-f root"
         )
         result = self.protocol._parse_new_environ_data(data)
         self.assertEqual(result, {"USER": "-f root"})
@@ -132,8 +130,9 @@ class TestCVE2026_24061Detection(unittest.TestCase):
         self.protocol = HoneyPotTelnetAuthProtocol(mock_portal)
         self.protocol.environ_received = {}
 
-        # Mock the transport
+        # Mock the transport, with a capturing event pipeline
         self.protocol.transport = MagicMock()
+        self.dispatched = capture_events(self.protocol.transport)
 
     @patch("cowrie.telnet.userauth.log")
     def test_detect_exploit_f_root(self, mock_log: MagicMock) -> None:
@@ -150,11 +149,11 @@ class TestCVE2026_24061Detection(unittest.TestCase):
 
         # Check that exploit was detected
         exploit_logged = False
-        for call in mock_log.msg.call_args_list:
-            if call[1].get("eventid") == "cowrie.telnet.exploit_attempt":
+        for call in self.dispatched:
+            if call.get("eventid") == "cowrie.telnet.exploit_attempt":
                 exploit_logged = True
-                self.assertEqual(call[1].get("cve"), "CVE-2026-24061")
-                self.assertEqual(call[1].get("value"), "-f root")
+                self.assertEqual(call.get("cve"), "CVE-2026-24061")
+                self.assertEqual(call.get("value"), "-f root")
                 break
         self.assertTrue(exploit_logged, "CVE-2026-24061 exploit should be detected")
 
@@ -171,10 +170,10 @@ class TestCVE2026_24061Detection(unittest.TestCase):
         self.protocol.telnet_NEW_ENVIRON(data)
 
         exploit_logged = False
-        for call in mock_log.msg.call_args_list:
-            if call[1].get("eventid") == "cowrie.telnet.exploit_attempt":
+        for call in self.dispatched:
+            if call.get("eventid") == "cowrie.telnet.exploit_attempt":
                 exploit_logged = True
-                self.assertEqual(call[1].get("cve"), "CVE-2026-24061")
+                self.assertEqual(call.get("cve"), "CVE-2026-24061")
                 break
         self.assertTrue(exploit_logged, "CVE-2026-24061 variant should be detected")
 
@@ -191,8 +190,8 @@ class TestCVE2026_24061Detection(unittest.TestCase):
         self.protocol.telnet_NEW_ENVIRON(data)
 
         exploit_logged = False
-        for call in mock_log.msg.call_args_list:
-            if call[1].get("eventid") == "cowrie.telnet.exploit_attempt":
+        for call in self.dispatched:
+            if call.get("eventid") == "cowrie.telnet.exploit_attempt":
                 exploit_logged = True
                 break
         self.assertTrue(exploit_logged, "Lowercase 'user' should also be detected")
@@ -210,11 +209,13 @@ class TestCVE2026_24061Detection(unittest.TestCase):
         self.protocol.telnet_NEW_ENVIRON(data)
 
         exploit_logged = False
-        for call in mock_log.msg.call_args_list:
-            if call[1].get("eventid") == "cowrie.telnet.exploit_attempt":
+        for call in self.dispatched:
+            if call.get("eventid") == "cowrie.telnet.exploit_attempt":
                 exploit_logged = True
                 break
-        self.assertFalse(exploit_logged, "Normal username should not trigger exploit detection")
+        self.assertFalse(
+            exploit_logged, "Normal username should not trigger exploit detection"
+        )
 
     @patch("cowrie.telnet.userauth.log")
     def test_logs_client_var_event(self, mock_log: MagicMock) -> None:
@@ -229,11 +230,11 @@ class TestCVE2026_24061Detection(unittest.TestCase):
         self.protocol.telnet_NEW_ENVIRON(data)
 
         var_logged = False
-        for call in mock_log.msg.call_args_list:
-            if call[1].get("eventid") == "cowrie.client.var":
+        for call in self.dispatched:
+            if call.get("eventid") == "cowrie.client.var":
                 var_logged = True
-                self.assertEqual(call[1].get("name"), "TERM")
-                self.assertEqual(call[1].get("value"), "xterm")
+                self.assertEqual(call.get("name"), "TERM")
+                self.assertEqual(call.get("value"), "xterm")
                 break
         self.assertTrue(var_logged, "Environment variable should be logged")
 
@@ -250,8 +251,8 @@ class TestCVE2026_24061Detection(unittest.TestCase):
 
         # Should not log anything since SEND is ignored
         var_logged = False
-        for call in mock_log.msg.call_args_list:
-            if call[1].get("eventid") == "cowrie.client.var":
+        for call in self.dispatched:
+            if call.get("eventid") == "cowrie.client.var":
                 var_logged = True
                 break
         self.assertFalse(var_logged, "SEND command should be ignored")
@@ -303,6 +304,7 @@ class TestCVE2026_24061Emulation(unittest.TestCase):
         self.protocol.environ_received = {}
         self.mock_transport = MagicMock()
         self.protocol.transport = self.mock_transport
+        self.dispatched = capture_events(self.mock_transport)
 
     def test_extract_username_from_f_space_root(self) -> None:
         """Test extracting username from '-f root' format."""
@@ -408,7 +410,8 @@ class TestCVE2026_24061Emulation(unittest.TestCase):
 
         # Verify the credentials used the exploit username
         self.assertEqual(len(captured_creds), 1)
-        self.assertEqual(captured_creds[0].username, b"root")  
+        self.assertEqual(captured_creds[0].username, b"root")
+
     @patch("cowrie.telnet.userauth.CowrieConfig")
     @patch("cowrie.telnet.userauth.log")
     def test_exploit_success_is_logged(
@@ -425,21 +428,21 @@ class TestCVE2026_24061Emulation(unittest.TestCase):
         self.mock_transport.wontChain.return_value = MagicMock()
 
         self.protocol.cve_2026_24061_user = "root"
-        self.protocol.username = b""  
+        self.protocol.username = b""
         # Mock portal.login
         d = MagicMock()
         d.addCallback = MagicMock(return_value=d)
         d.addErrback = MagicMock(return_value=d)
-        self.protocol.portal.login = MagicMock(return_value=d)  
+        self.protocol.portal.login = MagicMock(return_value=d)
         self.protocol.telnet_Password(b"id")
 
         # Check for exploit success log
         exploit_success_logged = False
-        for call in mock_log.msg.call_args_list:
-            if call[1].get("eventid") == "cowrie.telnet.exploit_success":
+        for call in self.dispatched:
+            if call.get("eventid") == "cowrie.telnet.exploit_success":
                 exploit_success_logged = True
-                self.assertEqual(call[1].get("cve"), "CVE-2026-24061")
-                self.assertEqual(call[1].get("username"), "root")
+                self.assertEqual(call.get("cve"), "CVE-2026-24061")
+                self.assertEqual(call.get("username"), "root")
                 break
         self.assertTrue(exploit_success_logged, "Exploit success should be logged")
 

--- a/src/cowrie/test/test_telnet_transport.py
+++ b/src/cowrie/test/test_telnet_transport.py
@@ -24,6 +24,7 @@ from twisted.python import failure, log
 from zope.interface import implementer
 
 from cowrie.telnet.transport import CowrieTelnetTransport
+from cowrie.test.eventcapture import capture_events
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -253,15 +254,11 @@ class TestInvalidIACSequence(unittest.TestCase):
         self.transport = CowrieTelnetTransport()
         self.tcp = MagicMock()
         self.transport.transport = self.tcp
+        self.dispatched = capture_events(self.transport)
 
     def _capture(self, run: Callable[[], None]) -> list[dict]:
-        events: list[dict] = []
-        log.addObserver(events.append)
-        try:
-            run()
-        finally:
-            log.removeObserver(events.append)
-        return [e for e in events if e.get("eventid") == "cowrie.telnet.error"]
+        run()
+        return [e for e in self.dispatched if e.get("eventid") == "cowrie.telnet.error"]
 
     def test_invalid_iac_byte_dropped_cleanly(self) -> None:
         # IAC (0xFF) followed by 0x01, which is not a valid IAC command byte.
@@ -289,15 +286,13 @@ class TestOptionLoggingDeduplication(unittest.TestCase):
         self.transport.transport = MagicMock()
         # Normally initialised in connectionMade.
         self.transport._logged_options = set()
+        self.dispatched = capture_events(self.transport)
 
     def _capture(self, run: Callable[[], None]) -> list[dict]:
-        events: list[dict] = []
-        log.addObserver(events.append)
-        try:
-            run()
-        finally:
-            log.removeObserver(events.append)
-        return [e for e in events if e.get("eventid") == "cowrie.telnet.option"]
+        run()
+        return [
+            e for e in self.dispatched if e.get("eventid") == "cowrie.telnet.option"
+        ]
 
     def test_repeated_negotiation_logged_once(self) -> None:
         def run() -> None:

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -21,6 +21,7 @@ from cowrie.commands.tftp import (
     TFTP_BLOCK_SIZE,
 )
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.eventcapture import capture_events
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
@@ -104,6 +105,7 @@ class ShellTftpCommandTests(unittest.TestCase):
         self.tr = FakeTransport("", "31337")
         self.proto.makeConnection(self.tr)
         self.tr.clear()
+        capture_events(self.proto)
 
     def tearDown(self) -> None:
         self.proto.connectionLost()
@@ -164,6 +166,7 @@ class ShellTftpAsyncTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.proto.makeConnection(cls.tr)
+        capture_events(cls.proto)
 
         # Setup mock TFTP server
         server_protocol = MockTFTPServer(cls.test_content)

--- a/src/cowrie/test/test_wget.py
+++ b/src/cowrie/test/test_wget.py
@@ -19,6 +19,7 @@ from cowrie.commands.wget import Command_wget
 from cowrie.core.artifact import Artifact
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.eventcapture import capture_events
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
@@ -34,8 +35,7 @@ class WgetArtifactCleanupTests(unittest.TestCase):
         self.tr = FakeTransport("", "31337")
         self.proto.makeConnection(self.tr)
         self.tr.clear()
-        # The fake factory has no logDispatch; error() dispatches a log event.
-        self.proto.logDispatch = lambda **_kw: None  # type: ignore[method-assign]
+        self.events = capture_events(self.proto)
 
         self.tmpdir = tempfile.mkdtemp()
         self._orig_artifact_dir = Artifact.artifactDir
@@ -70,6 +70,30 @@ class WgetArtifactCleanupTests(unittest.TestCase):
             "failed download left an orphaned temp file behind",
         )
         self.assertEqual(os.listdir(self.tmpdir), [])
+
+    def test_failed_download_emits_attributed_event(self) -> None:
+        # error() runs in a deferred callback; the event it emits must carry
+        # the session identity (bound on the EventLog) even though it fires
+        # outside the transport's execution context.
+        cmd = Command_wget.__new__(Command_wget)
+        cmd.protocol = self.proto
+        cmd.errorWritefn = lambda _data: None
+        cmd.exit = lambda code=None: None  # type: ignore[method-assign]
+        cmd.url = b"http://no.such.host/file"
+        cmd.host = "no.such.host"
+        cmd.port = 80
+        cmd.artifact = Artifact("wget-download")
+
+        cmd.error(Failure(error.DNSLookupError()))
+
+        failed = [
+            e
+            for e in self.events
+            if e["eventid"] == "cowrie.session.file_download.failed"
+        ]
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0]["session"], "test0000")
+        self.assertEqual(failed[0]["url"], "http://no.such.host/file")
 
     def test_exit_removes_empty_artifact(self) -> None:
         # An aborted download (CTRL-C, size limit) reaches exit() with an empty

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -154,9 +154,10 @@ Makes a Cowrie SSH/Telnet honeypot.
         # dispatcher to the output plugins and the console renderer
         # (see docs/EVENT_PIPELINE.rst).
         self.dispatcher = EventDispatcher([*self.output_plugins, ConsoleRenderer()])
-        reactor.addSystemEventTrigger(  # type: ignore[attr-defined]
-            "before", "shutdown", self.dispatcher.stop
-        )
+        # Stop only after reactor teardown: connections closed during
+        # shutdown still emit their final events (ttylog closed, stdin
+        # capture); the guard exists for deferreds firing later than that.
+        reactor.addSystemEventTrigger("after", "shutdown", self.dispatcher.stop)
 
         self.topService = service.MultiService()
         application = service.Application("cowrie")

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -32,7 +32,6 @@ from cowrie.core.utils import create_endpoint_services, get_endpoints_from_secti
 from cowrie.pool_interface.handler import PoolHandler
 
 if TYPE_CHECKING:
-
     from cowrie.core.output import Output
 
 
@@ -137,7 +136,6 @@ Makes a Cowrie SSH/Telnet honeypot.
             engine: str = x.split("_")[1]
             try:
                 output = import_module(f"cowrie.output.{engine}").Output()
-                log.addObserver(output.emit)
                 self.output_plugins.append(output)
                 log.msg(f"Loaded output engine: {engine}")
             except ImportError as e:

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -32,7 +32,8 @@ from cowrie.core.utils import create_endpoint_services, get_endpoints_from_secti
 from cowrie.pool_interface.handler import PoolHandler
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+
+    from cowrie.core.output import Output
 
 
 class Options(usage.Options):
@@ -63,7 +64,7 @@ class CowrieServiceMaker:
     tapname: ClassVar[str] = "cowrie"
     description: ClassVar[str] = "She sells sea shells by the sea shore."
     options = Options
-    output_plugins: list[Callable]
+    output_plugins: list[Output]
     topService: service.Service
 
     def __init__(self) -> None:
@@ -154,6 +155,8 @@ Makes a Cowrie SSH/Telnet honeypot.
         # dispatcher to the output plugins and the console renderer
         # (see docs/EVENT_PIPELINE.rst).
         self.dispatcher = EventDispatcher([*self.output_plugins, ConsoleRenderer()])
+        for plugin in self.output_plugins:
+            plugin.dispatcher = self.dispatcher
         # Stop only after reactor teardown: connections closed during
         # shutdown still emit their final events (ttylog closed, stdin
         # capture); the guard exists for deferreds firing later than that.

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import os
 import sys
 from importlib import import_module
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
 from twisted._version import __version__ as __twisted_version__
 from twisted.application import service
@@ -28,11 +28,9 @@ from cowrie import __version__ as __cowrie_version__
 from cowrie.core import checkers, uuid
 from cowrie.core.config import CowrieConfig
 from cowrie.core.events import ConsoleRenderer, EventDispatcher
+from cowrie.core.output import Output
 from cowrie.core.utils import create_endpoint_services, get_endpoints_from_section
 from cowrie.pool_interface.handler import PoolHandler
-
-if TYPE_CHECKING:
-    from cowrie.core.output import Output
 
 
 class Options(usage.Options):
@@ -126,6 +124,16 @@ Makes a Cowrie SSH/Telnet honeypot.
             )
             sys.exit(1)
 
+        # The event pipeline: session EventLogs deliver through this
+        # dispatcher to the output plugins and the console renderer
+        # (see docs/EVENT_PIPELINE.rst). It exists before the plugins so
+        # events they dispatch from start() are delivered; the plugin
+        # sinks join the fan-out once loading is complete.
+        renderer = ConsoleRenderer()
+        self.dispatcher = EventDispatcher([renderer])
+        self.dispatcher.registerShutdown(reactor)
+        Output.dispatcher = self.dispatcher
+
         # Load output modules
         self.output_plugins = []
         for x in CowrieConfig.sections():
@@ -149,16 +157,7 @@ Makes a Cowrie SSH/Telnet honeypot.
                 log.err()
                 log.msg(f"Failed to load output engine: {engine}")
 
-        # The event pipeline: session EventLogs deliver through this
-        # dispatcher to the output plugins and the console renderer
-        # (see docs/EVENT_PIPELINE.rst).
-        self.dispatcher = EventDispatcher([*self.output_plugins, ConsoleRenderer()])
-        for plugin in self.output_plugins:
-            plugin.dispatcher = self.dispatcher
-        # Stop only after reactor teardown: connections closed during
-        # shutdown still emit their final events (ttylog closed, stdin
-        # capture); the guard exists for deferreds firing later than that.
-        reactor.addSystemEventTrigger("after", "shutdown", self.dispatcher.stop)
+        self.dispatcher.sinks = [*self.output_plugins, renderer]
 
         self.topService = service.MultiService()
         application = service.Application("cowrie")

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -27,6 +27,7 @@ from backend_pool.pool_server import PoolServerFactory
 from cowrie import __version__ as __cowrie_version__
 from cowrie.core import checkers, uuid
 from cowrie.core.config import CowrieConfig
+from cowrie.core.events import ConsoleRenderer, EventDispatcher
 from cowrie.core.utils import create_endpoint_services, get_endpoints_from_section
 from cowrie.pool_interface.handler import PoolHandler
 
@@ -148,6 +149,14 @@ Makes a Cowrie SSH/Telnet honeypot.
             except Exception:
                 log.err()
                 log.msg(f"Failed to load output engine: {engine}")
+
+        # The event pipeline: session EventLogs deliver through this
+        # dispatcher to the output plugins and the console renderer
+        # (see docs/EVENT_PIPELINE.rst).
+        self.dispatcher = EventDispatcher([*self.output_plugins, ConsoleRenderer()])
+        reactor.addSystemEventTrigger(  # type: ignore[attr-defined]
+            "before", "shutdown", self.dispatcher.stop
+        )
 
         self.topService = service.MultiService()
         application = service.Application("cowrie")


### PR DESCRIPTION
## Summary

Replaces the way Cowrie delivers structured events to output plugins. Events are now attributed to their session **at the point of emission** and delivered through a single central dispatcher, instead of being reconstructed downstream from the Twisted log stream. The event schema in `docs/OUTPUT.rst` is unchanged; plugins keep receiving the same dictionaries through the same `write()`.

Design is documented in `docs/EVENT_PIPELINE.rst`.

## The problem

Every output plugin's `emit()` was registered as a global Twisted log observer, so every log line in the process passed through every plugin, which then attributed each event to a session by regex-matching Twisted's log-context prefix. That derivation is fragile:

- **Events from deferred callbacks were silently lost.** A `log.msg(eventid=...)` fired from an HTTP download callback ran under `system="HTTP11ClientProtocol,client"`, matched no regex, and was dropped — including every `cowrie.command.input` for commands a downloaded script runs after fetching its payload.
- **Late events lost attribution.** `cowrie.session.closed` deleted each plugin's session table entry, so a download deferred that outlived its session arrived with a sessionno that no longer resolved.
- **Dual emission.** wget/curl emitted download events twice (once for plugins, once for the console) to work around the above; the copies had already drifted.
- **N copies of state, N times the work.** Each plugin maintained its own session table and re-ran regex/bytes/timestamp/interpolation for every log line in the process. A plugin raising from `write()` aborted the dispatch loop for the plugins after it and leaked its table forever.

## What this does

Two pieces in `cowrie.core.events`:

- **`EventLog`** — a session-scoped emitter the transport creates in `connectionMade()`, with the connection's identity bound once. The protocol and commands reach it via `self.protocol.events`. Because identity is bound at creation, an event is attributable from any execution context, including a deferred callback that outlives the connection (those arrive flagged `late: true`). The bound `session`/`src_ip`/`protocol` are authoritative — attacker-influenced fields (a direct-tcpip request's claimed originator) can't spoof them.
- **`EventDispatcher`** — one instance owned by the application container. Enriches each event once (sensor, uuid, timestamp, message interpolation, bytes conversion) and fans out to each sink with per-sink error isolation and rate-limited failure logging. A built-in `ConsoleRenderer` sink renders each event's line into `cowrie.log`, stamped with the session prefix, so a download callback's lines no longer show up under `[HTTP11ClientProtocol,client]`.

The global `log.addObserver(plugin.emit)` registration, `Output.emit()` with its attribution regexes, `Output.logDispatch()`, and the per-plugin `sessions`/`ips` tables are removed. `Output` is now `start`/`stop`/`write` plus a `dispatch()` for the plugins that emit their own enrichment events (virustotal, reversedns, greynoise, abuseipdb) — these now reach every configured sink instead of depending on the observer path.

## Compatibility

- No config changes; an upgrade is a restart.
- No change to the event schema or the `cowrie.log` format.
- Third-party plugins that implement only `start`/`stop`/`write` are unaffected. A plugin that overrode `emit()` or `logDispatch()` would need updating — none in-tree do.
- The internal `sessionno` (`S`/`T`-prefixed transport counter) is no longer added to delivered events; it was never part of the documented schema and `emit()` always stripped it.

## Testing

Full suite green (`python -m unittest discover src`), ruff and mypy clean. `EventLog`/`EventDispatcher` are plain objects, so tests inject a capturing sink and assert on delivered dictionaries — helpers live in `cowrie.test.eventcapture`. New coverage includes attribution from a deferred context, the telnet session→insults chain, session-less event routing, and shutdown-ordering delivery.

## Not in scope / follow-ups

- The diagnostic log stream (~490 `log.msg`/`log.err` sites) is still on the legacy API. Converting it to `twisted.logger` with namespaces and levels is now unblocked (nothing parses the log stream anymore) but is a separate change.
- A few session-less emitters (backend pool, proxy bookkeeping) remain on `log.msg(eventid=...)`; they never reached the plugins historically.
