### PR TITLE
fix: prevent session hang from IPv4-embedded IPv6 download URLs

### DIFF
--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -14,6 +14,7 @@ import treq
 from twisted.internet import error
 from twisted.internet.defer import inlineCallbacks
 from twisted.logger import Logger
+from twisted.python import failure
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
@@ -320,7 +321,15 @@ class Command_curl(HoneyPotCommand):
 
         self.artifact = Artifact("curl-download")
 
-        self.deferred = self.treqDownload(url)
+        # treq.get() can raise synchronously before returning a Deferred (e.g.
+        # idna.core.InvalidCodepoint for an IPv4-embedded IPv6 URL literal such
+        # as [::ffff:8.8.8.8]). Route that raise through error() so the command
+        # exits instead of being orphaned on the cmdstack until session timeout.
+        try:
+            self.deferred = self.treqDownload(url)
+        except Exception:
+            self.error(failure.Failure())
+            return
         if self.deferred:
             self.deferred.addCallback(self.success)
             self.deferred.addErrback(self.error)

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -18,6 +18,7 @@ from twisted.internet.defer import CancelledError, inlineCallbacks
 from twisted.internet.protocol import ClientCreator, Protocol
 from twisted.logger import Logger
 from twisted.protocols.ftp import CommandFailed, FTPClient
+from twisted.python import failure
 from twisted.web.iweb import UNKNOWN_LENGTH
 
 from cowrie.core.artifact import Artifact
@@ -301,15 +302,23 @@ class Command_wget(HoneyPotCommand):
             )
             self.errorWrite(f"{proto_label} request sent, awaiting response... ")
 
-        if self.scheme == "ftp":
-            self.deferred = self.ftpDownload(urldata)
-            if self.deferred:
-                self.deferred.addErrback(self.error)
-        else:
-            self.deferred = self.httpDownload(url)
-            if self.deferred:
-                self.deferred.addCallback(self.success)
-                self.deferred.addErrback(self.error)
+        # treq.get() can raise synchronously before returning a Deferred (e.g.
+        # idna.core.InvalidCodepoint for an IPv4-embedded IPv6 URL literal such
+        # as [::ffff:8.8.8.8]). Route that raise through error() so the command
+        # exits instead of being orphaned on the cmdstack until session timeout.
+        try:
+            if self.scheme == "ftp":
+                self.deferred = self.ftpDownload(urldata)
+                if self.deferred:
+                    self.deferred.addErrback(self.error)
+            else:
+                self.deferred = self.httpDownload(url)
+                if self.deferred:
+                    self.deferred.addCallback(self.success)
+                    self.deferred.addErrback(self.error)
+        except Exception:
+            self.error(failure.Failure())
+            return
 
     def httpDownload(self, url: str) -> Any:
         """

--- a/src/cowrie/core/network.py
+++ b/src/cowrie/core/network.py
@@ -35,21 +35,26 @@ BLOCKED_IPS = [
 # its low 32 bits, just like an IPv4-mapped address does.
 _NAT64_PREFIX = ipaddress.ip_network("64:ff9b::/96")
 
+# IPv4-compatible prefix (::a.b.c.d, deprecated by RFC 4291): also embeds an
+# IPv4 address in its low 32 bits. ::/96 also contains ::1 and ::, whose
+# embedded 0.0.0.x values are non-global and stay blocked.
+_IPV4_COMPATIBLE_PREFIX = ipaddress.ip_network("::/96")
+
 
 def _embedded_ipv4(
     ip: ipaddress.IPv6Address,
 ) -> ipaddress.IPv4Address | None:
     """
     Return the IPv4 address embedded in an IPv6 address, or None if there is
