### PR TITLE
feat: support the exec shell builtin

### DIFF
--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -118,6 +118,9 @@ class HoneyPotShell:
         # Trampoline state for _advance (see its docstring).
         self._advancing: bool = False
         self._advance_pending: bool = False
+        # True once `exec` has replaced this shell with the command now
+        # running: when that command finishes, the shell is gone (see resume).
+        self._exec_replaced: bool = False
 
     # -- bashparse.ShellContext interface -----------------------------------
 
@@ -591,6 +594,24 @@ class HoneyPotShell:
             cmd_tokens = [piece, *cmdAndArgs]
             break
 
+        # `exec cmd` replaces the shell with cmd: the command runs through the
+        # normal machinery and the shell terminates when it finishes. exec's
+        # own options do not change what runs (-a NAME supplies argv[0], -c
+        # cleans the environment, -l makes it a login shell), so they are
+        # dropped. In a pipeline each stage runs in a subshell, so `exec`
+        # there never replaces this shell. A bare `exec` (possibly with only
+        # redirections) runs no command and the shell survives it.
+        exec_replace = False
+        if cmd_tokens and cmd_tokens[0] == "exec":
+            cmd_tokens.pop(0)
+            while cmd_tokens and cmd_tokens[0].startswith("-"):
+                opt = cmd_tokens.pop(0)
+                if opt == "--":
+                    break
+                if "a" in opt and cmd_tokens:
+                    cmd_tokens.pop(0)
+            exec_replace = bool(cmd_tokens) and "|" not in cmd_tokens
+
         if not cmd_tokens:
             # A statement of only assignments (no command) persists those
             # variables for the rest of the session. They are shell variables,
@@ -604,7 +625,12 @@ class HoneyPotShell:
         # A call to a shell function defined earlier runs its body with the
         # positional parameters bound to the call arguments. A pipeline that
         # includes the function name is left to the normal command machinery.
-        if cmd_tokens[0] in self.functions and "|" not in cmd_tokens:
+        # `exec` never sees functions: it only runs files.
+        if (
+            not exec_replace
+            and cmd_tokens[0] in self.functions
+            and "|" not in cmd_tokens
+        ):
             self._call_function(cmd_tokens[0], cmd_tokens[1:])
             return
 
@@ -699,7 +725,12 @@ class HoneyPotShell:
                     "Command not found: %(input)s",
                     input=cmd["command"] + " " + " ".join(cmd["rargs"]),
                 )
