### PR TITLE
fix: log telnet process end as an exit status, not a Failure repr

### DIFF
--- a/src/cowrie/llm/telnet.py
+++ b/src/cowrie/llm/telnet.py
@@ -112,7 +112,13 @@ class TelnetSessionProcessProtocol(protocol.ProcessProtocol):
         self.session = None
 
     def processEnded(self, reason=None):
-        log.msg(f"Process ended. Telnet Session disconnected: {reason}")
+        exit_code = getattr(reason.value, "exitCode", None) if reason else None
+        if exit_code is not None:
+            log.msg(
+                f"Process ended with exit code {exit_code}. Telnet session disconnected"
+            )
+        else:
+            log.msg("Process ended. Telnet session disconnected")
         self.session.loseConnection()
 
     def getHost(self):

--- a/src/cowrie/telnet/session.py
+++ b/src/cowrie/telnet/session.py
@@ -143,7 +143,13 @@ class TelnetSessionProcessProtocol(protocol.ProcessProtocol):
         here SSH is doing signal handling, I don't think telnet supports that so
         I'm simply going to bail out
         """
-        log.msg(f"Process ended. Telnet Session disconnected: {reason}")
+        exit_code = getattr(reason.value, "exitCode", None) if reason else None
+        if exit_code is not None:
+            log.msg(
+                f"Process ended with exit code {exit_code}. Telnet session disconnected"
+            )
+        else:
+            log.msg("Process ended. Telnet session disconnected")
         self.session.loseConnection()
 
     def getHost(self):


### PR DESCRIPTION
## Summary

`TelnetSessionProcessProtocol.processEnded` interpolated the raw `twisted.python.failure.Failure` into its log message, so every telnet session end — including a perfectly normal exit — rendered as:

```
Process ended. Telnet Session disconnected: [Failure instance: Traceback (failure with no frames): <class 'twisted.internet.error.ProcessDone'>: A process has ended without apparent errors: process finished with exit code 0.
        ]
```

That reads like a crash, but "Traceback (failure with no frames)" just means there was never a stack; it is benign log noise.

Extract the exit code from the reason and log a plain one-liner instead, in both the shell and LLM telnet session variants:

```
Process ended with exit code 0. Telnet session disconnected
```

Falls back to "Process ended. Telnet session disconnected" when there is no reason or no exit code on it, matching the style `pipe.py` already uses for command process ends.

## Testing

Full suite (717 tests), ruff, and mypy pass.