-    none. Covers IPv4-mapped (``::ffff:0:0/96``), 6to4 (``2002::/16``), and
-    NAT64 (``64:ff9b::/96``) forms, all of which can reach an IPv4 target
-    through an IPv6 wrapper.
+    none. Covers IPv4-mapped (``::ffff:0:0/96``), 6to4 (``2002::/16``), NAT64
+    (``64:ff9b::/96``), and IPv4-compatible (``::/96``) forms, all of which can
+    reach an IPv4 target through an IPv6 wrapper.
     """
     if ip.ipv4_mapped is not None:
         return ip.ipv4_mapped
     if ip.sixtofour is not None:
         return ip.sixtofour
-    if ip in _NAT64_PREFIX:
+    if ip in _NAT64_PREFIX or ip in _IPV4_COMPATIBLE_PREFIX:
         return ipaddress.IPv4Address(int(ip) & 0xFFFFFFFF)
     return None
 

--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -101,6 +101,20 @@ class CurlArtifactCleanupTests(unittest.TestCase):
         artifact.close()
         artifact.close()  # must not raise on the already-closed file
 
+    def test_embedded_ipv6_url_does_not_hang(self) -> None:
+        # An IPv4-embedded IPv6 URL literal such as [::ffff:8.8.8.8] passes the
+        # network guard (globally routable) but makes treq.get() raise
+        # idna.core.InvalidCodepoint synchronously. That raise must be caught so
+        # the command exits, instead of orphaning it on the cmdstack (a session
+        # hang / DoS) until the session times out.
+        self.proto.lineReceived(b"curl -s 'http://[::ffff:8.8.8.8]/'; echo rc=$?")
+        out = self.tr.value()
+        self.assertIn(
+            b"rc=",
+            out,
+            "shell never resumed: the command hung instead of exiting",
+        )
+
     def test_late_download_callbacks_after_exit_are_inert(self) -> None:
         # The command can exit while treq is still delivering the body (size
         # limit in collect(), CTRL-C). The late callbacks must not write to the

--- a/src/cowrie/test/test_network.py
+++ b/src/cowrie/test/test_network.py
@@ -114,6 +114,25 @@ class TestCommunicationAllowed(unittest.TestCase):
         self.assertTrue(allowed)
 
     @inlineCallbacks
+    def test_ipv4_compatible_loopback_blocked(self):
+        # ::127.0.0.1 is the deprecated IPv4-compatible form (::a.b.c.d); it
+        # embeds a loopback IPv4 address and must be blocked like ::ffff:127.0.0.1.
+        allowed = yield communication_allowed("::127.0.0.1")
+        self.assertFalse(allowed)
+
+    @inlineCallbacks
+    def test_ipv4_compatible_private_blocked(self):
+        # ::10.0.0.1 embeds a private IPv4 address and must be blocked.
+        allowed = yield communication_allowed("::10.0.0.1")
+        self.assertFalse(allowed)
+
+    @inlineCallbacks
+    def test_ipv4_compatible_metadata_blocked(self):
+        # ::169.254.169.254 embeds the cloud metadata IP and must be blocked.
+        allowed = yield communication_allowed("::169.254.169.254")
+        self.assertFalse(allowed)
+
+    @inlineCallbacks
     def test_cgnat_blocked(self):
         # 100.64.0.0/10 carrier-grade NAT space is not globally routable.
         allowed = yield communication_allowed("100.64.0.1")

--- a/src/cowrie/test/test_wget.py
+++ b/src/cowrie/test/test_wget.py
@@ -49,6 +49,20 @@ class WgetArtifactCleanupTests(unittest.TestCase):
             os.remove(os.path.join(self.tmpdir, name))
         os.rmdir(self.tmpdir)
 
+    def test_embedded_ipv6_url_does_not_hang(self) -> None:
+        # An IPv4-embedded IPv6 URL literal such as [::ffff:8.8.8.8] passes the
+        # network guard (globally routable) but makes treq.get() raise
+        # idna.core.InvalidCodepoint synchronously. That raise must be caught so
+        # the command exits, instead of orphaning it on the cmdstack (a session
+        # hang / DoS) until the session times out.
+        self.proto.lineReceived(b"wget -q 'http://[::ffff:8.8.8.8]/'; echo rc=$?")
+        out = self.tr.value()
+        self.assertIn(
+            b"rc=",
+            out,
+            "shell never resumed: the command hung instead of exiting",
+        )
+
     def test_failed_download_removes_temp_artifact(self) -> None:
         # Bypass HoneyPotCommand.__init__: its stdout/stderr wiring needs a
         # running process protocol (self.protocol.pp), which is irrelevant to


### PR DESCRIPTION
## Summary

An IPv4-embedded IPv6 URL literal such as `http://[::ffff:8.8.8.8]/` makes `treq.get()` raise `idna.core.InvalidCodepoint` **synchronously**, before it returns a Deferred. hyperlink sees the dots, classifies the host as a name, and IDNA-encodes it, which fails on the colon.

In `curl.py` and `wget.py` the download call was not wrapped in `try/except`, and the errback was attached only on the following line. Because `start()` is an `inlineCallbacks` generator, the synchronous raise escaped as an unhandled Deferred failure; `call_command` ignores the Deferred returned by `start()`, so `exit()` was never called. The command was orphaned on the cmdstack until the session timed out.

Impact: a per-request **session hang (DoS)** triggerable by any authenticated visitor (Cowrie accepts near-arbitrary credentials), each hung request holding a connection slot and flooding the log with `critical` tracebacks. This survives the reserved-IP guard because globally-routable wrapped targets (`[::ffff:8.8.8.8]`, `[64:ff9b::8.8.8.8]`) correctly pass the guard and then hit the unguarded crash.

## Changes

- **`curl.py`, `wget.py`** — wrap the download dispatch so a synchronous raise from `treq.get()` is routed through `error()`, which reports the failure and exits the command cleanly. This handles *any* synchronous raise, not only this URL family.
- **`core/network.py`** — defense-in-depth: `_embedded_ipv4()` now also unwraps the deprecated IPv4-compatible form (`::a.b.c.d`, e.g. `::127.0.0.1`, `::10.0.0.1`, `::169.254.169.254`), which embeds an IPv4 address in its low 32 bits like the IPv4-mapped, 6to4, and NAT64 forms but was previously read as global unicast and slipped the guard.

## Tests

- `test_curl.py` / `test_wget.py`: a `[::ffff:8.8.8.8]` URL now exits (the shell resumes) instead of hanging.
- `test_network.py`: `::127.0.0.1`, `::10.0.0.1`, `::169.254.169.254` are now blocked.

Full curl/wget/network suites pass; `ruff check`, `ruff format`, and `mypy` are clean.

https://claude.ai/code/session_011JLD6oA2s38WmQxKNUmWZK