### PR TITLE
feat: config-driven log levels and per-class twisted.logger diagnostics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,6 +59,14 @@ Release 3.0.0
 * Bundled ``cowrie.cfg.dist`` has ``contents_path``, ``filesystem``,
   and ``processes`` commented out (each documents how to override).
 * ``data_path`` removed from cfg.dist.
+* New ``[honeypot] log_level`` option sets the diagnostic verbosity of
+  ``cowrie.log`` -- and of stdout in foreground/Docker mode -- (default
+  ``info``), with per-subsystem overrides via ``log_level_<namespace>``
+  (e.g. ``log_level_cowrie.ssh = debug``) or the matching
+  ``COWRIE_HONEYPOT_LOG_LEVEL_*`` environment variables. Rendered
+  attacker-event lines (``cowrie.events``) keep an ``info`` floor unless
+  explicitly overridden. Structured event output (cowrie.json,
+  databases) is unaffected.
 
 **DEPENDENCIES:**
 
@@ -68,6 +76,14 @@ Release 3.0.0
 
 **INTERNAL:**
 
+* Diagnostic logging converted from the legacy ``twisted.python.log``
+  API to per-class ``twisted.logger.Logger`` instances with namespaces
+  and levels; messages are lazy PEP-3101 format strings with runtime
+  values passed as data (see docs/EVENT_PIPELINE.rst). The backend
+  pool's session-less emitters dropped their vestigial ``eventid=``
+  markers and are plain diagnostics: pool bookkeeping is
+  infrastructure, not attacker behavior, and never reached the output
+  plugins.
 * New ``cowrie/shell/honeyfs.py`` module owns the per-process pickle
   cache. ``HoneyPotFilesystem`` instances now share a single
   ``pickle.load`` via ``honeyfs.get_tree()`` (deepcopied per session)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -118,4 +118,4 @@ RUN [ "python3", "/cowrie/cowrie-git/bin/regen-dropin.cache" ]
 EXPOSE 2222 2223
 
 ENTRYPOINT [ "/cowrie/cowrie-env/bin/python3" ]
-CMD [ "/cowrie/cowrie-env/bin/twistd", "-n", "--umask=0022", "--pidfile=", "cowrie" ]
+CMD [ "/cowrie/cowrie-env/bin/twistd", "-n", "--umask=0022", "--pidfile=", "--logger", "cowrie.python.logfile.stdoutLogger", "cowrie" ]

--- a/docs/EVENT_PIPELINE.rst
+++ b/docs/EVENT_PIPELINE.rst
@@ -342,38 +342,68 @@ helpers in ``cowrie.test.eventcapture`` (``capture_eventlog``,
 pipeline onto a protocol or transport; the shell tests' ``FakeTransport``
 carries one so command tests can assert on ``tr.dispatchedEvents``.
 
-Future work: diagnostics to ``twisted.logger``
-**********************************************
+Diagnostics on ``twisted.logger``
+*********************************
 
-The event side is complete; the diagnostic side is still on the legacy
-``twisted.python.log`` API (~490 ``log.msg`` / ``log.err`` call sites). Now
-that no consumer parses the log stream, those can convert to per-class
-``twisted.logger.Logger`` instances. The observer side is already there --
-``python/logfile.py`` writes ``cowrie.log`` through ``textFileLogObserver``
-and the twistd plugin registers ``ILogObserver`` providers -- so only the
-emitters need converting. What the conversion buys:
+The diagnostic side runs on per-class ``twisted.logger.Logger`` instances:
+each emitting class carries ``_log = Logger()`` (modules with free functions
+carry one at module level), giving every line a namespace derived from its
+origin (``cowrie.ssh.transport.HoneyPotSSHTransport``,
+``cowrie.commands.wget``) and a real level. The legacy
+``twisted.python.log`` API is no longer used for diagnostics.
 
 Levels and namespaces
-    Per-class ``Logger`` instances give every line a namespace
-    (``cowrie.ssh.transport``, ``cowrie.commands.wget``) and a real level.
-    Combined with ``LogLevelFilterPredicate`` this yields per-subsystem
-    verbosity control from configuration -- debug a single subsystem in
-    production without drowning in the rest. Today the log has exactly one
-    volume setting: everything.
+    ``python/logfile.py`` wraps the log observer -- ``cowrie.log``, or
+    stdout in foreground and Docker mode -- in a ``FilteringLogObserver``
+    driven by configuration: ``[honeypot] log_level`` sets the default
+    (info), and ``log_level_<namespace>`` options (or the equivalent
+    ``COWRIE_HONEYPOT_LOG_LEVEL_*`` environment variables) override per
+    subsystem by dotted prefix -- debug a single subsystem in production
+    without drowning in the rest (``log_level_cowrie.ssh = debug``).
+    Overrides work at module granularity: configparser lowercases option
+    names, so a class-qualified namespace cannot be targeted, but the
+    module prefix above it covers it. Filtering happens at the observer,
+    so test observers and any future sinks still see everything.
+
+Session prefixes
+    ``twisted.logger`` does not read the reactor's ``ILogContext``, which
+    is where legacy ``log.msg`` lines inherited their
+    ``[HoneyPotSSHTransport,3,1.2.3.4]`` prefix. The observer in
+    ``python/logfile.py`` restores it: a diagnostic emitted inside a
+    connection's context is stamped with that system prefix (keeping it
+    correlatable to a session in the log), while lines outside any
+    connection context render their ``namespace#level``. Level filtering
+    uses the namespace either way.
 
 Lazy formatting
-    ``self._log.debug("block {n} received", n=num)`` costs nearly nothing
-    when filtered out, so debug statements can stay in the code permanently
-    instead of being commented in and out during development.
+    Diagnostic messages are PEP-3101 format strings with the runtime values
+    passed as keywords: ``self._log.debug("block {n} received", n=num)``
+    costs nearly nothing when filtered out, so debug statements can stay in
+    the code permanently. Runtime values are never interpolated into the
+    format string itself -- attacker-controlled text (commands, URLs,
+    version strings) may contain braces and must stay data, the same rule
+    the event pipeline applies to its authoritative fields.
 
 Failures
-    ``self._log.failure("wget transfer failed")`` replaces ``log.err`` with
-    explicit tracebacks attached as structured data.
+    ``self._log.failure("wget transfer failed")`` replaces ``log.err``,
+    capturing the active exception with its traceback as structured data.
 
-A small number of session-less emitters (backend pool, proxy backend
-bookkeeping) also remain on ``log.msg(eventid=...)``; they never reached the
-output plugins historically, and making them first-class events is a separate
-follow-up.
+Console event lines
+    The console renderer emits through a ``Logger`` under the
+    ``cowrie.events`` namespace, stamping the session's
+    ``protocol,session,src_ip`` prefix via ``log_system``. That namespace
+    keeps an explicit ``info`` floor: raising the global ``log_level``
+    quiets diagnostics without silently erasing the attack record from
+    the log, preserving ``cowrie.log`` as the superset. Operators who do
+    want event lines filtered set ``log_level_cowrie.events`` explicitly.
+
+The backend pool's session-less emitters historically carried
+``eventid=`` markers on the legacy API without ever reaching the output
+plugins; they are deliberately plain diagnostics, converted like the
+rest -- pool bookkeeping is about the honeypot's own infrastructure,
+not attacker behavior, so it does not become events. The SSH connection
+service keeps the last legacy import in product code, for
+``log.callWithLogger``, which is not a diagnostic emitter.
 
 Why not ``twisted.logger`` for events too
 =========================================

--- a/src/backend_pool/libvirt/backend_service.py
+++ b/src/backend_pool/libvirt/backend_service.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-from twisted.python import log
+from twisted.logger import Logger
 
 import backend_pool.libvirt.guest_handler
 import backend_pool.libvirt.network_handler
@@ -31,6 +31,8 @@ class LibvirtError(Exception):
 
 
 class LibvirtBackendService:
+    _log = Logger()
+
     def __init__(self) -> None:
         # lazy import to avoid exception if not using the backend_pool
         # and libvirt not installed (#1185)
@@ -43,10 +45,8 @@ class LibvirtBackendService:
         # open connection to libvirt
         self.conn: Any = libvirt.open(libvirt_uri)
         if self.conn is None:
-            log.msg(
-                eventid="cowrie.backend_pool.libvirtd",
-                format="Failed to open connection to libvirtd at %(uri)s",
-                uri=libvirt_uri,
+            self._log.error(
+                "Failed to open connection to libvirtd at {uri}", uri=libvirt_uri
             )
             raise LibvirtError()
 
@@ -60,11 +60,7 @@ class LibvirtBackendService:
         seed: int = random.randint(0, sys.maxsize)
         self.network_table = backend_pool.util.generate_network_table(seed)
 
-        log.msg(
-            eventid="cowrie.backend_pool.libvirtd",
-            format="Connection to libvirtd established at %(uri)s",
-            uri=libvirt_uri,
-        )
+        self._log.info("Connection to libvirtd established at {uri}", uri=libvirt_uri)
 
     def start_backend(self) -> None:
         """
@@ -83,10 +79,7 @@ class LibvirtBackendService:
         self.ready = True
 
     def stop_backend(self) -> None:
-        log.msg(
-            eventid="cowrie.backend_pool.libvirtd",
-            format="Doing libvirtd clean shutdown...",
-        )
+        self._log.info("Doing libvirtd clean shutdown...")
 
         self.ready = False
 
@@ -95,10 +88,7 @@ class LibvirtBackendService:
     def shutdown_backend(self) -> None:
         self.conn.close()  # close libvirt connection
 
-        log.msg(
-            eventid="cowrie.backend_pool.libvirtd",
-            format="Connection to libvirtd closed successfully",
-        )
+        self._log.info("Connection to libvirtd closed successfully")
 
     def get_mac_ip(self, ip_tester: Callable[[str], bool]) -> tuple[str, str]:
         """
@@ -134,9 +124,7 @@ class LibvirtBackendService:
             self.conn, guest_mac, guest_unique_id
         )
         if dom is None:
-            log.msg(
-                eventid="cowrie.backend_pool.libvirtd", format="Failed to create guest"
-            )
+            self._log.error("Failed to create guest")
             return None
 
         return dom, snapshot, guest_ip
@@ -164,12 +152,8 @@ class LibvirtBackendService:
                 and os.path.isfile(snapshot)
             ):
                 os.remove(snapshot)  # destroy its disk snapshot
-        except Exception as error:
-            log.err(
-                eventid="cowrie.backend_pool.libvirtd",
-                format="Error destroying guest: %(error)s",
-                error=error,
-            )
+        except Exception:
+            self._log.failure("Error destroying guest")
 
     def __destroy_all_guests(self) -> None:
         domains = self.conn.listDomainsID()

--- a/src/backend_pool/libvirt/guest_handler.py
+++ b/src/backend_pool/libvirt/guest_handler.py
@@ -9,18 +9,22 @@ import sys
 from configparser import NoOptionError
 from typing import Any
 
-from twisted.python import log
+from twisted.logger import Logger
 
 import backend_pool.libvirt.snapshot_handler
 import backend_pool.util
 from cowrie.core.config import CowrieConfig
+
+_log = Logger()
 
 
 class QemuGuestError(Exception):
     pass
 
 
-def create_guest(connection: Any, mac_address: str, guest_unique_id: str) -> tuple[Any, str]:
+def create_guest(
+    connection: Any, mac_address: str, guest_unique_id: str
+) -> tuple[Any, str]:
     # lazy import to avoid exception if not using the backend_pool and libvirt not installed (#1185)
     import libvirt
 
@@ -41,10 +45,8 @@ def create_guest(connection: Any, mac_address: str, guest_unique_id: str) -> tup
 
     # check if base image exists
     if not os.path.isfile(base_image):
