### PR TITLE
fix: block non-globally-routable outbound targets

### DIFF
--- a/src/cowrie/core/network.py
+++ b/src/cowrie/core/network.py
@@ -56,9 +56,15 @@ def _embedded_ipv4(
 
 def _is_blocked(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """
-    Return True if the address falls within any blocked range. An IPv6
-    address that embeds an IPv4 address is also checked as that IPv4 address,
-    so a private or metadata target cannot be reached through an IPv6 wrapper.
+    Return True if the address must not be contacted. An IPv6 address that
+    embeds an IPv4 address is also checked as that IPv4 address, so a private
+    or metadata target cannot be reached through an IPv6 wrapper.
+
+    A candidate is blocked if it is not globally routable or if it falls
+    within an explicit blocked range. The explicit list stays authoritative
+    for targets that are not globally routable yet not covered by is_global
+    (e.g. the Alibaba metadata IP) and guards against interpreter versions
+    whose is_global misclassifies IPv4-mapped addresses.
     """
     candidates: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = [ip]
     if isinstance(ip, ipaddress.IPv6Address):
@@ -67,6 +73,8 @@ def _is_blocked(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
             candidates.append(embedded)
 
     for candidate in candidates:
+        if not candidate.is_global:
+            return True
         for blocked in BLOCKED_IPS:
             if candidate in ipaddress.ip_network(blocked, strict=False):
                 return True

--- a/src/cowrie/test/test_network.py
+++ b/src/cowrie/test/test_network.py
@@ -114,6 +114,18 @@ class TestCommunicationAllowed(unittest.TestCase):
         self.assertTrue(allowed)
 
     @inlineCallbacks
+    def test_cgnat_blocked(self):
+        # 100.64.0.0/10 carrier-grade NAT space is not globally routable.
+        allowed = yield communication_allowed("100.64.0.1")
+        self.assertFalse(allowed)
+
+    @inlineCallbacks
+    def test_benchmarking_range_blocked(self):
+        # 198.18.0.0/15 benchmarking space is not globally routable.
+        allowed = yield communication_allowed("198.18.0.1")
+        self.assertFalse(allowed)
+
+    @inlineCallbacks
     def test_cname_resolution(self):
         # Test with a CNAME that resolves to an allowed IP
         allowed = yield communication_allowed("www.google.com")


### PR DESCRIPTION
Follow-up to #40329. That PR closed the IPv4-mapped bypass with an explicit
blocklist plus embedded-IPv4 extraction. This adds `not ip.is_global` as an
*additional* block condition so the filter also catches non-routable ranges the
hand-maintained list misses.

## What this adds

`_is_blocked()` now blocks a candidate address if it is not globally routable,
in addition to the existing explicit-range and embedded-IPv4 checks. No check
is removed. Newly covered ranges include:

- carrier-grade NAT (`100.64.0.0/10`)
- benchmarking (`198.18.0.0/15`)
- documentation / TEST-NET ranges

## Why keep the explicit list too

`is_global` is a broad, CPython-maintained net, but it is not sufficient on its
own:

- It misses targets that are not globally routable yet not flagged by
  `is_global` — e.g. the Alibaba metadata IP `100.100.100.200`.
- Its correct handling of IPv4-mapped addresses depends on the CVE-2024-4032
  fix (shipped in 3.10.15 / 3.11.10 / 3.12.5 / 3.13). Since the project floor is
  `requires-python = ">=3.10"`, an older patch release would misclassify a
  mapped address. The explicit list and embedded-IPv4 extraction keep the
  filter correct regardless of interpreter patch level.

So this is belt-and-suspenders: `is_global` widens coverage, the explicit list
guarantees the version-independent floor.

## Tests

Added `test_cgnat_blocked` (`100.64.0.1`) and `test_benchmarking_range_blocked`
(`198.18.0.1`), both IP literals so no DNS. Full `test_network` suite (21 tests)
plus wget/curl/tftp command tests pass; ruff and mypy clean.

https://claude.ai/code/session_014z61U9Cda7WkM5t9CDWQhY