### PR TITLE
fix: ignore channel EOF/CLOSE for already-closed SSH channels

### DIFF
--- a/src/cowrie/ssh/connection.py
+++ b/src/cowrie/ssh/connection.py
@@ -42,3 +42,22 @@ class CowrieSSHConnection(connection.SSHConnection):
             d.addCallback(self._cbChannelRequest, localChannel)
             d.addErrback(self._ebChannelRequest, localChannel)
         return d
+
+    # Some clients (observed: libssh2) send CHANNEL_EOF / CHANNEL_CLOSE for a
+    # channel whose close handshake already completed, often alongside the
+    # final DISCONNECT. Twisted's handlers look the channel up unguarded and
+    # raise KeyError to the reactor; ignore the stale message instead.
+
+    def ssh_CHANNEL_EOF(self, packet):
+        localChannel = struct.unpack(">L", packet[:4])[0]
+        if localChannel not in self.channels:
+            log.msg(f"Ignoring CHANNEL_EOF for unknown channel {localChannel}")
+            return
+        connection.SSHConnection.ssh_CHANNEL_EOF(self, packet)
+
+    def ssh_CHANNEL_CLOSE(self, packet):
+        localChannel = struct.unpack(">L", packet[:4])[0]
+        if localChannel not in self.channels:
+            log.msg(f"Ignoring CHANNEL_CLOSE for unknown channel {localChannel}")
+            return
+        connection.SSHConnection.ssh_CHANNEL_CLOSE(self, packet)

--- a/src/cowrie/test/test_ssh_connection.py
+++ b/src/cowrie/test/test_ssh_connection.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for CowrieSSHConnection channel message handling: stale EOF
+# ABOUTME: and CLOSE for an already-closed channel are ignored, not a crash.
+
+from __future__ import annotations
+
+import struct
+import unittest
+
+from cowrie.ssh.connection import CowrieSSHConnection
+
+
+class _StubChannel:
+    """Records delivery of channel callbacks; never closes locally."""
+
+    localClosed = False
+    remoteClosed = False
+
+    def __init__(self) -> None:
+        self.gotEOF = False
+        self.gotClose = False
+
+    def eofReceived(self) -> None:
+        self.gotEOF = True
+
+    def closeReceived(self) -> None:
+        self.gotClose = True
+
+    def logPrefix(self) -> str:
+        return "stub"
+
+
+class StaleChannelMessageTests(unittest.TestCase):
+    """A libssh2 client can send CHANNEL_EOF / CHANNEL_CLOSE for a channel
+    whose close handshake already completed (issue #40296); the connection
+    must ignore them instead of raising KeyError to the reactor."""
+
+    def setUp(self) -> None:
+        self.conn = CowrieSSHConnection()
+
+    def test_eof_for_unknown_channel_is_ignored(self) -> None:
+        self.conn.ssh_CHANNEL_EOF(struct.pack(">L", 0))
+
+    def test_close_for_unknown_channel_is_ignored(self) -> None:
+        self.conn.ssh_CHANNEL_CLOSE(struct.pack(">L", 0))
+
+    def test_eof_for_known_channel_is_delivered(self) -> None:
+        channel = _StubChannel()
+        self.conn.channels[0] = channel
+        self.conn.ssh_CHANNEL_EOF(struct.pack(">L", 0))
+        self.assertTrue(channel.gotEOF)
+
+    def test_close_for_known_channel_is_delivered(self) -> None:
+        channel = _StubChannel()
+        self.conn.channels[0] = channel
+        self.conn.ssh_CHANNEL_CLOSE(struct.pack(">L", 0))
+        self.assertTrue(channel.gotClose)


### PR DESCRIPTION
## Summary

Fixes #40296.

Some clients (observed: libssh2 1.11.1) send `SSH_MSG_CHANNEL_EOF` for a channel whose close handshake already completed, typically in the same TCP segment as the final `SSH_MSG_DISCONNECT`. Twisted's `ssh_CHANNEL_EOF` looks the channel up with an unguarded `self.channels[localChannel]`, so the stale message raised `KeyError` all the way to the reactor as an Unhandled Error.

The issue proposed guarding `ssh_CHANNEL_EOF` only, but `ssh_CHANNEL_CLOSE` has the identical unguarded lookup, and a stale EOF at teardown is usually followed by the matching stale CLOSE — guarding only EOF would just move the crash to the next packet. Both handlers are overridden in `CowrieSSHConnection`: a message for an unknown channel is logged and ignored; known channels delegate to the base class unchanged.

## Testing

New `src/cowrie/test/test_ssh_connection.py`: stale EOF and CLOSE for an unknown channel reproduce the exact `KeyError: 0` before the fix and are ignored after; delivery to known channels is asserted to still work. Full suite (730 tests), ruff, and mypy pass.