### PR TITLE
fix: derive OptionParsingError from Exception

### DIFF
--- a/src/cowrie/commands/iptables.py
+++ b/src/cowrie/commands/iptables.py
@@ -15,7 +15,7 @@ from cowrie.shell.command import HoneyPotCommand
 commands = {}
 
 
-class OptionParsingError(RuntimeError):
+class OptionParsingError(Exception):
     def __init__(self, msg: str) -> None:
         self.msg = msg
 


### PR DESCRIPTION
## Summary

`OptionParsingError` subclassed `RuntimeError`, while its sibling
`OptionParsingExit` subclasses `Exception`. Both are internal signals raised by
`ModifiedOptionParser` during iptables option parsing and are caught only by
their own type (never as `RuntimeError`), so deriving `OptionParsingError` from
`Exception` makes the pair consistent and is behavior-preserving.

It also lets `mypyc` compile the class: mypyc cannot native-compile a class that
inherits from a builtin exception type other than `Exception` ("Inheriting from
most builtin types is unimplemented").

## Scope note

This is a small consistency cleanup, not a claim that `mypyc` now compiles the
whole tree. mypyc remains informational (the tox `typing` env runs it with a
leading `-`): past this class it still hits unrelated limitations, since cowrie
subclasses many Twisted base classes that mypyc cannot native-compile.

## Verification

- `mypy --config-file=pyproject.toml src` -> Success (266 files)
- The raise/catch path in `ModifiedOptionParser.error()` still works and
  `OptionParsingError` remains an `Exception` subclass.

https://claude.ai/code/session_011JLD6oA2s38WmQxKNUmWZK