### PR TITLE
test: capture late download events through the session EventLog

### DIFF
--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -115,8 +115,6 @@ class CurlArtifactCleanupTests(unittest.TestCase):
         cmd.host = "198.51.100.1"
         cmd.port = 80
         cmd.artifact = Artifact("curl-download")
-        events: list[dict] = []
-        self.proto.logDispatch = lambda **kw: events.append(kw)  # type: ignore[method-assign]
         self.proto.cmdstack.append(cmd)
 
         cmd.artifact.write(b"partial data")
@@ -129,7 +127,7 @@ class CurlArtifactCleanupTests(unittest.TestCase):
         self.assertEqual(
             [
                 ev
-                for ev in events
+                for ev in self.events
                 if str(ev.get("eventid", "")).startswith("cowrie.session.file_download")
             ],
             [],

--- a/src/cowrie/test/test_wget.py
+++ b/src/cowrie/test/test_wget.py
@@ -128,8 +128,6 @@ class WgetArtifactCleanupTests(unittest.TestCase):
         cmd.quiet = True
         cmd.started = time.time()
         cmd.artifact = Artifact("wget-download")
-        events: list[dict] = []
-        self.proto.logDispatch = lambda **kw: events.append(kw)  # type: ignore[method-assign]
         self.proto.cmdstack.append(cmd)
 
         cmd.artifact.write(b"partial data")
@@ -142,7 +140,7 @@ class WgetArtifactCleanupTests(unittest.TestCase):
         self.assertEqual(
             [
                 ev
-                for ev in events
+                for ev in self.events
                 if str(ev.get("eventid", "")).startswith("cowrie.session.file_download")
             ],
             [],


### PR DESCRIPTION
## Summary

`mypy src` fails on main: the wget/curl late-callback tests stub `protocol.logDispatch`, which the event pipeline removed. Worse than the type error, the stub made the tests vacuous — wget and curl now dispatch through `protocol.events`, so the lambda never fired, the captured list stayed empty, and the no-late-events assertion passed regardless of behavior.

Assert against the EventLog capture that `setUp` already installs via `capture_events()` instead. Verified the capture is not itself vacuous: a `cowrie.session.file_download` event dispatched through `protocol.events` lands in the captured list.

## Testing

`mypy src` clean (264 files); full suite (726 tests) and ruff pass.