### PR TITLE
feat: provision the session user's home and ~/.ssh

### DIFF
--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -395,6 +395,34 @@ class HoneyPotFilesystem:
         )
         self.newcount += 1
 
+    def provision_home(self, home: str, uid: int, gid: int) -> None:
+        """Ensure the session user's home directory and ``~/.ssh`` exist.
+
+        A user allowed in by a wildcard credential often has a home the
+        filesystem image never created; without it ``cd ~`` and any write into
+        the home fail. Pre-creating ``~/.ssh`` (mode 0700) lets an attacker's
+        ``echo key > ~/.ssh/authorized_keys`` succeed, so the installed key is
+        captured instead of lost to a "No such file or directory" error.
+
+        Idempotent: existing directories (and their contents) are left intact.
+        """
+        if not home.startswith("/"):
+            return
+        try:
+            self._ensure_dir(home, uid, gid, 0o755)
+            self._ensure_dir(f"{home}/.ssh", uid, gid, 0o700)
+        except OSError as e:
+            log.msg(f"Could not provision home {home}: {e}")
+
+    def _ensure_dir(self, path: str, uid: int, gid: int, perm: int) -> None:
+        """Create ``path`` (and any missing parents) as a directory if absent."""
+        if self.isdir(path):
+            return
+        parent = os.path.dirname(path)
+        if parent and parent != "/" and not self.isdir(parent):
+            self._ensure_dir(parent, uid, gid, 0o755)
+        self.mkdir(path, uid, gid, 4096, stat.S_IFDIR | perm)
+
     def isfile(self, path: str) -> bool:
         """
         Return True if path is an existing regular file. This follows symbolic

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -68,6 +68,9 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         self.sessionno: int
         self.factory = None
 
+        self.fs.provision_home(
+            self.user.avatar.home, self.user.avatar.uid, self.user.avatar.gid
+        )
         if self.fs.exists(self.user.avatar.home):
             self.cwd = self.user.avatar.home
         else:

--- a/src/cowrie/test/test_fs.py
+++ b/src/cowrie/test/test_fs.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# ABOUTME: tests for cowrie/shell/fs.py path resolution
-# ABOUTME: covers resolve_path normalization and empty-path robustness
+# ABOUTME: tests for cowrie/shell/fs.py path resolution and home provisioning
+# ABOUTME: covers resolve_path normalization, empty-path robustness, and ~/.ssh setup
 
 from __future__ import annotations
 
 import os
+import stat
 import unittest
 
 from cowrie.shell import fs
@@ -36,6 +37,58 @@ class ResolvePathTests(unittest.TestCase):
         # from any command that forwards an unset shell variable, e.g. an
         # attacker's `[ -w "$mnt" ]` where $mnt expanded to nothing.
         self.assertEqual(self.fs.resolve_path("", "/home/user"), "/home/user")
+
+
+class ProvisionHomeTests(unittest.TestCase):
+    """provision_home() gives the session user a home directory and ~/.ssh."""
+
+    def test_missing_home_is_created_owned_by_user(self) -> None:
+        # The default image has no /home/admin; a user allowed in by a
+        # wildcard credential must still land in a real home directory.
+        hpfs = fs.HoneyPotFilesystem("arch", "/home/admin")
+        hpfs.provision_home("/home/admin", 1000, 1000)
+        self.assertTrue(hpfs.isdir("/home/admin"))
+        entry = hpfs.getfile("/home/admin")
+        assert entry is not None
+        self.assertEqual(entry[fs.A_UID], 1000)
+        self.assertEqual(entry[fs.A_GID], 1000)
+
+    def test_ssh_dir_is_created_mode_0700(self) -> None:
+        hpfs = fs.HoneyPotFilesystem("arch", "/home/admin")
+        hpfs.provision_home("/home/admin", 1000, 1000)
+        self.assertTrue(hpfs.isdir("/home/admin/.ssh"))
+        entry = hpfs.getfile("/home/admin/.ssh")
+        assert entry is not None
+        self.assertEqual(stat.S_IMODE(entry[fs.A_MODE]), 0o700)
+        self.assertEqual(entry[fs.A_UID], 1000)
+
+    def test_authorized_keys_can_be_written_after_provisioning(self) -> None:
+        # The point of the feature: an attacker's key install succeeds so the
+        # key is captured instead of failing with "No such file or directory".
+        hpfs = fs.HoneyPotFilesystem("arch", "/home/admin")
+        hpfs.provision_home("/home/admin", 1000, 1000)
+        path = "/home/admin/.ssh/authorized_keys"
+        self.assertTrue(hpfs.mkfile(path, 1000, 1000, 0, stat.S_IFREG | 0o644))
+        self.assertTrue(hpfs.isfile(path))
+
+    def test_ssh_added_when_home_already_exists(self) -> None:
+        # The image ships /root without a .ssh; provisioning adds it without
+        # disturbing the existing home.
+        hpfs = fs.HoneyPotFilesystem("arch", "/root")
+        self.assertTrue(hpfs.isdir("/root"))
+        self.assertFalse(hpfs.isdir("/root/.ssh"))
+        hpfs.provision_home("/root", 0, 0)
+        self.assertTrue(hpfs.isdir("/root/.ssh"))
+        # Existing contents are preserved.
+        self.assertTrue(hpfs.exists("/root/.bashrc"))
+
+    def test_provisioning_is_idempotent(self) -> None:
+        hpfs = fs.HoneyPotFilesystem("arch", "/home/admin")
+        hpfs.provision_home("/home/admin", 1000, 1000)
+        hpfs.provision_home("/home/admin", 1000, 1000)
+        # A second call must not create a duplicate .ssh entry.
+        ssh_dirs = [c for c in hpfs.get_path("/home/admin") if c[fs.A_NAME] == ".ssh"]
+        self.assertEqual(len(ssh_dirs), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

A user allowed in by a wildcard credential often has a home directory the
filesystem image never created, so `cd ~` and any write into the home fail. In
the wild this shows up as an attacker's SSH-key install failing:

```
admin@svr04:~$ echo ssh-rsa AAAAB3Nz...kUMRr rsa-key-20230629 > ~/.ssh/authorized_keys
-bash: /home/admin/.ssh/authorized_keys: No such file or directory
```

The shell error is correct bash behaviour for a missing `~/.ssh`, but the
deeper problem is that the logged-in user has no home directory at all, which
is unrealistic and costs us a high-value IOC (the installed public key).

`provision_home(home, uid, gid)` runs at session start and:

- creates the user's home directory (mode 0755, owned by the login uid/gid) if
  the image never included it, and
- pre-creates `~/.ssh` (mode 0700) so `echo key > ~/.ssh/authorized_keys`
  succeeds and the key is captured in the (session-local) filesystem.

It is idempotent and non-destructive: existing homes such as `/home/phil` and
`/root` keep their contents; only what is missing is added. Since `get_tree()`
deep-copies the tree per session, provisioning never leaks across connections.
Provisioning failures are caught and logged rather than breaking the session.

## Test plan

- New `ProvisionHomeTests` in `src/cowrie/test/test_fs.py`: missing-home
  creation and ownership, `~/.ssh` mode 0700, authorized_keys write succeeds,
  `.ssh` added to an already-existing home without disturbing it, and
  idempotency (no duplicate `.ssh`).
- Verified end-to-end: `echo key > ~/.ssh/authorized_keys`, then
  `cat ~/.ssh/authorized_keys` returns the key and `ls -la ~/.ssh` shows
  `drwx------`.
- Full suite: `PYTHONPATH=src python -m unittest discover src` — 738 passing.
- `ruff check src` and mypy clean.