-                message = self.command_not_found_message(cmd["command"]).encode("utf8")
+                if exec_replace:
+                    message = f"-bash: exec: {cmd['command']}: not found\n".encode()
+                else:
+                    message = self.command_not_found_message(cmd["command"]).encode(
+                        "utf8"
+                    )
                 redirects = cmd.get("redirects", [])
                 if redirects:
                     temp_pp = PipeProtocol(
@@ -718,6 +749,11 @@ class HoneyPotShell:
                     self.protocol.terminal.write(message)
 
                 self.last_exit_code = 127  # command not found
+                if exec_replace and not self.interactive:
+                    # A failed exec ends a non-interactive shell with 127; an
+                    # interactive one survives it (bash without execfail).
+                    self._terminate(127)
+                    return
                 self._advance()
                 pp = None  # Got a error. Don't run any piped commands
                 break
@@ -726,6 +762,7 @@ class HoneyPotShell:
             return
 
         if pp:
+            self._exec_replaced = exec_replace
             self.protocol.call_command(pp, cmdclass, *cmd_array[0]["rargs"])
 
     def command_not_found_message(self, cmd: str) -> str:
@@ -745,11 +782,37 @@ class HoneyPotShell:
         return f"-bash: {cmd}: command not found\n"
 
     def resume(self) -> None:
+        if self._exec_replaced:
+            # The command that replaced this shell via `exec` has finished;
+            # there is no shell to come back to.
+            self._terminate(self.last_exit_code)
+            return
         if self.interactive:
             self.protocol.setInsertMode()
         # Go through the _advance trampoline so a command that resumes us
         # synchronously does not deepen the Python stack (see _advance).
         self._advance()
+
+    def _terminate(self, code: int) -> None:
+        """End this shell, as when `exec` replaces it: unwind to whatever ran
+        it, or end the process with ``code`` when nothing else is running.
+
+        This mirrors the `exit` builtin's teardown: the shell leaves the
+        cmdstack and either the launching command carries on (nested shell) or,
+        with the cmdstack empty, the process ends and the SSH channel reports
+        ``code`` to the client.
+        """
+        self.last_exit_code = code
+        if self in self.protocol.cmdstack:
+            self.protocol.cmdstack.remove(self)
+        if self.protocol.cmdstack:
+            self.protocol.cmdstack[-1].resume()
+        else:
+            # The client may already be disconnected, leaving no transport.
+            try:
+                self.protocol.terminal.transport.processEnded(process_status(code))
+            except AttributeError:
+                pass
 
     def showPrompt(self) -> None:
         if not self.interactive:

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -493,6 +493,30 @@ class HoneyPotShell:
         self.cmdpending[0:0] = [*body, _Continuation(restore)]
         self._advance()
 
+    def _strip_exec(self, tokens: list[str]) -> tuple[bool, bool]:
+        """Consume a leading ``exec`` and its options from ``tokens`` in place.
+
+        Returns ``(exec_seen, replaces_shell)``. ``exec cmd`` runs the remaining
+        command through the normal machinery and, when it replaces the shell,
+        the shell terminates once the command finishes. exec's own options do
+        not change what runs (``-a NAME`` supplies argv[0], ``-c`` cleans the
+        environment, ``-l`` makes it a login shell), so they are dropped. A
+        pipeline stage and a backgrounded (``&``) command run in a subshell, so
+        ``exec`` there never replaces this shell; a bare ``exec`` (possibly with
+        only redirections) runs no command and the shell survives it.
+        """
+        if not tokens or tokens[0] != "exec":
+            return False, False
+        tokens.pop(0)
+        while tokens and tokens[0].startswith("-"):
+            opt = tokens.pop(0)
+            if opt == "--":
+                break
+            if "a" in opt and tokens:
+                tokens.pop(0)
+        replaces = bool(tokens) and "|" not in tokens and tokens[-1] != "&"
+        return True, replaces
+
     def runCommand(self):
         pp = None
 
@@ -594,27 +618,7 @@ class HoneyPotShell:
             cmd_tokens = [piece, *cmdAndArgs]
             break
 
-        # `exec cmd` replaces the shell with cmd: the command runs through the
-        # normal machinery and the shell terminates when it finishes. exec's
-        # own options do not change what runs (-a NAME supplies argv[0], -c
-        # cleans the environment, -l makes it a login shell), so they are
-        # dropped. A pipeline stage and a backgrounded (&) command run in a
-        # subshell, so `exec` there never replaces this shell. A bare `exec`
-        # (possibly with only redirections) runs no command and the shell
-        # survives it.
-        exec_seen = bool(cmd_tokens) and cmd_tokens[0] == "exec"
-        exec_replace = False
-        if exec_seen:
-            cmd_tokens.pop(0)
-            while cmd_tokens and cmd_tokens[0].startswith("-"):
-                opt = cmd_tokens.pop(0)
-                if opt == "--":
-                    break
-                if "a" in opt and cmd_tokens:
-                    cmd_tokens.pop(0)
-            exec_replace = (
-                bool(cmd_tokens) and "|" not in cmd_tokens and cmd_tokens[-1] != "&"
-            )
+        exec_seen, exec_replace = self._strip_exec(cmd_tokens)
 
         if not cmd_tokens:
             # A statement of only assignments (no command) persists those

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -598,11 +598,13 @@ class HoneyPotShell:
         # normal machinery and the shell terminates when it finishes. exec's
         # own options do not change what runs (-a NAME supplies argv[0], -c
         # cleans the environment, -l makes it a login shell), so they are
-        # dropped. In a pipeline each stage runs in a subshell, so `exec`
-        # there never replaces this shell. A bare `exec` (possibly with only
-        # redirections) runs no command and the shell survives it.
+        # dropped. A pipeline stage and a backgrounded (&) command run in a
+        # subshell, so `exec` there never replaces this shell. A bare `exec`
+        # (possibly with only redirections) runs no command and the shell
+        # survives it.
+        exec_seen = bool(cmd_tokens) and cmd_tokens[0] == "exec"
         exec_replace = False
-        if cmd_tokens and cmd_tokens[0] == "exec":
+        if exec_seen:
             cmd_tokens.pop(0)
             while cmd_tokens and cmd_tokens[0].startswith("-"):
                 opt = cmd_tokens.pop(0)
@@ -610,7 +612,9 @@ class HoneyPotShell:
                     break
                 if "a" in opt and cmd_tokens:
                     cmd_tokens.pop(0)
-            exec_replace = bool(cmd_tokens) and "|" not in cmd_tokens
+            exec_replace = (
+                bool(cmd_tokens) and "|" not in cmd_tokens and cmd_tokens[-1] != "&"
+            )
 
         if not cmd_tokens:
             # A statement of only assignments (no command) persists those
@@ -725,7 +729,9 @@ class HoneyPotShell:
                     "Command not found: %(input)s",
                     input=cmd["command"] + " " + " ".join(cmd["rargs"]),
                 )
