### PR TITLE
fix: parse input queued while a command is running

### DIFF
--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -9,7 +9,6 @@ This module contains code to run a command
 
 from __future__ import annotations
 
-import shlex
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
@@ -165,9 +164,7 @@ class HoneyPotCommand:
 
     def lineReceived(self, line: str) -> None:
         log.msg(f"QUEUED INPUT: {line}")
-        # FIXME: naive command parsing, see lineReceived below
-        # line = "".join(line)
-        self.protocol.cmdstack[0].cmdpending.append(shlex.split(line, posix=True))
+        self.protocol.cmdstack[0].queue_line(line)
 
     def resume(self) -> None:
         pass

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -179,6 +179,14 @@ class HoneyPotShell:
         self._queue_statements(self.bashparser.parse(line))
         self._advance()
 
+    def queue_line(self, line: str) -> None:
+        """Queue a line that arrived while a command holds the terminal.
+
+        The statements are parsed now but run only when this shell resumes
+        after the command exits, like tty input read by the next reader.
+        """
+        self._queue_statements(self.bashparser.parse(line))
+
     def _queue_statements(self, statements: list[Statement]) -> bool:
         """Append parsed statements to ``cmdpending`` for sequential execution.
 

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -185,6 +185,9 @@ class HoneyPotShell:
         The statements are parsed now but run only when this shell resumes
         after the command exits, like tty input read by the next reader.
         """
+        self.protocol.events.dispatch(
+            "cowrie.command.input", "CMD: %(input)s", input=line
+        )
         self._queue_statements(self.bashparser.parse(line))
 
     def _queue_statements(self, statements: list[Statement]) -> bool:

--- a/src/cowrie/test/test_queued_input.py
+++ b/src/cowrie/test/test_queued_input.py
@@ -51,6 +51,21 @@ class QueuedInputTests(unittest.TestCase):
         self._finish_sleep()
         self.assertEqual(self.tr.value(), b"one\ntwo\n" + PROMPT)
 
+    def test_queued_line_dispatches_input_event(self) -> None:
+        self.proto.lineReceived(b"sleep 100\n")
+        self.proto.lineReceived(b"echo hello\n")
+        self._finish_sleep()
+        events = [
+            e
+            for e in self.tr.dispatchedEvents
+            if e["eventid"] == "cowrie.command.input"
+            and e["input"].strip() == "echo hello"
+        ]
+        self.assertEqual(
+            len(events), 1, f"expected one CMD event for the queued line: {events!r}"
+        )
+        self.assertEqual(events[0]["session"], "test-suite")
+
     def test_queued_exit_ends_session_without_error(self) -> None:
         self.proto.lineReceived(b"sleep 100\n")
         self.proto.lineReceived(b"echo bye\n")

--- a/src/cowrie/test/test_queued_input.py
+++ b/src/cowrie/test/test_queued_input.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for input typed while a foreground command is running: the
+# ABOUTME: command queues it and the shell runs it after the command exits.
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+
+class QueuedInputTests(unittest.TestCase):
+    """Lines sent while a command holds the terminal run once it exits."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def _finish_sleep(self) -> None:
+        """End the pending sleep command as if its timer fired."""
+        cmd = self.proto.cmdstack[-1]
+        cmd.scheduled.cancel()
+        cmd.done()
+
+    def test_queued_line_runs_after_command_exits(self) -> None:
+        self.proto.lineReceived(b"sleep 100\n")
+        self.proto.lineReceived(b"echo hello\n")
+        self._finish_sleep()
+        self.assertEqual(self.tr.value(), b"hello\n" + PROMPT)
+
+    def test_queued_line_with_multiple_statements(self) -> None:
+        self.proto.lineReceived(b"sleep 100\n")
+        self.proto.lineReceived(b"echo one; echo two\n")
+        self._finish_sleep()
+        self.assertEqual(self.tr.value(), b"one\ntwo\n" + PROMPT)
+
+    def test_queued_exit_ends_session_without_error(self) -> None:
+        self.proto.lineReceived(b"sleep 100\n")
+        self.proto.lineReceived(b"echo bye\n")
+        self.proto.lineReceived(b"exit\n")
+        self._finish_sleep()
+        self.assertEqual(self.tr.value(), b"bye\n")


### PR DESCRIPTION
## Summary

A line typed while a foreground command holds the terminal (common bot behavior: send all lines at once while a download command runs) was queued into the shell's `cmdpending` as a raw `shlex` token list, a leftover from the pre-Lark parser. `runCommand` now expects `Statement` objects, so the shell crashed when it resumed after the command exited:

```
  File "src/cowrie/shell/honeypot.py", line 525, in runCommand
    if self._short_circuit(command.op):
builtins.AttributeError: 'list' object has no attribute 'op'
```

- `HoneyPotCommand.lineReceived` now hands the line to a new `HoneyPotShell.queue_line`, which parses it with the bash parser and queues the statements; they run when the shell resumes, like tty input read by the next reader. This removes the last use of `shlex`.
- `queue_line` also dispatches the same `cowrie.command.input` event the shell emits for a directly received line; previously mid-command input only produced a `QUEUED INPUT` log message and was missing from the event stream.

## Testing

New `src/cowrie/test/test_queued_input.py` drives the interactive protocol with `sleep` as the in-flight command and covers: a queued line running after the command exits, a queued multi-statement line, the input event dispatch, and the queued `echo`-then-`exit` sequence seen in the wild. The first commit's tests reproduced the production traceback exactly before the fix. Full suite (721 tests), ruff, and mypy pass.