### PR TITLE
fix: block IPv4-mapped and embedded-IPv4 IPv6 addresses in outbound filter

### DIFF
--- a/src/cowrie/core/network.py
+++ b/src/cowrie/core/network.py
@@ -25,8 +25,53 @@ BLOCKED_IPS = [
     "224.0.0.0/4",  # Multicast addresses
     "240.0.0.0/4",  # Reserved addresses
     "255.255.255.255",  # Limited broadcast address
-    "::1",  # IPv6 loopback range
+    "::1",  # IPv6 loopback
+    "fe80::/10",  # IPv6 link-local
+    "fc00::/7",  # IPv6 unique-local (private)
+    "ff00::/8",  # IPv6 multicast
 ]
+
+# NAT64 well-known prefix (RFC 6052): 64:ff9b::/96 embeds an IPv4 address in
+# its low 32 bits, just like an IPv4-mapped address does.
+_NAT64_PREFIX = ipaddress.ip_network("64:ff9b::/96")
+
+
+def _embedded_ipv4(
+    ip: ipaddress.IPv6Address,
+) -> ipaddress.IPv4Address | None:
+    """
+    Return the IPv4 address embedded in an IPv6 address, or None if there is
+    none. Covers IPv4-mapped (``::ffff:0:0/96``), 6to4 (``2002::/16``), and
+    NAT64 (``64:ff9b::/96``) forms, all of which can reach an IPv4 target
+    through an IPv6 wrapper.
+    """
+    if ip.ipv4_mapped is not None:
+        return ip.ipv4_mapped
+    if ip.sixtofour is not None:
+        return ip.sixtofour
+    if ip in _NAT64_PREFIX:
+        return ipaddress.IPv4Address(int(ip) & 0xFFFFFFFF)
+    return None
+
+
+def _is_blocked(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """
+    Return True if the address falls within any blocked range. An IPv6
+    address that embeds an IPv4 address is also checked as that IPv4 address,
+    so a private or metadata target cannot be reached through an IPv6 wrapper.
+    """
+    candidates: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = [ip]
+    if isinstance(ip, ipaddress.IPv6Address):
+        embedded = _embedded_ipv4(ip)
+        if embedded is not None:
+            candidates.append(embedded)
+
+    for candidate in candidates:
+        for blocked in BLOCKED_IPS:
+            if candidate in ipaddress.ip_network(blocked, strict=False):
+                return True
+    return False
+
 
 # Valid TCP/UDP port range: 1-65535
 # https://www.debuggex.com/r/jjEFZZQ34aPvCBMA
@@ -130,12 +175,10 @@ def communication_allowed(address: str) -> Generator[Deferred, None, bool]:
     # At this point, resolved_ip should always be a valid string (IPv4 or IPv6)
     try:
         ip = ipaddress.ip_address(resolved_ip)
-
-        # Check if the resolved IP falls within any blocked IP ranges
-        for blocked in BLOCKED_IPS:
-            if ip in ipaddress.ip_network(blocked, strict=False):
-                return False  # Blocked IP found
     except ValueError:
         return False  # If the resolved IP is not a valid IP address, return False
+
+    if _is_blocked(ip):
+        return False  # Blocked IP found
 
     return True  # Communication is allowed

--- a/src/cowrie/test/test_network.py
+++ b/src/cowrie/test/test_network.py
@@ -78,6 +78,42 @@ class TestCommunicationAllowed(unittest.TestCase):
         self.assertFalse(allowed)
 
     @inlineCallbacks
+    def test_ipv4_mapped_loopback_blocked(self):
+        # ::ffff:127.0.0.1 embeds a loopback IPv4 address and must be blocked.
+        allowed = yield communication_allowed("::ffff:127.0.0.1")
+        self.assertFalse(allowed)
+
+    @inlineCallbacks
+    def test_ipv4_mapped_private_blocked(self):
+        # ::ffff:10.0.0.1 embeds a private IPv4 address and must be blocked.
+        allowed = yield communication_allowed("::ffff:10.0.0.1")
+        self.assertFalse(allowed)
+
+    @inlineCallbacks
+    def test_ipv4_mapped_metadata_blocked(self):
+        # ::ffff:169.254.169.254 embeds the cloud metadata IP and must be blocked.
+        allowed = yield communication_allowed("::ffff:169.254.169.254")
+        self.assertFalse(allowed)
+
+    @inlineCallbacks
+    def test_ipv6_link_local_blocked(self):
+        # fe80::/10 link-local addresses must be blocked.
+        allowed = yield communication_allowed("fe80::1")
+        self.assertFalse(allowed)
+
+    @inlineCallbacks
+    def test_ipv6_unique_local_blocked(self):
+        # fc00::/7 unique-local (private) addresses must be blocked.
+        allowed = yield communication_allowed("fc00::1")
+        self.assertFalse(allowed)
+
+    @inlineCallbacks
+    def test_ipv6_mapped_public_allowed(self):
+        # An IPv4-mapped public address stays allowed.
+        allowed = yield communication_allowed("::ffff:8.8.8.8")
+        self.assertTrue(allowed)
+
+    @inlineCallbacks
     def test_cname_resolution(self):
         # Test with a CNAME that resolves to an allowed IP
         allowed = yield communication_allowed("www.google.com")


### PR DESCRIPTION
An IPv4-mapped IPv6 address such as `::ffff:169.254.169.254` is parsed by
`ipaddress.ip_address()` as an IPv6 address, so it never matched the IPv4 CIDR
entries in `BLOCKED_IPS`. Only literal `::1` was caught among IPv6 addresses.
As a result the outbound-connection filter used by `wget`, `curl`, `nc`,
`tftp`, and `ftpget` could be bypassed to reach loopback, private-network, and
cloud-metadata targets through an IPv6 wrapper, e.g.:

- `::ffff:127.0.0.1` (loopback)
- `::ffff:10.0.0.1` (private)
- `::ffff:169.254.169.254` (cloud metadata)

The attacker controls the destination directly (`wget "http://[::ffff:169.254.169.254]/"`)
or via a hostname whose AAAA/CNAME points at a mapped address.

A second gap: for non-mapped IPv6, only `::1` was blocked, leaving link-local
(`fe80::/10`), unique-local (`fc00::/7`), and multicast (`ff00::/8`) reachable.

## Fix

- Extract the embedded IPv4 address from IPv4-mapped (`::ffff:0:0/96`), 6to4
  (`2002::/16`), and NAT64 (`64:ff9b::/96`) forms and check it against the
  blocklist in addition to the IPv6 address itself.
- Add the IPv6 link-local, unique-local, and multicast ranges to `BLOCKED_IPS`.

## Tests

Added coverage in `test_network.py` for mapped loopback/private/metadata
addresses (blocked), IPv6 link-local and unique-local (blocked), and a mapped
public address (still allowed). All use IP literals, so no DNS is required.

https://claude.ai/code/session_014z61U9Cda7WkM5t9CDWQhY