### PR TITLE
fix: resolve CNAME chains and AAAA records in communication_allowed

### DIFF
--- a/src/cowrie/core/network.py
+++ b/src/cowrie/core/network.py
@@ -27,7 +27,9 @@ BLOCKED_IPS = [
 
 # Valid TCP/UDP port range: 1-65535
 # https://www.debuggex.com/r/jjEFZZQ34aPvCBMA
-PORT_PATTERN = re.compile(r"^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$")
+PORT_PATTERN = re.compile(
+    r"^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$"
+)
 
 
 def is_valid_port(port: str) -> bool:
@@ -73,8 +75,10 @@ def resolve_cname(
             # Iterate through the DNS records to find CNAME or A/AAAA record
             for rr in headers:
                 if isinstance(rr.payload, dns.Record_CNAME):
-                    # It's a CNAME, resolve the target domain recursively
-                    resolved_ip = yield resolve_cname(rr.payload.name, visited)
+                    # It's a CNAME, resolve the target domain recursively.
+                    # rr.payload.name is a dns.Name; lookupAddress only accepts
+                    # str or bytes, and the visited set holds str.
+                    resolved_ip = yield resolve_cname(str(rr.payload.name), visited)
                     if resolved_ip:
                         return resolved_ip
                 elif isinstance(rr.payload, dns.Record_A):

--- a/src/cowrie/core/network.py
+++ b/src/cowrie/core/network.py
@@ -4,6 +4,7 @@
 
 import ipaddress
 import re
+import socket
 from collections.abc import Generator
 
 from twisted.internet.defer import Deferred, inlineCallbacks
@@ -85,8 +86,10 @@ def resolve_cname(
                     # We found an A record (IPv4 address), return it immediately
                     return str(rr.payload.dottedQuad())
                 elif isinstance(rr.payload, dns.Record_AAAA):
-                    # We found an AAAA record (IPv6 address), return it immediately
-                    return str(rr.payload.dottedQuad())
+                    # We found an AAAA record (IPv6 address), return it
+                    # immediately. Record_AAAA has no dottedQuad(); its
+                    # address field holds the packed 16-byte value.
+                    return socket.inet_ntop(socket.AF_INET6, rr.payload.address)
     except Exception as e:
         # A failed lookup (NXDOMAIN for an attacker's single-word hostname, a
         # timeout, ...) is routine and handled here by returning None. Log it at

--- a/src/cowrie/test/test_network.py
+++ b/src/cowrie/test/test_network.py
@@ -5,7 +5,8 @@
 import unittest
 from unittest import mock
 
-from twisted.internet.defer import fail, inlineCallbacks
+from twisted.internet.defer import fail, inlineCallbacks, succeed
+from twisted.names import dns
 from twisted.names import error as names_error
 from twisted.python import log
 
@@ -85,6 +86,58 @@ class TestCommunicationAllowed(unittest.TestCase):
         # Test with a CNAME that resolves to a blocked IP (e.g., 127.0.0.1)
         allowed = yield communication_allowed("localhost")  # Should be blocked
         self.assertFalse(allowed)
+
+
+def _fake_lookup(records: dict[str, list[dns.RRHeader]]):
+    """A lookupAddress double serving canned answers. It enforces the same
+    argument contract as twisted's resolver: only str or bytes are accepted."""
+
+    def lookup(name):
+        if not isinstance(name, (bytes, str)):
+            raise TypeError(f"Expected bytes or str but found {type(name)!r}")
+        if name in records:
+            return succeed((records[name], [], []))
+        return fail(names_error.DNSNameError(name))
+
+    return lookup
+
+
+def _cname(target: str) -> dns.RRHeader:
+    return dns.RRHeader(type=dns.CNAME, payload=dns.Record_CNAME(target.encode()))
+
+
+def _a(address: str) -> dns.RRHeader:
+    return dns.RRHeader(type=dns.A, payload=dns.Record_A(address))
+
+
+class TestResolveCnameChain(unittest.TestCase):
+    """resolve_cname must follow CNAME chains to the final address record
+    (issue #40283) and read AAAA records with the IPv6 API."""
+
+    def _resolve(self, records: dict[str, list[dns.RRHeader]], name: str):
+        with mock.patch(
+            "cowrie.core.network.client.lookupAddress",
+            side_effect=_fake_lookup(records),
+        ):
+            results: list = []
+            resolve_cname(name, set()).addBoth(results.append)
+        self.assertEqual(len(results), 1)
+        return results[0]
+
+    def test_cname_chain_resolves_to_a_record(self) -> None:
+        records = {
+            "cdn.example.com": [_cname("edge.example.net")],
+            "edge.example.net": [_cname("origin.example.org")],
+            "origin.example.org": [_a("203.0.113.7")],
+        }
+        self.assertEqual(self._resolve(records, "cdn.example.com"), "203.0.113.7")
+
+    def test_cname_cycle_returns_none(self) -> None:
+        records = {
+            "a.example.com": [_cname("b.example.com")],
+            "b.example.com": [_cname("a.example.com")],
+        }
+        self.assertIsNone(self._resolve(records, "a.example.com"))
 
 
 class TestResolveCnameLogging(unittest.TestCase):

--- a/src/cowrie/test/test_network.py
+++ b/src/cowrie/test/test_network.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import unittest
+from collections.abc import Callable
+from typing import Any
 from unittest import mock
 
-from twisted.internet.defer import fail, inlineCallbacks, succeed
+from twisted.internet.defer import Deferred, fail, inlineCallbacks, succeed
 from twisted.names import dns
 from twisted.names import error as names_error
 from twisted.python import log
@@ -88,13 +90,15 @@ class TestCommunicationAllowed(unittest.TestCase):
         self.assertFalse(allowed)
 
 
-def _fake_lookup(records: dict[str, list[dns.RRHeader]]):
+def _fake_lookup(
+    records: dict[str, list[dns.RRHeader]],
+) -> Callable[[Any], Deferred]:
     """A lookupAddress double serving canned answers. It enforces the same
     argument contract as twisted's resolver: only str or bytes are accepted."""
 
-    def lookup(name):
+    def lookup(name: Any) -> Deferred:
         if not isinstance(name, (bytes, str)):
-            raise TypeError(f"Expected bytes or str but found {type(name)!r}")
+            raise TypeError(type(name).__name__)
         if name in records:
             return succeed((records[name], [], []))
         return fail(names_error.DNSNameError(name))
@@ -110,16 +114,20 @@ def _a(address: str) -> dns.RRHeader:
     return dns.RRHeader(type=dns.A, payload=dns.Record_A(address))
 
 
+def _aaaa(address: str) -> dns.RRHeader:
+    return dns.RRHeader(type=dns.AAAA, payload=dns.Record_AAAA(address))
+
+
 class TestResolveCnameChain(unittest.TestCase):
     """resolve_cname must follow CNAME chains to the final address record
     (issue #40283) and read AAAA records with the IPv6 API."""
 
-    def _resolve(self, records: dict[str, list[dns.RRHeader]], name: str):
+    def _resolve(self, records: dict[str, list[dns.RRHeader]], name: str) -> str | None:
         with mock.patch(
             "cowrie.core.network.client.lookupAddress",
             side_effect=_fake_lookup(records),
         ):
-            results: list = []
+            results: list[str | None] = []
             resolve_cname(name, set()).addBoth(results.append)
         self.assertEqual(len(results), 1)
         return results[0]
@@ -131,6 +139,10 @@ class TestResolveCnameChain(unittest.TestCase):
             "origin.example.org": [_a("203.0.113.7")],
         }
         self.assertEqual(self._resolve(records, "cdn.example.com"), "203.0.113.7")
+
+    def test_aaaa_record_resolves(self) -> None:
+        records = {"v6.example.com": [_aaaa("2001:db8::1")]}
+        self.assertEqual(self._resolve(records, "v6.example.com"), "2001:db8::1")
 
     def test_cname_cycle_returns_none(self) -> None:
         records = {


### PR DESCRIPTION
## Summary

Fixes #40283, plus a second latent bug found in the same function.

**CNAME (the reported bug):** `resolve_cname()` passed `rr.payload.name` — a `twisted.names.dns.Name` object — to its recursive call. `lookupAddress` only accepts str or bytes, so any hostname behind a CNAME chain raised `TypeError`, which the broad exception handler swallowed as a routine DNS failure: `communication_allowed()` returned False and the download was silently blocked. The `Name` object also never matched the `visited` set's str entries. Fixed with the issue's proposed `str(rr.payload.name)` (verified `dns.Name.__str__` yields the plain domain name on Twisted 26.4).

**AAAA (found while writing the tests):** the `Record_AAAA` branch called `rr.payload.dottedQuad()`, a method that only exists on `Record_A` — the resulting `AttributeError` was swallowed by the same handler, silently blocking IPv6-only hosts. Fixed with `socket.inet_ntop` on the packed address.

## Testing

New tests in `src/cowrie/test/test_network.py` drive `resolve_cname()` against a canned resolver that enforces twisted's str/bytes argument contract, so the CNAME test reproduces the exact production `TypeError` before the fix: a three-hop CNAME chain resolves to the final A record, an AAAA answer resolves to the IPv6 string, and a CNAME cycle still terminates with None. Full suite (733 tests), ruff, and mypy pass.