### PR TITLE
fix: queue mid-command input on the innermost shell

### DIFF
--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -164,7 +164,13 @@ class HoneyPotCommand:
 
     def lineReceived(self, line: str) -> None:
         log.msg(f"QUEUED INPUT: {line}")
-        self.protocol.cmdstack[0].queue_line(line)
+        # Queue on the innermost shell, the next stdin reader once this
+        # command exits: an outer shell only resumes after the shells above
+        # it unwind, so a line queued there would wait on the whole stack.
+        for item in reversed(self.protocol.cmdstack):
+            if hasattr(item, "queue_line"):
+                item.queue_line(line)
+                return
 
     def resume(self) -> None:
         pass

--- a/src/cowrie/test/test_queued_input.py
+++ b/src/cowrie/test/test_queued_input.py
@@ -66,6 +66,17 @@ class QueuedInputTests(unittest.TestCase):
         )
         self.assertEqual(events[0]["session"], "test-suite")
 
+    def test_queued_line_reaches_active_subshell(self) -> None:
+        # With a persistent sub-shell (`sh`) active, input sent while a
+        # command runs must queue on that sub-shell: queued on the root
+        # shell it would never run, since the root only resumes once the
+        # sub-shell exits.
+        self.proto.lineReceived(b"sh\n")
+        self.proto.lineReceived(b"sleep 100\n")
+        self.proto.lineReceived(b"echo hello\n")
+        self._finish_sleep()
+        self.assertIn(b"hello\n", self.tr.value())
+
     def test_queued_exit_ends_session_without_error(self) -> None:
         self.proto.lineReceived(b"sleep 100\n")
         self.proto.lineReceived(b"echo bye\n")


### PR DESCRIPTION
## Summary

Fixes #40284.

Input received while a command holds the terminal was queued on the root shell (`cmdstack[0]`), which only resumes once every nested shell above it exits. With a persistent sub-shell active (`sh`), the queued commands therefore never ran: bots that push `sh` and then burst one download command per architecture in a single segment lost every command after the first — no download attempt, no `file_download` events, just `QUEUED INPUT` lines that vanish.

Queue on the shell nearest the running command instead. That shell is the next stdin reader: it resumes as soon as the in-flight command exits and runs the queued statements in order. When no sub-shell is active the innermost shell is the root shell, so the existing behavior is unchanged (covered by the tests added in #40299).

## Testing

New test in `src/cowrie/test/test_queued_input.py` reproduces the issue: `sh`, then an async command, then a line queued mid-command. Before the fix the queued command silently vanished; now it runs when the command exits. Full suite (723 tests), ruff, and mypy pass.