-        log.msg(
-            eventid="cowrie.backend_pool.guest_handler",
-            format="Base image provided was not found: %(base_image)s",
-            base_image=base_image,
+        _log.error(
+            "Base image provided was not found: {base_image}", base_image=base_image
         )
         os._exit(1)
 
@@ -70,10 +72,7 @@ def create_guest(connection: Any, mac_address: str, guest_unique_id: str) -> tup
     if not backend_pool.libvirt.snapshot_handler.create_disk_snapshot(
         base_image, disk_img
     ):
-        log.msg(
-            eventid="cowrie.backend_pool.guest_handler",
-            format="There was a problem creating the disk snapshot.",
-        )
+        _log.error("There was a problem creating the disk snapshot.")
         raise QemuGuestError()
 
     guest_config = guest_xml.format(
@@ -91,21 +90,10 @@ def create_guest(connection: Any, mac_address: str, guest_unique_id: str) -> tup
     try:
         dom = connection.createXML(guest_config, 0)
         if dom is None:
-            log.err(
-                eventid="cowrie.backend_pool.guest_handler",
-                format="Failed to create a domain from an XML definition.",
-            )
+            _log.error("Failed to create a domain from an XML definition.")
             sys.exit(1)
-    except libvirt.libvirtError as e:
-        log.err(
-            eventid="cowrie.backend_pool.guest_handler",
-            format="Error booting guest: %(error)s",
-            error=e,
-        )
+    except libvirt.libvirtError:
+        _log.failure("Error booting guest")
         raise
-    log.msg(
-        eventid="cowrie.backend_pool.guest_handler",
-        format="Guest %(name)s has booted",
-        name=dom.name(),
-    )
+    _log.info("Guest {name} has booted", name=dom.name())
     return dom, disk_img

--- a/src/backend_pool/libvirt/network_handler.py
+++ b/src/backend_pool/libvirt/network_handler.py
@@ -7,10 +7,12 @@ from __future__ import annotations
 import sys
 from typing import Any
 
-from twisted.python import log
+from twisted.logger import Logger
 
 import backend_pool.util
 from cowrie.core.config import CowrieConfig
+
+_log = Logger()
 
 
 def create_filter(connection: Any) -> Any:
@@ -25,12 +27,8 @@ def create_filter(connection: Any) -> Any:
 
     try:
         return connection.nwfilterDefineXML(filter_xml)
-    except libvirt.libvirtError as e:
-        log.err(
-            eventid="cowrie.backend_pool.network_handler",
-            format="Filter already exists: %(error)s",
-            error=e,
-        )
+    except libvirt.libvirtError:
+        _log.failure("Filter already exists")
         return connection.nwfilterLookupByName("cowrie-default-filter")
 
 
@@ -71,22 +69,15 @@ def create_network(connection: Any, network_table: dict[str, str]) -> Any:
     try:
         net = connection.networkCreateXML(network_config)
         if net is None:
-            log.msg(
-                eventid="cowrie.backend_pool.network_handler",
-                format="Failed to define a virtual network",
-            )
+            _log.error("Failed to define a virtual network")
             sys.exit(1)
 
         # set the network active
         # not needed since apparently transient networks are created as active; uncomment if persistent
         # net.create()
 
-    except libvirt.libvirtError as e:
-        log.err(
-            eventid="cowrie.backend_pool.network_handler",
-            format="Network already exists: %(error)s",
-            error=e,
-        )
+    except libvirt.libvirtError:
+        _log.failure("Network already exists")
         return connection.networkLookupByName("cowrie")
 
     return net

--- a/src/backend_pool/pool_server.py
+++ b/src/backend_pool/pool_server.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 
 from twisted.internet.address import IPv4Address, IPv6Address
 from twisted.internet.protocol import Factory, Protocol
-from twisted.python import log
+from twisted.logger import Logger
 
 from backend_pool.nat import NATService
 from backend_pool.pool_service import NoAvailableVMs, PoolService
@@ -36,6 +36,8 @@ class PoolServer(Protocol):
     """
     Main PoolServer
     """
+
+    _log = Logger()
 
     def __init__(self, factory: PoolServerFactory) -> None:
         self.factory: PoolServerFactory = factory
@@ -82,9 +84,8 @@ class PoolServer(Protocol):
             recv = struct.unpack(f"!{ip_len}s", data[3:])
             attacker_ip = recv[0].decode()
 
-            log.msg(
-                eventid="cowrie.backend_pool.server",
-                format="Requesting a VM for attacker @ %(attacker_ip)s",
+            self._log.info(
+                "Requesting a VM for attacker @ {attacker_ip}",
                 attacker_ip=attacker_ip,
             )
 
@@ -94,11 +95,7 @@ class PoolServer(Protocol):
                     guest_ip,
                     guest_snapshot,
                 ) = self.factory.pool_service.request_vm(attacker_ip)
-                log.msg(
-                    eventid="cowrie.backend_pool.server",
-                    format="Providing VM id %(guest_id)s",
-                    guest_id=guest_id,
-                )
+                self._log.info("Providing VM id {guest_id}", guest_id=guest_id)
 
                 ssh_port: int = CowrieConfig.getint(
                     "backend_pool", "guest_ssh_port", fallback=22
@@ -142,10 +139,7 @@ class PoolServer(Protocol):
                         guest_snapshot.encode(),
                     )
             except NoAvailableVMs:
-                log.msg(
-                    eventid="cowrie.backend_pool.server",
-                    format="No VM available, returning error code",
-                )
+                self._log.info("No VM available, returning error code")
                 response = struct.pack("!cI", RES_OP_R, 1)
 
         elif res_op == RES_OP_F:
@@ -153,11 +147,7 @@ class PoolServer(Protocol):
             recv = struct.unpack("!I", data[1:])
             guest_id = recv[0]
 
-            log.msg(
-                eventid="cowrie.backend_pool.server",
-                format="Freeing VM %(guest_id)s",
-                guest_id=guest_id,
-            )
+            self._log.info("Freeing VM {guest_id}", guest_id=guest_id)
 
             # free the NAT
             if (not self.local_pool and self.use_nat) or self.pool_only:
@@ -171,10 +161,8 @@ class PoolServer(Protocol):
             recv = struct.unpack("!I", data[1:])
             guest_id = recv[0]
 
-            log.msg(
-                eventid="cowrie.backend_pool.server",
-                format="Reusing VM %(guest_id)s (not used by attacker)",
-                guest_id=guest_id,
+            self._log.info(
+                "Reusing VM {guest_id} (not used by attacker)", guest_id=guest_id
             )
 
             # free the NAT
@@ -192,6 +180,8 @@ class PoolServerFactory(Factory[PoolServer]):
     """
     Factory for PoolServer
     """
+
+    _log = Logger()
 
     def __init__(self) -> None:
         self.initialised: bool = False
@@ -211,17 +201,14 @@ class PoolServerFactory(Factory[PoolServer]):
             self.pool_service.start_pool()
 
     def stopFactory(self) -> None:
-        log.msg(eventid="cowrie.backend_pool.server", format="Stopping backend pool...")
+        self._log.info("Stopping backend pool...")
         if self.pool_service:
             self.pool_service.shutdown_pool()
 
     def buildProtocol(self, addr: IAddress | None) -> PoolServer:
         assert addr is not None
         assert isinstance(addr, (IPv4Address, IPv6Address))
-        log.msg(
-            eventid="cowrie.backend_pool.server",
-            format="Received connection from %(host)s:%(port)s",
-            host=addr.host,
-            port=addr.port,
+        self._log.info(
+            "Received connection from {host}:{port}", host=addr.host, port=addr.port
         )
         return PoolServer(self)

--- a/src/backend_pool/pool_service.py
+++ b/src/backend_pool/pool_service.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass
 from threading import Lock
 
 from twisted.internet import reactor, threads
-from twisted.python import log
+from twisted.logger import Logger
 
 import backend_pool.libvirt.backend_service
 import backend_pool.util
@@ -87,6 +87,8 @@ class PoolService:
     only by the single producer.
     """
 
+    _log = Logger()
+
     def __init__(self, nat_service):
         self.qemu = backend_pool.libvirt.backend_service.LibvirtBackendService()
         self.nat_service = nat_service
@@ -124,9 +126,8 @@ class PoolService:
         )
 
         if self.ssh_port == -1 and self.telnet_port == -1:
-            log.msg(
-                eventid="cowrie.backend_pool.service",
-                format="Invalid configuration: one of SSH or Telnet ports must be defined!",
+            self._log.error(
+                "Invalid configuration: one of SSH or Telnet ports must be defined!"
             )
             os._exit(1)
 
@@ -160,7 +161,7 @@ class PoolService:
         # and libvirt not installed (#1185)
         import libvirt
 
-        log.msg(eventid="cowrie.backend_pool.service", format="Trying pool clean stop")
+        self._log.info("Trying pool clean stop")
 
         # stop loop
         if self.loop_next_call:
@@ -175,9 +176,7 @@ class PoolService:
 
         # close any NAT sockets
         if (not self.local_pool and self.use_nat) or self.pool_only:
-            log.msg(
-                eventid="cowrie.backend_pool.service", format="Free all NAT bindings"
-            )
+            self._log.info("Free all NAT bindings")
             self.nat_service.free_all()
 
         try:
@@ -198,10 +197,7 @@ class PoolService:
             print("Not connected to QEMU")  # noqa: T201
 
     def restart_pool(self) -> None:
-        log.msg(
-            eventid="cowrie.backend_pool.service",
-            format="Refreshing pool, terminating current instances and rebooting",
-        )
+        self._log.info("Refreshing pool, terminating current instances and rebooting")
         self.stop_pool()
         self.start_pool()
 
@@ -268,9 +264,8 @@ class PoolService:
                 # (and guest.connected == 0) sometimes did not
                 # work correctly as some VMs are not signaled as freed
                 if timed_out:
-                    log.msg(
-                        eventid="cowrie.backend_pool.service",
-                        format="Guest %(guest_id)s (%(guest_ip)s) marked for deletion (timed-out)",
+                    self._log.info(
+                        "Guest {guest_id} ({guest_ip}) marked for deletion (timed-out)",
                         guest_id=guest.id,
                         guest_ip=guest.guest_ip,
                     )
@@ -287,9 +282,8 @@ class PoolService:
             )
             for guest in usable_guests:
                 if not self.has_connectivity(guest.guest_ip):
-                    log.msg(
-                        eventid="cowrie.backend_pool.service",
-                        format="Guest %(guest_id)s @ %(guest_ip)s has no connectivity... Destroying",
+                    self._log.info(
+                        "Guest {guest_id} @ {guest_ip} has no connectivity... Destroying",
                         guest_id=guest.id,
                         guest_ip=guest.guest_ip,
                     )
@@ -304,12 +298,8 @@ class PoolService:
             try:
                 self.qemu.destroy_guest(guest.domain, guest.snapshot)
                 guest.state = POOL_STATE_DESTROYED
-            except Exception as error:
-                log.err(
-                    eventid="cowrie.backend_pool.service",
-                    format="Error destroying guest: %(error)s",
-                    error=error,
-                )
+            except Exception:
+                self._log.failure("Error destroying guest")
 
     def __producer_remove_destroyed(self) -> None:
         """
@@ -333,9 +323,8 @@ class PoolService:
                 self.any_vm_up = True  # TODO fix for no VM available
                 guest.state = POOL_STATE_AVAILABLE
                 boot_time = int(time.time() - guest.start_timestamp)
-                log.msg(
-                    eventid="cowrie.backend_pool.service",
-                    format="Guest %(guest_id)s ready for connections @ %(guest_ip)s! (boot %(boot_time)ss)",
+                self._log.info(
+                    "Guest {guest_id} ready for connections @ {guest_ip}! (boot {boot_time}s)",
                     guest_id=guest.id,
                     guest_ip=guest.guest_ip,
                     boot_time=boot_time,
@@ -448,7 +437,7 @@ class PoolService:
         if not guest:
             # TODO fix for no VM available
             if self.any_vm_up:
-                log.msg("Inconsistent state in pool, restarting...")
+                self._log.info("Inconsistent state in pool, restarting...")
                 self.stop_pool()
             raise NoAvailableVMs()
 

--- a/src/backend_pool/telnet_exec.py
+++ b/src/backend_pool/telnet_exec.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 from twisted.conch.telnet import StatefulTelnetProtocol, TelnetTransport
 from twisted.internet import defer, reactor
 from twisted.internet.protocol import ClientFactory
-from twisted.python import log
+from twisted.logger import Logger
 
 if TYPE_CHECKING:
     from twisted.internet.interfaces import IAddress
@@ -109,6 +109,8 @@ class TelnetClient(StatefulTelnetProtocol):
 
 
 class TelnetFactory(ClientFactory):
+    _log = Logger()
+
     def __init__(self, username, password, prompt, command, done_deferred, callback):
         self.username = username
         self.password = password
@@ -125,7 +127,7 @@ class TelnetFactory(ClientFactory):
         return transport
 
     def clientConnectionFailed(self, connector, reason):
-        log.err(f"Telnet connection failed. Reason: {reason}")
+        self._log.failure("Telnet connection failed.", failure=reason)
 
 
 class TelnetClientCommand:

--- a/src/cowrie/__init__.py
+++ b/src/cowrie/__init__.py
@@ -5,14 +5,16 @@
 
 import sys
 
-from twisted.python import log
-
 try:
     import cowrie._version as cowrie_version
 
     __version__ = cowrie_version
 except ModuleNotFoundError:
-    log.err(
-        "Cowrie is not installed. Run `pip install -e .` to install Cowrie into your virtual enviroment"
+    # This runs before any log observer exists and exits immediately, so
+    # the logging system would swallow it; write straight to stderr.
+    print(  # noqa: T201
+        "Cowrie is not installed. Run `pip install -e .` to install Cowrie"
+        " into your virtual enviroment",
+        file=sys.stderr,
     )
     sys.exit(1)

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -17,7 +17,7 @@ import time
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from twisted.internet import reactor
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core import utils
 from cowrie.shell.command import HoneyPotCommand, process_status
@@ -125,6 +125,8 @@ commands["who"] = Command_who
 
 
 class Command_echo(HoneyPotCommand):
+    _log = Logger()
+
     def call(self) -> None:
         newline = True
         escape_decode = False
@@ -165,7 +167,7 @@ class Command_echo(HoneyPotCommand):
                 self.write(string)
 
         except ValueError:
-            log.msg("echo command received Python incorrect hex escape")
+            self._log.info("echo command received Python incorrect hex escape")
 
 
 commands["/bin/echo"] = Command_echo

--- a/src/cowrie/commands/base64.py
+++ b/src/cowrie/commands/base64.py
@@ -9,7 +9,7 @@ import base64
 import getopt
 import sys
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.shell.command import HoneyPotCommand
 
@@ -20,6 +20,8 @@ class Command_base64(HoneyPotCommand):
     """
     author: Ivan Korolev (@fe7ch)
     """
+
+    _log = Logger()
 
     mode: str
     ignore: bool
@@ -110,8 +112,8 @@ Try 'base64 --help' for more information.
             if not self.fs.isdir(pname):
                 try:
                     self.dojob(self.fs.file_contents(pname))
-                except Exception as e:
-                    log.err(str(e))
+                except Exception:
+                    self._log.failure("base64: failed to read file")
                     self.errorWrite(f"base64: {args[0]}: No such file or directory\n")
             else:
                 self.errorWrite("base64: read error: Is a directory\n")

--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -13,7 +13,7 @@ from urllib import parse
 import treq
 from twisted.internet import error
 from twisted.internet.defer import inlineCallbacks
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
@@ -201,6 +201,8 @@ class Command_curl(HoneyPotCommand):
     curl command
     """
 
+    _log = Logger()
+
     limit_size: int = CowrieConfig.getint("honeypot", "download_limit_size", fallback=0)
     outfile: str | None = None  # outfile is the file saved inside the honeypot
     artifact: (
@@ -297,8 +299,9 @@ class Command_curl(HoneyPotCommand):
 
         # Check rate limit before proceeding
         if not curl_rate_limiter.check(self.host):
-            log.msg(
-                f"curl: rate limit exceeded for host: {self.host}. Simulating connection timeout"
+            self._log.info(
+                "curl: rate limit exceeded for host: {host}. Simulating connection timeout",
+                host=self.host,
             )
 
             # Simulate connection timeout
@@ -310,7 +313,7 @@ class Command_curl(HoneyPotCommand):
 
         allowed = yield communication_allowed(self.host)
         if not allowed:
-            log.msg("Attempt to access blocked network address")
+            self._log.info("Attempt to access blocked network address")
             self.errorWrite(f"curl: (6) Could not resolve host: {self.host}\n")
             self.exit(6)
             return None
@@ -378,8 +381,11 @@ class Command_curl(HoneyPotCommand):
             return
 
         if self.limit_size > 0 and self.totallength > self.limit_size:
-            log.msg(
-                f"Not saving URL ({self.url.decode()}) (size: {self.totallength}) exceeds file size limit ({self.limit_size})"
+            self._log.info(
+                "Not saving URL ({url}) (size: {size}) exceeds file size limit ({limit})",
+                url=self.url.decode(),
+                size=self.totallength,
+                limit=self.limit_size,
             )
             self.exit()
             return
@@ -407,8 +413,11 @@ class Command_curl(HoneyPotCommand):
             return
         self.currentlength += len(data)
         if self.limit_size > 0 and self.currentlength > self.limit_size:
-            log.msg(
-                f"Not saving URL ({self.url.decode()}) (size: {self.currentlength}) exceeds file size limit ({self.limit_size})"
+            self._log.info(
+                "Not saving URL ({url}) (size: {size}) exceeds file size limit ({limit})",
+                url=self.url.decode(),
+                size=self.currentlength,
+                limit=self.limit_size,
             )
             self.exit()
             return
@@ -503,11 +512,7 @@ class Command_curl(HoneyPotCommand):
         # defer.CancelledError,
         # error.ConnectingCancelledError,
 
-        log.msg(response.printTraceback())
-        errormsg = ""
-        if hasattr(response, "getErrorMessage"):  # Exceptions
-            errormsg = response.getErrorMessage()
-        log.msg(errormsg)
+        self._log.failure("Unhandled curl error", failure=response)
         self.write("\n")
 
         self.exit()

--- a/src/cowrie/commands/nc.py
+++ b/src/cowrie/commands/nc.py
@@ -10,7 +10,7 @@ import socket
 import struct
 
 from twisted.internet.defer import inlineCallbacks
-from twisted.python import log  # pylint: disable=no-name-in-module
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.network import communication_allowed, is_valid_port
@@ -26,7 +26,7 @@ nc_rate_limiter = RateLimiter(
     enabled=CowrieConfig.getboolean("honeypot", "nc_rate_limit_enabled", fallback=True),
     max_requests=CowrieConfig.getint("honeypot", "nc_rate_limit_requests", fallback=5),
     window_seconds=CowrieConfig.getint("honeypot", "nc_rate_limit_window", fallback=60),
-    max_keys=CowrieConfig.getint("honeypot", "nc_rate_limit_max_hosts", fallback=1000)
+    max_keys=CowrieConfig.getint("honeypot", "nc_rate_limit_max_hosts", fallback=1000),
 )
 
 
@@ -66,6 +66,8 @@ class Command_nc(HoneyPotCommand):
     netcat
     """
 
+    _log = Logger()
+
     s: socket.socket
     CONNECT_TIMEOUT: float = 10.0  # seconds
 
@@ -74,10 +76,18 @@ class Command_nc(HoneyPotCommand):
         if error_msg:
             self.errorWrite(f"nc: {error_msg}\n")
 
-        self.errorWrite("usage: nc [-46CDdFhklNnrStUuvZz] [-I length] [-i interval] [-M ttl]\n")
-        self.errorWrite("\t  [-m minttl] [-O length] [-P proxy_username] [-p source_port]\n")
-        self.errorWrite("\t  [-q seconds] [-s source] [-T keyword] [-V rtable] [-W recvlimit] [-w timeout]\n")
-        self.errorWrite("\t  [-X proxy_protocol] [-x proxy_address[:port]]\t\t  [destination] [port]\n")
+        self.errorWrite(
+            "usage: nc [-46CDdFhklNnrStUuvZz] [-I length] [-i interval] [-M ttl]\n"
+        )
+        self.errorWrite(
+            "\t  [-m minttl] [-O length] [-P proxy_username] [-p source_port]\n"
+        )
+        self.errorWrite(
+            "\t  [-q seconds] [-s source] [-T keyword] [-V rtable] [-W recvlimit] [-w timeout]\n"
+        )
+        self.errorWrite(
+            "\t  [-X proxy_protocol] [-x proxy_address[:port]]\t\t  [destination] [port]\n"
+        )
 
     def print_help_message(self) -> None:
         self.errorWrite("OpenBSD netcat\n")
@@ -92,7 +102,9 @@ class Command_nc(HoneyPotCommand):
         self.errorWrite("\t\t-F\t\tPass socket fd\n")
         self.errorWrite("\t\t-h\t\tThis help text\n")
         self.errorWrite("\t\t-I length\tTCP receive buffer length\n")
-        self.errorWrite("\t\t-i interval\tDelay interval for lines sent, ports scanned\n")
+        self.errorWrite(
+            "\t\t-i interval\tDelay interval for lines sent, ports scanned\n"
+        )
         self.errorWrite("\t\t-k\t\tKeep inbound sockets open for multiple connects\n")
         self.errorWrite("\t\t-l\t\tListen mode, for inbound connects\n")
         self.errorWrite("\t\t-M ttl\t\tOutgoing TTL / Hop Limit\n")
@@ -112,13 +124,17 @@ class Command_nc(HoneyPotCommand):
         self.errorWrite("\t\t-u\t\tUDP mode\n")
         self.errorWrite("\t\t-V rtable\tSpecify alternate routing table\n")
         self.errorWrite("\t\t-v\t\tVerbose\n")
-        self.errorWrite("\t\t-W recvlimit\tTerminate after receiving a number of packets\n")
+        self.errorWrite(
+            "\t\t-W recvlimit\tTerminate after receiving a number of packets\n"
+        )
         self.errorWrite("\t\t-w timeout\tTimeout for connects and final net reads\n")
-        self.errorWrite("\t\t" '-X proto\tProxy protocol: "4", "5" (SOCKS) or "connect"' "\n")
+        self.errorWrite('\t\t-X proto\tProxy protocol: "4", "5" (SOCKS) or "connect"\n')
         self.errorWrite("\t\t-x addr[:port]\tSpecify proxy address and port\n")
         self.errorWrite("\t\t-Z\t\tDCCP mode\n")
         self.errorWrite("\t\t-z\t\tZero-I/O mode [used for scanning]\n")
-        self.errorWrite("\tPort numbers can be individual or ranges: lo-hi [inclusive]\n")
+        self.errorWrite(
+            "\tPort numbers can be individual or ranges: lo-hi [inclusive]\n"
+        )
 
     @inlineCallbacks
     def start(self):
@@ -216,15 +232,23 @@ class Command_nc(HoneyPotCommand):
 
         # Check rate limit before proceeding
         if not nc_rate_limiter.check(host):
-            log.msg(f"nc: rate limit exceeded for host: {host}. Simulating operation timeout")
+            self._log.info(
+                "nc: rate limit exceeded for host: {host}. Simulating operation timeout",
+                host=host,
+            )
             if verbose:
-                self.errorWrite(f"nc: connect to {host} port {port} (tcp) failed: Operation timed out\n")
+                self.errorWrite(
+                    f"nc: connect to {host} port {port} (tcp) failed: Operation timed out\n"
+                )
             self.exit()
             return
 
         allowed = yield communication_allowed(host)
         if not allowed:
-            log.msg(f"nc: blocked connection attempt to {host} (private/reserved IP range)")
+            self._log.info(
+                "nc: blocked connection attempt to {host} (private/reserved IP range)",
+                host=host,
+            )
             self.exit()
             return
 
@@ -241,7 +265,9 @@ class Command_nc(HoneyPotCommand):
             self.s.connect((host, int(port)))
 
             if verbose:
-                self.errorWrite(f"Connection to {host} {port} port [tcp/*] succeeded!\n")
+                self.errorWrite(
+                    f"Connection to {host} {port} port [tcp/*] succeeded!\n"
+                )
 
             # Zero I/O mode: test connection only, no data transfer
             if zero_io:
@@ -252,11 +278,15 @@ class Command_nc(HoneyPotCommand):
             self.recv_data()
         except TimeoutError:
             if verbose:
-                self.errorWrite(f"nc: connect to {host} port {port} (tcp) failed: Operation timed out\n")
+                self.errorWrite(
+                    f"nc: connect to {host} port {port} (tcp) failed: Operation timed out\n"
+                )
             self.exit()
         except OSError:
             if verbose:
-                self.errorWrite(f"nc: connect to {host} port {port} (tcp) failed: Connection refused\n")
+                self.errorWrite(
+                    f"nc: connect to {host} port {port} (tcp) failed: Connection refused\n"
+                )
             self.exit()
         except Exception:
             self.exit()

--- a/src/cowrie/commands/ssh.py
+++ b/src/cowrie/commands/ssh.py
@@ -14,7 +14,7 @@ import time
 from typing import TYPE_CHECKING
 
 from twisted.internet import reactor
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
 from cowrie.shell.command import HoneyPotCommand
@@ -40,6 +40,8 @@ class Command_ssh(HoneyPotCommand):
     """
     ssh
     """
+
+    _log = Logger()
 
     host: str
     callbacks: list[Callable]
@@ -145,7 +147,7 @@ class Command_ssh(HoneyPotCommand):
         self.exit()
 
     def lineReceived(self, line: str) -> None:
-        log.msg("INPUT (ssh):", line)
+        self._log.info("INPUT (ssh): {line}", line=line)
         if len(self.callbacks):
             self.callbacks.pop(0)(line)
 

--- a/src/cowrie/commands/tar.py
+++ b/src/cowrie/commands/tar.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import os
 import tarfile
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.fs import A_REALFILE
@@ -17,6 +17,8 @@ commands = {}
 
 
 class Command_tar(HoneyPotCommand):
+    _log = Logger()
+
     def mkfullpath(self, path: str, f: tarfile.TarInfo) -> None:
         components, d = path.split("/"), []
         while len(components):
@@ -98,7 +100,7 @@ class Command_tar(HoneyPotCommand):
                     f.mtime,
                 )
             else:
-                log.msg(f"tar: skipping [{f.name}]")
+                self._log.info("tar: skipping [{name}]", name=f.name)
 
 
 commands["/bin/tar"] = Command_tar

--- a/src/cowrie/commands/tee.py
+++ b/src/cowrie/commands/tee.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import getopt
 import os
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.fs import FileNotFound
@@ -24,6 +24,8 @@ class Command_tee(HoneyPotCommand):
     """
     tee command
     """
+
+    _log = Logger()
 
     append = False
     teeFiles: list[str]
@@ -115,7 +117,7 @@ class Command_tee(HoneyPotCommand):
 
     def handle_CTRL_C(self) -> None:
         if not self.ignoreInterupts:
-            log.msg("Received CTRL-C, exiting..")
+            self._log.info("Received CTRL-C, exiting..")
             self.write("^C\n")
             self.exit()
 

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 from twisted.internet import defer, reactor
 from twisted.internet.defer import CancelledError, inlineCallbacks
 from twisted.internet.protocol import DatagramProtocol
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
@@ -57,6 +57,8 @@ class TFTPClient(DatagramProtocol):
     Async TFTP client using Twisted's DatagramProtocol
     Implements RFC 1350 TFTP protocol
     """
+
+    _log = Logger()
 
     def __init__(self, host: str, port: int, filename: str, artifact: Artifact):
         self.host = host
@@ -107,7 +109,7 @@ class TFTPClient(DatagramProtocol):
     def datagramReceived(self, datagram: bytes, addr: tuple[str, int]) -> None:
         """Handle received TFTP packet"""
         if len(datagram) < 4:
-            log.msg("TFTP: Received malformed packet (too short)")
+            self._log.info("TFTP: Received malformed packet (too short)")
             return
 
         # Extract opcode
@@ -127,13 +129,13 @@ class TFTPClient(DatagramProtocol):
         elif opcode == OPCODE_ERROR:
             self.handleERROR(datagram)
         else:
-            log.msg(f"TFTP: Unexpected opcode {opcode}")
+            self._log.info("TFTP: Unexpected opcode {opcode}", opcode=opcode)
 
     def handleDATA(self, packet: bytes) -> None:
         """Handle DATA packet"""
         # DATA format: opcode(2) block#(2) data(0-512 bytes)
         if len(packet) < 4:
-            log.msg("TFTP: Malformed DATA packet")
+            self._log.info("TFTP: Malformed DATA packet")
             return
 
         block_num = struct.unpack("!H", packet[2:4])[0]
@@ -160,15 +162,17 @@ class TFTPClient(DatagramProtocol):
             # Duplicate packet, re-send ACK
             self.sendACK(block_num)
         else:
-            log.msg(
-                f"TFTP: Out of order block {block_num}, expected {self.current_block + 1}"
+            self._log.debug(
+                "TFTP: Out of order block {block}, expected {expected}",
+                block=block_num,
+                expected=self.current_block + 1,
             )
 
     def handleERROR(self, packet: bytes) -> None:
         """Handle ERROR packet"""
         # ERROR format: opcode(2) errorcode(2) errmsg(string) 0
         if len(packet) < 5:
-            log.msg("TFTP: Malformed ERROR packet")
+            self._log.info("TFTP: Malformed ERROR packet")
             return
 
         error_code = struct.unpack("!H", packet[2:4])[0]
@@ -208,6 +212,8 @@ class Command_tftp(HoneyPotCommand):
     """
     TFTP command - async implementation using Twisted
     """
+
+    _log = Logger()
 
     port: int = 69
     hostname: str | None = None
@@ -402,7 +408,7 @@ class Command_tftp(HoneyPotCommand):
 
     def handle_CTRL_C(self) -> None:
         """Handle CTRL-C interruption - cancel TFTP transfer"""
-        log.msg("TFTP: Received CTRL-C, canceling transfer")
+        self._log.info("TFTP: Received CTRL-C, canceling transfer")
 
         # Cancel timeout if active
         if self.tftp_client and self.tftp_client.timeout_call:

--- a/src/cowrie/commands/unzip.py
+++ b/src/cowrie/commands/unzip.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import os
 import zipfile
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.fs import A_REALFILE
@@ -17,6 +17,8 @@ commands = {}
 
 
 class Command_unzip(HoneyPotCommand):
+    _log = Logger()
+
     def mkfullpath(self, path: str) -> None:
         components, d = path.split("/"), []
         while len(components):
@@ -114,7 +116,11 @@ class Command_unzip(HoneyPotCommand):
                 continue
             if f.is_dir():
                 self.fs.mkdir(
-                    dest, self.current_user["uid"], self.current_user["gid"], 4096, 33188
+                    dest,
+                    self.current_user["uid"],
+                    self.current_user["gid"],
+                    4096,
+                    33188,
                 )
             elif not f.is_dir():
                 self.mkfullpath(os.path.dirname(dest))
@@ -126,7 +132,7 @@ class Command_unzip(HoneyPotCommand):
                     33188,
                 )
             else:
-                log.msg(f"  skipping: {f.filename}\n")
+                self._log.info("  skipping: {filename}\n", filename=f.filename)
 
 
 commands["/bin/unzip"] = Command_unzip

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -16,8 +16,8 @@ import treq
 from twisted.internet import defer, error, reactor
 from twisted.internet.defer import CancelledError, inlineCallbacks
 from twisted.internet.protocol import ClientCreator, Protocol
+from twisted.logger import Logger
 from twisted.protocols.ftp import CommandFailed, FTPClient
-from twisted.python import log
 from twisted.web.iweb import UNKNOWN_LENGTH
 
 from cowrie.core.artifact import Artifact
@@ -97,6 +97,8 @@ class Command_wget(HoneyPotCommand):
     """
     wget command
     """
+
+    _log = Logger()
 
     limit_size: int = CowrieConfig.getint("honeypot", "download_limit_size", fallback=0)
     quiet: bool = False
@@ -244,8 +246,9 @@ class Command_wget(HoneyPotCommand):
 
         # Check rate limit before proceeding
         if not wget_rate_limiter.check(self.host):
-            log.msg(
-                f"wget: rate limit exceeded for host: {self.host}. Simulating connection timeout"
+            self._log.info(
+                "wget: rate limit exceeded for host: {host}. Simulating connection timeout",
+                host=self.host,
             )
 
             # Simulate connection timeout
@@ -258,7 +261,7 @@ class Command_wget(HoneyPotCommand):
 
         allowed = yield communication_allowed(self.host)
         if not allowed:
-            log.msg("Attempt to access blocked network address")
+            self._log.info("Attempt to access blocked network address")
             if not self.quiet:
                 tm = time.strftime("%Y-%m-%d %H:%M:%S")
                 self.errorWrite(f"--{tm}--  {url}\n")
@@ -380,12 +383,15 @@ class Command_wget(HoneyPotCommand):
                     quit_deferred = self.ftp_client.quit()
                     if isinstance(quit_deferred, defer.Deferred):
                         quit_deferred.addErrback(
-                            lambda failure: log.msg(
-                                f"FTP quit failed during abort: {failure.getErrorMessage()}"
+                            lambda f: self._log.info(
+                                "FTP quit failed during abort: {error}",
+                                error=f.getErrorMessage(),
                             )
                         )
                 except Exception as e:  # pragma: no cover - defensive
-                    log.msg(f"FTP quit raised exception during abort: {e!s}")
+                    self._log.info(
+                        "FTP quit raised exception during abort: {error}", error=e
+                    )
                 finally:
                     self.ftp_client = None
             return defer.succeed(None)
@@ -407,12 +413,12 @@ class Command_wget(HoneyPotCommand):
                 quit_deferred = self.ftp_client.quit()
                 if isinstance(quit_deferred, defer.Deferred):
                     quit_deferred.addErrback(
-                        lambda failure: log.msg(
-                            f"FTP quit failed: {failure.getErrorMessage()}"
+                        lambda f: self._log.info(
+                            "FTP quit failed: {error}", error=f.getErrorMessage()
                         )
                     )
             except Exception as e:  # pragma: no cover - defensive
-                log.msg(f"FTP quit raised exception: {e!s}")
+                self._log.info("FTP quit raised exception: {error}", error=e)
             finally:
                 self.ftp_client = None
 
@@ -435,8 +441,11 @@ class Command_wget(HoneyPotCommand):
             and self.limit_size > 0
             and self.totallength > self.limit_size
         ):
-            log.msg(
-                f"Not saving URL ({self.url.decode()}) (size: {self.totallength}) exceeds file size limit ({self.limit_size})"
+            self._log.info(
+                "Not saving URL ({url}) (size: {size}) exceeds file size limit ({limit})",
+                url=self.url.decode(),
+                size=self.totallength,
+                limit=self.limit_size,
             )
             self.exit()
             return False
@@ -524,8 +533,11 @@ class Command_wget(HoneyPotCommand):
         eta: float
         self.currentlength += len(data)
         if self.limit_size > 0 and self.currentlength > self.limit_size:
-            log.msg(
-                f"Not saving URL ({self.url.decode()}) (size: {self.currentlength}) exceeds file size limit ({self.limit_size})"
+            self._log.info(
+                "Not saving URL ({url}) (size: {size}) exceeds file size limit ({limit})",
+                url=self.url.decode(),
+                size=self.currentlength,
+                limit=self.limit_size,
             )
             self.exit()
             return
@@ -674,7 +686,7 @@ class Command_wget(HoneyPotCommand):
             self.exit()
             return
 
-        log.err(response, "Unhandled wget error")
+        self._log.failure("Unhandled wget error", failure=response)
         self.errorWrite("\n")
         self.exit()
 

--- a/src/cowrie/commands/yum.py
+++ b/src/cowrie/commands/yum.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 from twisted.internet import defer, reactor
 from twisted.internet.defer import inlineCallbacks
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.shell.command import HoneyPotCommand
 
@@ -44,6 +44,8 @@ class Command_yum(HoneyPotCommand):
     suppports only the 'install PACKAGE' command & 'moo'.
     Any installed packages, places a 'Segfault' at /usr/bin/PACKAGE.'''
     """
+
+    _log = Logger()
 
     packages: dict[str, dict[str, Any]]
 
@@ -258,7 +260,7 @@ Options:
 
     @inlineCallbacks
     def lineReceived(self, line):
-        log.msg("INPUT (yum):", line)
+        self._log.info("INPUT (yum): {line}", line=line)
 
         self.write("Downloading packages:\n")
         yield self.sleep(0.5, 1)

--- a/src/cowrie/core/auth.py
+++ b/src/cowrie/core/auth.py
@@ -19,7 +19,7 @@ from random import randint
 from re import Pattern
 from typing import Any
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.resources import read_data_bytes
@@ -38,6 +38,8 @@ class UserDB:
     """
     By Walter de Jong <walter@sara.nl>
     """
+
+    _log = Logger()
 
     def __init__(self) -> None:
         self.userdb: dict[
@@ -67,7 +69,9 @@ class UserDB:
                     .splitlines()
                 )
             except FileNotFoundError:
-                log.msg("Could not read etc/userdb.txt, default database activated")
+                self._log.info(
+                    "Could not read etc/userdb.txt, default database activated"
+                )
                 dblines = _USERDB_DEFAULTS
 
         for user in dblines:
@@ -139,6 +143,8 @@ class AuthRandom:
     Users will be authenticated after a random number of attempts.
     """
 
+    _log = Logger()
+
     def __init__(self) -> None:
         # Default values
         self.mintry: int
@@ -158,7 +164,9 @@ class AuthRandom:
 
         if self.maxtry < self.mintry:
             self.maxtry = self.mintry + 1
-            log.msg(f"maxtry < mintry, adjusting maxtry to: {self.maxtry}")
+            self._log.info(
+                "maxtry < mintry, adjusting maxtry to: {maxtry}", maxtry=self.maxtry
+            )
 
         self.uservar: dict[Any, Any] = {}
         self.uservar_file: str = "{}/auth_random.json".format(
@@ -210,7 +218,11 @@ class AuthRandom:
             ipinfo = self.uservar[src_ip]
             ipinfo["try"] = 0
             if userpass in cache:
-                log.msg(f"first time for {src_ip}, found cached: {userpass}")
+                self._log.info(
+                    "first time for {src_ip}, found cached: {userpass}",
+                    src_ip=src_ip,
+                    userpass=userpass,
+                )
                 ipinfo["max"] = 1
                 ipinfo["user"] = str(thelogin)
                 ipinfo["pw"] = str(thepasswd)
@@ -218,11 +230,15 @@ class AuthRandom:
                 self.savevars()
                 return auth
             ipinfo["max"] = randint(self.mintry, self.maxtry)
-            log.msg("first time for {}, need: {}".format(src_ip, ipinfo["max"]))
+            self._log.info(
+                "first time for {src_ip}, need: {need}",
+                src_ip=src_ip,
+                need=ipinfo["max"],
+            )
         else:
             if userpass in cache:
                 ipinfo = self.uservar[src_ip]
-                log.msg(f"Found cached: {userpass}")
+                self._log.info("Found cached: {userpass}", userpass=userpass)
                 ipinfo["max"] = 1
                 ipinfo["user"] = str(thelogin)
                 ipinfo["pw"] = str(thepasswd)
@@ -242,14 +258,14 @@ class AuthRandom:
 
         # Don't count repeated username/password combinations
         if userpass in ipinfo["tried"]:
-            log.msg("already tried this combination")
+            self._log.info("already tried this combination")
             self.savevars()
             return auth
 
         ipinfo["try"] += 1
         attempts: int = ipinfo["try"]
         need: int = ipinfo["max"]
-        log.msg(f"login attempt: {attempts}")
+        self._log.info("login attempt: {attempts}", attempts=attempts)
 
         # Check if enough login attempts are tried
         if attempts < need:
@@ -264,12 +280,14 @@ class AuthRandom:
         # Returning after successful login
         elif attempts > need:
             if "user" not in ipinfo or "pw" not in ipinfo:
-                log.msg("return, but username or password not set!!!")
+                self._log.info("return, but username or password not set!!!")
                 ipinfo["tried"].append(userpass)
                 ipinfo["try"] = 1
             else:
-                log.msg(
-                    "login return, expect: [{}/{}]".format(ipinfo["user"], ipinfo["pw"])
+                self._log.info(
+                    "login return, expect: [{user}/{pw}]",
+                    user=ipinfo["user"],
+                    pw=ipinfo["pw"],
                 )
                 if thelogin == ipinfo["user"] and str(thepasswd) == ipinfo["pw"]:
                     auth = True

--- a/src/cowrie/core/checkers.py
+++ b/src/cowrie/core/checkers.py
@@ -17,7 +17,8 @@ from twisted.cred.checkers import ICredentialsChecker
 from twisted.cred.credentials import ISSHPrivateKey
 from twisted.cred.error import UnauthorizedLogin, UnhandledCredentials
 from twisted.internet import defer
-from twisted.python import failure, log
+from twisted.logger import Logger
+from twisted.python import failure
 from zope.interface import implementer
 
 from cowrie.core import auth
@@ -98,6 +99,8 @@ class HoneypotPasswordChecker:
     Checker that accepts "keyboard-interactive" and "password"
     """
 
+    _log = Logger()
+
     credentialInterfaces = (
         conchcredentials.IUsernamePasswordIP,
         conchcredentials.IPluggableAuthenticationModulesIP,
@@ -146,8 +149,9 @@ class HoneypotPasswordChecker:
         if hasattr(auth, authclass):
             authname = getattr(auth, authclass)
         else:
-            log.msg(
-                f"auth_class: {authclass} not found in cowrie.core.auth, using UserDB"
+            self._log.info(
+                "auth_class: {authclass} not found in cowrie.core.auth, using UserDB",
+                authclass=authclass,
             )
             authname = auth.UserDB
 

--- a/src/cowrie/core/config.py
+++ b/src/cowrie/core/config.py
@@ -13,9 +13,11 @@ import configparser
 from os import environ
 from os.path import exists
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core.resources import read_data_bytes
+
+_log = Logger()
 
 
 def to_environ_key(key: str) -> str:
@@ -55,11 +57,9 @@ def readConfigFile(cfgfile: list[str] | str) -> configparser.ConfigParser:
     """
     parser = EnvironmentConfigParser(interpolation=configparser.ExtendedInterpolation())
     try:
-        parser.read_string(
-            read_data_bytes("etc", "cowrie.cfg.dist").decode("utf-8")
-        )
+        parser.read_string(read_data_bytes("etc", "cowrie.cfg.dist").decode("utf-8"))
     except FileNotFoundError:
-        log.msg("Bundled cowrie.cfg.dist not found in cowrie.data")
+        _log.warn("Bundled cowrie.cfg.dist not found in cowrie.data")
     parser.read(cfgfile)
     return parser
 
@@ -84,9 +84,9 @@ def get_config_path() -> list[str]:
     found_confs = [path for path in config_files if exists(path)]
 
     if found_confs:
-        log.msg(f"Reading configuration from {found_confs!r}")
+        _log.info("Reading configuration from {files!r}", files=found_confs)
     else:
-        log.msg("No operator config file found; using bundled defaults only")
+        _log.info("No operator config file found; using bundled defaults only")
     return found_confs
 
 

--- a/src/cowrie/core/events.py
+++ b/src/cowrie/core/events.py
@@ -20,8 +20,7 @@ import time
 from os import environ
 from typing import TYPE_CHECKING, Any
 
-from twisted.logger import formatTime
-from twisted.python import log
+from twisted.logger import Logger, formatTime
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.output import convert
@@ -29,10 +28,29 @@ from cowrie.core.output import convert
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+# Pipeline diagnostics (sink failures) log under this module's namespace;
+# the rendered event lines carry their own so operators can control their
+# verbosity independently (log_level_cowrie.events).
+_log = Logger()
+_console_log = Logger(namespace="cowrie.events")
+
 # Log every FAILURE_LOG_INTERVAL'th delivery failure per sink after the
 # first, so an unreachable database does not turn every event into an
 # error line.
 FAILURE_LOG_INTERVAL = 100
+
+
+def _sink_failure_line(message: str) -> None:
+    """Default diagnostic emitter for sink failures. The message is data,
+    not a format string: exception text may contain braces."""
+    _log.error("{log_message}", log_message=message)
+
+
+def _console_line(message: str, system: str = "-") -> None:
+    """Default emitter for rendered event lines: the diagnostic log, with
+    the session identity as the line's system prefix. The message is data,
+    not a format string: it interpolates attacker-controlled fields."""
+    _console_log.info("{log_message}", log_message=message, log_system=system)
 
 
 class EventDispatcher:
@@ -44,7 +62,7 @@ class EventDispatcher:
     def __init__(
         self,
         sinks: list[Any],
-        logmsg: Callable[..., None] = log.msg,
+        logmsg: Callable[..., None] = _sink_failure_line,
     ) -> None:
         self.sinks = sinks
         self.logmsg = logmsg
@@ -225,7 +243,7 @@ class ConsoleRenderer:
     # Session-less operational events still deserve their log line.
     accepts_sessionless = True
 
-    def __init__(self, logmsg: Callable[..., None] = log.msg) -> None:
+    def __init__(self, logmsg: Callable[..., None] = _console_line) -> None:
         self.logmsg = logmsg
 
     def write(self, event: dict[str, Any]) -> None:

--- a/src/cowrie/core/fingerprint.py
+++ b/src/cowrie/core/fingerprint.py
@@ -23,9 +23,11 @@ from __future__ import annotations
 
 import struct
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.vendor.ja4.common import GREASE_TABLE, TLS_MAPPER, sha_encode
+
+_log = Logger()
 
 # Convert FoxIO's string-based GREASE table to integer set for our use
 GREASE_VALUES = {int(k, 16) for k in GREASE_TABLE}
@@ -149,7 +151,7 @@ def parse_tls_client_hello(data: bytes) -> dict | None:
             offset += ext_length
 
     except Exception as e:
-        log.msg(f"Error parsing TLS Client Hello: {e}")
+        _log.info("Error parsing TLS Client Hello: {error}", error=e)
         return None
     else:
         return {
@@ -223,7 +225,7 @@ def parse_http_request(data: bytes) -> dict | None:
                 accept_language = header_value
 
     except Exception as e:
-        log.msg(f"Error parsing HTTP request: {e}")
+        _log.info("Error parsing HTTP request: {error}", error=e)
         return None
     else:
         return {

--- a/src/cowrie/core/network.py
+++ b/src/cowrie/core/network.py
@@ -8,8 +8,10 @@ import socket
 from collections.abc import Generator
 
 from twisted.internet.defer import Deferred, inlineCallbacks
+from twisted.logger import Logger
 from twisted.names import client, dns
-from twisted.python import log
+
+_log = Logger()
 
 BLOCKED_IPS = [
     "0.0.0.0/8",  # Current IP range 0.0.0.0 - 10.255.255.255
@@ -60,7 +62,7 @@ def resolve_cname(
     or None if not resolvable. `visited` is a set that tracks the domains we've already resolved to prevent cycles.
     """
 
-    log.msg(f"resolve_cname({address})")
+    _log.debug("resolve_cname({address})", address=address)
 
     # Prevent cyclic resolution (avoid infinite loops)
     if address in visited:
@@ -95,10 +97,12 @@ def resolve_cname(
         # timeout, ...) is routine and handled here by returning None. Log it at
         # informational level; log.err would format it as an "Unhandled Error"
         # with a traceback, which is misleading for a caught exception.
-        log.msg(f"DNS lookup failed for {address!r}: {e}")
+        _log.info(
+            "DNS lookup failed for {address!r}: {error}", address=address, error=e
+        )
         return None  # In case of any failure, return None
 
-    log.msg("no valid a or cname record")
+    _log.info("no valid a or cname record")
     return None  # No valid A or CNAME records were found
 
 

--- a/src/cowrie/core/uuid.py
+++ b/src/cowrie/core/uuid.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 import os
 import uuid
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
+
+_log = Logger()
 
 
 def create_uuid() -> uuid.UUID:
@@ -40,19 +42,24 @@ def get_uuid() -> str:
         try:
             uuid.UUID(uuid_from_file)  # Will raise ValueError if invalid format
         except ValueError:
-            log.msg(f"UUID read from file {uuidpath} is invalid: '{uuid_from_file}'")
+            _log.info(
+                "UUID read from file {uuidpath} is invalid: '{uuid_from_file}'",
+                uuidpath=uuidpath,
+                uuid_from_file=uuid_from_file,
+            )
         else:
             return uuid_from_file
     except FileNotFoundError:
         # First run
         pass
-    except PermissionError as e:
-        log.err(
-            f"Permission denied when attempting to read uuid from {uuidpath}: {e!r}"
+    except PermissionError:
+        _log.failure(
+            "Permission denied when attempting to read uuid from {uuidpath}",
+            uuidpath=uuidpath,
         )
-    except OSError as e:
+    except OSError:
         # Catch other I/O errors (e.g., directory not found, device error)
-        log.err(f"I/O error when reading uuid from {uuidpath}: {e!r}")
+        _log.failure("I/O error when reading uuid from {uuidpath}", uuidpath=uuidpath)
 
     new_uuid_str = str(create_uuid())
 
@@ -60,9 +67,12 @@ def get_uuid() -> str:
         os.makedirs(os.path.dirname(uuidpath), exist_ok=True)
         with open(uuidpath, "w", encoding="ascii") as f:
             f.write(f"{new_uuid_str}\n")
-    except PermissionError as e:
-        log.err(f"Permission denied when attempting to write uuid to {uuidpath}: {e!r}")
-    except OSError as e:
-        log.err(f"I/O error when writing uuid to {uuidpath}: {e!r}")
+    except PermissionError:
+        _log.failure(
+            "Permission denied when attempting to write uuid to {uuidpath}",
+            uuidpath=uuidpath,
+        )
+    except OSError:
+        _log.failure("I/O error when writing uuid to {uuidpath}", uuidpath=uuidpath)
 
     return new_uuid_str

--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -122,6 +122,28 @@ backend = shell
 # This affects both `cowrie.log` and `cowrie.json`
 logtype = rotating
 
+# Verbosity of the diagnostic log (`cowrie.log`, or stdout in
+# foreground/Docker mode). Valid levels, most to least verbose:
+# debug, info, warn, error, critical. Lines below the level stay out
+# of the log; the structured event output (cowrie.json, databases) is
+# not affected.
+# (default: info)
+#log_level = info
+
+# Per-subsystem overrides: append the logging namespace (the emitting
+# module path, lowercase) to `log_level_`. A prefix covers everything
+# beneath it, so `log_level_cowrie.ssh` covers all of the SSH
+# subsystem. The same keys work as environment variables
+# (COWRIE_HONEYPOT_LOG_LEVEL_COWRIE.SSH=debug).
+#
+# Rendered attacker-event lines (logins, commands, downloads) log
+# under the `cowrie.events` namespace and keep an `info` floor even
+# when `log_level` is raised, so quieting diagnostics does not erase
+# the attack record; set `log_level_cowrie.events` explicitly to
+# change that.
+#log_level_cowrie.ssh = debug
+#log_level_cowrie.commands = debug
+
 # Timezone Cowrie uses for logging
 # This can be any valid timezone for the TZ environment variable
 # The special value `system` will let Cowrie use the system time zone

--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -12,13 +12,15 @@ from typing import TYPE_CHECKING, Any
 
 from twisted.conch.insults import insults
 from twisted.internet.protocol import connectionDone
-from twisted.python import failure, log
+from twisted.logger import Logger
 
 from cowrie.core import ttylog
 from cowrie.core.config import CowrieConfig
 from cowrie.shell import protocol
 
 if TYPE_CHECKING:
+    from twisted.python import failure
+
     from cowrie.core.events import EventLog
 
 
@@ -26,6 +28,8 @@ class LoggingServerProtocol(insults.ServerProtocol):
     """
     Wrapper for ServerProtocol that implements TTY logging
     """
+
+    _log = Logger()
 
     ttylogPath: str = CowrieConfig.get("honeypot", "ttylog_path", fallback=".")
     downloadPath: str = CowrieConfig.get("honeypot", "download_path", fallback=".")
@@ -126,7 +130,7 @@ class LoggingServerProtocol(insults.ServerProtocol):
 
         self.bytesReceived += len(data)
         if self.bytesReceivedLimit and self.bytesReceived > self.bytesReceivedLimit:
-            log.msg(format="Data upload limit reached")
+            self._log.info("Data upload limit reached")
             self.eofReceived()
             return
 
@@ -184,7 +188,7 @@ class LoggingServerProtocol(insults.ServerProtocol):
                         destfile="",
                     )
             except OSError as e:
-                log.msg(f"Failed to save stdin contents: {e}")
+                self._log.error("Failed to save stdin contents: {error}", error=e)
             finally:
                 self.stdinlogOpen = False
 

--- a/src/cowrie/llm/avatar.py
+++ b/src/cowrie/llm/avatar.py
@@ -9,7 +9,8 @@ from twisted.conch import avatar
 from twisted.conch.error import ConchError
 from twisted.conch.interfaces import IConchUser, ISession
 from twisted.conch.ssh.connection import OPEN_UNKNOWN_CHANNEL_TYPE
-from twisted.python import components, log
+from twisted.logger import Logger
+from twisted.python import components
 from zope.interface import implementer
 
 from cowrie.llm import server
@@ -19,6 +20,8 @@ from cowrie.ssh import session as sshsession
 
 @implementer(IConchUser)
 class CowrieUser(avatar.ConchUser):
+    _log = Logger()
+
     def __init__(self, username: bytes, server: server.CowrieServer) -> None:
         avatar.ConchUser.__init__(self)
         self.username: str = username.decode("utf-8")
@@ -26,7 +29,7 @@ class CowrieUser(avatar.ConchUser):
         self.channelLookup[b"session"] = sshsession.HoneyPotSSHSession
 
     def logout(self) -> None:
-        log.msg(f"avatar {self.username} logging out")
+        self._log.info("avatar {username} logging out", username=self.username)
 
     def lookupChannel(self, channelType, windowSize, maxPacket, data):
         """

--- a/src/cowrie/llm/llm.py
+++ b/src/cowrie/llm/llm.py
@@ -15,8 +15,7 @@ from typing import TYPE_CHECKING, Any
 from twisted.internet import defer, protocol, reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.internet.endpoints import HostnameEndpoint
-from twisted.python import failure as tw_failure
-from twisted.python import log
+from twisted.logger import Logger
 from twisted.web.client import (
     Agent,
     HTTPConnectionPool,
@@ -31,6 +30,8 @@ from cowrie.core.config import CowrieConfig
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
+    from twisted.python import failure as tw_failure
 
 
 @implementer(IBodyProducer)
@@ -89,6 +90,8 @@ class LLMClient:
     Client for communicating with OpenAI-compatible LLM APIs.
     """
 
+    _log = Logger()
+
     def __init__(self) -> None:
         self._conn_pool = HTTPConnectionPool(reactor)
         self._conn_pool._factory = QuietHTTP11ClientFactory  # pyright: ignore[reportPrivateUsage]
@@ -114,13 +117,15 @@ class LLMClient:
                 reactor, parsed.hostname or "localhost", parsed.port or 8080
             )
             self.agent = ProxyAgent(proxy_endpoint, reactor, pool=self._conn_pool)
-            log.msg(f"LLM using proxy: {parsed.hostname}:{parsed.port}")
+            self._log.info(
+                "LLM using proxy: {host}:{port}", host=parsed.hostname, port=parsed.port
+            )
         else:
             self.agent = Agent(reactor, pool=self._conn_pool)
         self.is_anthropic = "anthropic.com" in self.host
 
         if not self.api_key:
-            log.msg("WARNING: No LLM API key configured in [llm] section")
+            self._log.warn("WARNING: No LLM API key configured in [llm] section")
 
     def _build_headers(self) -> Headers:
         """Build HTTP headers with authentication."""
@@ -187,7 +192,9 @@ class LLMClient:
         request_body = self._format_request_body(prompt)
 
         if self.debug:
-            log.msg(f"LLM request: {json.dumps(request_body, indent=2)}")
+            self._log.info(
+                "LLM request: {request}", request=json.dumps(request_body, indent=2)
+            )
 
         url = f"{self.host}{self.path}"
         d: Deferred[Any] = self.agent.request(
@@ -215,17 +222,24 @@ class LLMClient:
         status_code, response = yield self._send_request(prompt)
 
         if status_code != 200:
-            log.err(f"LLM API error (status {status_code}): {response.decode('utf-8')}")
+            self._log.error(
+                "LLM API error (status {status}): {response}",
+                status=status_code,
+                response=response.decode("utf-8"),
+            )
             return ""
 
         try:
             response_json = json.loads(response)
-        except json.JSONDecodeError as e:
-            log.err(f"Failed to parse LLM response: {e}")
+        except json.JSONDecodeError:
+            self._log.failure("Failed to parse LLM response")
             return ""
 
         if self.debug:
-            log.msg(f"LLM response: {json.dumps(response_json, indent=2)}")
+            self._log.info(
+                "LLM response: {response}",
+                response=json.dumps(response_json, indent=2),
+            )
 
         # OpenAI-compatible format
         if "choices" in response_json and len(response_json["choices"]) > 0:
@@ -237,5 +251,5 @@ class LLMClient:
             content = response_json["content"][0].get("text", "")
             return content
 
-        log.err(f"Unexpected LLM response format: {response}")
+        self._log.error("Unexpected LLM response format: {response}", response=response)
         return ""

--- a/src/cowrie/llm/protocol.py
+++ b/src/cowrie/llm/protocol.py
@@ -13,8 +13,9 @@ from typing import TYPE_CHECKING
 from twisted.conch import recvline
 from twisted.conch.insults import insults
 from twisted.internet import defer, error
+from twisted.logger import Logger
 from twisted.protocols.policies import TimeoutMixin
-from twisted.python import failure, log
+from twisted.python import failure
 
 from cowrie.core.config import CowrieConfig
 from cowrie.llm.llm import LLMClient
@@ -38,6 +39,8 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
     """
     Base protocol for interactive and non-interactive use
     """
+
+    _log = Logger()
 
     # The session's event emitter, set from the transport in connectionMade.
     events: EventLog
@@ -232,7 +235,7 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         """
         Handle errors from the LLM client.
         """
-        log.err(f"LLM error: {err}")
+        self._log.failure("LLM error", failure=err)
         if self.terminal is None:
             return
         # Show nothing - just the prompt, as if the command produced no output
@@ -268,6 +271,8 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
 
 
 class HoneyPotExecProtocol(HoneyPotBaseProtocol):
+    _log = Logger()
+
     # input_data is static buffer for stdin received from remote client
     input_data = b""
 
@@ -280,7 +285,7 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
         try:
             self.execcmd = execcmd.decode("utf8")
         except UnicodeDecodeError:
-            log.err(f"Unusual execcmd: {execcmd!r}")
+            self._log.failure("Unusual execcmd: {execcmd!r}", execcmd=execcmd)
 
         HoneyPotBaseProtocol.__init__(self, avatar)
 
@@ -328,7 +333,7 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
         """
         Handle errors from the LLM client during exec.
         """
-        log.err(f"LLM exec error: {exec_failure}")
+        self._log.failure("LLM exec error", failure=exec_failure)
         if self.terminal is None:
             return
 

--- a/src/cowrie/llm/server.py
+++ b/src/cowrie/llm/server.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from twisted.python import log
+from twisted.logger import Logger
 
 if TYPE_CHECKING:
     from twisted.cred.portal import IRealm
@@ -19,13 +19,17 @@ class CowrieServer:
     multiple Cowrie connections
     """
 
+    _log = Logger()
+
     def __init__(self, realm: IRealm) -> None:
         from cowrie.core.config import CowrieConfig
 
-        log.msg("Initialized LLM backend server")
+        self._log.info("Initialized LLM backend server")
         # Get hostname from config or use default
         self.hostname = CowrieConfig.get("honeypot", "hostname", fallback="svr04")
-        log.msg(f"LLM backend server using hostname: {self.hostname}")
+        self._log.info(
+            "LLM backend server using hostname: {hostname}", hostname=self.hostname
+        )
 
         # We don't need a virtual filesystem for the LLM backend
         # The LLM will simulate all filesystem interactions

--- a/src/cowrie/llm/telnet.py
+++ b/src/cowrie/llm/telnet.py
@@ -9,19 +9,25 @@
 from __future__ import annotations
 
 import traceback
+from typing import TYPE_CHECKING
 
 from twisted.conch.ssh import session
 from twisted.conch.telnet import ECHO, SGA, TelnetBootstrapProtocol
 from twisted.internet import interfaces, protocol
 from twisted.internet.protocol import connectionDone
-from twisted.python import failure, log
+from twisted.logger import Logger
 from zope.interface import implementer
 
 from cowrie.insults import insults
 from cowrie.llm import protocol as llmproto
 
+if TYPE_CHECKING:
+    from twisted.python import failure
+
 
 class HoneyPotTelnetSession(TelnetBootstrapProtocol):
+    _log = Logger()
+
     id = 0  # telnet can only have 1 simultaneous session, unlike SSH
 
     def __init__(self, username, server):
@@ -66,7 +72,7 @@ class HoneyPotTelnetSession(TelnetBootstrapProtocol):
             self.protocol.makeConnection(processprotocol)
             processprotocol.makeConnection(session.wrapProtocol(self.protocol))
         except Exception:
-            log.msg(traceback.format_exc())
+            self._log.info("{traceback}", traceback=traceback.format_exc())
 
     def connectionLost(self, reason: failure.Failure = connectionDone) -> None:
         TelnetBootstrapProtocol.connectionLost(self, reason)
@@ -75,7 +81,7 @@ class HoneyPotTelnetSession(TelnetBootstrapProtocol):
         self.protocol = None
 
     def logout(self) -> None:
-        log.msg(f"avatar {self.username} logging out")
+        self._log.info("avatar {username} logging out", username=self.username)
 
 
 @implementer(interfaces.ITransport)
@@ -85,6 +91,8 @@ class TelnetSessionProcessProtocol(protocol.ProcessProtocol):
     Transport to the remote endpoint and process protocol to the local subsystem.
     """
 
+    _log = Logger()
+
     def __init__(self, sess):
         self.session = sess
         self.lostOutOrErrFlag = False
@@ -93,7 +101,7 @@ class TelnetSessionProcessProtocol(protocol.ProcessProtocol):
         self.session.write(data)
 
     def errReceived(self, data: bytes) -> None:
-        log.msg(f"Error received: {data.decode()}")
+        self._log.info("Error received: {data}", data=data.decode())
 
     def outConnectionLost(self) -> None:
         """
@@ -114,11 +122,12 @@ class TelnetSessionProcessProtocol(protocol.ProcessProtocol):
     def processEnded(self, reason=None):
         exit_code = getattr(reason.value, "exitCode", None) if reason else None
         if exit_code is not None:
-            log.msg(
-                f"Process ended with exit code {exit_code}. Telnet session disconnected"
+            self._log.info(
+                "Process ended with exit code {exit_code}. Telnet session disconnected",
+                exit_code=exit_code,
             )
         else:
-            log.msg("Process ended. Telnet session disconnected")
+            self._log.info("Process ended. Telnet session disconnected")
         self.session.loseConnection()
 
     def getHost(self):

--- a/src/cowrie/output/axiom.py
+++ b/src/cowrie/output/axiom.py
@@ -8,7 +8,7 @@ import json
 
 import treq
 from twisted.internet import defer
-from twisted.python import log
+from twisted.logger import Logger
 from twisted.web import http_headers
 
 import cowrie.core.output
@@ -21,6 +21,8 @@ class Output(cowrie.core.output.Output):
     """
     axiom.co output
     """
+
+    _log = Logger()
 
     def start(self) -> None:
         self.api_token = CowrieConfig.get("output_axiom", "api_token")
@@ -47,7 +49,7 @@ class Output(cowrie.core.output.Output):
         try:
             msg = json.dumps(event, separators=(",", ":")).encode()
         except TypeError:
-            log.err("jsonlog: Can't serialize: '" + repr(event) + "'")
+            self._log.error("jsonlog: Can't serialize: '{event!r}'", event=event)
             return
 
         resp = yield treq.post(
@@ -59,4 +61,4 @@ class Output(cowrie.core.output.Output):
 
         if resp.code != 200:
             error = yield resp.text()
-            log.err("jsonlog: Can't submit to Axiom: '" + repr(error) + "'")
+            self._log.error("jsonlog: Can't submit to Axiom: '{error!r}'", error=error)

--- a/src/cowrie/output/crashreporter.py
+++ b/src/cowrie/output/crashreporter.py
@@ -16,8 +16,8 @@ import json
 
 import treq
 from twisted.internet import defer
+from twisted.logger import Logger
 from twisted.logger._levels import LogLevel
-from twisted.python import log
 
 import cowrie.core.output
 from cowrie._version import __version__
@@ -31,6 +31,8 @@ class Output(cowrie.core.output.Output):
     """
     Cowrie Crashreporter output
     """
+
+    _log = Logger()
 
     def start(self):
         """
@@ -77,6 +79,6 @@ class Output(cowrie.core.output.Output):
             )
             content = yield r.text()
             if self.debug:
-                log.msg("crashreport: " + content)
+                self._log.info("crashreport: {content}", content=content)
         except Exception as e:
-            log.msg("crashreporter failed" + repr(e))
+            self._log.info("crashreporter failed{error!r}", error=e)

--- a/src/cowrie/output/csirtg.py
+++ b/src/cowrie/output/csirtg.py
@@ -9,14 +9,16 @@ import os
 import sys
 from datetime import datetime
 
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
 
+_log = Logger()
+
 token = CowrieConfig.get("output_csirtg", "token", fallback="a1b2c3d4")
 if token == "a1b2c3d4":
-    log.msg("output_csirtg: token not found in configuration file")
+    _log.info("output_csirtg: token not found in configuration file")
     sys.exit(1)
 
 os.environ["CSIRTG_TOKEN"] = token
@@ -27,6 +29,8 @@ class Output(cowrie.core.output.Output):
     """
     CSIRTG output
     """
+
+    _log = Logger()
 
     def start(self):
         """
@@ -95,11 +99,16 @@ class Output(cowrie.core.output.Output):
         }
 
         if self.debug is True:
-            log.msg(f"output_csirtg: Submitting {i!r} to CSIRTG")
+            self._log.info(
+                "output_csirtg: Submitting {indicator!r} to CSIRTG", indicator=i
+            )
 
         ind = csirtgsdk.indicator.Indicator(i).submit()
 
         if self.debug is True:
-            log.msg(f"output_csirtg: Submitted {ind!r} to CSIRTG")
+            self._log.info("output_csirtg: Submitted {result!r} to CSIRTG", result=ind)
 
-        log.msg("output_csirtg: submitted to csirtg at {} ".format(ind["location"]))
+        self._log.info(
+            "output_csirtg: submitted to csirtg at {location} ",
+            location=ind["location"],
+        )

--- a/src/cowrie/output/cuckoo.py
+++ b/src/cowrie/output/cuckoo.py
@@ -15,7 +15,7 @@ from urllib.parse import urljoin, urlparse
 
 from treq.client import HTTPClient
 from twisted.internet import defer, error, reactor, ssl
-from twisted.python import log
+from twisted.logger import Logger
 from twisted.web import client
 from twisted.web.iweb import IPolicyForHTTPS
 from zope.interface import implementer
@@ -45,6 +45,8 @@ class Output(cowrie.core.output.Output):
     """
     cuckoo output
     """
+
+    _log = Logger()
 
     api_user: str
     api_passwd: str
@@ -90,7 +92,7 @@ class Output(cowrie.core.output.Output):
             is_dup = yield self.cuckoo_check_if_dup(os.path.basename(outfile))
             if is_dup:
                 return
-        log.msg("Sending file to Cuckoo")
+        self._log.info("Sending file to Cuckoo")
         yield self.postfile(outfile, fileName)
 
     @defer.inlineCallbacks
@@ -99,7 +101,7 @@ class Output(cowrie.core.output.Output):
         Check if file already was analyzed by cuckoo
         """
         try:
-            log.msg(f"Looking for tasks for: {sha256}")
+            self._log.info("Looking for tasks for: {sha256}", sha256=sha256)
             response = yield self.client.get(
                 urljoin(self.url_base, f"/files/view/sha256/{sha256}".encode()),
                 auth=(self.api_user, self.api_passwd),
@@ -110,18 +112,17 @@ class Output(cowrie.core.output.Output):
             error.ConnectingCancelledError,
             error.DNSLookupError,
         ) as e:
-            log.msg(e)
+            self._log.info("{error}", error=e)
             return False
         except Exception as e:
-            log.msg(e)
+            self._log.info("{error}", error=e)
             return False
 
         if 200 <= response.code < 300:
             body = yield response.json()
-            log.msg(
-                "Sample found in Sandbox, with ID: {}".format(
-                    body.get("sample", {}).get("id", 0)
-                )
+            self._log.info(
+                "Sample found in Sandbox, with ID: {sample_id}",
+                sample_id=body.get("sample", {}).get("id", 0),
             )
             return True
 
@@ -143,19 +144,19 @@ class Output(cowrie.core.output.Output):
                     timeout=HTTP_TIMEOUT,
                 )
         except Exception as e:
-            log.msg(f"Cuckoo Request failed: {e}")
+            self._log.info("Cuckoo Request failed: {error}", error=e)
             return
 
         if 200 <= response.code < 300:
             body = yield response.json()
-            log.msg(
-                "Cuckoo Request: {}, Task created with ID: {}".format(
-                    response.code, body["task_id"]
-                )
+            self._log.info(
+                "Cuckoo Request: {code}, Task created with ID: {task_id}",
+                code=response.code,
+                task_id=body["task_id"],
             )
         else:
             yield response.text()
-            log.msg(f"Cuckoo Request failed: {response.code}")
+            self._log.info("Cuckoo Request failed: {code}", code=response.code)
 
     @defer.inlineCallbacks
     def posturl(self, scanUrl):
@@ -170,16 +171,16 @@ class Output(cowrie.core.output.Output):
                 timeout=HTTP_TIMEOUT,
             )
         except Exception as e:
-            log.msg(f"Cuckoo Request failed: {e}")
+            self._log.info("Cuckoo Request failed: {error}", error=e)
             return
 
         if 200 <= response.code < 300:
             body = yield response.json()
-            log.msg(
-                "Cuckoo Request: {}, Task created with ID: {}".format(
-                    response.code, body["task_id"]
-                )
+            self._log.info(
+                "Cuckoo Request: {code}, Task created with ID: {task_id}",
+                code=response.code,
+                task_id=body["task_id"],
             )
         else:
             yield response.text()
-            log.msg(f"Cuckoo Request failed: {response.code}")
+            self._log.info("Cuckoo Request failed: {code}", code=response.code)

--- a/src/cowrie/output/datadog.py
+++ b/src/cowrie/output/datadog.py
@@ -14,7 +14,7 @@ import platform
 from io import BytesIO
 
 from twisted.internet import reactor
-from twisted.python import log
+from twisted.logger import Logger
 from twisted.web import client, http_headers
 from twisted.web.client import FileBodyProducer
 
@@ -23,13 +23,15 @@ from cowrie.core.config import CowrieConfig
 
 
 class Output(cowrie.core.output.Output):
+    _log = Logger()
+
     def start(self) -> None:
         self.url = CowrieConfig.get("output_datadog", "url").encode("utf8")
         self.api_key = CowrieConfig.get(
             "output_datadog", "api_key", fallback=""
         ).encode("utf8")
         if len(self.api_key) == 0:
-            log.msg("Datadog output module: API key is not defined.")
+            self._log.info("Datadog output module: API key is not defined.")
         self.ddsource = CowrieConfig.get(
             "output_datadog", "ddsource", fallback="cowrie"
         )

--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -19,7 +19,7 @@ import os
 
 import treq
 from twisted.internet import defer, error
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -35,6 +35,8 @@ class Output(cowrie.core.output.Output):
     """
     dshield output
     """
+
+    _log = Logger()
 
     debug: bool = False
     userid: str
@@ -67,7 +69,7 @@ class Output(cowrie.core.output.Output):
         except (binascii.Error, ValueError):
             return
         if "=" in self.auth_key:
-            log.msg(
+            self._log.warn(
                 "dshield: auth_key looks base64-encoded but the current "
                 "DShield submit API expects the raw key. Update your "
                 "config if submissions are rejected."
@@ -108,26 +110,32 @@ class Output(cowrie.core.output.Output):
                 }
             )
             if self.debug:
-                log.msg(
-                    f"dshield: log appended, batch size {len(self.batch)} max size {self.batch_size}"
+                self._log.info(
+                    "dshield: log appended, batch size {batch_len} max size {batch_size}",
+                    batch_len=len(self.batch),
+                    batch_size=self.batch_size,
                 )
 
             if len(self.batch) >= self.batch_size:
                 if self.debug:
-                    log.msg("dshield: batch size reached, submitting")
+                    self._log.info("dshield: batch size reached, submitting")
                 batch_to_send = self.batch
                 self.submit_entries(batch_to_send)
                 self.batch = []
         elif eventid in ("cowrie.login.success", "cowrie.login.failed"):
-            log.msg("dshield: cowrie.login.success or cowrie.login.failed")
+            self._log.info("dshield: cowrie.login.success or cowrie.login.failed")
             self._state(session)["username"] = event.get("username", "")
             self._state(session)["password"] = event.get("password", "")
-            log.msg(f"dshield: {state['username']} {state['password']}")
+            self._log.info(
+                "dshield: {username} {password}",
+                username=state["username"],
+                password=state["password"],
+            )
         elif eventid == "cowrie.direct-tcpip.request":
-            log.msg("dshield: cowrie.direct-tcpip.request")
+            self._log.info("dshield: cowrie.direct-tcpip.request")
             self._state(session)["lastcommand"] = event.get("message", "")
         elif eventid == "cowrie.command.input":
-            log.msg("dshield: cowrie.command.input")
+            self._log.info("dshield: cowrie.command.input")
             self._state(session)["lastcommand"] = event["input"]
         elif eventid == "cowrie.client.kex":
             self._state(session)["hassh"] = event["hassh"]
@@ -147,7 +155,7 @@ class Output(cowrie.core.output.Output):
         """
         url = DEBUG_SUBMIT_URL if self.debug else SUBMIT_URL
         if self.debug:
-            log.msg(f"dshield: using debug url {url!r}")
+            self._log.info("dshield: using debug url {url!r}", url=url)
 
         # Build authentication header
         nonce = base64.b64encode(os.urandom(8)).decode("ascii")
@@ -161,7 +169,9 @@ class Output(cowrie.core.output.Output):
             f"ISC-HMAC-SHA256 Credentials={hash64} Userid={self.userid} Nonce={nonce}"
         )
         if self.debug:
-            log.msg(f"dshield: authentication header {auth_header}")
+            self._log.info(
+                "dshield: authentication header {auth_header}", auth_header=auth_header
+            )
 
         payload = {
             "type": "cowrie",
@@ -177,8 +187,8 @@ class Output(cowrie.core.output.Output):
         }
 
         if self.debug:
-            log.msg(f"dshield: posting headers {headers!r}")
-            log.msg(f"dshield: posting payload {payload!r}")
+            self._log.info("dshield: posting headers {headers!r}", headers=headers)
+            self._log.info("dshield: posting payload {payload!r}", payload=payload)
 
         try:
             response = yield treq.post(
@@ -194,20 +204,22 @@ class Output(cowrie.core.output.Output):
             error.ConnectingCancelledError,
             error.DNSLookupError,
         ) as e:
-            log.msg(f"dshield: request failed: {e}")
+            self._log.info("dshield: request failed: {error}", error=e)
             self.transmission_error(batch)
             return
         except Exception as e:
-            log.msg(f"dshield: request failed: {e}")
+            self._log.info("dshield: request failed: {error}", error=e)
             self.transmission_error(batch)
             return
 
         if self.debug:
-            log.msg(f"dshield: status code {response.code}")
-            log.msg(f"dshield: response {body}")
+            self._log.info("dshield: status code {code}", code=response.code)
+            self._log.info("dshield: response {body}", body=body)
 
         if 200 <= response.code < 300:
-            log.msg(f"dshield: submit response {body}")
+            self._log.info("dshield: submit response {body}", body=body)
         else:
-            log.msg(f"dshield: ERROR status {response.code}: {body}")
+            self._log.error(
+                "dshield: ERROR status {code}: {body}", code=response.code, body=body
+            )
             self.transmission_error(batch)

--- a/src/cowrie/output/greynoise.py
+++ b/src/cowrie/output/greynoise.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import treq
 from twisted.internet import defer, error
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -24,6 +24,8 @@ class Output(cowrie.core.output.Output):
     """
     greynoise output
     """
+
+    _log = Logger()
 
     def start(self):
         """
@@ -82,24 +84,26 @@ class Output(cowrie.core.output.Output):
             error.ConnectingCancelledError,
             error.DNSLookupError,
         ):
-            log.msg("GreyNoise requests timeout")
+            self._log.info("GreyNoise requests timeout")
             return
 
         if response.code == 404:
             rsp = yield response.json()
-            log.err(f"GreyNoise: {rsp['ip']} - {rsp['message']}")
+            self._log.error("GreyNoise: {ip} - {msg}", ip=rsp["ip"], msg=rsp["message"])
             return
 
         if response.code != 200:
             rsp = yield response.text()
-            log.err(f"GreyNoise: got error {rsp}")
+            self._log.error("GreyNoise: got error {response}", response=rsp)
             return
 
         j = yield response.json()
         if self.debug:
-            log.msg("GreyNoise: debug: " + repr(j))
+            self._log.info("GreyNoise: debug: {response!r}", response=j)
 
         if j["message"] == "Success":
             message(j)
         else:
-            log.msg("GreyNoise: no results for for IP {}".format(event["src_ip"]))
+            self._log.info(
+                "GreyNoise: no results for for IP {src_ip}", src_ip=event["src_ip"]
+            )

--- a/src/cowrie/output/hpfeeds3.py
+++ b/src/cowrie/output/hpfeeds3.py
@@ -10,11 +10,10 @@ Output plugin for HPFeeds
 from __future__ import annotations
 
 import json
-import logging
 
 from hpfeeds.twisted import ClientSessionService
 from twisted.internet import endpoints, reactor, ssl
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -24,6 +23,8 @@ class Output(cowrie.core.output.Output):
     """
     Output plugin for HPFeeds
     """
+
+    _log = Logger()
 
     channel = "cowrie.sessions"
 
@@ -115,7 +116,7 @@ class Output(cowrie.core.output.Output):
         elif event["eventid"] == "cowrie.session.closed":
             meta = self.meta.pop(session, None)
             if meta:
-                log.msg("publishing metadata to hpfeeds", logLevel=logging.DEBUG)
+                self._log.debug("publishing metadata to hpfeeds")
                 meta["endTime"] = event["timestamp"]
                 meta["hashes"] = list(meta["hashes"])
                 self.client.publish(self.channel, json.dumps(meta).encode("utf-8"))

--- a/src/cowrie/output/influx.py
+++ b/src/cowrie/output/influx.py
@@ -9,7 +9,7 @@ import re
 
 from influxdb import InfluxDBClient
 from influxdb.exceptions import InfluxDBClientError
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -20,6 +20,8 @@ class Output(cowrie.core.output.Output):
     influx output
     """
 
+    _log = Logger()
+
     def start(self):
         host = CowrieConfig.get("output_influx", "host", fallback="")
         port = CowrieConfig.getint("output_influx", "port", fallback=8086)
@@ -29,11 +31,13 @@ class Output(cowrie.core.output.Output):
         try:
             self.client = InfluxDBClient(host=host, port=port, ssl=ssl, verify_ssl=ssl)
         except InfluxDBClientError as e:
-            log.msg(f"output_influx: I/O error({e.code}): '{e.message}'")
+            self._log.info(
+                "output_influx: I/O error({code}): '{msg}'", code=e.code, msg=e.message
+            )
             return
 
         if self.client is None:
-            log.msg("output_influx: cannot instantiate client!")
+            self._log.info("output_influx: cannot instantiate client!")
             return
 
         if CowrieConfig.has_option(
@@ -58,9 +62,10 @@ class Output(cowrie.core.output.Output):
 
             match = re.search(r"^\d+[dhmw]{1}$", retention_policy_duration)
             if not match:
-                log.msg(
+                self._log.warn(
                     "output_influx: invalid retention policy."
-                    f"Using default '{retention_policy_duration}'.."
+                    "Using default '{duration}'..",
+                    duration=retention_policy_duration,
                 )
                 retention_policy_duration = retention_policy_duration_default
         else:
@@ -107,7 +112,7 @@ class Output(cowrie.core.output.Output):
 
     def write(self, event):
         if self.client is None:
-            log.msg("output_influx: client object is not instantiated")
+            self._log.info("output_influx: client object is not instantiated")
             return
 
         # event id
@@ -211,12 +216,16 @@ class Output(cowrie.core.output.Output):
             # are not implemented
         else:
             # other events should be handled
-            log.msg(f"output_influx: event '{eventid}' not handled. Skipping..")
+            self._log.info(
+                "output_influx: event '{eventid}' not handled. Skipping..",
+                eventid=eventid,
+            )
             return
 
         result = self.client.write_points([m])
 
         if not result:
-            log.msg(
-                f"output_influx: error when writing '{eventid}' measurement in the db."
+            self._log.info(
+                "output_influx: error when writing '{eventid}' measurement in the db.",
+                eventid=eventid,
             )

--- a/src/cowrie/output/jsonlog.py
+++ b/src/cowrie/output/jsonlog.py
@@ -8,7 +8,7 @@ import json
 import os
 from pathlib import Path
 
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 import cowrie.python.logfile
@@ -19,6 +19,8 @@ class Output(cowrie.core.output.Output):
     """
     jsonlog output
     """
+
+    _log = Logger()
 
     def start(self):
         self.epoch_timestamp = CowrieConfig.getboolean(
@@ -56,4 +58,4 @@ class Output(cowrie.core.output.Output):
             self.outfile.write(json.dumps(event, separators=(",", ":")) + "\n")
             self.outfile.flush()
         except TypeError:
-            log.err("jsonlog: Can't serialize: '" + repr(event) + "'")
+            self._log.error("jsonlog: Can't serialize: '{event!r}'", event=event)

--- a/src/cowrie/output/malshare.py
+++ b/src/cowrie/output/malshare.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 
 import treq
 from twisted.internet import defer, error
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -26,6 +26,8 @@ class Output(cowrie.core.output.Output):
     """
     malshare output
     """
+
+    _log = Logger()
 
     apiKey: str
 
@@ -79,16 +81,16 @@ class Output(cowrie.core.output.Output):
             error.ConnectingCancelledError,
             error.DNSLookupError,
         ) as e:
-            log.msg(f"MalShare Request failed: {e}")
+            self._log.info("MalShare Request failed: {error}", error=e)
             return
         except Exception as e:
-            log.msg(f"MalShare Request failed: {e}")
+            self._log.info("MalShare Request failed: {error}", error=e)
             return
 
         # Drain the body so the connection returns to the pool.
         yield response.text()
 
         if 200 <= response.code < 300:
-            log.msg("Submitted to MalShare")
+            self._log.info("Submitted to MalShare")
         else:
-            log.msg(f"MalShare Request failed: {response.code}")
+            self._log.info("MalShare Request failed: {code}", code=response.code)

--- a/src/cowrie/output/misp.py
+++ b/src/cowrie/output/misp.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pymisp import MISPAttribute, MISPEvent, MISPObject, MISPSighting
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -46,6 +46,8 @@ class Output(cowrie.core.output.Output):
 
     Events are now consolidated to create one comprehensive event per session
     """
+
+    _log = Logger()
 
     def start(self) -> None:
         """
@@ -153,7 +155,7 @@ class Output(cowrie.core.output.Output):
                     )
                     if malware_attrib:
                         if self.debug:
-                            log.msg("MISP: File known, add sighting")
+                            self._log.info("MISP: File known, add sighting")
                         self.add_sighting(event, malware_attrib)
 
             elif event["eventid"] == "cowrie.session.file_upload":
@@ -169,7 +171,7 @@ class Output(cowrie.core.output.Output):
                 file_sha_attrib = self.find_attribute("sha256", event["shasum"])
                 if file_sha_attrib:
                     if self.debug:
-                        log.msg("MISP: File known, add sighting")
+                        self._log.info("MISP: File known, add sighting")
                     self.add_sighting(event, file_sha_attrib)
 
             # Handle login attempts (both failed and successful)
@@ -228,7 +230,10 @@ class Output(cowrie.core.output.Output):
                         cmd_details
                     )
                     if self.debug:
-                        log.msg(f"MISP: Dangerous command detected: {command}")
+                        self._log.info(
+                            "MISP: Dangerous command detected: {command}",
+                            command=command,
+                        )
 
             # When a session closes, create a comprehensive event
             elif event["eventid"] == "cowrie.session.closed":
@@ -289,9 +294,12 @@ class Output(cowrie.core.output.Output):
         try:
             self.misp_api.add_sighting(sighting, attribute)
             if self.debug:
-                log.msg(f"MISP: Added sighting to attribute {attribute['id']}")
+                self._log.info(
+                    "MISP: Added sighting to attribute {attribute_id}",
+                    attribute_id=attribute["id"],
+                )
         except Exception as e:
-            log.msg(f"MISP: Error adding sighting: {e}")
+            self._log.info("MISP: Error adding sighting: {error}", error=e)
 
     def create_session_event(self, session_id, session_data):
         """
@@ -611,6 +619,10 @@ class Output(cowrie.core.output.Output):
         result = self.misp_api.add_event(misp_event)
 
         if self.debug:
-            log.msg(f"MISP: Session event creation result for {session_id}: {result}")
+            self._log.info(
+                "MISP: Session event creation result for {session}: {result}",
+                session=session_id,
+                result=result,
+            )
 
         return result

--- a/src/cowrie/output/mongodb.py
+++ b/src/cowrie/output/mongodb.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import pymongo
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -17,11 +17,13 @@ class Output(cowrie.core.output.Output):
     mongodb output
     """
 
+    _log = Logger()
+
     def insert_one(self, collection, event):
         try:
             object_id = collection.insert_one(event).inserted_id
         except Exception as e:
-            log.msg(f"mongo error - {e}")
+            self._log.info("mongo error - {error}", error=e)
         else:
             return object_id
 
@@ -29,7 +31,7 @@ class Output(cowrie.core.output.Output):
         try:
             object_id = collection.update_one({"session": session}, {"$set": doc})
         except Exception as e:
-            log.msg(f"mongo error - {e}")
+            self._log.info("mongo error - {error}", error=e)
         else:
             return object_id
 
@@ -53,7 +55,7 @@ class Output(cowrie.core.output.Output):
             self.col_ipforwards = self.mongo_db["ipforwards"]
             self.col_ipforwardsdata = self.mongo_db["ipforwardsdata"]
         except Exception as e:
-            log.msg(f"output_mongodb: Error: {e!s}")
+            self._log.info("output_mongodb: Error: {error}", error=e)
 
     def stop(self):
         self.mongo_client.close()
@@ -76,7 +78,7 @@ class Output(cowrie.core.output.Output):
                 event["endtime"] = None
                 event["sshversion"] = None
                 event["termsize"] = None
-                log.msg("Session Created")
+                self._log.info("Session Created")
                 self.insert_one(self.col_sessions, event)
 
             case "cowrie.login.success" | "cowrie.login.failed":

--- a/src/cowrie/output/mysql.py
+++ b/src/cowrie/output/mysql.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import mysql.connector
 from twisted.enterprise import adbapi
 from twisted.internet import defer
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -36,6 +36,8 @@ class ReconnectingConnectionPool(adbapi.ConnectionPool):
     http://twistedmatrix.com/pipermail/twisted-python/2009-July/020007.html
     """
 
+    _log = Logger()
+
     def _runInteraction(self, interaction, *args, **kw):
         try:
             return adbapi.ConnectionPool._runInteraction(self, interaction, *args, **kw)
@@ -49,7 +51,9 @@ class ReconnectingConnectionPool(adbapi.ConnectionPool):
             ):
                 raise
 
-            log.msg(f"output_mysql: got error {e!r}, retrying operation")
+            self._log.info(
+                "output_mysql: got error {error!r}, retrying operation", error=e
+            )
             conn = self.connections.get(self.threadID())
             self.disconnect(conn)
             # Try the interaction again
@@ -60,6 +64,8 @@ class Output(cowrie.core.output.Output):
     """
     MySQL output
     """
+
+    _log = Logger()
 
     debug: bool = False
 
@@ -82,7 +88,11 @@ class Output(cowrie.core.output.Output):
             )
         # except (MySQLdb.Error, MySQLdb._exceptions.Error) as e:
         except Exception as e:
-            log.msg(f"output_mysql: Error {e.args[0]}: {e.args[1]}")
+            self._log.info(
+                "output_mysql: Error {errno}: {errmsg}",
+                errno=e.args[0],
+                errmsg=e.args[1],
+            )
 
     def stop(self):
         self.db.close()
@@ -93,19 +103,21 @@ class Output(cowrie.core.output.Output):
         1406, "Data too long for column '...' at row ..."
         """
         if error.value.args[0] in (1146, 1406):
-            log.msg(f"output_mysql: MySQL Error: {error.value.args!r}")
-            log.msg(
+            self._log.info("output_mysql: MySQL Error: {args!r}", args=error.value.args)
+            self._log.info(
                 "output_mysql: MySQL schema maybe misconfigured, doublecheck database!"
             )
         else:
-            log.msg(f"output_mysql: MySQL Error: {error.value.args!r}")
+            self._log.info("output_mysql: MySQL Error: {args!r}", args=error.value.args)
 
     def simpleQuery(self, sql, args):
         """
         Just run a deferred sql query, only care about errors
         """
         if self.debug:
-            log.msg(f"output_mysql: MySQL query: {sql} {args!r}")
+            self._log.info(
+                "output_mysql: MySQL query: {sql} {args!r}", sql=sql, args=args
+            )
         d = self.db.runQuery(sql, args)
         d.addErrback(self.sqlerror)
 
@@ -113,8 +125,9 @@ class Output(cowrie.core.output.Output):
     def write(self, event):
         if event["eventid"] == "cowrie.session.connect":
             if self.debug:
-                log.msg(
-                    f"output_mysql: SELECT `id` FROM `sensors` WHERE `ip` = '{self.sensor}'"
+                self._log.info(
+                    "output_mysql: SELECT `id` FROM `sensors` WHERE `ip` = '{sensor}'",
+                    sensor=self.sensor,
                 )
             r = yield self.db.runQuery(
                 "SELECT `id` FROM `sensors` WHERE `ip` = %s",
@@ -124,8 +137,9 @@ class Output(cowrie.core.output.Output):
                 sensorid = r[0][0]
             else:
                 if self.debug:
-                    log.msg(
-                        f"output_mysql: INSERT INTO `sensors` (`ip`) VALUES ('{self.sensor}')"
+                    self._log.info(
+                        "output_mysql: INSERT INTO `sensors` (`ip`) VALUES ('{sensor}')",
+                        sensor=self.sensor,
                     )
                 yield self.db.runQuery(
                     "INSERT INTO `sensors` (`ip`) VALUES (%s)",

--- a/src/cowrie/output/oraclecloud.py
+++ b/src/cowrie/output/oraclecloud.py
@@ -11,7 +11,7 @@ import secrets
 import string
 
 import oci
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -21,6 +21,8 @@ class Output(cowrie.core.output.Output):
     """
     Oracle Cloud output
     """
+
+    _log = Logger()
 
     def generate_random_log_id(self):
         charset = string.ascii_letters + string.digits
@@ -60,12 +62,14 @@ class Output(cowrie.core.output.Output):
                 ),
             )
         except oci.exceptions.ServiceError as ex:
-            log.err(
-                f"Oracle Cloud plugin Error: {ex.message}\n"
-                + f"Oracle Cloud plugin Status Code: {ex.status}\n"
+            self._log.failure(
+                "Oracle Cloud plugin Error: {msg}\n"
+                "Oracle Cloud plugin Status Code: {status}\n",
+                msg=ex.message,
+                status=ex.status,
             )
         except Exception as ex:
-            log.err(f"Oracle Cloud plugin Error: {ex}")
+            self._log.failure("Oracle Cloud plugin Error: {error}", error=ex)
             raise
 
     def start(self):
@@ -102,7 +106,7 @@ class Output(cowrie.core.output.Output):
                 config_with_key_content
             )
         else:
-            log.msg(
+            self._log.info(
                 "output_oraclecloud.authtype must be instance_principals or user_principals"
             )
             raise ValueError()

--- a/src/cowrie/output/postgresql.py
+++ b/src/cowrie/output/postgresql.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from psycopg2 import OperationalError
 from twisted.enterprise import adbapi
 from twisted.internet import defer
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -20,6 +20,8 @@ class ReconnectingPostgreSQLConnectionPool(adbapi.ConnectionPool):
 
     This handles reconnections on known transient errors like server disconnects or deadlocks.
     """
+
+    _log = Logger()
 
     def _runInteraction(self, interaction, *args, **kw):
         try:
@@ -36,7 +38,10 @@ class ReconnectingPostgreSQLConnectionPool(adbapi.ConnectionPool):
             if e.pgcode not in transient_errors:
                 raise
 
-            log.msg(f"output_postgresql: transient error {e!r}, retrying interaction")
+            self._log.info(
+                "output_postgresql: transient error {error!r}, retrying interaction",
+                error=e,
+            )
             conn = self.connections.get(self.threadID())
             self.disconnect(conn)
             return super()._runInteraction(interaction, *args, **kw)
@@ -46,6 +51,8 @@ class Output(cowrie.core.output.Output):
     """
     PostgreSQL output for Cowrie
     """
+
+    _log = Logger()
 
     debug: bool = False
 
@@ -67,13 +74,19 @@ class Output(cowrie.core.output.Output):
                 cp_max=1,
             )
         except Exception as e:
-            log.msg(f"output_mysql: Error {e.args[0]}: {e.args[1]}")
+            self._log.info(
+                "output_mysql: Error {errno}: {errmsg}",
+                errno=e.args[0],
+                errmsg=e.args[1],
+            )
 
     def stop(self):
         self.db.close()
 
     def sqlerror(self, error):
-        log.msg(f"output_postgresql: PostgreSQL Error: {error.value.args!r}")
+        self._log.info(
+            "output_postgresql: PostgreSQL Error: {args!r}", args=error.value.args
+        )
 
     def simpleQuery(self, sql, args):
         if (
@@ -84,7 +97,11 @@ class Output(cowrie.core.output.Output):
             sql += " RETURNING id"
 
         if self.debug:
-            log.msg(f"output_postgresql: PostgreSQL query: {sql} {args!r}")
+            self._log.info(
+                "output_postgresql: PostgreSQL query: {sql} {args!r}",
+                sql=sql,
+                args=args,
+            )
 
         d = self.db.runQuery(sql, args)
         d.addErrback(self.sqlerror)
@@ -93,8 +110,9 @@ class Output(cowrie.core.output.Output):
     def write(self, event):
         if event["eventid"] == "cowrie.session.connect":
             if self.debug:
-                log.msg(
-                    f"output_postgresql: SELECT id FROM sensors WHERE ip = '{self.sensor}'"
+                self._log.info(
+                    "output_postgresql: SELECT id FROM sensors WHERE ip = '{sensor}'",
+                    sensor=self.sensor,
                 )
             r = yield self.db.runQuery(
                 "SELECT id FROM sensors WHERE ip = %s",
@@ -104,8 +122,9 @@ class Output(cowrie.core.output.Output):
                 sensorid = r[0][0]
             else:
                 if self.debug:
-                    log.msg(
-                        f"output_postgresql: INSERT INTO sensors (ip) VALUES ('{self.sensor}')"
+                    self._log.info(
+                        "output_postgresql: INSERT INTO sensors (ip) VALUES ('{sensor}')",
+                        sensor=self.sensor,
                     )
                 yield self.db.runQuery(
                     "INSERT INTO sensors (ip) VALUES (%s) ",

--- a/src/cowrie/output/prometheus.py
+++ b/src/cowrie/output/prometheus.py
@@ -17,7 +17,7 @@ import socket
 import time
 
 from prometheus_client import Counter, Gauge, Histogram, start_http_server
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -83,6 +83,8 @@ py_exceptions = Counter(
 
 
 class Output(cowrie.core.output.Output):
+    _log = Logger()
+
     def start(self) -> None:
         port = CowrieConfig.getint("output_prometheus", "port", fallback=9000)
         addr = CowrieConfig.get("output_prometheus", "address", fallback="::")
@@ -92,8 +94,8 @@ class Output(cowrie.core.output.Output):
         start_http_server(port, addr=addr)
 
         if self.debug:
-            log.msg(f"[Prometheus] Exporter started on port: {port}")
-            log.msg(f"[Prometheus] Host label: {HOST_LABEL}")
+            self._log.info("[Prometheus] Exporter started on port: {port}", port=port)
+            self._log.info("[Prometheus] Host label: {label}", label=HOST_LABEL)
 
         # Helper structures
         self._start_times: dict[str, float] = {}
@@ -112,7 +114,7 @@ class Output(cowrie.core.output.Output):
             eid = event["eventid"]
 
             if self.debug:
-                log.msg(f"[Prometheus] Event: {eid}")
+                self._log.info("[Prometheus] Event: {eventid}", eventid=eid)
 
             if eid == "cowrie.session.connect":
                 self._on_session_connect(event)
@@ -140,7 +142,7 @@ class Output(cowrie.core.output.Output):
 
         except Exception as e:
             if self.debug:
-                log.msg(f"[Prometheus] Exception: {e!s}")
+                self._log.info("[Prometheus] Exception: {error}", error=e)
             py_exceptions.labels(exception=e.__class__.__name__).inc()
 
     def _on_session_connect(self, ev: dict) -> None:

--- a/src/cowrie/output/reversedns.py
+++ b/src/cowrie/output/reversedns.py
@@ -9,8 +9,8 @@ import ipaddress
 from functools import lru_cache
 
 from twisted.internet import defer
+from twisted.logger import Logger
 from twisted.names import client, error
-from twisted.python import log
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -20,6 +20,8 @@ class Output(cowrie.core.output.Output):
     """
     Output plugin used for reverse DNS lookup
     """
+
+    _log = Logger()
 
     timeout: list[int]
 
@@ -45,10 +47,10 @@ class Output(cowrie.core.output.Output):
             Create log messages for connect events
             """
             if result is None:
-                log.msg("reversedns: no results (1)")
+                self._log.info("reversedns: no results (1)")
                 return
             if len(result[0]) == 0:
-                log.msg("reversedns: no results (2)")
+                self._log.info("reversedns: no results (2)")
                 return
 
             payload = result[0][0].payload
@@ -84,16 +86,15 @@ class Output(cowrie.core.output.Output):
 
         def cbError(failure):
             if failure.type == defer.TimeoutError:
-                log.msg("reversedns: Timeout in DNS lookup")
+                self._log.info("reversedns: Timeout in DNS lookup")
             elif failure.type == error.DNSNameError:
                 # DNSNameError is the NXDOMAIN response
-                log.msg("reversedns: No PTR record returned")
+                self._log.info("reversedns: No PTR record returned")
             elif failure.type == error.DNSServerError:
                 # DNSServerError is the SERVFAIL response
-                log.msg("reversedns: DNS server not responding")
+                self._log.info("reversedns: DNS server not responding")
             else:
-                log.msg("reversedns: Error in DNS lookup")
-                failure.printTraceback()
+                self._log.failure("reversedns: Error in DNS lookup", failure=failure)
 
         if event["eventid"] == "cowrie.session.connect":
             d = self.reversedns(event["src_ip"])

--- a/src/cowrie/output/rmq.py
+++ b/src/cowrie/output/rmq.py
@@ -7,17 +7,19 @@ from __future__ import annotations
 import json
 
 from twisted.internet.address import IPv4Address, IPv6Address
-from twisted.python import log
+from twisted.logger import Logger
 from twisted.python.constants import NamedConstant, ValueConstant
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
 
+_log = Logger()
+
 try:
     import pika
     from pika.exceptions import AMQPConnectionError
 except ImportError:
-    log.err("Missing dependency: pika")
+    _log.error("Missing dependency: pika")
     pika = None
     AMQPConnectionError = Exception
 
@@ -41,12 +43,14 @@ class Output(cowrie.core.output.Output):
     with reconnection logic.
     """
 
+    _log = Logger()
+
     def start(self):
         """
         Initialize the RabbitMQ connection and declare the exchange.
         """
         if not pika:
-            log.err("Pika module is not installed, RabbitMQ output disabled")
+            self._log.error("Pika module is not installed, RabbitMQ output disabled")
             return
 
         self.host = CowrieConfig.get("output_rmq", "host", fallback="localhost")
@@ -82,9 +86,9 @@ class Output(cowrie.core.output.Output):
                 exchange_type=self.exchange_type,
                 durable=True,
             )
-            log.msg("Connected to RabbitMQ")
+            self._log.info("Connected to RabbitMQ")
         except Exception as e:
-            log.err(f"Failed to connect to RabbitMQ: {e}")
+            self._log.failure("Failed to connect to RabbitMQ: {error}", error=e)
             self.connection = None
             self.channel = None
 
@@ -94,7 +98,7 @@ class Output(cowrie.core.output.Output):
         """
         if self.connection:
             self.connection.close()
-            log.msg("Disconnected from RabbitMQ")
+            self._log.info("Disconnected from RabbitMQ")
 
     def write(self, event):
         """
@@ -114,10 +118,12 @@ class Output(cowrie.core.output.Output):
         while attempt < 2:  # Try at most twice
             try:
                 if not self.connection or self.connection.is_closed:
-                    log.msg("RabbitMQ connection is closed, attempting to reconnect")
+                    self._log.info(
+                        "RabbitMQ connection is closed, attempting to reconnect"
+                    )
                     self._connect()
                     if not self.connection or self.connection.is_closed:
-                        log.err("Failed to reconnect to RabbitMQ")
+                        self._log.error("Failed to reconnect to RabbitMQ")
                         break  # Exit loop if reconnection fails
 
                 self.channel.basic_publish(
@@ -126,15 +132,18 @@ class Output(cowrie.core.output.Output):
                     body=message.encode("utf-8"),
                     properties=properties,
                 )
-                log.msg(f"Published event to RabbitMQ: {routing_key}")
+                self._log.info(
+                    "Published event to RabbitMQ: {routing_key}",
+                    routing_key=routing_key,
+                )
                 break  # Exit loop on success
 
             except (AMQPConnectionError, pika.exceptions.StreamLostError) as e:
-                log.err(f"AMQPConnectionError: {e}")
+                self._log.failure("AMQPConnectionError: {error}", error=e)
                 self.connection = None  # Force reconnection on next attempt
                 attempt += 1  # Increment attempt counter to retry
                 continue  # Retry after reconnection
 
             except Exception as e:
-                log.err(f"Error publishing to RabbitMQ: {e}")
+                self._log.failure("Error publishing to RabbitMQ: {error}", error=e)
                 break  # Exit loop on non-recoverable error

--- a/src/cowrie/output/s3.py
+++ b/src/cowrie/output/s3.py
@@ -15,7 +15,7 @@ from typing import Any
 from botocore.exceptions import ClientError
 from botocore.session import get_session
 from twisted.internet import defer, threads
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -25,6 +25,8 @@ class Output(cowrie.core.output.Output):
     """
     s3 output
     """
+
+    _log = Logger()
 
     def start(self) -> None:
         self.bucket = CowrieConfig.get("output_s3", "bucket")
@@ -40,7 +42,7 @@ class Output(cowrie.core.output.Output):
                     CowrieConfig.get("output_s3", "secret_access_key"),
                 )
         except NoOptionError:
-            log.msg(
+            self._log.info(
                 "No AWS credentials found in config - using botocore global settings."
             )
 
@@ -79,16 +81,25 @@ class Output(cowrie.core.output.Output):
     @defer.inlineCallbacks
     def upload(self, shasum, filename):
         if shasum in self.seen:
-            log.msg(f"Already uploaded file with sha {shasum} to S3")
+            self._log.info(
+                "Already uploaded file with sha {shasum} to S3", shasum=shasum
+            )
             return
 
         exists = yield self._object_exists_remote(shasum)
         if exists:
-            log.msg(f"Somebody else already uploaded file with sha {shasum} to S3")
+            self._log.info(
+                "Somebody else already uploaded file with sha {shasum} to S3",
+                shasum=shasum,
+            )
             self.seen.add(shasum)
             return
 
-        log.msg(f"Uploading file with sha {shasum} ({filename}) to S3")
+        self._log.info(
+            "Uploading file with sha {shasum} ({filename}) to S3",
+            shasum=shasum,
+            filename=filename,
+        )
         with open(filename, "rb") as fp:
             yield threads.deferToThread(
                 self.client.put_object,

--- a/src/cowrie/output/signal.py
+++ b/src/cowrie/output/signal.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 
 import treq
-from twisted.python import log  # pylint: disable=no-name-in-module
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -19,6 +19,8 @@ from cowrie.core.config import CowrieConfig
 
 class Output(cowrie.core.output.Output):
     """Signal messenger output plugin."""
+
+    _log = Logger()
 
     def start(self) -> None:
         self.api_url = CowrieConfig.get("output_signal", "api_url").rstrip("/")
@@ -48,7 +50,7 @@ class Output(cowrie.core.output.Output):
             self._send(msgtxt)
 
     def _send(self, message: str) -> None:
-        log.msg("Signal plugin sending notification")
+        self._log.info("Signal plugin sending notification")
         payload = json.dumps(
             {
                 "number": self.sender,
@@ -65,4 +67,6 @@ class Output(cowrie.core.output.Output):
             headers=headers,
             allow_redirects=False,
         )
-        d.addErrback(log.err, "Signal plugin request failed")
+        d.addErrback(
+            lambda f: self._log.failure("Signal plugin request failed", failure=f)
+        )

--- a/src/cowrie/output/slack.py
+++ b/src/cowrie/output/slack.py
@@ -9,7 +9,7 @@ import time
 from typing import Any
 
 from slack import WebClient
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -19,6 +19,8 @@ class Output(cowrie.core.output.Output):
     """
     slack output
     """
+
+    _log = Logger()
 
     def start(self) -> None:
         self.name = "slack output engine"
@@ -32,9 +34,10 @@ class Output(cowrie.core.output.Output):
         )
         self.verbose = CowrieConfig.getboolean("output_slack", "verbose", fallback=True)
         if not self.show_timestamp and not self.simplified:
-            log.msg(
-                f"{self.name}: setting 'timestamp=false' is only effective when "
-                + "'simplified' mode is enabled, this will be ignored."
+            self._log.warn(
+                "{name}: setting 'timestamp=false' is only effective when "
+                "'simplified' mode is enabled, this will be ignored.",
+                name=self.name,
             )
 
     def stop(self) -> None:

--- a/src/cowrie/output/splunk.py
+++ b/src/cowrie/output/splunk.py
@@ -15,7 +15,7 @@ from io import BytesIO
 from typing import Any
 
 from twisted.internet import reactor, ssl
-from twisted.python import log
+from twisted.logger import Logger
 from twisted.web import client, http_headers
 from twisted.web.client import FileBodyProducer
 from twisted.web.iweb import IPolicyForHTTPS
@@ -29,6 +29,8 @@ class Output(cowrie.core.output.Output):
     """
     Splunk HEC output
     """
+
+    _log = Logger()
 
     token: str
     agent: Any
@@ -97,7 +99,11 @@ class Output(cowrie.core.output.Output):
             if response.code == 200:
                 return
             else:
-                log.msg(f"SplunkHEC response: {response.code} {response.phrase}")
+                self._log.info(
+                    "SplunkHEC response: {code} {phrase}",
+                    code=response.code,
+                    phrase=response.phrase,
+                )
                 d = client.readBody(response)
                 d.addCallback(cbBody)
                 d.addErrback(cbPartial)
@@ -108,7 +114,7 @@ class Output(cowrie.core.output.Output):
 
         def processResult(result):
             j = json.loads(result)
-            log.msg(f"SplunkHEC response: {j['text']}")
+            self._log.info("SplunkHEC response: {text}", text=j["text"])
 
         d.addCallback(cbResponse)
         d.addErrback(cbError)

--- a/src/cowrie/output/sqlite.py
+++ b/src/cowrie/output/sqlite.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from twisted.enterprise import adbapi
 from twisted.internet import defer
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -19,6 +19,8 @@ class Output(cowrie.core.output.Output):
     """
     sqlite output
     """
+
+    _log = Logger()
 
     db: Any
 
@@ -34,7 +36,7 @@ class Output(cowrie.core.output.Output):
                 "sqlite3", database=sqliteFilename, check_same_thread=False
             )
         except sqlite3.OperationalError as e:
-            log.msg(e)
+            self._log.info("{error}", error=e)
 
         self.db.start()
 
@@ -45,8 +47,7 @@ class Output(cowrie.core.output.Output):
         self.db.close()
 
     def sqlerror(self, error):
-        log.err("sqlite error")
-        error.printTraceback()
+        self._log.failure("sqlite error", failure=error)
 
     def simpleQuery(self, sql, args):
         """

--- a/src/cowrie/output/telegram.py
+++ b/src/cowrie/output/telegram.py
@@ -6,7 +6,7 @@
 # Simple Telegram Bot logger
 
 import treq
-from twisted.python import log
+from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -16,6 +16,8 @@ class Output(cowrie.core.output.Output):
     """
     telegram output
     """
+
+    _log = Logger()
 
     def start(self):
         self.bot_token = CowrieConfig.get("output_telegram", "bot_token")
@@ -57,7 +59,7 @@ class Output(cowrie.core.output.Output):
             self.send_message(msgtxt)
 
     def send_message(self, message):
-        log.msg("Telegram plugin will try to call TelegramBot")
+        self._log.info("Telegram plugin will try to call TelegramBot")
         try:
             treq.get(
                 "https://api.telegram.org/bot" + self.bot_token + "/sendMessage",
@@ -69,4 +71,4 @@ class Output(cowrie.core.output.Output):
                 allow_redirects=False,
             )
         except Exception:
-            log.msg("Telegram plugin request error")
+            self._log.info("Telegram plugin request error")

--- a/src/cowrie/output/virustotal.py
+++ b/src/cowrie/output/virustotal.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 from twisted.internet import defer, reactor
 from twisted.internet.protocol import connectionDone
-from twisted.python import log
+from twisted.logger import Logger
 from twisted.web import client, http_headers
 from twisted.web.iweb import IBodyProducer, IResponse
 from zope.interface import implementer
@@ -62,6 +62,8 @@ class Output(cowrie.core.output.Output):
     """
     virustotal output
     """
+
+    _log = Logger()
 
     apiKey: str
     debug: bool = False
@@ -115,15 +117,15 @@ class Output(cowrie.core.output.Output):
     def write(self, event: dict[str, Any]) -> None:
         if event["eventid"] == "cowrie.session.file_download":
             if self.scan_url and "url" in event:
-                log.msg("Checking url scan report at VT")
+                self._log.info("Checking url scan report at VT")
                 self.scanurl(event)
             if self._is_new_shasum(event["shasum"]) and self.scan_file:
-                log.msg("Checking file scan report at VT")
+                self._log.info("Checking file scan report at VT")
                 self.scanfile(event)
 
         elif event["eventid"] == "cowrie.session.file_upload":
             if self._is_new_shasum(event["shasum"]) and self.scan_file:
-                log.msg("Checking file scan report at VT")
+                self._log.info("Checking file scan report at VT")
                 self.scanfile(event)
 
     def _is_new_shasum(self, shasum):
@@ -141,7 +143,9 @@ class Output(cowrie.core.output.Output):
         # If the file was first downloaded more than a "period of time" (e.g 1 min) ago -
         # it has been apparently scanned before in VT and therefore is not going to be checked again
         if file_modification_time < datetime.datetime.now() - TIME_SINCE_FIRST_DOWNLOAD:
-            log.msg(f"File with shasum '{shasum}' was downloaded before")
+            self._log.info(
+                "File with shasum '{shasum}' was downloaded before", shasum=shasum
+            )
             return False
         return True
 
@@ -193,11 +197,15 @@ class Output(cowrie.core.output.Output):
                     d.addCallback(process_response)
                 return d
             else:
-                log.msg(f"{error_prefix} failed: {response.code} {response.phrase}")
+                self._log.info(
+                    "{prefix} failed: {code} {phrase}",
+                    prefix=error_prefix,
+                    code=response.code,
+                    phrase=response.phrase,
+                )
 
         def cbError(failure):
-            log.msg(f"{error_prefix} error")
-            failure.printTraceback()
+            self._log.failure("{prefix} error", failure=failure, prefix=error_prefix)
 
         d.addCallback(cbResponse)
         d.addErrback(cbError)
@@ -228,14 +236,14 @@ class Output(cowrie.core.output.Output):
 
         def process_response(body_bytes):
             if self.debug:
-                log.msg(f"VT scanfile result: {body_bytes}")
+                self._log.info("VT scanfile result: {body}", body=body_bytes)
             result = body_bytes.decode("utf8")
             j = json.loads(result)
 
             # Check for errors in v3 API response
             if "error" in j:
                 if j["error"]["code"] == "NotFoundError":
-                    log.msg("VT: New file - not found in database")
+                    self._log.info("VT: New file - not found in database")
                     self.dispatch(
                         eventid="cowrie.virustotal.scanfile",
                         format="VT: New file %(sha256)s",
@@ -257,8 +265,10 @@ class Output(cowrie.core.output.Output):
                             event["outfile"], fileName, event["shasum"]
                         )
                 else:
-                    log.msg(
-                        f"VT: Error - {j['error']['code']}: {j['error']['message']}"
+                    self._log.info(
+                        "VT: Error - {code}: {msg}",
+                        code=j["error"]["code"],
+                        msg=j["error"]["message"],
                     )
                 return
 
@@ -271,7 +281,7 @@ class Output(cowrie.core.output.Output):
                 last_analysis_results = attributes.get("last_analysis_results", {})
                 stats = attributes.get("last_analysis_stats", {})
 
-                log.msg("VT: File found in database")
+                self._log.info("VT: File found in database")
                 scans_summary = self._parse_scan_results(last_analysis_results)
 
                 malicious_count = stats.get("malicious", 0)
@@ -292,11 +302,12 @@ class Output(cowrie.core.output.Output):
                     scans=scans_summary,
                     is_new="false",
                 )
-                log.msg(
-                    f"VT: permalink: https://www.virustotal.com/gui/file/{event['shasum']}"
+                self._log.info(
+                    "VT: permalink: https://www.virustotal.com/gui/file/{sha256}",
+                    sha256=event["shasum"],
                 )
             else:
-                log.msg("VT: unexpected response format")
+                self._log.info("VT: unexpected response format")
 
         return self._make_request(
             b"GET",
@@ -320,7 +331,7 @@ class Output(cowrie.core.output.Output):
         with open(artifact, "rb") as f:
             files = {("file", fileName, f)}
             if self.debug:
-                log.msg(f"submitting to VT: {files!r}")
+                self._log.info("submitting to VT: {files!r}", files=files)
             contentType, body = encode_multipart_formdata(fields, files)
         producer = StringProducer(body)
         headers = self._build_headers(
@@ -329,14 +340,16 @@ class Output(cowrie.core.output.Output):
 
         def process_response(body_bytes):
             if self.debug:
-                log.msg(f"VT postfile result: {body_bytes}")
+                self._log.info("VT postfile result: {body}", body=body_bytes)
             result = body_bytes.decode("utf8")
             j = json.loads(result)
 
             # Check for errors in v3 API response
             if "error" in j:
-                log.msg(
-                    f"VT: Upload error - {j['error']['code']}: {j['error']['message']}"
+                self._log.info(
+                    "VT: Upload error - {code}: {msg}",
+                    code=j["error"]["code"],
+                    msg=j["error"]["message"],
                 )
                 return
 
@@ -345,15 +358,15 @@ class Output(cowrie.core.output.Output):
             if "data" in j:
                 data = j["data"]
                 if data.get("id"):
-                    log.msg("VT: File uploaded successfully")
+                    self._log.info("VT: File uploaded successfully")
                     if self.collection_name:
                         self._add_to_collection("files", sha256, f"file {sha256}")
                     if self.comment:
                         return self._post_comment("files", sha256, "Comment")
                 else:
-                    log.msg("VT: Upload successful but no file ID returned")
+                    self._log.info("VT: Upload successful but no file ID returned")
             else:
-                log.msg("VT: unexpected upload response format")
+                self._log.info("VT: unexpected upload response format")
 
         return self._make_request(
             b"POST",
@@ -369,8 +382,9 @@ class Output(cowrie.core.output.Output):
         Check url scan report for a hash
         """
         if event["url"] in self.url_cache:
-            log.msg(
-                f"output_virustotal: url {event['url']} was already successfully submitted"
+            self._log.info(
+                "output_virustotal: url {url} was already successfully submitted",
+                url=event["url"],
             )
             return
 
@@ -383,9 +397,11 @@ class Output(cowrie.core.output.Output):
 
         def process_response(body_bytes):
             if self.debug:
-                log.msg(f"VT scanurl result: {body_bytes}")
+                self._log.info("VT scanurl result: {body}", body=body_bytes)
             if body_bytes == b"[]\n":
-                log.err(f"VT scanurl did not return results: {body_bytes}")
+                self._log.error(
+                    "VT scanurl did not return results: {body}", body=body_bytes
+                )
                 return
             result = body_bytes.decode("utf8")
             j = json.loads(result)
@@ -396,7 +412,7 @@ class Output(cowrie.core.output.Output):
             # Check for errors in v3 API response
             if "error" in j:
                 if j["error"]["code"] == "NotFoundError":
-                    log.msg("VT: New URL - not found in database")
+                    self._log.info("VT: New URL - not found in database")
                     self.dispatch(
                         eventid="cowrie.virustotal.scanurl",
                         format="VT: New URL %(url)s",
@@ -409,8 +425,10 @@ class Output(cowrie.core.output.Output):
                     # Submit URL for scanning
                     return self.submiturl(event)
                 else:
-                    log.msg(
-                        f"VT: Error - {j['error']['code']}: {j['error']['message']}"
+                    self._log.info(
+                        "VT: Error - {code}: {msg}",
+                        code=j["error"]["code"],
+                        msg=j["error"]["message"],
                     )
                 return
 
@@ -422,12 +440,12 @@ class Output(cowrie.core.output.Output):
                 # Check if URL has been scanned
                 last_analysis_results = attributes.get("last_analysis_results", {})
                 if not last_analysis_results:
-                    log.msg("VT: URL was submitted but has not yet been scanned")
+                    self._log.info("VT: URL was submitted but has not yet been scanned")
                     return
 
                 stats = attributes.get("last_analysis_stats", {})
 
-                log.msg("VT: URL has been scanned before")
+                self._log.info("VT: URL has been scanned before")
                 scans_summary = self._parse_scan_results(last_analysis_results)
 
                 malicious_count = stats.get("malicious", 0)
@@ -448,9 +466,12 @@ class Output(cowrie.core.output.Output):
                     scans=scans_summary,
                     is_new="false",
                 )
-                log.msg(f"VT: permalink: https://www.virustotal.com/gui/url/{url_id}")
+                self._log.info(
+                    "VT: permalink: https://www.virustotal.com/gui/url/{url_id}",
+                    url_id=url_id,
+                )
             else:
-                log.msg("VT: unexpected response format")
+                self._log.info("VT: unexpected response format")
 
         d = self._make_request(
             b"GET",
@@ -463,7 +484,9 @@ class Output(cowrie.core.output.Output):
             # Log success message on successful response
             d.addCallback(
                 lambda _: (
-                    log.msg("VT scanurl successful: 200 OK") if _ is not None else None
+                    self._log.info("VT scanurl successful: 200 OK")
+                    if _ is not None
+                    else None
                 )
             )
         return d
@@ -478,14 +501,16 @@ class Output(cowrie.core.output.Output):
 
         def process_response(body_bytes):
             if self.debug:
-                log.msg(f"VT submiturl result: {body_bytes}")
+                self._log.info("VT submiturl result: {body}", body=body_bytes)
             result = body_bytes.decode("utf8")
             j = json.loads(result)
 
             # Check for errors in v3 API response
             if "error" in j:
-                log.msg(
-                    f"VT: URL submission error - {j['error']['code']}: {j['error']['message']}"
+                self._log.info(
+                    "VT: URL submission error - {code}: {msg}",
+                    code=j["error"]["code"],
+                    msg=j["error"]["message"],
                 )
                 return
 
@@ -495,7 +520,7 @@ class Output(cowrie.core.output.Output):
             if "data" in j:
                 data = j["data"]
                 if data.get("id"):
-                    log.msg("VT: URL submitted successfully for scanning")
+                    self._log.info("VT: URL submitted successfully for scanning")
                     url_id = (
                         base64.urlsafe_b64encode(event["url"].encode())
                         .decode()
@@ -506,9 +531,9 @@ class Output(cowrie.core.output.Output):
                     if self.comment:
                         return self._post_comment("urls", url_id, "URL comment")
                 else:
-                    log.msg("VT: URL submission successful but no ID returned")
+                    self._log.info("VT: URL submission successful but no ID returned")
             else:
-                log.msg("VT: unexpected URL submission response format")
+                self._log.info("VT: unexpected URL submission response format")
 
         return self._make_request(
             b"POST",
@@ -539,23 +564,35 @@ class Output(cowrie.core.output.Output):
 
         def process_response(body_bytes):
             if self.debug:
-                log.msg(f"VT post{comment_type.lower()} result: {body_bytes}")
+                self._log.info(
+                    "VT post{comment_type} result: {body}",
+                    comment_type=comment_type.lower(),
+                    body=body_bytes,
+                )
             result = body_bytes.decode("utf8")
             j = json.loads(result)
 
             # Check for errors in v3 API response
             if "error" in j:
-                log.msg(
-                    f"VT: {comment_type} error - {j['error']['code']}: {j['error']['message']}"
+                self._log.info(
+                    "VT: {comment_type} error - {code}: {msg}",
+                    comment_type=comment_type,
+                    code=j["error"]["code"],
+                    msg=j["error"]["message"],
                 )
                 return False
 
             # Process successful comment response
             if "data" in j:
-                log.msg(f"VT: {comment_type} posted successfully")
+                self._log.info(
+                    "VT: {comment_type} posted successfully", comment_type=comment_type
+                )
                 return True
             else:
-                log.msg(f"VT: unexpected {comment_type.lower()} response format")
+                self._log.info(
+                    "VT: unexpected {comment_type} response format",
+                    comment_type=comment_type.lower(),
+                )
                 return False
 
         return self._make_request(
@@ -583,7 +620,7 @@ class Output(cowrie.core.output.Output):
 
         def process_response(body_bytes):
             if self.debug:
-                log.msg(f"VT find collection result: {body_bytes}")
+                self._log.info("VT find collection result: {body}", body=body_bytes)
             j = json.loads(body_bytes.decode("utf8"))
             # The name filter may be loose, so match the name exactly.
             if "error" not in j:
@@ -593,8 +630,10 @@ class Output(cowrie.core.output.Output):
                         "id"
                     ):
                         self.collection_id = item["id"]
-                        log.msg(
-                            f"VT: Using existing collection '{self.collection_name}' with ID: {item['id']}"
+                        self._log.info(
+                            "VT: Using existing collection '{collection}' with ID: {collection_id}",
+                            collection=self.collection_name,
+                            collection_id=item["id"],
                         )
                         return
             # No existing collection found (or the search errored): create it.
@@ -625,13 +664,14 @@ class Output(cowrie.core.output.Output):
 
         def process_response(body_bytes):
             if self.debug:
-                log.msg(f"VT create collection result: {body_bytes}")
+                self._log.info("VT create collection result: {body}", body=body_bytes)
             j = json.loads(body_bytes.decode("utf8"))
 
             if "error" in j:
-                log.msg(
-                    f"VT: Collection creation error - {j['error'].get('code')}: "
-                    f"{j['error'].get('message', 'Unknown error')}"
+                self._log.info(
+                    "VT: Collection creation error - {code}: {msg}",
+                    code=j["error"].get("code"),
+                    msg=j["error"].get("message", "Unknown error"),
                 )
                 return
 
@@ -639,13 +679,15 @@ class Output(cowrie.core.output.Output):
                 collection_id = j["data"].get("id")
                 if collection_id:
                     self.collection_id = collection_id
-                    log.msg(
-                        f"VT: Collection '{self.collection_name}' created with ID: {collection_id}"
+                    self._log.info(
+                        "VT: Collection '{collection}' created with ID: {collection_id}",
+                        collection=self.collection_name,
+                        collection_id=collection_id,
                     )
                 else:
-                    log.msg("VT: Collection created but no ID returned")
+                    self._log.info("VT: Collection created but no ID returned")
             else:
-                log.msg("VT: unexpected collection creation response format")
+                self._log.info("VT: unexpected collection creation response format")
 
         self._make_request(
             b"POST",
@@ -670,8 +712,9 @@ class Output(cowrie.core.output.Output):
         if not self.collection_name or not self.collection_id:
             # Collection not configured or not initialized yet
             if self.debug and self.collection_name:
-                log.msg(
-                    f"VT: Cannot add {resource_descriptor} to collection - collection ID not yet available"
+                self._log.info(
+                    "VT: Cannot add {resource} to collection - collection ID not yet available",
+                    resource=resource_descriptor,
                 )
             return defer.succeed(None)
 
@@ -688,20 +731,24 @@ class Output(cowrie.core.output.Output):
 
         def process_response(body_bytes):
             if self.debug:
-                log.msg(f"VT add to collection result: {body_bytes}")
+                self._log.info("VT add to collection result: {body}", body=body_bytes)
             result = body_bytes.decode("utf8")
             j = json.loads(result)
 
             # Check for errors in v3 API response
             if "error" in j:
-                log.msg(
-                    f"VT: Add to collection error - {j['error']['code']}: {j['error'].get('message', 'Unknown error')}"
+                self._log.info(
+                    "VT: Add to collection error - {code}: {msg}",
+                    code=j["error"]["code"],
+                    msg=j["error"].get("message", "Unknown error"),
                 )
                 return False
 
             # Success
-            log.msg(
-                f"VT: Added {resource_descriptor} to collection '{self.collection_name}'"
+            self._log.info(
+                "VT: Added {resource} to collection '{collection}'",
+                resource=resource_descriptor,
+                collection=self.collection_name,
             )
             return True
 

--- a/src/cowrie/output/xmpp.py
+++ b/src/cowrie/output/xmpp.py
@@ -10,7 +10,7 @@ import string
 from random import choice
 
 from twisted.application import service
-from twisted.python import log
+from twisted.logger import Logger
 from twisted.words.protocols.jabber import jid
 from twisted.words.protocols.jabber.jid import JID
 from wokkel import muc
@@ -22,13 +22,15 @@ from cowrie.core.config import CowrieConfig
 
 
 class XMPPLoggerProtocol(muc.MUCClient):  # type: ignore
+    _log = Logger()
+
     def __init__(self, rooms, server, nick):
         muc.MUCClient.__init__(self)
         self.server = rooms.host
         self.jrooms = rooms
         self._roomOccupantMap = {}
-        log.msg(rooms.user)
-        log.msg(rooms.host)
+        self._log.info("{user}", user=rooms.user)
+        self._log.info("{host}", host=rooms.host)
         self.nick = nick
         self.last = {}
         self.activity = None
@@ -40,16 +42,16 @@ class XMPPLoggerProtocol(muc.MUCClient):  # type: ignore
         self.join(self.jrooms, self.nick)
 
     def joinedRoom(self, room):
-        log.msg(f"Joined room {room.name}")
+        self._log.info("Joined room {room}", room=room.name)
 
     def connectionMade(self):
-        log.msg("Connected!")
+        self._log.info("Connected!")
 
         # send initial presence
         self.send(AvailablePresence())
 
     def connectionLost(self, reason):
-        log.msg("Disconnected!")
+        self._log.info("Disconnected!")
 
     def onMessage(self, msg):
         pass

--- a/src/cowrie/pool_interface/client.py
+++ b/src/cowrie/pool_interface/client.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import struct
 
 from twisted.internet.protocol import ClientFactory, Protocol
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
 
@@ -17,6 +17,8 @@ class PoolClient(Protocol):
     """
     Represents the connection between a protocol instance (SSH or Telnet) and a QEMU pool
     """
+
+    _log = Logger()
 
     def __init__(self, factory):
         self.factory = factory
@@ -60,7 +62,7 @@ class PoolClient(Protocol):
     def dataReceived(self, data):
         # only makes sense to process data if we have a parent to send it to
         if not self.parent:
-            log.err("Parent not set, discarding data from pool")
+            self._log.error("Parent not set, discarding data from pool")
             return
 
         response = struct.unpack("!cI", data[0:5])
@@ -78,9 +80,8 @@ class PoolClient(Protocol):
 
         elif res_op == b"r":
             if res_code != 0:
-                log.msg(
-                    eventid="cowrie.pool_client",
-                    format="Error in pool while requesting guest. Losing connection...",
+                self._log.error(
+                    "Error in pool while requesting guest. Losing connection..."
                 )
                 self.parent.loseConnection()
                 return

--- a/src/cowrie/pool_interface/handler.py
+++ b/src/cowrie/pool_interface/handler.py
@@ -9,7 +9,7 @@ import os
 
 from twisted.internet import reactor
 from twisted.internet.endpoints import TCP4ClientEndpoint
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.pool_interface.client import PoolClientFactory
 
@@ -24,6 +24,8 @@ class PoolHandler:
     successful (initial_pool_connection_success), it issues an initialisation command to the server. Only after this
     command returns (initialisation_response) connections can use the pool.
     """
+
+    _log = Logger()
 
     def __init__(self, pool_host, pool_port, cowrie_plugin):
         # used for initialisation only
@@ -43,14 +45,14 @@ class PoolHandler:
         d.addErrback(self.initial_pool_connection_error)
 
     def initial_pool_connection_success(self, client):
-        log.msg("Initialising pool with Cowrie settings...")
+        self._log.info("Initialising pool with Cowrie settings...")
         # TODO get settings from config and send
 
         client.set_parent(self)
         client.send_initialisation()
 
     def initial_pool_connection_error(self, reason):
-        log.err(f"Could not connect to VM pool: {reason.value}")
+        self._log.error("Could not connect to VM pool: {reason}", reason=reason.value)
         os._exit(1)
 
     def initialisation_response(self, res_code):
@@ -58,11 +60,11 @@ class PoolHandler:
         When the pool's initialisation is successful, signal to the plugin that SSH and Telnet can be started.
         """
         if res_code == 0:
-            log.msg("VM pool fully initialised")
+            self._log.info("VM pool fully initialised")
             self.pool_ready = True
             self.cowrie_plugin.pool_ready()
         else:
-            log.err("VM pool could not initialise correctly!")
+            self._log.error("VM pool could not initialise correctly!")
             os._exit(1)
 
     def request_interface(self, initial_setup=False):

--- a/src/cowrie/python/logfile.py
+++ b/src/cowrie/python/logfile.py
@@ -1,17 +1,44 @@
-# SPDX-FileCopyrightText: 2018-2025 Michel Oosterhof <michel@oosterhof.net>
+# SPDX-FileCopyrightText: 2018-2026 Michel Oosterhof <michel@oosterhof.net>
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
 
 from __future__ import annotations
 
+import sys
 from os import environ
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
-from twisted.logger import textFileLogObserver
-from twisted.python import logfile
+from twisted.logger import (
+    FilteringLogObserver,
+    InvalidLogLevelError,
+    Logger,
+    LogLevel,
+    LogLevelFilterPredicate,
+    textFileLogObserver,
+)
+from twisted.python import context, logfile
+from twisted.python.log import ILogContext
 
 from cowrie.core.config import CowrieConfig
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_log = Logger()
+
+# The [honeypot] option carrying the default diagnostic level, and the
+# prefix for per-namespace overrides (log_level_cowrie.ssh = debug).
+LOG_LEVEL_OPTION = "log_level"
+NAMESPACE_PREFIX = LOG_LEVEL_OPTION + "_"
+ENVIRONMENT_PREFIX = "COWRIE_HONEYPOT_LOG_LEVEL_"
+
+# The console renderer's namespace for attacker-event lines. It gets an
+# explicit info floor so a global log_level = warn quiets diagnostics
+# without silently erasing the attack record from cowrie.log; operators
+# who really want event lines gone set log_level_cowrie.events themselves.
+EVENTS_NAMESPACE = "cowrie.events"
 
 
 class CowrieDailyLogFile(logfile.DailyLogFile):
@@ -30,7 +57,93 @@ class CowrieDailyLogFile(logfile.DailyLogFile):
         raise TypeError
 
 
-def logger():
+def _logLevel(name: str, option: str, fallback: LogLevel) -> LogLevel:
+    try:
+        level: LogLevel = LogLevel.levelWithName(name.strip().lower())
+    except InvalidLogLevelError:
+        _log.warn(
+            "Invalid log level {name!r} for [honeypot] {option}; using {fallback}",
+            name=name,
+            option=option,
+            fallback=fallback.name,
+        )
+        return fallback
+    return level
+
+
+def levelPredicate() -> LogLevelFilterPredicate:
+    """
+    The diagnostic verbosity for the log output, from configuration:
+    [honeypot] log_level sets the default (info unless configured), and
+    log_level_<namespace> options override per subsystem, e.g.
+    ``log_level_cowrie.ssh = debug``. Namespaces are matched by dotted
+    prefix, so a module-level override covers the classes within it.
+    Note that configparser lowercases option names, so overrides work at
+    module granularity (module paths are lowercase); a class-qualified
+    namespace cannot be targeted directly. Environment variables
+    (``COWRIE_HONEYPOT_LOG_LEVEL_<namespace>``) override the same way.
+    """
+    default = _logLevel(
+        CowrieConfig.get("honeypot", LOG_LEVEL_OPTION, fallback="info"),
+        LOG_LEVEL_OPTION,
+        LogLevel.info,
+    )
+    predicate = LogLevelFilterPredicate(defaultLogLevel=default)
+    configured: set[str] = set()
+    for option in CowrieConfig.options("honeypot"):
+        if option.startswith(NAMESPACE_PREFIX):
+            namespace = option[len(NAMESPACE_PREFIX) :]
+            level = _logLevel(CowrieConfig.get("honeypot", option), option, default)
+            predicate.setLogLevelForNamespace(namespace, level)
+            configured.add(namespace)
+    # options() cannot see environment-only keys, so scan them directly;
+    # the environment wins over the file, matching EnvironmentConfigParser.
+    for key, value in environ.items():
+        if key.startswith(ENVIRONMENT_PREFIX):
+            namespace = key[len(ENVIRONMENT_PREFIX) :].lower()
+            level = _logLevel(value, key, default)
+            predicate.setLogLevelForNamespace(namespace, level)
+            configured.add(namespace)
+    if EVENTS_NAMESPACE not in configured:
+        predicate.setLogLevelForNamespace(EVENTS_NAMESPACE, LogLevel.info)
+    return predicate
+
+
+def _observer(outFile: Any) -> Callable[[dict], None]:
+    """
+    The rendering pipeline shared by the file and stdout loggers:
+    stamp the legacy connection prefix, filter by configured level,
+    render classic log text.
+    """
+    # use Z for UTC (Zulu) time, it's shorter.
+    if "TZ" in environ and environ["TZ"] == "UTC":
+        timeFormat = "%Y-%m-%dT%H:%M:%S.%fZ"
+    else:
+        timeFormat = "%Y-%m-%dT%H:%M:%S.%f%z"
+
+    filtered = FilteringLogObserver(
+        textFileLogObserver(outFile, timeFormat=timeFormat),
+        [levelPredicate()],
+    )
+
+    def annotated(event: dict) -> None:
+        # twisted.logger does not read the reactor's ILogContext, so a
+        # Logger line emitted inside a connection's context would render
+        # under its namespace instead of the [HoneyPotSSHTransport,3,ip]
+        # prefix legacy log.msg inherited. Restore that prefix so
+        # diagnostics stay correlatable to a session; lines outside any
+        # connection context keep their namespace#level prefix.
+        # (Levels still filter by namespace either way.)
+        if "log_system" not in event:
+            system = (context.get(ILogContext) or {}).get("system", "-")
+            if system != "-":
+                event = {**event, "log_system": system}
+        filtered(event)
+
+    return annotated
+
+
+def logger() -> Callable[[dict], None]:
     """
     Custom logger that can log in a defined timezone and with custom
     roll over properties
@@ -38,6 +151,7 @@ def logger():
     directory = CowrieConfig.get("honeypot", "log_path", fallback=".")
 
     logtype = CowrieConfig.get("honeypot", "logtype", fallback="plain")
+    cowrielog: Any
     if logtype == "rotating":
         cowrielog = CowrieDailyLogFile("cowrie.log", directory)
     elif logtype == "plain":
@@ -45,10 +159,13 @@ def logger():
     else:
         raise ValueError
 
-    # use Z for UTC (Zulu) time, it's shorter.
-    if "TZ" in environ and environ["TZ"] == "UTC":
-        timeFormat = "%Y-%m-%dT%H:%M:%S.%fZ"
-    else:
-        timeFormat = "%Y-%m-%dT%H:%M:%S.%f%z"
+    return _observer(cowrielog)
 
-    return textFileLogObserver(cowrielog, timeFormat=timeFormat)
+
+def stdoutLogger() -> Callable[[dict], None]:
+    """
+    The same filtered, session-prefixed rendering as ``logger()``, to
+    stdout: used by ``COWRIE_STDOUT=yes`` and the Docker entry point so
+    the log_level configuration applies there too.
+    """
+    return _observer(sys.stdout)

--- a/src/cowrie/scripts/cowrie.py
+++ b/src/cowrie/scripts/cowrie.py
@@ -151,7 +151,9 @@ def cowrie_start(args: list[str]) -> NoReturn:
         twisted_args.extend(["--pidfile", str(pid_file)])
         twisted_args.extend(["--logger", "cowrie.python.logfile.logger"])
     else:
-        twisted_args.extend(["-n", "-l", "-"])
+        # The same filtered, session-prefixed rendering as cowrie.log,
+        # on stdout, so [honeypot] log_level applies in foreground mode.
+        twisted_args.extend(["-n", "--logger", "cowrie.python.logfile.stdoutLogger"])
 
     # Add any additional arguments passed to the script
     twisted_args.extend(args)

--- a/src/cowrie/shell/avatar.py
+++ b/src/cowrie/shell/avatar.py
@@ -11,7 +11,8 @@ from twisted.conch.error import ConchError
 from twisted.conch.interfaces import IConchUser, ISession, ISFTPServer
 from twisted.conch.ssh import filetransfer as conchfiletransfer
 from twisted.conch.ssh.connection import OPEN_UNKNOWN_CHANNEL_TYPE
-from twisted.python import components, log
+from twisted.logger import Logger
+from twisted.python import components
 from zope.interface import implementer
 
 from cowrie.core.config import CowrieConfig
@@ -23,6 +24,8 @@ from cowrie.ssh import session as sshsession
 
 @implementer(IConchUser)
 class CowrieUser(avatar.ConchUser):
+    _log = Logger()
+
     def __init__(self, username: bytes, server: server.CowrieServer) -> None:
         avatar.ConchUser.__init__(self)
         self.username: str = username.decode("utf-8")
@@ -53,7 +56,7 @@ class CowrieUser(avatar.ConchUser):
             )
 
     def logout(self) -> None:
-        log.msg(f"avatar {self.username} logging out")
+        self._log.info("avatar {username} logging out", username=self.username)
 
     def lookupChannel(self, channelType, windowSize, maxPacket, data):
         """

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -15,7 +15,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 from twisted.internet import error
-from twisted.python import failure, log
+from twisted.logger import Logger
+from twisted.python import failure
 
 
 def process_status(code: int) -> failure.Failure:
@@ -33,6 +34,8 @@ class HoneyPotCommand:
     """
     This is the super class for all commands in cowrie/commands
     """
+
+    _log = Logger()
 
     # True once exit() has run. An async callback firing after the command
     # already exited (a download completing after an abort) checks this so a
@@ -171,12 +174,12 @@ class HoneyPotCommand:
                 pass
 
     def handle_CTRL_C(self) -> None:
-        log.msg("Received CTRL-C, exiting..")
+        self._log.info("Received CTRL-C, exiting..")
         self.write("^C\n")
         self.exit(130)  # 128 + SIGINT, like a real shell
 
     def lineReceived(self, line: str) -> None:
-        log.msg(f"QUEUED INPUT: {line}")
+        self._log.info("QUEUED INPUT: {line}", line=line)
         # Queue on the innermost shell, the next stdin reader once this
         # command exits: an outer shell only resumes after the shells above
         # it unwind, so a line queued there would wait on the whole stack.

--- a/src/cowrie/shell/filetransfer.py
+++ b/src/cowrie/shell/filetransfer.py
@@ -26,7 +26,7 @@ from twisted.conch.ssh.filetransfer import (
     FXF_TRUNC,
     FXF_WRITE,
 )
-from twisted.python import log
+from twisted.logger import Logger
 from twisted.python.compat import nativeString
 from zope.interface import implementer
 
@@ -180,6 +180,8 @@ class CowrieSFTPDirectory:
 
 @implementer(ISFTPServer)
 class SFTPServerForCowrieUser:
+    _log = Logger()
+
     def __init__(self, avatar):
         self.avatar = avatar
         self.avatar.server.initFileSystem(self.avatar.home)
@@ -214,39 +216,41 @@ class SFTPServerForCowrieUser:
 
     @translate_fs_errors
     def openFile(self, filename, flags, attrs):
-        log.msg(f"SFTP openFile: {filename}")
+        self._log.info("SFTP openFile: {filename}", filename=filename)
         return CowrieSFTPFile(self, self._absPath(filename), flags, attrs)
 
     @translate_fs_errors
     def removeFile(self, filename):
-        log.msg(f"SFTP removeFile: {filename}")
+        self._log.info("SFTP removeFile: {filename}", filename=filename)
         return self.fs.remove(self._absPath(filename))
 
     @translate_fs_errors
     def renameFile(self, oldpath, newpath):
-        log.msg(f"SFTP renameFile: {oldpath} {newpath}")
+        self._log.info(
+            "SFTP renameFile: {oldpath} {newpath}", oldpath=oldpath, newpath=newpath
+        )
         return self.fs.rename(self._absPath(oldpath), self._absPath(newpath))
 
     @translate_fs_errors
     def makeDirectory(self, path, attrs):
-        log.msg(f"SFTP makeDirectory: {path}")
+        self._log.info("SFTP makeDirectory: {path}", path=path)
         path = self._absPath(path)
         self.fs.mkdir2(path)
         self._setAttrs(path, attrs)
 
     @translate_fs_errors
     def removeDirectory(self, path):
-        log.msg(f"SFTP removeDirectory: {path}")
+        self._log.info("SFTP removeDirectory: {path}", path=path)
         return self.fs.rmdir(self._absPath(path))
 
     @translate_fs_errors
     def openDirectory(self, path):
-        log.msg(f"SFTP OpenDirectory: {path}")
+        self._log.info("SFTP OpenDirectory: {path}", path=path)
         return CowrieSFTPDirectory(self, self._absPath(path))
 
     @translate_fs_errors
     def getAttrs(self, path, followLinks):
-        log.msg(f"SFTP getAttrs: {path}")
+        self._log.info("SFTP getAttrs: {path}", path=path)
         path = self._absPath(path)
         if followLinks:
             s = self.fs.stat(path)
@@ -256,18 +260,22 @@ class SFTPServerForCowrieUser:
 
     @translate_fs_errors
     def setAttrs(self, path, attrs):
-        log.msg(f"SFTP setAttrs: {path}")
+        self._log.info("SFTP setAttrs: {path}", path=path)
         path = self._absPath(path)
         return self._setAttrs(path, attrs)
 
     @translate_fs_errors
     def readLink(self, path):
-        log.msg(f"SFTP readLink: {path}")
+        self._log.info("SFTP readLink: {path}", path=path)
         path = self._absPath(path)
         return self.fs.readlink(path)
 
     def makeLink(self, linkPath, targetPath):
-        log.msg(f"SFTP makeLink: {linkPath} {targetPath}")
+        self._log.info(
+            "SFTP makeLink: {linkPath} {targetPath}",
+            linkPath=linkPath,
+            targetPath=targetPath,
+        )
         linkPath = self._absPath(linkPath)
         targetPath = self._absPath(targetPath)
         return self.fs.symlink(targetPath, linkPath)

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -18,7 +18,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.resources import read_data_bytes
@@ -109,6 +109,8 @@ class PermissionDenied(Exception):
 
 
 class HoneyPotFilesystem:
+    _log = Logger()
+
     # The session's event emitter, bound by the SFTP adapter; file writes
     # reaching close() only arrive through SFTP.
     events: EventLog
@@ -116,8 +118,8 @@ class HoneyPotFilesystem:
     def __init__(self, arch: str, home: str) -> None:
         try:
             self.fs: list[Any] = honeyfs.get_tree()
-        except Exception as e:
-            log.err(e, "ERROR: Failed to load filesystem")
+        except Exception:
+            self._log.failure("ERROR: Failed to load filesystem")
             sys.exit(2)
 
         # Keep track of arch so we can return appropriate binary
@@ -140,7 +142,7 @@ class HoneyPotFilesystem:
             try:
                 self.init_honeyfs(contents_path)
             except Exception as e:
-                log.msg(f"Failed to load honeyfs {e!r}")
+                self._log.info("Failed to load honeyfs {error!r}", error=e)
 
     def init_honeyfs(self, honeyfs_path: str) -> None:
         """

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-from twisted.python import log
+from twisted.logger import Logger
 from twisted.python.compat import iterbytes
 
 from cowrie.core.config import CowrieConfig
@@ -73,6 +73,8 @@ class _Continuation:
 
 
 class HoneyPotShell:
+    _log = Logger()
+
     def __init__(
         self,
         protocol: Any,
@@ -667,9 +669,9 @@ class HoneyPotShell:
                 cmd["command"], environ.get("PATH", "").split(":")
             )
             if cmdclass:
-                log.msg(
+                self._log.info(
+                    "Command found: {input}",
                     input=cmd["command"] + " " + " ".join(cmd["rargs"]),
-                    format="Command found: %(input)s",
                 )
                 if index == len(cmd_array) - 1:
                     lastpp = PipeProtocol(
@@ -792,7 +794,7 @@ class HoneyPotShell:
         """
         EOF with the shell as the active reader (no command running) logs out.
         """
-        log.msg("received eof, logging out")
+        self._log.info("received eof, logging out")
         self.protocol.terminal.transport.processEnded(process_status(0))
 
     def handle_CTRL_C(self) -> None:

--- a/src/cowrie/shell/pipe.py
+++ b/src/cowrie/shell/pipe.py
@@ -11,12 +11,15 @@ import os
 import re
 import stat
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from twisted.python import failure, log
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
 from cowrie.shell import fs
+
+if TYPE_CHECKING:
+    from twisted.python import failure
 
 # FD target type constants
 FD_STDIN = "stdin"
@@ -34,6 +37,8 @@ MAX_OPEN_FILES = 1024
 
 
 class PipeProtocol:
+    _log = Logger()
+
     def __init__(
         self,
         protocol: Any,
@@ -261,7 +266,11 @@ class PipeProtocol:
                 self.protocol.fs.update_size(outfile, 0)
                 start_size = 0
             except OSError as e:
-                log.msg(f"Failed to truncate redirect target {safeoutfile}: {e}")
+                self._log.info(
+                    "Failed to truncate redirect target {outfile}: {error}",
+                    outfile=safeoutfile,
+                    error=e,
+                )
                 return None
         return safeoutfile, start_size
 
@@ -271,7 +280,7 @@ class PipeProtocol:
         try:
             self.protocol.terminal.write(message.encode("utf8"))
         except Exception:
-            log.msg(message)
+            self._log.info("{msg}", msg=message)
 
     def connectionMade(self) -> None:
         if self.input_data is None:
@@ -313,10 +322,18 @@ class PipeProtocol:
         pass
 
     def processExited(self, reason: failure.Failure) -> None:
-        log.msg(f"processExited for {self.cmd}, status {reason.value.exitCode}")
+        self._log.info(
+            "processExited for {cmd}, status {status}",
+            cmd=self.cmd,
+            status=reason.value.exitCode,
+        )
 
     def processEnded(self, reason: failure.Failure) -> None:
-        log.msg(f"processEnded for {self.cmd}, status {reason.value.exitCode}")
+        self._log.info(
+            "processEnded for {cmd}, status {status}",
+            cmd=self.cmd,
+            status=reason.value.exitCode,
+        )
 
     def _pipe_to_next(self, data: bytes) -> bool:
         """
@@ -334,7 +351,7 @@ class PipeProtocol:
         if self.protocol is not None and self.protocol.terminal is not None:
             self.protocol.terminal.write(data)
         else:
-            log.msg("Connection was probably lost. Could not write to terminal")
+            self._log.info("Connection was probably lost. Could not write to terminal")
 
     def write_stdout(self, data: bytes) -> None:
         self._write_to_fd(1, data)
@@ -370,7 +387,7 @@ class PipeProtocol:
             with open(real_path, "ab") as f:
                 f.write(data)
         except OSError as e:
-            log.msg(f"Failed to write redirected output: {e}")
+            self._log.info("Failed to write redirected output: {error}", error=e)
             return
 
         if is_stdout:

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -6,9 +6,7 @@
 from __future__ import annotations
 
 import socket
-import sys
 import time
-import traceback
 from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
@@ -16,8 +14,8 @@ from typing import TYPE_CHECKING, ClassVar
 from twisted.conch import recvline
 from twisted.conch.insults import insults
 from twisted.internet.protocol import connectionDone
+from twisted.logger import Logger
 from twisted.protocols.policies import TimeoutMixin
-from twisted.python import failure, log
 
 import cowrie.commands
 from cowrie.core.config import CowrieConfig
@@ -25,6 +23,8 @@ from cowrie.core.resources import read_data_bytes
 from cowrie.shell import command, honeypot
 
 if TYPE_CHECKING:
+    from twisted.python import failure
+
     from cowrie.core.events import EventLog
 
 
@@ -32,6 +32,8 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
     """
     Base protocol for interactive and non-interactive use
     """
+
+    _log = Logger()
 
     # The session's event emitter, set from the transport in connectionMade.
     events: EventLog
@@ -41,17 +43,8 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         try:
             module = import_module(f"cowrie.commands.{c}")
             commands.update(module.commands)
-        except ImportError as e:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            log.err(
-                "Failed to import command {}: {}: {}".format(
-                    c,
-                    e,
-                    "".join(
-                        traceback.format_exception(exc_type, exc_value, exc_traceback)
-                    ),
-                )
-            )
+        except ImportError:
+            _log.failure("Failed to import command {cmd}", cmd=c)
 
     def __init__(self, avatar):
         self.user = avatar
@@ -233,7 +226,7 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         if self.fs.isfile(path):
             return self.scriptcmd(path)
 
-        log.msg(f"Can't find command {cmd}")
+        self._log.info("Can't find command {cmd}", cmd=cmd)
         return None
 
     def lineReceived(self, line: bytes) -> None:
@@ -247,7 +240,7 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         if self.cmdstack:
             self.cmdstack[-1].lineReceived(string)
         else:
-            log.msg(f"discarding input {string}")
+            self._log.info("discarding input {input}", input=string)
             stat = command.process_status(0)
             self.terminal.transport.processEnded(stat)
 
@@ -306,6 +299,8 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
 
 
 class HoneyPotExecProtocol(HoneyPotBaseProtocol):
+    _log = Logger()
+
     # input_data is static buffer for stdin received from remote client
     input_data = b""
 
@@ -318,7 +313,7 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
         try:
             self.execcmd = execcmd.decode("utf8")
         except UnicodeDecodeError:
-            log.err(f"Unusual execcmd: {execcmd!r}")
+            self._log.error("Unusual execcmd: {execcmd!r}", execcmd=execcmd)
 
         HoneyPotBaseProtocol.__init__(self, avatar)
 

--- a/src/cowrie/shell/pwd.py
+++ b/src/cowrie/shell/pwd.py
@@ -10,7 +10,7 @@ from binascii import crc32
 from random import randint, seed
 from typing import Any
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.shell.honeyfs import read_honeyfs_bytes
 
@@ -21,6 +21,8 @@ class Passwd:
     /etc/passwd. Note that contrary to the name, it does not handle any
     passwords.
     """
+
+    _log = Logger()
 
     passwd: list[dict[str, Any]]
 
@@ -34,8 +36,8 @@ class Passwd:
         """
         try:
             raw = read_honeyfs_bytes("etc/passwd").decode("ascii")
-        except Exception as err:
-            log.err(err, "ERROR: Failed to load /etc/passwd")
+        except Exception:
+            self._log.failure("ERROR: Failed to load /etc/passwd")
             sys.exit(2)
 
         for rawline in raw.splitlines():
@@ -47,7 +49,9 @@ class Passwd:
                 continue
 
             if len(line.split(":")) != 7:
-                log.msg("Error parsing line `" + line + "` in <honeyfs>/etc/passwd")
+                self._log.info(
+                    "Error parsing line `{line}` in <honeyfs>/etc/passwd", line=line
+                )
                 continue
 
             (
@@ -132,6 +136,8 @@ class Group:
     /etc/group.
     """
 
+    _log = Logger()
+
     group: list[dict[str, Any]]
 
     def __init__(self) -> None:
@@ -144,8 +150,8 @@ class Group:
         """
         try:
             raw = read_honeyfs_bytes("etc/group").decode("ascii")
-        except Exception as err:
-            log.err(err, "ERROR: Failed to load /etc/group")
+        except Exception:
+            self._log.failure("ERROR: Failed to load /etc/group")
             sys.exit(2)
 
         for rawline in raw.splitlines():

--- a/src/cowrie/shell/server.py
+++ b/src/cowrie/shell/server.py
@@ -10,7 +10,7 @@ import json
 import random
 from typing import TYPE_CHECKING
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.resources import open_data_binary
@@ -30,6 +30,8 @@ class CowrieServer:
     multiple Cowrie connections
     """
 
+    _log = Logger()
+
     def __init__(self, realm: IRealm) -> None:
         self.fs: fs.HoneyPotFilesystem | None = None
         self.process = None
@@ -45,7 +47,9 @@ class CowrieServer:
         except configparser.Error:
             self.arch = "linux-x64-lsb"
 
-        log.msg(f"Initialized emulated server as architecture: {self.arch}")
+        self._log.info(
+            "Initialized emulated server as architecture: {arch}", arch=self.arch
+        )
 
     def initFileSystem(self, home: str) -> None:
         """
@@ -63,5 +67,5 @@ class CowrieServer:
                     cmdoutput = json.load(f)
             self.process = cmdoutput["command"]["ps"]
         except (FileNotFoundError, KeyError, json.JSONDecodeError) as e:
-            log.msg(f"Could not load process list {e!r}")
+            self._log.info("Could not load process list {error!r}", error=e)
             self.process = None

--- a/src/cowrie/ssh/channel.py
+++ b/src/cowrie/ssh/channel.py
@@ -13,7 +13,7 @@ import time
 from typing import TYPE_CHECKING
 
 from twisted.conch.ssh import channel
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core import ttylog
 from cowrie.core.config import CowrieConfig
@@ -33,6 +33,7 @@ class CowrieSSHChannel(channel.SSHChannel):
     insults.LoggingServerProtocol records.
     """
 
+    _log = Logger()
     ttylogFile: str = ""
     bytesReceived: int = 0
     bytesWritten: int = 0
@@ -99,7 +100,10 @@ class CowrieSSHChannel(channel.SSHChannel):
         """
         self.bytesReceived += len(data)
         if self.bytesReceivedLimit and self.bytesReceived > self.bytesReceivedLimit:
-            log.msg(f"Data upload limit reached for channel {self.id}")
+            self._log.info(
+                "Data upload limit reached for channel {channel_id}",
+                channel_id=self.id,
+            )
             self.eofReceived()
             return
 

--- a/src/cowrie/ssh/connection.py
+++ b/src/cowrie/ssh/connection.py
@@ -13,6 +13,7 @@ import struct
 
 from twisted.conch.ssh import common, connection
 from twisted.internet import defer
+from twisted.logger import Logger
 from twisted.python import log
 
 
@@ -21,6 +22,8 @@ class CowrieSSHConnection(connection.SSHConnection):
     Subclass this for a workaround for the Granados SSH library.
     Channel request for openshell needs to return success immediatly
     """
+
+    _log = Logger()
 
     def ssh_CHANNEL_REQUEST(self, packet):
         localChannel = struct.unpack(">L", packet[:4])[0]
@@ -51,13 +54,19 @@ class CowrieSSHConnection(connection.SSHConnection):
     def ssh_CHANNEL_EOF(self, packet):
         localChannel = struct.unpack(">L", packet[:4])[0]
         if localChannel not in self.channels:
-            log.msg(f"Ignoring CHANNEL_EOF for unknown channel {localChannel}")
+            self._log.info(
+                "Ignoring CHANNEL_EOF for unknown channel {channel_id}",
+                channel_id=localChannel,
+            )
             return
         connection.SSHConnection.ssh_CHANNEL_EOF(self, packet)
 
     def ssh_CHANNEL_CLOSE(self, packet):
         localChannel = struct.unpack(">L", packet[:4])[0]
         if localChannel not in self.channels:
-            log.msg(f"Ignoring CHANNEL_CLOSE for unknown channel {localChannel}")
+            self._log.info(
+                "Ignoring CHANNEL_CLOSE for unknown channel {channel_id}",
+                channel_id=localChannel,
+            )
             return
         connection.SSHConnection.ssh_CHANNEL_CLOSE(self, packet)

--- a/src/cowrie/ssh/factory.py
+++ b/src/cowrie/ssh/factory.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 
 from twisted.conch.openssh_compat import primes
 from twisted.conch.ssh import factory, keys, transport
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
 from cowrie.ssh import connection
@@ -35,6 +35,7 @@ class CowrieSSHFactory(factory.SSHFactory):
     They listen directly to the TCP port
     """
 
+    _log = Logger()
     starttime: float | None = None
     privateKeys: dict[bytes, bytes]
     publicKeys: dict[bytes, bytes]
@@ -100,7 +101,7 @@ class CowrieSSHFactory(factory.SSHFactory):
         ).encode("ascii")
 
         factory.SSHFactory.startFactory(self)
-        log.msg("Ready to accept SSH connections")
+        self._log.info("Ready to accept SSH connections")
 
     def stopFactory(self) -> None:
         factory.SSHFactory.stopFactory(self)
@@ -128,10 +129,10 @@ class CowrieSSHFactory(factory.SSHFactory):
             ske = t.supportedKeyExchanges[:]
             if b"diffie-hellman-group-exchange-sha1" in ske:
                 ske.remove(b"diffie-hellman-group-exchange-sha1")
-                log.msg("No moduli, no diffie-hellman-group-exchange-sha1")
+                self._log.info("No moduli, no diffie-hellman-group-exchange-sha1")
             if b"diffie-hellman-group-exchange-sha256" in ske:
                 ske.remove(b"diffie-hellman-group-exchange-sha256")
-                log.msg("No moduli, no diffie-hellman-group-exchange-sha256")
+                self._log.info("No moduli, no diffie-hellman-group-exchange-sha256")
             t.supportedKeyExchanges = ske
 
         try:

--- a/src/cowrie/ssh/forwarding.py
+++ b/src/cowrie/ssh/forwarding.py
@@ -9,7 +9,7 @@ This module contains code for handling SSH direct-tcpip connection requests
 from __future__ import annotations
 
 from twisted.conch.ssh import forwarding
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.fingerprint import (
@@ -122,6 +122,7 @@ class FakeForwardingChannel(forwarding.SSHConnectForwardingChannel):
     This channel does not forward, but just logs requests.
     """
 
+    _log = Logger()
     name = b"cowrie-discarded-direct-tcpip"
 
     def channelOpen(self, specificData: bytes) -> None:
@@ -153,7 +154,7 @@ class FakeForwardingChannel(forwarding.SSHConnectForwardingChannel):
                             ja4=ja4,
                         )
                 except Exception as e:
-                    log.msg(f"Error generating JA4 fingerprint: {e}")
+                    self._log.info("Error generating JA4 fingerprint: {error}", error=e)
 
         # Check for HTTP request
         elif (
@@ -181,7 +182,9 @@ class FakeForwardingChannel(forwarding.SSHConnectForwardingChannel):
                             ja4h=ja4h,
                         )
                 except Exception as e:
-                    log.msg(f"Error generating JA4H fingerprint: {e}")
+                    self._log.info(
+                        "Error generating JA4H fingerprint: {error}", error=e
+                    )
 
         if events:
             events.dispatch(
@@ -200,6 +203,7 @@ class TCPTunnelForwardingChannel(forwarding.SSHConnectForwardingChannel):
     This class modifies the original to perform TCP tunneling via the CONNECT method
     """
 
+    _log = Logger()
     name = b"cowrie-tunneled-direct-tcpip"
 
     def __init__(self, hostport, dstport, *args, **kw):
@@ -245,7 +249,9 @@ class TCPTunnelForwardingChannel(forwarding.SSHConnectForwardingChannel):
                             ja4=ja4,
                         )
                 except Exception as e:
-                    log.msg(f"Error generating JA4 fingerprint in tunnel: {e}")
+                    self._log.info(
+                        "Error generating JA4 fingerprint in tunnel: {error}", error=e
+                    )
 
         # Check for HTTP request
         elif (
@@ -273,7 +279,9 @@ class TCPTunnelForwardingChannel(forwarding.SSHConnectForwardingChannel):
                             ja4h=ja4h,
                         )
                 except Exception as e:
-                    log.msg(f"Error generating JA4H fingerprint in tunnel: {e}")
+                    self._log.info(
+                        "Error generating JA4H fingerprint in tunnel: {error}", error=e
+                    )
 
         if events:
             events.dispatch(
@@ -292,11 +300,11 @@ class TCPTunnelForwardingChannel(forwarding.SSHConnectForwardingChannel):
             try:
                 res_code = int(data.split(b" ")[1], 10)
             except ValueError:
-                log.err("Failed to parse TCP tunnel response code")
+                self._log.error("Failed to parse TCP tunnel response code")
                 self._close("Connection refused")
                 return
             if res_code != 200:
-                log.err(f"Unexpected response code: {res_code}")
+                self._log.error("Unexpected response code: {code}", code=res_code)
                 self._close("Connection refused")
             # Strip off rest of packet
             eop = data.find(b"\r\n\r\n")

--- a/src/cowrie/ssh/session.py
+++ b/src/cowrie/ssh/session.py
@@ -13,13 +13,15 @@ from typing import Literal
 
 from twisted.conch.ssh import session
 from twisted.conch.ssh.common import getNS
-from twisted.python import log
+from twisted.logger import Logger
 
 
 class HoneyPotSSHSession(session.SSHSession):
     """
     This is an SSH channel that's used for SSH sessions
     """
+
+    _log = Logger()
 
     def __init__(self, *args, **kw):
         session.SSHSession.__init__(self, *args, **kw)
@@ -29,7 +31,7 @@ class HoneyPotSSHSession(session.SSHSession):
         value, rest = getNS(rest)
 
         if rest:
-            log.msg(f"Extra data in request_env: {rest!r}")
+            self._log.info("Extra data in request_env: {rest!r}", rest=rest)
             return 1
 
         self.conn.transport.events.dispatch(
@@ -44,11 +46,11 @@ class HoneyPotSSHSession(session.SSHSession):
         return 0
 
     def request_agent(self, data: bytes) -> int:
-        log.msg(f"request_agent: {data!r}")
+        self._log.info("request_agent: {data!r}", data=data)
         return 0
 
     def request_x11_req(self, data: bytes) -> int:
-        log.msg(f"request_x11: {data!r}")
+        self._log.info("request_x11: {data!r}", data=data)
         return 0
 
     def closed(self) -> None:
@@ -80,4 +82,4 @@ class HoneyPotSSHSession(session.SSHSession):
         self.conn.sendClose(self)
 
     def channelClosed(self) -> None:
-        log.msg("Called channelClosed in SSHSession")
+        self._log.info("Called channelClosed in SSHSession")

--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -22,8 +22,9 @@ from typing import Any
 from twisted.conch.ssh import transport
 from twisted.conch.ssh.common import getNS
 from twisted.internet.protocol import connectionDone
+from twisted.logger import Logger
 from twisted.protocols.policies import TimeoutMixin
-from twisted.python import failure, log, randbytes
+from twisted.python import failure, randbytes
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.events import EventLog, transport_events
@@ -31,6 +32,7 @@ from cowrie.core.utils import escape_nonprintable
 
 
 class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
+    _log = Logger()
     startTime: float = 0.0
     gotVersion: bool = False
     buf: bytes
@@ -100,7 +102,7 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         # completes drives the base sendKexInit into raising a RuntimeError.
         # Disconnect such a protocol violation cleanly instead.
         if self._keyExchangeState != self._KEY_EXCHANGE_NONE:
-            log.msg("Duplicate KEXINIT during key exchange, disconnecting")
+            self._log.info("Duplicate KEXINIT during key exchange, disconnecting")
             self.transport.loseConnection()
             return
         transport.SSHServerTransport.sendKexInit(self)
@@ -133,8 +135,9 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
                 )
             m = re.match(rb"SSH-(\d+\.\d+)-(.*)", self.otherVersionString)
             if m is None:
-                log.msg(
-                    f"Bad protocol version identification: {self.otherVersionString!r}"
+                self._log.info(
+                    "Bad protocol version identification: {version!r}",
+                    version=self.otherVersionString,
                 )
                 # OpenSSH sending the same message
                 self.transport.write(b"Invalid SSH identification string.\n")
@@ -251,7 +254,7 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         Make sure all sessions time out eventually.
         Timeout is reset when authentication succeeds.
         """
-        log.msg("Timeout reached in HoneyPotSSHTransport")
+        self._log.info("Timeout reached in HoneyPotSSHTransport")
         self.transport.loseConnection()
 
     def setService(self, service):
@@ -300,8 +303,10 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         else:
             # this message is used to detect Cowrie behaviour
             # self.transport.write(b"Packet corrupt\n")
-            log.msg(
-                f"[SERVER] - Disconnecting with error, code {reason} reason: {desc}"
+            self._log.info(
+                "[SERVER] - Disconnecting with error, code {code} reason: {desc}",
+                code=reason,
+                desc=desc,
             )
             self.transport.loseConnection()
 
@@ -316,4 +321,8 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
                             disconnection.
         @type description: L{str}
         """
-        log.msg(f"Got remote error, code {reasonCode} reason: {description}")
+        self._log.info(
+            "Got remote error, code {code} reason: {description}",
+            code=reasonCode,
+            description=description,
+        )

--- a/src/cowrie/ssh/userauth.py
+++ b/src/cowrie/ssh/userauth.py
@@ -15,7 +15,7 @@ from twisted.conch.ssh import userauth
 from twisted.conch.ssh.common import NS, getNS
 from twisted.conch.ssh.transport import DISCONNECT_PROTOCOL_ERROR
 from twisted.internet import defer
-from twisted.python import log
+from twisted.logger import Logger
 from twisted.python.failure import Failure
 
 from cowrie.core import credentials
@@ -46,6 +46,7 @@ class HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer):
     * IP based authentication
     """
 
+    _log = Logger()
     bannerSent: bool = False
     user: bytes
     _pamDeferred: defer.Deferred | None
@@ -77,8 +78,8 @@ class HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer):
             banner = read_honeyfs_bytes("etc/issue.net").decode(
                 "utf-8", errors="replace"
             )
-        except FileNotFoundError as e:
-            log.err(e, "ERROR: Failed to load /etc/issue.net")
+        except FileNotFoundError:
+            self._log.failure("ERROR: Failed to load /etc/issue.net")
             return
 
         if not banner or not banner.strip():
@@ -223,7 +224,11 @@ class HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer):
                 response, packet = getNS(packet)
                 resp.append((response, 0))
             if packet:
-                log.msg(f"PAM Response: {len(packet):d} extra bytes: {packet!r}")
+                self._log.info(
+                    "PAM Response: {extra:d} extra bytes: {packet!r}",
+                    extra=len(packet),
+                    packet=packet,
+                )
         except Exception as e:
             d.errback(Failure(e))
         else:

--- a/src/cowrie/ssh_proxy/client_transport.py
+++ b/src/cowrie/ssh_proxy/client_transport.py
@@ -9,8 +9,8 @@ from typing import Any
 
 from twisted.conch.ssh import transport
 from twisted.internet import defer, protocol
+from twisted.logger import Logger
 from twisted.protocols.policies import TimeoutMixin
-from twisted.python import log
 
 from cowrie.core.config import CowrieConfig
 from cowrie.ssh_proxy.util import bin_string_to_hex, string_to_hex
@@ -43,6 +43,8 @@ class BackendSSHTransport(transport.SSHClientTransport, TimeoutMixin):
     authentication to that server, and sending messages it gets to the handler.
     """
 
+    _log = Logger()
+
     def __init__(self, factory: BackendSSHFactory):
         self.delayedPackets: list[tuple[int, bytes]] = []
         self.factory: BackendSSHFactory = factory
@@ -54,7 +56,9 @@ class BackendSSHTransport(transport.SSHClientTransport, TimeoutMixin):
         self.frontendTriedPassword = None
 
     def connectionMade(self):
-        log.msg(f"Connected to SSH backend at {self.transport.getPeer().host}")
+        self._log.info(
+            "Connected to SSH backend at {host}", host=self.transport.getPeer().host
+        )
         self.factory.server.client = self
         self.factory.server.sshParse.set_client(self)
         transport.SSHClientTransport.connectionMade(self)
@@ -63,7 +67,7 @@ class BackendSSHTransport(transport.SSHClientTransport, TimeoutMixin):
         return defer.succeed(True)
 
     def connectionSecure(self):
-        log.msg("Backend Connection Secured")
+        self._log.info("Backend Connection Secured")
         self.canAuth = True
         self.authenticateBackend()
 
@@ -88,7 +92,11 @@ class BackendSSHTransport(transport.SSHClientTransport, TimeoutMixin):
         # so these credentials from the config may not be needed after all
         username = CowrieConfig.get("proxy", "backend_user")
         password = CowrieConfig.get("proxy", "backend_pass")
-        log.msg(f"Will auth with backend: {username}/{password}")
+        self._log.info(
+            "Will auth with backend: {username}/{password}",
+            username=username,
+            password=password,
+        )
 
         self.sendPacket(5, bin_string_to_hex(b"ssh-userauth"))
         payload = (
@@ -140,7 +148,7 @@ class BackendSSHTransport(transport.SSHClientTransport, TimeoutMixin):
         Make sure all sessions time out eventually.
         Timeout is reset when authentication succeeds.
         """
-        log.msg("Timeout reached in BackendSSHTransport")
+        self._log.info("Timeout reached in BackendSSHTransport")
         self.transport.loseConnection()
         self.factory.server.transport.loseConnection()
 
@@ -156,7 +164,7 @@ class BackendSSHTransport(transport.SSHClientTransport, TimeoutMixin):
             if message == b"exit-status":
                 pointer += leng + 1  # also boolean ignored
                 exit_status = get_int(payload[pointer:])
-                log.msg(f"exitCode: {exit_status}")
+                self._log.debug("exitCode: {exit_status}", exit_status=exit_status)
 
         if transport.SSHClientTransport.isEncrypted(self, "both"):
             self.packet_buffer(messageNum, payload)
@@ -170,7 +178,9 @@ class BackendSSHTransport(transport.SSHClientTransport, TimeoutMixin):
         """
         if not self.factory.server.frontendAuthenticated:
             # wait till frontend connects and authenticates to send packets to them
-            log.msg("Connection to client not ready, buffering packet from backend")
+            self._log.debug(
+                "Connection to client not ready, buffering packet from backend"
+            )
             self.delayedPackets.append((message_num, payload))
         else:
             if len(self.delayedPackets) > 0:

--- a/src/cowrie/ssh_proxy/protocols/exec_term.py
+++ b/src/cowrie/ssh_proxy/protocols/exec_term.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import os
 import time
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core import ttylog
 from cowrie.core.config import CowrieConfig
@@ -17,6 +17,8 @@ from cowrie.ssh_proxy.protocols import base_protocol
 
 
 class ExecTerm(base_protocol.BaseProtocol):
+    _log = Logger()
+
     def __init__(self, uuid, channelName, ssh, channelId, command):
         super().__init__(uuid, channelName, ssh)
 
@@ -29,7 +31,7 @@ class ExecTerm(base_protocol.BaseProtocol):
                     input=command.decode("utf8"),
                 )
         except UnicodeDecodeError:
-            log.err(f"Unusual execcmd: {command!r}")
+            self._log.error("Unusual execcmd: {command!r}", command=command)
 
         self.transportId = ssh.server.transportId
         self.channelId = channelId

--- a/src/cowrie/ssh_proxy/protocols/port_forward.py
+++ b/src/cowrie/ssh_proxy/protocols/port_forward.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core.fingerprint import (
     generate_ja4,
@@ -20,6 +20,8 @@ from cowrie.ssh_proxy.protocols import base_protocol
 
 
 class PortForward(base_protocol.BaseProtocol):
+    _log = Logger()
+
     def __init__(self, uuid, chan_name, ssh):
         super().__init__(uuid, chan_name, ssh)
         self.events = ssh.server.events
@@ -50,7 +52,10 @@ class PortForward(base_protocol.BaseProtocol):
                             ja4=ja4,
                         )
                 except Exception as e:
-                    log.msg(f"Error generating JA4 fingerprint in SSH proxy: {e}")
+                    self._log.info(
+                        "Error generating JA4 fingerprint in SSH proxy: {error}",
+                        error=e,
+                    )
 
         # Check for HTTP request
         elif (
@@ -76,4 +81,7 @@ class PortForward(base_protocol.BaseProtocol):
                             ja4h=ja4h,
                         )
                 except Exception as e:
-                    log.msg(f"Error generating JA4H fingerprint in SSH proxy: {e}")
+                    self._log.info(
+                        "Error generating JA4H fingerprint in SSH proxy: {error}",
+                        error=e,
+                    )

--- a/src/cowrie/ssh_proxy/protocols/sftp.py
+++ b/src/cowrie/ssh_proxy/protocols/sftp.py
@@ -10,7 +10,7 @@ import hashlib
 import os
 
 from twisted.conch.ssh import filetransfer
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.utils import escape_nonprintable
@@ -54,6 +54,7 @@ from cowrie.ssh_proxy.protocols import base_protocol
 
 
 class SFTP(base_protocol.BaseProtocol):
+    _log = Logger()
     prevID: int = 0
     ID: int = 0
     handle: bytes = b""
@@ -128,8 +129,10 @@ class SFTP(base_protocol.BaseProtocol):
         elif sftp_num == filetransfer.FXP_REALPATH:
             self.path = self.extract_string()
             self.command = b"cd " + self.path
-            log.msg(
-                parent + "[SFTP] Entered Command: " + escape_nonprintable(self.command)
+            self._log.info(
+                "{parent}[SFTP] Entered Command: {command}",
+                parent=parent,
+                command=escape_nonprintable(self.command),
             )
 
         elif sftp_num == filetransfer.FXP_OPEN:
@@ -143,13 +146,19 @@ class SFTP(base_protocol.BaseProtocol):
             elif pflags[7] == "1":
                 self.command = b"get " + self.path
             else:
-                # Unknown PFlag
-                log.msg(
-                    parent + f"[SFTP] New SFTP pflag detected: {pflags!r} {self.data!r}"
+                # Unknown PFlag: novel attacker behaviour, keep visible
+                # at the default log level.
+                self._log.info(
+                    "{parent}[SFTP] New SFTP pflag detected: {pflags!r} {data!r}",
+                    parent=parent,
+                    pflags=pflags,
+                    data=self.data,
                 )
 
-            log.msg(
-                parent + " [SFTP] Entered Command: " + escape_nonprintable(self.command)
+            self._log.info(
+                "{parent} [SFTP] Entered Command: {command}",
+                parent=parent,
+                command=escape_nonprintable(self.command),
             )
 
         elif sftp_num == filetransfer.FXP_READ:
@@ -183,31 +192,36 @@ class SFTP(base_protocol.BaseProtocol):
             elif cmd == b"posix-rename@openssh.com":
                 self.command = b"mv " + self.path + b" " + self.extract_string()
             else:
-                # UNKNOWN COMMAND
-                log.msg(
-                    parent
-                    + f"[SFTP] New SFTP Extended Command detected: {cmd!r} {self.data!r}"
+                # UNKNOWN COMMAND: novel attacker behaviour, keep visible
+                # at the default log level.
+                self._log.info(
+                    "{parent}[SFTP] New SFTP Extended Command detected: {cmd!r} {data!r}",
+                    parent=parent,
+                    cmd=cmd,
+                    data=self.data,
                 )
 
         elif sftp_num == filetransfer.FXP_EXTENDED_REPLY:
-            log.msg(
-                parent + " [SFTP] Entered Command: " + escape_nonprintable(self.command)
+            self._log.info(
+                "{parent} [SFTP] Entered Command: {command}",
+                parent=parent,
+                command=escape_nonprintable(self.command),
             )
             # self.out.command_entered(self.uuid, self.command)
 
         elif sftp_num == filetransfer.FXP_CLOSE:
             if self.handle == self.extract_string():
                 if b"get" in self.command:
-                    log.msg(
-                        parent
-                        + " [SFTP] Finished Downloading: "
-                        + escape_nonprintable(self.path)
+                    self._log.info(
+                        "{parent} [SFTP] Finished Downloading: {path}",
+                        parent=parent,
+                        path=escape_nonprintable(self.path),
                     )
                 elif b"put" in self.command:
-                    log.msg(
-                        parent
-                        + " [SFTP] Finished Uploading: "
-                        + escape_nonprintable(self.path)
+                    self._log.info(
+                        "{parent} [SFTP] Finished Uploading: {path}",
+                        parent=parent,
+                        path=escape_nonprintable(self.path),
                     )
 
                     # TODO: should use artifact functions
@@ -261,22 +275,21 @@ class SFTP(base_protocol.BaseProtocol):
                 code = self.extract_int(4)
                 if code in [0, 1]:
                     if b"get" not in self.command and b"put" not in self.command:
-                        log.msg(
-                            parent
-                            + " [SFTP] Entered Command: "
-                            + escape_nonprintable(self.command)
+                        self._log.info(
+                            "{parent} [SFTP] Entered Command: {command}",
+                            parent=parent,
+                            command=escape_nonprintable(self.command),
                         )
                 else:
-                    message = self.extract_string()
-                    log.msg(
-                        parent
-                        + " [SFTP] Failed Command: "
-                        + escape_nonprintable(self.command)
-                        + " Reason: "
-                        + escape_nonprintable(message)
+                    reason = self.extract_string()
+                    self._log.info(
+                        "{parent} [SFTP] Failed Command: {command} Reason: {reason}",
+                        parent=parent,
+                        command=escape_nonprintable(self.command),
+                        reason=escape_nonprintable(reason),
                     )
         else:
-            log.msg("[SFTP] Unhandled packet: {sftp_num}")
+            self._log.debug("[SFTP] Unhandled packet: {sftp_num}", sftp_num=sftp_num)
 
     def extract_attrs(self) -> bytes:
         cmd: str = ""

--- a/src/cowrie/ssh_proxy/protocols/ssh.py
+++ b/src/cowrie/ssh_proxy/protocols/ssh.py
@@ -10,7 +10,7 @@ import uuid
 from typing import Any
 
 from twisted.conch.ssh import connection, transport, userauth
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.utils import escape_nonprintable
@@ -70,6 +70,8 @@ PACKETLAYOUT = (
 
 
 class SSH(base_protocol.BaseProtocol):
+    _log = Logger()
+
     def __init__(self, server):
         super().__init__()
 
@@ -118,8 +120,10 @@ class SSH(base_protocol.BaseProtocol):
         elif message_num == transport.MSG_EXT_INFO:
             extensioncount: int = self.extract_int(4)
             for _ in range(extensioncount):
-                log.msg(
-                    f"SSH_MSG_EXT_INFO: {self.extract_string()!r}={self.extract_string()!r}"
+                self._log.debug(
+                    "SSH_MSG_EXT_INFO: {name!r}={value!r}",
+                    name=self.extract_string(),
+                    value=self.extract_string(),
                 )
             self.sendOn = False
 
@@ -144,7 +148,7 @@ class SSH(base_protocol.BaseProtocol):
             auth_list = self.extract_string()
 
             if b"publickey" in auth_list:
-                log.msg("[SSH] Detected Public Key Auth - Disabling!")
+                self._log.info("[SSH] Detected Public Key Auth - Disabling!")
                 payload = string_to_hex("password") + chr(0).encode()
                 # self.server.sendPacket(51, payload)
 
@@ -179,7 +183,9 @@ class SSH(base_protocol.BaseProtocol):
             channel_type = self.extract_string()
             channel_id = self.extract_int(4)
 
-            log.msg(f"got channel {channel_type!r} request")
+            self._log.debug(
+                "got channel {channel_type!r} request", channel_type=channel_type
+            )
 
             if channel_type == b"session":
                 # if using an interactive session reset frontend timeout
@@ -228,7 +234,9 @@ class SSH(base_protocol.BaseProtocol):
                     )
 
                 else:
-                    log.msg("[SSH] Detected Port Forwarding Channel - Disabling!")
+                    self._log.info(
+                        "[SSH] Detected Port Forwarding Channel - Disabling!"
+                    )
                     if self.server.events:
                         self.server.events.dispatch(
                             "cowrie.direct-tcpip.data",
@@ -249,7 +257,10 @@ class SSH(base_protocol.BaseProtocol):
             else:
                 # UNKNOWN CHANNEL TYPE
                 if channel_type not in [b"exit-status"]:
-                    log.msg(f"[SSH Unknown Channel Type Detected - {channel_type!r}")
+                    self._log.info(
+                        "[SSH Unknown Channel Type Detected - {channel_type!r}",
+                        channel_type=channel_type,
+                    )
 
         elif message_num == connection.MSG_CHANNEL_OPEN_CONFIRMATION:
             channel = self.get_channel(self.extract_int(4), parent)
@@ -277,7 +288,9 @@ class SSH(base_protocol.BaseProtocol):
                 channel["session"] = term.Term(
                     the_uuid, channel["name"], self, channel["clientID"]
                 )
-                log.msg(f"MSG_CHANNEL_REQUEST: {channel_type!r}")
+                self._log.debug(
+                    "MSG_CHANNEL_REQUEST: {channel_type!r}", channel_type=channel_type
+                )
 
             elif channel_type == b"exec":
                 channel["name"] = "[EXEC" + str(channel["serverID"]) + "]"
@@ -286,12 +299,20 @@ class SSH(base_protocol.BaseProtocol):
                 channel["session"] = exec_term.ExecTerm(
                     the_uuid, channel["name"], self, channel["serverID"], command
                 )
-                log.msg(f"MSG_CHANNEL_REQUEST: {channel_type!r}: {command!r}")
+                self._log.debug(
+                    "MSG_CHANNEL_REQUEST: {channel_type!r}: {command!r}",
+                    channel_type=channel_type,
+                    command=command,
+                )
 
             elif channel_type == b"subsystem":
                 self.extract_bool()
                 subsystem = self.extract_string()
-                log.msg(f"MSG_CHANNEL_REQUEST: {channel_type!r}: {subsystem!r}")
+                self._log.debug(
+                    "MSG_CHANNEL_REQUEST: {channel_type!r}: {subsystem!r}",
+                    channel_type=channel_type,
+                    subsystem=subsystem,
+                )
 
                 if subsystem == b"sftp":
                     if CowrieConfig.getboolean("ssh", "sftp_enabled"):
@@ -304,18 +325,25 @@ class SSH(base_protocol.BaseProtocol):
                         self.send_back(parent, 100, int_to_hex(channel["serverID"]))
                 else:
                     # UNKNOWN SUBSYSTEM
-                    log.msg(f"MSG_CHANNEL_REQUEST: {channel_type!r}: {subsystem!r}")
-                    log.msg(
-                        "[SSH] Unknown Subsystem Type Detected - "
-                        + escape_nonprintable(subsystem)
+                    self._log.debug(
+                        "MSG_CHANNEL_REQUEST: {channel_type!r}: {subsystem!r}",
+                        channel_type=channel_type,
+                        subsystem=subsystem,
+                    )
+                    self._log.info(
+                        "[SSH] Unknown Subsystem Type Detected - {subsystem}",
+                        subsystem=escape_nonprintable(subsystem),
                     )
             elif channel_type == b"env":
                 _ = self.extract_bool()
                 var = self.extract_string()
                 value = self.extract_string()
-                log.msg(
-                    f"MSG_CHANNEL_REQUEST: env: "
-                    f"{escape_nonprintable(var)}={escape_nonprintable(value)}"
+                # Attacker-supplied environment variables are a signal,
+                # not protocol trace; keep visible at the default level.
+                self._log.info(
+                    "MSG_CHANNEL_REQUEST: env: {var}={value}",
+                    var=escape_nonprintable(var),
+                    value=escape_nonprintable(value),
                 )
 
             else:
@@ -326,9 +354,9 @@ class SSH(base_protocol.BaseProtocol):
                     b"exit-status",
                     b"exit-signal",
                 ]:
-                    log.msg(
-                        "[SSH] Unknown Channel Request Type Detected - "
-                        + escape_nonprintable(channel_type)
+                    self._log.info(
+                        "[SSH] Unknown Channel Request Type Detected - {channel_type}",
+                        channel_type=escape_nonprintable(channel_type),
                     )
 
         elif message_num == connection.MSG_CHANNEL_FAILURE:
@@ -342,7 +370,7 @@ class SSH(base_protocol.BaseProtocol):
             if "[SERVER]" in channel and "[CLIENT]" in channel:
                 # CHANNEL CLOSED
                 if channel["session"] is not None:
-                    log.msg("remote close")
+                    self._log.debug("remote close")
                     channel["session"].channel_closed()
 
                 self.channels.remove(channel)
@@ -366,7 +394,9 @@ class SSH(base_protocol.BaseProtocol):
                     self.send_back(parent, 82, b"")
 
         else:
-            log.msg(f"Unhandled SSH packet: {message_num}")
+            self._log.debug(
+                "Unhandled SSH packet: {message_num}", message_num=message_num
+            )
 
         if self.sendOn:
             if parent == "[SERVER]":

--- a/src/cowrie/ssh_proxy/protocols/term.py
+++ b/src/cowrie/ssh_proxy/protocols/term.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import os
 import time
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core import ttylog
 from cowrie.core.config import CowrieConfig
@@ -17,6 +17,8 @@ from cowrie.ssh_proxy.protocols import base_protocol
 
 
 class Term(base_protocol.BaseProtocol):
+    _log = Logger()
+
     def __init__(self, uuid, chan_name, ssh, channelId):
         super().__init__(uuid, chan_name, ssh)
 
@@ -106,7 +108,9 @@ class Term(base_protocol.BaseProtocol):
                                 input=self.command.decode("utf8"),
                             )
                     except UnicodeDecodeError:
-                        log.err(f"Unusual execcmd: {self.command!r}")
+                        self._log.error(
+                            "Unusual execcmd: {command!r}", command=self.command
+                        )
 
                     self.command = b""
                     self.pointer = 0

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -16,8 +16,9 @@ from twisted.conch.ssh import transport
 from twisted.conch.ssh.common import getNS
 from twisted.internet import reactor
 from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.logger import Logger
 from twisted.protocols.policies import TimeoutMixin
-from twisted.python import failure, log, randbytes
+from twisted.python import failure, randbytes
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.events import EventLog, transport_events
@@ -34,6 +35,7 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
     After both sides are authenticated, forward all things from one side to another.
     """
 
+    _log = Logger()
     buf: bytes
     ourVersionString: bytes
     gotVersion: bool
@@ -112,12 +114,14 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             self.connect_to_backend(backend_ip, backend_port)
 
     def pool_connection_error(self, reason: failure.Failure) -> None:
-        log.msg(f"Connection to backend pool refused: {reason.value}")
+        self._log.info(
+            "Connection to backend pool refused: {error}", error=reason.value
+        )
         if self.transport:
             self.transport.loseConnection()
 
     def pool_connection_success(self, pool_interface):
-        log.msg("Connected to backend pool")
+        self._log.info("Connected to backend pool")
 
         self.pool_interface = pool_interface
         self.pool_interface.set_parent(self)
@@ -131,8 +135,12 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             snapshot = data[1]
             ssh_port = data[2]
 
-            log.msg(f"Got backend data from pool: {honey_ip.decode()}:{ssh_port}")
-            log.msg(f"Snapshot file: {snapshot.decode()}")
+            self._log.info(
+                "Got backend data from pool: {honey_ip}:{ssh_port}",
+                honey_ip=honey_ip.decode(),
+                ssh_port=ssh_port,
+            )
+            self._log.info("Snapshot file: {snapshot}", snapshot=snapshot.decode())
 
             self.connect_to_backend(honey_ip, ssh_port)
 
@@ -229,8 +237,9 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
                 )
             m = re.match(rb"SSH-(\d+.\d+)-(.*)", self.otherVersionString)
             if m is None:
-                log.msg(
-                    f"Bad protocol version identification: {self.otherVersionString!r}"
+                self._log.info(
+                    "Bad protocol version identification: {version!r}",
+                    version=self.otherVersionString,
                 )
                 if self.transport:
                     self.transport.write(b"Protocol mismatch.\n")
@@ -338,7 +347,7 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         Make sure all sessions time out eventually.
         Timeout is reset when authentication succeeds.
         """
-        log.msg("Timeout reached in FrontendSSHTransport")
+        self._log.info("Timeout reached in FrontendSSHTransport")
 
         if self.transport:
             self.transport.loseConnection()
@@ -421,7 +430,11 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             transport.SSHServerTransport.sendDisconnect(self, reason, desc)
         else:
             self.transport.write(b"Packet corrupt\n")
-            log.msg(f"Disconnecting with error, code {reason}\nreason: {desc}")
+            self._log.info(
+                "Disconnecting with error, code {code}\nreason: {desc}",
+                code=reason,
+                desc=desc,
+            )
             self.transport.loseConnection()
 
     def receiveError(self, reasonCode: str, description: str) -> None:
@@ -436,7 +449,11 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
                             disconnection.
         @type description: L{str}
         """
-        log.msg(f"Got remote error, code {reasonCode} reason: {description}")
+        self._log.info(
+            "Got remote error, code {code} reason: {description}",
+            code=reasonCode,
+            description=description,
+        )
 
     def packet_buffer(self, messageNum: int, payload: bytes) -> None:
         """
@@ -445,7 +462,9 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         """
         if not self.backendConnected:
             # wait till backend connects to send packets to them
-            log.msg("Connection to backend not ready, buffering packet from frontend")
+            self._log.debug(
+                "Connection to backend not ready, buffering packet from frontend"
+            )
             self.delayedPackets.append([messageNum, payload])
         else:
             if len(self.delayedPackets) > 0:

--- a/src/cowrie/telnet/factory.py
+++ b/src/cowrie/telnet/factory.py
@@ -15,7 +15,7 @@ import time
 from typing import TYPE_CHECKING
 
 from twisted.internet import protocol
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.shell.honeyfs import read_honeyfs_bytes
 from cowrie.telnet.transport import CowrieTelnetTransport
@@ -32,6 +32,8 @@ class HoneyPotTelnetFactory(protocol.ServerFactory):
     This factory creates HoneyPotTelnetAuthProtocol instances
     They listen directly to the TCP port
     """
+
+    _log = Logger()
 
     tac: IPlugin
     banner: bytes
@@ -51,8 +53,8 @@ class HoneyPotTelnetFactory(protocol.ServerFactory):
                 .decode("utf-8", errors="replace")
                 .encode("utf-8")
             )
-        except FileNotFoundError as e:
-            log.err(e, "ERROR: Failed to load /etc/issue.net")
+        except FileNotFoundError:
+            self._log.failure("ERROR: Failed to load /etc/issue.net")
             self.banner = b""
 
         # For use by the uptime command
@@ -67,7 +69,7 @@ class HoneyPotTelnetFactory(protocol.ServerFactory):
             )
 
         super().startFactory()
-        log.msg("Ready to accept Telnet connections")
+        self._log.info("Ready to accept Telnet connections")
 
     def stopFactory(self) -> None:
         """

--- a/src/cowrie/telnet/session.py
+++ b/src/cowrie/telnet/session.py
@@ -12,20 +12,26 @@ Telnet User Session management for the Honeypot
 from __future__ import annotations
 
 import traceback
+from typing import TYPE_CHECKING
 
 from twisted.conch.ssh import session
 from twisted.conch.telnet import ECHO, SGA, TelnetBootstrapProtocol
 from twisted.internet import interfaces, protocol
 from twisted.internet.protocol import connectionDone
-from twisted.python import failure, log
+from twisted.logger import Logger
 from zope.interface import implementer
 
 from cowrie.insults import insults
 from cowrie.shell import protocol as cproto
 from cowrie.shell import pwd
 
+if TYPE_CHECKING:
+    from twisted.python import failure
+
 
 class HoneyPotTelnetSession(TelnetBootstrapProtocol):
+    _log = Logger()
+
     id = 0  # telnet can only have 1 simultaneous session, unlike SSH
 
     def __init__(self, username, server):
@@ -85,7 +91,7 @@ class HoneyPotTelnetSession(TelnetBootstrapProtocol):
             self.protocol.makeConnection(processprotocol)
             processprotocol.makeConnection(session.wrapProtocol(self.protocol))
         except Exception:
-            log.msg(traceback.format_exc())
+            self._log.info("{traceback}", traceback=traceback.format_exc())
 
     def connectionLost(self, reason: failure.Failure = connectionDone) -> None:
         TelnetBootstrapProtocol.connectionLost(self, reason)
@@ -94,7 +100,7 @@ class HoneyPotTelnetSession(TelnetBootstrapProtocol):
         self.protocol = None
 
     def logout(self) -> None:
-        log.msg(f"avatar {self.username} logging out")
+        self._log.info("avatar {username} logging out", username=self.username)
 
 
 # Taken and adapted from
@@ -107,6 +113,8 @@ class TelnetSessionProcessProtocol(protocol.ProcessProtocol):
     local subsystem.
     """
 
+    _log = Logger()
+
     def __init__(self, sess):
         self.session = sess
         self.lostOutOrErrFlag = False
@@ -115,7 +123,7 @@ class TelnetSessionProcessProtocol(protocol.ProcessProtocol):
         self.session.write(data)
 
     def errReceived(self, data: bytes) -> None:
-        log.msg(f"Error received: {data.decode()}")
+        self._log.info("Error received: {data}", data=data.decode())
         # EXTENDED_DATA_STDERR is from ssh, no equivalent in telnet?
         # self.session.writeExtended(connection.EXTENDED_DATA_STDERR, err)
 
@@ -145,11 +153,12 @@ class TelnetSessionProcessProtocol(protocol.ProcessProtocol):
         """
         exit_code = getattr(reason.value, "exitCode", None) if reason else None
         if exit_code is not None:
-            log.msg(
-                f"Process ended with exit code {exit_code}. Telnet session disconnected"
+            self._log.info(
+                "Process ended with exit code {exit_code}. Telnet session disconnected",
+                exit_code=exit_code,
             )
         else:
-            log.msg("Process ended. Telnet session disconnected")
+            self._log.info("Process ended. Telnet session disconnected")
         self.session.loseConnection()
 
     def getHost(self):

--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -13,14 +13,18 @@ from __future__ import annotations
 
 import time
 import uuid
+from typing import TYPE_CHECKING
 
 from twisted.conch.telnet import AlreadyNegotiating, TelnetTransport
 from twisted.internet.protocol import connectionDone
+from twisted.logger import Logger
 from twisted.protocols.policies import TimeoutMixin
-from twisted.python import failure, log
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.events import EventLog, transport_events
+
+if TYPE_CHECKING:
+    from twisted.python import failure
 
 # Telnet option names for logging (RFC 854, RFC 855, RFC 1572, etc.)
 TELNET_OPTIONS: dict[int, str] = {
@@ -45,6 +49,8 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
     """
     CowrieTelnetTransport
     """
+
+    _log = Logger()
 
     # The session's event emitter, bound in connectionMade when the running
     # application provides a dispatcher.
@@ -110,7 +116,7 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
                     "Telnet protocol error %(error)s; dropping connection",
                     error=str(e),
                 )
-            log.err()
+            self._log.failure("Telnet protocol error; dropping connection")
             if self.transport:
                 self.transport.loseConnection()
 
@@ -119,7 +125,7 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         Make sure all sessions time out eventually.
         Timeout is reset when authentication succeeds.
         """
-        log.msg("Timeout reached in CowrieTelnetTransport")
+        self._log.info("Timeout reached in CowrieTelnetTransport")
         if self.transport:
             self.transport.loseConnection()
 
@@ -168,7 +174,7 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         # We only care about AlreadyNegotiating, everything else can be ignored
         # Possible other types include OptionRefused, AlreadyDisabled, AlreadyEnabled, ConnectionDone, ConnectionLost
         elif f.type is AssertionError:
-            log.msg(
+            self._log.info(
                 "Client tried to illegally refuse to disable an option; ignoring, but undefined behavior may result"
             )
             # TODO: Is ignoring this violation of the protocol the proper behavior?

--- a/src/cowrie/telnet/userauth.py
+++ b/src/cowrie/telnet/userauth.py
@@ -23,12 +23,14 @@ from twisted.conch.telnet import (
     ITelnetProtocol,
 )
 from twisted.internet.protocol import connectionDone
-from twisted.python import failure, log
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.credentials import UsernamePasswordIP
 
 if TYPE_CHECKING:
+    from twisted.python import failure
+
     from cowrie.telnet.transport import CowrieTelnetTransport
 
 # NEW-ENVIRON telnet option (RFC 1572)
@@ -53,6 +55,8 @@ class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
     protocol is replaced with HoneyPotTelnetSession.
     """
 
+    _log = Logger()
+
     loginPrompt = b"login: "
     passwordPrompt = b"Password: "
     windowSize: list[int]
@@ -62,7 +66,11 @@ class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
         self.transport.negotiationMap[NAWS] = self.telnet_NAWS
         # Initial option negotiation. Want something at least for Mirai
         for opt in (NAWS,):
-            self.transport.doChain(opt).addErrback(log.err)
+            self.transport.doChain(opt).addErrback(
+                lambda f: self._log.failure(
+                    "Telnet option negotiation failed", failure=f
+                )
+            )
 
         # Register NEW-ENVIRON subnegotiation handler for CVE-2026-24061 detection
         self.transport.negotiationMap[NEW_ENVIRON] = self.telnet_NEW_ENVIRON
@@ -183,7 +191,7 @@ class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
             width, height = struct.unpack("!HH", b"".join(data))
             self.windowSize = [height, width]
         else:
-            log.msg("Wrong number of NAWS bytes")
+            self._log.info("Wrong number of NAWS bytes")
 
     def telnet_NEW_ENVIRON(self, data: list[bytes]) -> None:
         """

--- a/src/cowrie/telnet_proxy/client_transport.py
+++ b/src/cowrie/telnet_proxy/client_transport.py
@@ -7,11 +7,13 @@ from __future__ import annotations
 
 from twisted.conch.telnet import TelnetTransport
 from twisted.internet import protocol
+from twisted.logger import Logger
 from twisted.protocols.policies import TimeoutMixin
-from twisted.python import log
 
 
 class BackendTelnetTransport(TelnetTransport, TimeoutMixin):
+    _log = Logger()
+
     def __init__(self):
         # self.delayedPacketsToFrontend = []
         self.backendConnected = False
@@ -19,7 +21,9 @@ class BackendTelnetTransport(TelnetTransport, TimeoutMixin):
         super().__init__()
 
     def connectionMade(self):
-        log.msg(f"Connected to Telnet backend at {self.transport.getPeer().host}")
+        self._log.info(
+            "Connected to Telnet backend at {host}", host=self.transport.getPeer().host
+        )
         self.telnetHandler = self.factory.server.telnetHandler
         self.telnetHandler.setClient(self)
 
@@ -45,7 +49,7 @@ class BackendTelnetTransport(TelnetTransport, TimeoutMixin):
         Make sure all sessions time out eventually.
         Timeout is reset when authentication succeeds.
         """
-        log.msg("Timeout reached in BackendTelnetTransport")
+        self._log.info("Timeout reached in BackendTelnetTransport")
 
         # close transports on both sides
         self.transport.loseConnection()

--- a/src/cowrie/telnet_proxy/handler.py
+++ b/src/cowrie/telnet_proxy/handler.py
@@ -9,7 +9,7 @@ import os
 import re
 import time
 
-from twisted.python import log
+from twisted.logger import Logger
 
 from cowrie.core import ttylog
 from cowrie.core.checkers import HoneypotPasswordChecker
@@ -42,6 +42,8 @@ def remove_all(original_string: bytes, remove_list: list[bytes]) -> bytes:
 
 
 class TelnetHandler:
+    _log = Logger()
+
     def __init__(self, server):
         # holds packet data; useful to manipulate it across functions as needed
         self.currentData: bytes = b""
@@ -149,7 +151,9 @@ class TelnetHandler:
             self.client.transport.write(packet)
             # log raw packets if user sets so
             if CowrieConfig.getboolean("proxy", "log_raw", fallback=False):
-                log.msg("to_backend - " + data.decode("unicode-escape"))
+                self._log.info(
+                    "to_backend - {data}", data=data.decode("unicode-escape")
+                )
 
             if self.ttylogEnabled and self.authStarted:
                 cleanData = data.replace(
@@ -171,7 +175,7 @@ class TelnetHandler:
 
         # log raw packets if user sets so
         if CowrieConfig.getboolean("proxy", "log_raw", fallback=False):
-            log.msg("to_frontend - " + data.decode("unicode-escape"))
+            self._log.info("to_frontend - {data}", data=data.decode("unicode-escape"))
 
         if self.ttylogEnabled and self.authStarted:
             ttylog.ttylog_write(
@@ -251,7 +255,10 @@ class TelnetHandler:
             # cleanup
             self.usernameState = process_backspaces(self.usernameState)
 
-            log.msg(f"User input login: {self.usernameState.decode('unicode-escape')}")
+            self._log.info(
+                "User input login: {username}",
+                username=self.usernameState.decode("unicode-escape"),
+            )
             self.inputingLogin = False
 
             # actually send to backend
@@ -281,8 +288,9 @@ class TelnetHandler:
             # cleanup
             self.passwordState = process_backspaces(self.passwordState)
 
-            log.msg(
-                f"User input password: {self.passwordState.decode('unicode-escape')}"
+            self._log.info(
+                "User input password: {password}",
+                password=self.passwordState.decode("unicode-escape"),
             )
             self.inputingPassword = False
 
@@ -299,7 +307,7 @@ class TelnetHandler:
                     CowrieConfig.getint("honeypot", "idle_timeout", fallback=300)
                 )
             else:
-                log.msg("Sending invalid auth to backend")
+                self._log.info("Sending invalid auth to backend")
                 passwordToSend = self.backendPassword + b"fake"
 
             # actually send to backend
@@ -314,14 +322,14 @@ class TelnetHandler:
         """
         hasPassword = re.search(self.passwordPromptRegex, self.currentData)
         if hasPassword:
-            log.msg("Password prompt from backend")
+            self._log.info("Password prompt from backend")
             self.authStarted = True
             self.inputingPassword = True
             self.passwordState = b""
 
         hasLogin = re.search(self.usernamePromptRegex, self.currentData)
         if hasLogin:
-            log.msg("Login prompt from backend")
+            self._log.info("Login prompt from backend")
             self.authStarted = True
             self.inputingLogin = True
             self.usernameState = b""
@@ -338,8 +346,9 @@ class TelnetHandler:
         if hasNegotiationLogin:
             self.usernameState = hasNegotiationLogin.group(2)
             username_str = self.usernameState.decode("unicode-escape")
-            log.msg(
-                f"Detected username {username_str} in negotiation, spoofing for backend..."
+            self._log.info(
+                "Detected username {username} in negotiation, spoofing for backend...",
+                username=username_str,
             )
 
             # Log the environment variable for consistency with shell mode

--- a/src/cowrie/telnet_proxy/server_transport.py
+++ b/src/cowrie/telnet_proxy/server_transport.py
@@ -13,21 +13,27 @@ from __future__ import annotations
 
 import time
 import uuid
+from typing import TYPE_CHECKING
 
 from twisted.conch.telnet import TelnetTransport
 from twisted.internet import reactor
 from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.logger import Logger
 from twisted.protocols.policies import TimeoutMixin
-from twisted.python import failure, log
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.events import EventLog, transport_events
 from cowrie.telnet_proxy import client_transport
 from cowrie.telnet_proxy.handler import TelnetHandler
 
+if TYPE_CHECKING:
+    from twisted.python import failure
+
 
 # object is added for Python 2.7 compatibility (#1198) - as is super with args
 class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
+    _log = Logger()
+
     # The session's event emitter, bound in connectionMade when the running
     # application provides a dispatcher.
     events: EventLog | None = None
@@ -94,13 +100,14 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
             self.connect_to_backend(backend_ip, backend_port)
 
     def pool_connection_error(self, reason):
-        log.msg(
-            f"Connection to backend pool refused: {reason.value}. Disconnecting frontend..."
+        self._log.info(
+            "Connection to backend pool refused: {reason}. Disconnecting frontend...",
+            reason=reason.value,
         )
         self.transport.loseConnection()
 
     def pool_connection_success(self, pool_interface):
-        log.msg("Connected to backend pool")
+        self._log.info("Connected to backend pool")
 
         self.pool_interface = pool_interface
         self.pool_interface.set_parent(self)
@@ -114,8 +121,12 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
             snapshot = data[1]
             telnet_port = data[3]
 
-            log.msg(f"Got backend data from pool: {honey_ip.decode()}:{telnet_port}")
-            log.msg(f"Snapshot file: {snapshot.decode()}")
+            self._log.info(
+                "Got backend data from pool: {honey_ip}:{telnet_port}",
+                honey_ip=honey_ip.decode(),
+                telnet_port=telnet_port,
+            )
+            self._log.info("Snapshot file: {snapshot}", snapshot=snapshot.decode())
 
             self.connect_to_backend(honey_ip, telnet_port)
 
@@ -179,7 +190,7 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
         Make sure all sessions time out eventually.
         Timeout is reset when authentication succeeds.
         """
-        log.msg("Timeout reached in FrontendTelnetTransport")
+        self._log.info("Timeout reached in FrontendTelnetTransport")
 
         # close transports on both sides
         if self.transport:
@@ -236,7 +247,9 @@ class FrontendTelnetTransport(TimeoutMixin, TelnetTransport):
         """
         if not self.client.backendConnected:
             # wait till backend connects to send packets to them
-            log.msg("Connection to backend not ready, buffering packet from frontend")
+            self._log.info(
+                "Connection to backend not ready, buffering packet from frontend"
+            )
             self.delayedPacketsToBackend.append(payload)
         else:
             if len(self.delayedPacketsToBackend) > 0:

--- a/src/cowrie/test/test_telnet_new_environ.py
+++ b/src/cowrie/test/test_telnet_new_environ.py
@@ -134,7 +134,7 @@ class TestCVE2026_24061Detection(unittest.TestCase):
         self.protocol.transport = MagicMock()
         self.dispatched = capture_events(self.protocol.transport)
 
-    @patch("cowrie.telnet.userauth.log")
+    @patch("cowrie.telnet.userauth.HoneyPotTelnetAuthProtocol._log")
     def test_detect_exploit_f_root(self, mock_log: MagicMock) -> None:
         """Test detection of USER=-f root exploit."""
         # Simulate receiving IS VAR USER VALUE -f root
@@ -157,7 +157,7 @@ class TestCVE2026_24061Detection(unittest.TestCase):
                 break
         self.assertTrue(exploit_logged, "CVE-2026-24061 exploit should be detected")
 
-    @patch("cowrie.telnet.userauth.log")
+    @patch("cowrie.telnet.userauth.HoneyPotTelnetAuthProtocol._log")
     def test_detect_exploit_froot_no_space(self, mock_log: MagicMock) -> None:
         """Test detection of USER=-froot (no space) variant."""
         data = [
@@ -177,7 +177,7 @@ class TestCVE2026_24061Detection(unittest.TestCase):
                 break
         self.assertTrue(exploit_logged, "CVE-2026-24061 variant should be detected")
 
-    @patch("cowrie.telnet.userauth.log")
+    @patch("cowrie.telnet.userauth.HoneyPotTelnetAuthProtocol._log")
     def test_detect_exploit_lowercase_user(self, mock_log: MagicMock) -> None:
         """Test detection with lowercase 'user' variable name."""
         data = [
@@ -196,7 +196,7 @@ class TestCVE2026_24061Detection(unittest.TestCase):
                 break
         self.assertTrue(exploit_logged, "Lowercase 'user' should also be detected")
 
-    @patch("cowrie.telnet.userauth.log")
+    @patch("cowrie.telnet.userauth.HoneyPotTelnetAuthProtocol._log")
     def test_no_false_positive_normal_user(self, mock_log: MagicMock) -> None:
         """Test that normal USER values don't trigger exploit detection."""
         data = [
@@ -217,7 +217,7 @@ class TestCVE2026_24061Detection(unittest.TestCase):
             exploit_logged, "Normal username should not trigger exploit detection"
         )
 
-    @patch("cowrie.telnet.userauth.log")
+    @patch("cowrie.telnet.userauth.HoneyPotTelnetAuthProtocol._log")
     def test_logs_client_var_event(self, mock_log: MagicMock) -> None:
         """Test that environment variables are logged as cowrie.client.var."""
         data = [
@@ -238,7 +238,7 @@ class TestCVE2026_24061Detection(unittest.TestCase):
                 break
         self.assertTrue(var_logged, "Environment variable should be logged")
 
-    @patch("cowrie.telnet.userauth.log")
+    @patch("cowrie.telnet.userauth.HoneyPotTelnetAuthProtocol._log")
     def test_ignores_send_command(self, mock_log: MagicMock) -> None:
         """Test that SEND command (server requesting values) is ignored."""
         # SEND command - server asking client for values, not client sending
@@ -332,7 +332,7 @@ class TestCVE2026_24061Emulation(unittest.TestCase):
         self.assertIsNone(result)
 
     @patch("cowrie.telnet.userauth.CowrieConfig")
-    @patch("cowrie.telnet.userauth.log")
+    @patch("cowrie.telnet.userauth.HoneyPotTelnetAuthProtocol._log")
     def test_exploit_sets_bypass_when_vulnerable(
         self, mock_log: MagicMock, mock_config: MagicMock
     ) -> None:
@@ -351,7 +351,7 @@ class TestCVE2026_24061Emulation(unittest.TestCase):
         self.assertEqual(self.protocol.cve_2026_24061_user, "root")
 
     @patch("cowrie.telnet.userauth.CowrieConfig")
-    @patch("cowrie.telnet.userauth.log")
+    @patch("cowrie.telnet.userauth.HoneyPotTelnetAuthProtocol._log")
     def test_exploit_does_not_set_bypass_when_not_vulnerable(
         self, mock_log: MagicMock, mock_config: MagicMock
     ) -> None:
@@ -370,7 +370,7 @@ class TestCVE2026_24061Emulation(unittest.TestCase):
         self.assertIsNone(getattr(self.protocol, "cve_2026_24061_user", None))
 
     @patch("cowrie.telnet.userauth.CowrieConfig")
-    @patch("cowrie.telnet.userauth.log")
+    @patch("cowrie.telnet.userauth.HoneyPotTelnetAuthProtocol._log")
     def test_auth_bypass_uses_exploit_user(
         self, mock_log: MagicMock, mock_config: MagicMock
     ) -> None:
@@ -413,7 +413,7 @@ class TestCVE2026_24061Emulation(unittest.TestCase):
         self.assertEqual(captured_creds[0].username, b"root")
 
     @patch("cowrie.telnet.userauth.CowrieConfig")
-    @patch("cowrie.telnet.userauth.log")
+    @patch("cowrie.telnet.userauth.HoneyPotTelnetAuthProtocol._log")
     def test_exploit_success_is_logged(
         self, mock_log: MagicMock, mock_config: MagicMock
     ) -> None:

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -14,9 +14,9 @@ from twisted.application import service
 from twisted.application.service import IServiceMaker
 from twisted.cred import portal
 from twisted.internet import reactor
-from twisted.logger import ILogObserver, globalLogPublisher
+from twisted.logger import ILogObserver, Logger, globalLogPublisher
 from twisted.plugin import IPlugin
-from twisted.python import log, usage
+from twisted.python import usage
 from zope.interface import implementer, provider
 
 import cowrie.llm.realm
@@ -32,6 +32,11 @@ from cowrie.core.output import Output
 from cowrie.core.utils import create_endpoint_services, get_endpoints_from_section
 from cowrie.pool_interface.handler import PoolHandler
 
+# Explicit namespace: this module lives under twisted.plugins, but its
+# lines are Cowrie startup diagnostics and must answer to the operator's
+# log_level_cowrie configuration like every other cowrie.* namespace.
+_log = Logger(namespace="cowrie.plugin")
+
 
 class Options(usage.Options):
     """
@@ -45,11 +50,16 @@ class Options(usage.Options):
 
 @provider(ILogObserver)
 def importFailureObserver(event: dict) -> None:
-    if "failure" in event and event["failure"].type is ImportError:
-        log.err(
-            "ERROR: {}. Please run `pip install -U -r requirements.txt` "
+    # Legacy log.err events carry "failure"; twisted.logger failures
+    # carry "log_failure". Critical so the hint still reaches stderr
+    # before logging starts.
+    error = event.get("failure", event.get("log_failure"))
+    if error is not None and error.type is ImportError:
+        _log.critical(
+            "ERROR: {error}. Please run `pip install -U -r requirements.txt` "
             "from Cowrie's install directory and virtualenv to install "
-            "the new dependency".format(event["failure"].value.message)
+            "the new dependency",
+            error=str(error.value),
         )
 
 
@@ -110,12 +120,17 @@ Makes a Cowrie SSH/Telnet honeypot.
         if tz != "system":
             os.environ["TZ"] = tz
 
-        log.msg(f"Python Version {str(sys.version).replace(chr(10), '')}")
-        log.msg(
-            f"Twisted Version {__twisted_version__.major}.{__twisted_version__.minor}.{__twisted_version__.micro}"
+        _log.info(
+            "Python Version {version}", version=str(sys.version).replace(chr(10), "")
         )
-        log.msg(f"Cowrie Version {__cowrie_version__.__version__}")
-        log.msg(f"Sensor UUID: {self.uuid}")
+        _log.info(
+            "Twisted Version {major}.{minor}.{micro}",
+            major=__twisted_version__.major,
+            minor=__twisted_version__.minor,
+            micro=__twisted_version__.micro,
+        )
+        _log.info("Cowrie Version {version}", version=__cowrie_version__.__version__)
+        _log.info("Sensor UUID: {uuid}", uuid=self.uuid)
 
         # check configurations
         if not self.enableTelnet and not self.enableSSH and not self.pool_only:
@@ -145,17 +160,18 @@ Makes a Cowrie SSH/Telnet honeypot.
             try:
                 output = import_module(f"cowrie.output.{engine}").Output()
                 self.output_plugins.append(output)
-                log.msg(f"Loaded output engine: {engine}")
-            except ImportError as e:
-                log.err(
-                    f"Failed to load output engine: {engine} due to ImportError: {e}"
+                _log.info("Loaded output engine: {engine}", engine=engine)
+            except ImportError:
+                _log.failure(
+                    "Failed to load output engine: {engine} due to ImportError",
+                    engine=engine,
                 )
-                log.msg(
-                    f"Please install the dependencies for {engine} listed in requirements-output.txt"
+                _log.info(
+                    "Please install the dependencies for {engine} listed in requirements-output.txt",
+                    engine=engine,
                 )
             except Exception:
-                log.err()
-                log.msg(f"Failed to load output engine: {engine}")
+                _log.failure("Failed to load output engine: {engine}", engine=engine)
 
         self.dispatcher.sinks = [*self.output_plugins, renderer]
 


### PR DESCRIPTION
## Summary

Completes the diagnostics phase of `docs/EVENT_PIPELINE.rst`: converts the ~400 legacy `twisted.python.log` call sites to per-class `twisted.logger.Logger` instances and adds config-driven log level filtering to `cowrie.log`.

## Filtering

- Wraps the `cowrie.log` observer in a `FilteringLogObserver` driven by new `[honeypot]` `log_level` and `log_level_<namespace>` options, matched by dotted namespace prefix. Filtering happens at the observer, so test observers and future sinks still see every emission.
- `COWRIE_HONEYPOT_LOG_LEVEL_<namespace>` environment overrides also work.
- Level filtering applies in foreground and Docker mode via a shared `stdoutLogger()` pipeline.

## Diagnostics

- Every line in `cowrie.log` now carries a namespace derived from its origin and a real level.
- Messages are lazy PEP-3101 format strings with runtime values passed as keywords, so attacker-controlled text is never interpreted as a format string.
- `log.err` sites with exception context become `Logger.failure()` with structured tracebacks.
- The logfile observer stamps `log_system` from the active connection context so diagnostics stay correlatable to a session.

## Level policy

`info` by default; packet/protocol dumps and per-block transfer traces are `debug` (hidden at the default `log_level` of `info`); explicit warnings are `warn`; failures without exception context are `error`. Attacker-activity records (commands, SFTP transfers, auth attempts) stay `info`. The `cowrie.events` namespace keeps an explicit `info` floor so a global `log_level = warn` quiets diagnostics without erasing the attack record.

## Pool bookkeeping

Pool bookkeeping in `backend_pool/` and `pool_interface` becomes plain per-class diagnostics: the session-less `log.msg(eventid=...)` markers never reached the output plugins after the event pipeline landed, so the vestigial `eventid`/`format` structure is dropped and message text preserved. This removes the last legacy diagnostic emitters; the only remaining `twisted.python.log` use in product code is `log.callWithLogger` in the SSH connection service.

## Testing

Verified end-to-end against a running honeypot; `ruff`, `mypy`, and the full suite (733 tests) pass.
