### PR TITLE
fix: handle TCP connect timeout in curl and wget downloads

### DIFF
--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -517,6 +517,13 @@ class Command_curl(HoneyPotCommand):
             self.exit()
             return
 
+        elif response.check(error.TCPTimedOutError) is not None:
+            self.errorWrite(
+                f"curl: (7) Failed to connect to {self.host} port {self.port}: Connection timed out\n"
+            )
+            self.exit()
+            return
+
         # possible errors:
         # defer.CancelledError,
         # error.ConnectingCancelledError,

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -695,6 +695,11 @@ class Command_wget(HoneyPotCommand):
             self.exit()
             return
 
+        if response.check(error.TCPTimedOutError) is not None:
+            self.errorWrite("failed: Connection timed out.\n")
+            self.exit()
+            return
+
         self._log.failure("Unhandled wget error", failure=response)
         self.errorWrite("\n")
         self.exit()

--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -71,6 +71,27 @@ class CurlArtifactCleanupTests(unittest.TestCase):
         )
         self.assertEqual(os.listdir(self.tmpdir), [])
 
+    def test_tcp_timeout_reports_connection_timed_out(self) -> None:
+        # A TCP connect that times out yields TCPTimedOutError, built by the
+        # reactor (so its Failure has no traceback frames). error() must report
+        # a curl-style timeout message and exit cleanly, not fall through to the
+        # CRITICAL "Unhandled curl error" branch that writes a bare newline
+        # (issue #40335).
+        cmd = Command_curl.__new__(Command_curl)
+        cmd.protocol = self.proto
+        writes: list[bytes] = []
+        cmd.writefn = lambda data: writes.append(data)
+        cmd.errorWritefn = lambda data: writes.append(data)
+        cmd.exit = lambda code=None: None  # type: ignore[method-assign]
+        cmd.url = b"http://192.0.2.1/file"
+        cmd.host = "192.0.2.1"
+        cmd.port = 80
+        cmd.artifact = Artifact("curl-download")
+
+        cmd.error(Failure(error.TCPTimedOutError()))
+
+        self.assertIn(b"Connection timed out", b"".join(writes))
+
     def test_missing_host_reports_error_without_crashing(self) -> None:
         # A URL with no host must report an error and stop, not fall through
         # to the download path and crash on the unset self.host.

--- a/src/cowrie/test/test_wget.py
+++ b/src/cowrie/test/test_wget.py
@@ -63,6 +63,26 @@ class WgetArtifactCleanupTests(unittest.TestCase):
             "shell never resumed: the command hung instead of exiting",
         )
 
+    def test_tcp_timeout_reports_connection_timed_out(self) -> None:
+        # A TCP connect that times out yields TCPTimedOutError, built by the
+        # reactor (so its Failure has no traceback frames). error() must report
+        # a wget-style timeout message and exit cleanly, not fall through to the
+        # CRITICAL "Unhandled wget error" branch that writes a bare newline
+        # (issue #40335).
+        cmd = Command_wget.__new__(Command_wget)
+        cmd.protocol = self.proto
+        writes: list[bytes] = []
+        cmd.errorWritefn = lambda data: writes.append(data)
+        cmd.exit = lambda code=None: None  # type: ignore[method-assign]
+        cmd.url = b"http://192.0.2.1/file"
+        cmd.host = "192.0.2.1"
+        cmd.port = 80
+        cmd.artifact = Artifact("wget-download")
+
+        cmd.error(Failure(error.TCPTimedOutError()))
+
+        self.assertIn(b"Connection timed out", b"".join(writes))
+
     def test_failed_download_removes_temp_artifact(self) -> None:
         # Bypass HoneyPotCommand.__init__: its stdout/stderr wiring needs a
         # running process protocol (self.protocol.pp), which is irrelevant to


### PR DESCRIPTION
Fixes #40335.

## Summary

A TCP connect attempt that stalls until it times out fires the download's errback with `twisted.internet.error.TCPTimedOutError`. Neither `Command_curl.error()` nor `Command_wget.error()` had a branch for it, so it fell through every `response.check(...)` case to the generic fallback: logged at CRITICAL as "Unhandled curl/wget error" and only a bare newline written back to the session.

Because `TCPTimedOutError` is constructed by the reactor's connector code rather than raised inside an `except`, its `Failure` carries no traceback frames, so the CRITICAL entry is a frame-less "Traceback (most recent call last):" header — it reads like a logging malfunction even though the timeout is expected.

The issue reports this for `wget`; `curl.error()` has the identical gap (it handles `DNSLookupError`, `ConnectingCancelledError`, `ConnectionRefusedError` but not `TCPTimedOutError`), so this fixes both.

## Changes

- **`wget.py`** — `error()` now handles `TCPTimedOutError`, writing `failed: Connection timed out.` and exiting cleanly.
- **`curl.py`** — `error()` now handles `TCPTimedOutError`, writing `curl: (7) Failed to connect to <host> port <port>: Connection timed out`, matching the sibling `ConnectionRefusedError` branch.

Both replace the CRITICAL fallback with a normal client-style message and clean exit.

## Tests

- `test_curl.py` / `test_wget.py`: `error(Failure(TCPTimedOutError()))` now writes a "Connection timed out" message instead of the bare newline the fallback produced.

Full curl/wget suites pass; `ruff check`, `ruff format`, and `mypy` are clean.

https://claude.ai/code/session_011JLD6oA2s38WmQxKNUmWZK