### PR TITLE
test: register the fake async command without shadowing the ClassVar

### DIFF
--- a/src/cowrie/test/test_script_execution.py
+++ b/src/cowrie/test/test_script_execution.py
@@ -249,12 +249,13 @@ class AsyncScriptExecutionTests(unittest.TestCase):
         self.tr = FakeTransport("", "31337")
         self.proto.makeConnection(self.tr)
         _AsyncCommand.pending = []
-        # Shadow the shared command table with a copy carrying our fake command.
-        self.proto.commands = dict(self.proto.commands)
+        # Register the fake command in the shared class-level command table;
+        # tearDown removes it again.
         self.proto.commands["asyncdl"] = _AsyncCommand
         self.tr.clear()
 
     def tearDown(self) -> None:
+        del self.proto.commands["asyncdl"]
         self.proto.connectionLost()
 
     def test_sh_script_with_async_commands(self) -> None:


### PR DESCRIPTION
## Summary

`mypy src` fails on main: the async script tests replaced the protocol's shared command table by assigning a copy through the instance, which mypy rejects because `commands` is a `ClassVar` on `HoneyPotBaseProtocol`. Register the fake command in the shared class-level table in `setUp` and remove it in `tearDown` instead.

## Testing

`mypy src` is clean (261 files) and the module's 29 tests pass.