-                if exec_replace:
+                if exec_seen and index == 0:
+                    # exec applies to the first pipeline segment only; it
+                    # reports a failed lookup as its own error.
                     message = f"-bash: exec: {cmd['command']}: not found\n".encode()
                 else:
                     message = self.command_not_found_message(cmd["command"]).encode(

--- a/src/cowrie/test/test_exec_builtin.py
+++ b/src/cowrie/test/test_exec_builtin.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for the `exec` shell builtin: the command replaces the shell,
+# ABOUTME: which ends when it finishes; redirection-only and failed exec differ.
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from cowrie.insults import insults
+from cowrie.shell import protocol
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.eventcapture import CaptureSink, make_exec_transport
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+
+class ExecInteractiveTests(unittest.TestCase):
+    """`exec cmd` in an interactive shell runs cmd and ends the session."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def run_line(self, line: bytes) -> bytes:
+        self.tr.clear()
+        self.proto.lineReceived(line)
+        out: bytes = self.tr.value()
+        return out[: -len(PROMPT)] if out.endswith(PROMPT) else out
+
+    def test_exec_runs_command_and_ends_session(self) -> None:
+        out = self.run_line(b"exec echo hi")
+        self.assertEqual(out, b"hi\n")
+        self.assertEqual(self.proto.cmdstack, [])
+
+    def test_exec_skips_rest_of_line(self) -> None:
+        # The shell is replaced, so a `;`-joined statement never runs.
+        out = self.run_line(b"exec echo hi; echo bye")
+        self.assertEqual(out, b"hi\n")
+        self.assertEqual(self.proto.cmdstack, [])
+
+    def test_exec_with_redirect_ends_session(self) -> None:
+        out = self.run_line(b"exec echo hi >/dev/null")
+        self.assertEqual(out, b"")
+        self.assertEqual(self.proto.cmdstack, [])
+
+    def test_bare_exec_is_noop(self) -> None:
+        shell = self.proto.cmdstack[0]
+        self.assertEqual(self.run_line(b"exec; echo $?"), b"0\n")
+        self.assertIn(shell, self.proto.cmdstack)
+
+    def test_exec_redirection_only_keeps_shell(self) -> None:
+        # `exec 2>/dev/null` adjusts the shell's own fds: no command runs and
+        # the shell survives.
+        shell = self.proto.cmdstack[0]
+        self.assertEqual(self.run_line(b"exec 2>/dev/null; echo $?"), b"0\n")
+        self.assertIn(shell, self.proto.cmdstack)
+
+    def test_exec_not_found_keeps_interactive_shell(self) -> None:
+        # An interactive shell survives a failed exec (bash without execfail).
+        shell = self.proto.cmdstack[0]
+        out = self.run_line(b"exec nosuchcmd")
+        self.assertEqual(out, b"-bash: exec: nosuchcmd: not found\n")
+        self.assertIn(shell, self.proto.cmdstack)
+        self.assertEqual(self.run_line(b"echo $?"), b"127\n")
+
+    def test_exec_in_pipeline_keeps_shell(self) -> None:
+        # A pipeline stage runs in a subshell, so `exec` there does not
+        # replace the interactive shell.
+        shell = self.proto.cmdstack[0]
+        self.assertEqual(self.run_line(b"exec echo hi | cat"), b"hi\n")
+        self.assertIn(shell, self.proto.cmdstack)
+
+    def test_exec_in_nested_shell_ends_only_that_shell(self) -> None:
+        out = self.run_line(b'sh -c "exec echo hi"; echo after')
+        self.assertEqual(out, b"hi\nafter\n")
+        self.assertNotEqual(self.proto.cmdstack, [])
+
+    def test_exec_not_found_in_nested_shell_is_127(self) -> None:
+        out = self.run_line(b'sh -c "exec nosuchcmd"; echo $?')
+        self.assertEqual(out, b"-bash: exec: nosuchcmd: not found\n127\n")
+        self.assertNotEqual(self.proto.cmdstack, [])
+
+    def test_exec_in_substitution_ends_only_capture_shell(self) -> None:
+        shell = self.proto.cmdstack[0]
+        self.assertEqual(self.run_line(b"echo a$(exec echo b; echo c)"), b"ab\n")
+        self.assertEqual(self.proto.cmdstack, [shell])
+        self.assertEqual(self.run_line(b"echo ok"), b"ok\n")
+
+    def test_exec_dash_a_sets_argv0_and_runs_command(self) -> None:
+        out = self.run_line(b"exec -a daemon echo hi")
+        self.assertEqual(out, b"hi\n")
+        self.assertEqual(self.proto.cmdstack, [])
+
+    def test_exec_assignment_persists_in_shell(self) -> None:
+        # exec is a POSIX special builtin: a prefix assignment on a bare
+        # `exec` persists in the shell.
+        self.assertEqual(self.run_line(b"A=1 exec; echo $A"), b"1\n")
+
+
+def run_exec(cmd: bytes) -> int:
+    """Run `cmd` over an exec channel and return the exit status the session
+    would report to the SSH client via processEnded."""
+    captured: dict[str, int] = {}
+
+    def process_ended(reason: object = None) -> None:
+        value = getattr(reason, "value", None)
+        captured["code"] = getattr(value, "exitCode", 0) if value is not None else 0
+
+    transport = make_exec_transport(CaptureSink(), processEnded=process_ended)
+
+    avatar = FakeAvatar(FakeServer())
+    lsp = insults.LoggingServerProtocol(protocol.HoneyPotExecProtocol, avatar, cmd)
+    lsp.makeConnection(transport)
+    return captured.get("code", 0)
+
+
+class ExecChannelTests(unittest.TestCase):
+    """`exec` over an SSH exec channel reports the command's exit status."""
+
+    def test_exec_propagates_command_status(self) -> None:
+        self.assertEqual(run_exec(b"exec true"), 0)
+        self.assertEqual(run_exec(b"exec false"), 1)
+
+    def test_exec_not_found_exits_127(self) -> None:
+        # A non-interactive shell exits when exec fails.
+        self.assertEqual(run_exec(b"exec nosuchcmd"), 127)
+
+    def test_exec_skips_following_statement(self) -> None:
+        # The `false` after exec never runs; the status is echo's.
+        self.assertEqual(run_exec(b"exec echo hi; false"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_exec_builtin.py
+++ b/src/cowrie/test/test_exec_builtin.py
@@ -78,6 +78,20 @@ class ExecInteractiveTests(unittest.TestCase):
         self.assertIn(shell, self.proto.cmdstack)
         self.assertEqual(self.run_line(b"echo $?"), b"127\n")
 
+    def test_exec_backgrounded_keeps_shell(self) -> None:
+        # `exec cmd &` replaces a backgrounded subshell, not this shell. The
+        # parser passes a trailing `&` through as a literal argument.
+        shell = self.proto.cmdstack[0]
+        self.assertEqual(self.run_line(b"exec echo hi &"), b"hi &\n")
+        self.assertIn(shell, self.proto.cmdstack)
+
+    def test_exec_backgrounded_not_found_keeps_shell(self) -> None:
+        shell = self.proto.cmdstack[0]
+        out = self.run_line(b"exec nosuchcmd &")
+        self.assertEqual(out, b"-bash: exec: nosuchcmd: not found\n")
+        self.assertIn(shell, self.proto.cmdstack)
+        self.assertEqual(self.run_line(b"echo $?"), b"127\n")
+
     def test_exec_in_pipeline_keeps_shell(self) -> None:
         # A pipeline stage runs in a subshell, so `exec` there does not
         # replace the interactive shell.
@@ -143,6 +157,11 @@ class ExecChannelTests(unittest.TestCase):
     def test_exec_skips_following_statement(self) -> None:
         # The `false` after exec never runs; the status is echo's.
         self.assertEqual(run_exec(b"exec echo hi; false"), 0)
+
+    def test_backgrounded_exec_failure_does_not_end_shell(self) -> None:
+        # The failed exec ends only the backgrounded subshell; the script
+        # carries on and reports the last statement's status.
+        self.assertEqual(run_exec(b"exec nosuchcmd &\ntrue"), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds support for the `exec` shell builtin, seen in the wild from Mirai-style
telnet loaders that run `exec /tmp/.x` (and `exec /tmp/.x &`) to hand the
session off to a dropped binary. Previously cowrie reported `exec: command
not found`, giving the technique away.

`exec cmd` runs `cmd` through the normal dispatch machinery and marks the
shell as replaced; when the command finishes the shell terminates, ending the
session (or only the nested / capture shell, as with `exit`). Behaviour
follows bash:

- `exec cmd` replaces the shell; a following `;`-joined statement never runs.
- Over an SSH exec channel the command's real exit status is reported to the
  client.
- A bare `exec`, or one with only redirections (`exec 2>/dev/null`), runs no
  command and the shell survives.
- `exec cmd | other` and `exec cmd &` run in a subshell, so the invoking shell
  survives.
- A failed lookup prints `-bash: exec: cmd: not found`; it exits a
  non-interactive shell with 127 while an interactive one survives (bash
  without `execfail`).
- `exec`'s own options (`-a NAME`, `-c`, `-l`) are accepted and dropped.

## Test plan

- New `src/cowrie/test/test_exec_builtin.py`: 18 tests covering session-ending,
  rest-of-line skipping, bare / redirection-only / backgrounded / pipeline
  survival, interactive vs non-interactive not-found, nested `sh -c`, command
  substitution, `-a`, prefix-assignment persistence, and exec-channel exit
  statuses.
- Full suite: `PYTHONPATH=src python -m unittest discover src` — 751 passing.
- `ruff check src` and mypy clean.

## Notes

Out of scope (separate technique from the same actor): `exec 5<>/dev/tcp/HOST/PORT`
fails earlier in the parser (`<>` read-write redirection is not in the grammar)
and `/dev/tcp` is not emulated at all. That is a distinct feature and is not
addressed here.
