### PR TITLE
fix: write each jsonlog event in a single call to survive rotation

### DIFF
--- a/src/cowrie/output/jsonlog.py
+++ b/src/cowrie/output/jsonlog.py
@@ -50,8 +50,10 @@ class Output(cowrie.core.output.Output):
             if i.startswith("log_") or i == "time" or i == "system":
                 del event[i]
         try:
-            json.dump(event, self.outfile, separators=(",", ":"))
-            self.outfile.write("\n")
+            # Serialize to a string first and write the line in one call: a
+            # rotating logfile checks for rotation on every write, so chunked
+            # writes could rotate mid-event and split the line across files.
+            self.outfile.write(json.dumps(event, separators=(",", ":")) + "\n")
             self.outfile.flush()
         except TypeError:
             log.err("jsonlog: Can't serialize: '" + repr(event) + "'")

--- a/src/cowrie/test/test_jsonlog.py
+++ b/src/cowrie/test/test_jsonlog.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for the jsonlog output plugin: a daily log rotation must
+# ABOUTME: never split a serialized event across two files.
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class JsonlogRotationTests(unittest.TestCase):
+    """Every line in every rotated file must be one complete JSON object."""
+
+    def setUp(self) -> None:
+        self.dir = tempfile.mkdtemp()
+        os.environ["COWRIE_HONEYPOT_LOGTYPE"] = "rotating"
+        os.environ["COWRIE_OUTPUT_JSONLOG_LOGFILE"] = str(Path(self.dir, "cowrie.json"))
+
+    def tearDown(self) -> None:
+        del os.environ["COWRIE_HONEYPOT_LOGTYPE"]
+        del os.environ["COWRIE_OUTPUT_JSONLOG_LOGFILE"]
+        shutil.rmtree(self.dir)
+
+    def test_rotation_never_splits_an_event(self) -> None:
+        from cowrie.output.jsonlog import Output
+
+        output = Output()  # Output.__init__ runs start(), opening the logfile
+        output.write({"eventid": "cowrie.test", "msg": "first"})
+
+        # Simulate midnight passing while an event is being written: after
+        # any chunk reaches the file, the date flips, so a serialization
+        # that writes in multiple chunks rotates between them and splits
+        # the line across the old and new file.
+        logfile = output.outfile
+        original_write = logfile.write
+
+        def write_then_midnight(data: str) -> None:
+            original_write(data)
+            logfile.lastDate = (1970, 1, 1)
+
+        logfile.write = write_then_midnight
+        output.write({"eventid": "cowrie.test", "msg": "second"})
+        output.write({"eventid": "cowrie.test", "msg": "third"})
+        output.stop()
+        logfile.close()
+
+        # Dated (rotated) files hold the older events; the bare logfile is
+        # the current one, so it reads last.
+        paths = sorted(
+            Path(self.dir).iterdir(), key=lambda p: (p.name == "cowrie.json", p.name)
+        )
+        events = []
+        for path in paths:
+            for line in path.read_text().splitlines():
+                events.append(json.loads(line))
+        self.assertEqual([e["msg"] for e in events], ["first", "second", "third"])


### PR DESCRIPTION
## Summary

Fixes #40285 — JSON log corruption at the daily rotation boundary, reported with a full root-cause analysis by @vbontchev.

With `logtype = rotating`, `json.dump(event, self.outfile)` writes the serialized event in chunks, and `BaseLogFile.write()` checks `shouldRotate()` on every chunk. If midnight rolls over between two chunks, the file rotates mid-event: the head of the JSON line ends up in the old file and the tail (plus the trailing newline) in the new one, leaving both lines invalid for any line-oriented JSON consumer.

Serialize with `json.dumps()` and write the whole line, newline included, in a single `write()` call, so the rotation check runs once per event and rotation can only happen between events. As a side effect, an event that fails to serialize (`TypeError`) no longer leaves a partial line in the file, since serialization now completes before any bytes are written.

## Testing

New `src/cowrie/test/test_jsonlog.py` runs the plugin against a real `CowrieDailyLogFile` in a temp directory and simulates midnight passing between file writes (the deterministic trigger suggested in the issue). Before the fix it fails with the exact split-line `JSONDecodeError`; with the fix every line in both the rotated and current file parses, with all events present in order.