### PR TITLE
ci: build bcrypt from git on free-threaded 3.15

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -120,6 +120,15 @@ jobs:
           allow-prereleases: ${{ matrix.prerelease }}
           cache: pip
 
+      # bcrypt 5.0.0 has no free-threaded 3.15 wheel and its vendored pyo3
+      # 0.26 refuses to build past 3.14; git main builds with pyo3 0.29,
+      # which supports 3.15, and still reports version 5.0.0 so it
+      # satisfies the requirements pin. Remove once the next bcrypt
+      # release ships.
+      - name: Install bcrypt from git for free-threaded 3.15
+        if: matrix.python-version == '3.15t'
+        run: python -m pip -q install "bcrypt @ git+https://github.com/pyca/bcrypt.git@f9b7febe5c3f31a8559653d23bd3d1a8771bef40"
+
       - name: Install dependencies
         run: |
           python -m pip -q install --upgrade pip setuptools setuptools-scm wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,16 @@ legacy_tox_ini = """
     commands =
         coverage run -m unittest discover src --verbose
 
+    # bcrypt 5.0.0 has no free-threaded 3.15 wheel and its vendored pyo3 0.26
+    # refuses to build past 3.14; git main builds with pyo3 0.29, which
+    # supports 3.15, and still reports version 5.0.0 so it satisfies the
+    # requirements pin. deps install before the package, so the pin resolves
+    # against this build. Remove once the next bcrypt release ships.
+    [testenv:py315t]
+    deps =
+        coverage
+        bcrypt @ git+https://github.com/pyca/bcrypt.git@f9b7febe5c3f31a8559653d23bd3d1a8771bef40
+
     [testenv:pypi]
     extras =
         dev


### PR DESCRIPTION
## Summary

The 3.15t leg fails during dependency installation: bcrypt 5.0.0 ships no free-threaded 3.15 wheel, so pip builds it from source, and its vendored pyo3 0.26 hard-errors past Python 3.14. Regular 3.15 passes because `PYO3_USE_ABI3_FORWARD_COMPATIBILITY` applies to the abi3 wheels/builds, but free-threaded builds cannot use abi3, so the version check is fatal there.

Analysis of the dependency chain:

- setuptools-rust is only the build backend; the pyo3 version comes from bcrypt's own Cargo.lock, so upgrading it changes nothing.
- pyo3 0.29.0 (2026-06-11) is the first release supporting 3.15. Verified locally that a pyo3 0.29 extension module builds and imports on CPython 3.15.0b3 free-threaded (GIL disabled).
- cryptography 49.0.0 already ships pyo3 0.29 and builds fine on 3.15t — bcrypt is the only blocker.
- bcrypt has no newer release (5.0.0 is latest), but git main builds with pyo3 0.29 and still reports version 5.0.0, so a pre-installed git build satisfies the `bcrypt==5.0.0` pin without touching requirements.txt.

This installs bcrypt from a pinned git SHA in the 3.15t leg only, both in the workflow environment and in the tox `py315t` test environment (tox deps install before the package, so the pin resolves against the git build). Temporary: remove once the next bcrypt release ships.

## Testing

`tox config -e py315t` resolves the new deps correctly; yamllint (project config) passes. The PR's own 3.15t CI leg is the end-to-end test.