### PR TITLE
fix: resolve tftp target hostname before UDP I/O

### DIFF
--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -75,7 +75,15 @@ class TFTPClient(DatagramProtocol):
 
     def startProtocol(self) -> None:
         """Called when protocol starts - send initial RRQ"""
-        self.sendRRQ()
+        try:
+            self.sendRRQ()
+        except Exception as e:
+            # Twisted's UDP transport raises synchronously here for a bad
+            # destination (e.g. a hostname). startProtocol() runs inside
+            # listenUDP(), before the caller has wired the transfer callbacks,
+            # so route the failure through the deferred instead of letting it
+            # escape and orphan the download.
+            self.deferred.errback(e)
 
     def stopProtocol(self) -> None:
         """Called when protocol stops"""
@@ -217,6 +225,7 @@ class Command_tftp(HoneyPotCommand):
 
     port: int = 69
     hostname: str | None = None
+    host_ip: str
     file_to_get: str
     limit_size = CowrieConfig.getint("honeypot", "download_limit_size", fallback=0)
     artifactFile: Artifact
@@ -275,6 +284,17 @@ class Command_tftp(HoneyPotCommand):
             self.exit(1)
             return
 
+        # Resolve the hostname to a numeric IP before any UDP I/O: Twisted's UDP
+        # transport rejects hostnames and raises InvalidAddressError. Done before
+        # the artifact is created so a resolution failure leaves nothing behind.
+        try:
+            self.host_ip = yield reactor.resolve(self.hostname)
+        except Exception:
+            self._log.info("TFTP: could not resolve host {host}", host=self.hostname)
+            self.write(f"tftp: {self.hostname}: Name or service not known\n")
+            self.exit(1)
+            return
+
         # Resolve local file path
         self.fakeoutfile = self.fs.resolve_path(self.file_to_get, self.protocol.cwd)
         path = self.fakeoutfile.rsplit("/", 1)[0] if "/" in self.fakeoutfile else "/"
@@ -300,9 +320,10 @@ class Command_tftp(HoneyPotCommand):
         """
         assert self.hostname is not None  # Checked in start()
 
-        # Create TFTP client
+        # Create TFTP client. host_ip is the numeric address resolved in
+        # start(); the UDP transport requires it (a hostname would be rejected).
         self.tftp_client = TFTPClient(
-            self.hostname, self.port, self.file_to_get, self.artifactFile
+            self.host_ip, self.port, self.file_to_get, self.artifactFile
         )
 
         # Listen on random UDP port

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 
 import os
 import struct
+import tempfile
 import unittest
 from typing import TYPE_CHECKING, Any, cast
 
 from twisted.internet import defer
 from twisted.internet import reactor as _reactor
 from twisted.internet.protocol import DatagramProtocol
+from twisted.python.failure import Failure
 
 from cowrie.commands.tftp import (
     OPCODE_ACK,
@@ -19,7 +21,9 @@ from cowrie.commands.tftp import (
     OPCODE_ERROR,
     OPCODE_RRQ,
     TFTP_BLOCK_SIZE,
+    Command_tftp,
 )
+from cowrie.core.artifact import Artifact
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.eventcapture import capture_events
 from cowrie.test.fake_server import FakeAvatar, FakeServer
@@ -320,6 +324,74 @@ class TFTPArtifactCloseTests(unittest.TestCase):
         with open(cmd.artifactFile.shasumFilename, "rb") as f:
             self.assertEqual(f.read(), content)
         os.remove(cmd.artifactFile.shasumFilename)
+
+
+class TFTPHostnameResolutionTests(unittest.TestCase):
+    """The TFTP client must feed a numeric IP to the UDP transport.
+
+    Twisted's UDP transport raises InvalidAddressError synchronously when
+    handed a hostname, and that raise happens inside listenUDP() -> startProtocol()
+    before start() has wired the download callbacks, orphaning the artifact and
+    producing an unhandled Deferred error (issue #40297).
+    """
+
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.mkdtemp()
+        self._orig_artifact_dir = Artifact.artifactDir
+        Artifact.artifactDir = self.tmpdir
+
+    def tearDown(self) -> None:
+        Artifact.artifactDir = self._orig_artifact_dir
+        for name in os.listdir(self.tmpdir):
+            os.remove(os.path.join(self.tmpdir, name))
+        os.rmdir(self.tmpdir)
+
+    def _make_command(self, host_ip: str) -> Command_tftp:
+        cmd = Command_tftp.__new__(Command_tftp)
+        cmd.hostname = "hostname.example.com"
+        cmd.host_ip = host_ip
+        cmd.port = 69
+        cmd.file_to_get = "test.sh"
+        cmd.artifactFile = Artifact("tftp-download")
+        return cmd
+
+    def test_transport_address_error_fails_cleanly(self) -> None:
+        # A non-numeric address reaching transport.write must not raise out of
+        # tftp_download_async(); it must surface as a failed transfer Deferred
+        # and leave no orphaned temp file.
+        cmd = self._make_command(host_ip="hostname.example.com")
+        temp = cmd.artifactFile.tempFilename
+        self.assertTrue(os.path.exists(temp))
+
+        d = cmd.tftp_download_async()  # must NOT raise
+        results: list[Any] = []
+        d.addBoth(results.append)
+        d.addBoth(cmd._ensure_artifact_closed)
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], Failure)
+        self.assertFalse(
+            os.path.exists(temp), "artifact orphaned on transport address error"
+        )
+
+    def test_download_uses_resolved_numeric_ip(self) -> None:
+        # When a numeric IP is supplied (as hostname resolution produces), the
+        # client contacts that IP and startProtocol does not raise.
+        cmd = self._make_command(host_ip="127.0.0.1")
+
+        d = cmd.tftp_download_async()  # must NOT raise
+        client = cmd.tftp_client
+        try:
+            assert client is not None
+            self.assertEqual(client.host, "127.0.0.1")
+        finally:
+            if client and client.timeout_call and client.timeout_call.active():
+                client.timeout_call.cancel()
+            if cmd.udp_port:
+                cmd.udp_port.stopListening()
+            d.addErrback(lambda _f: None)
+            d.cancel()
+            cmd.artifactFile.close()
 
 
 class TFTPProtocolTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #40297.

## Summary

Twisted's UDP transport only accepts numeric IP addresses: `transport.write()`
raises `InvalidAddressError` synchronously when handed a hostname. In the tftp
command that write happens in `TFTPClient.startProtocol()` -> `sendRRQ()`, which
runs **inside** `reactor.listenUDP()` during `tftp_download_async()` — before
`start()` has wired the transfer callbacks (`d.addBoth(...)` / `addErrback`).

Because `start()` is an `@inlineCallbacks` generator whose Deferred `call_command`
ignores, the synchronous raise surfaced as an "Unhandled error in Deferred"
(critical) and left the just-created zero-length artifact orphaned in the
download directory. It also left the command hanging on the cmdstack (never
exited).

## Changes

- **Resolve first.** After the `communication_allowed()` check and *before* the
  artifact is created, resolve the hostname to a numeric IP via
  `reactor.resolve()` and hand that IP to `TFTPClient`. A resolution failure now
  reports `tftp: <host>: Name or service not known` and exits cleanly, creating
  no artifact. (`reactor.resolve()` returns numeric IP literals unchanged, so an
  IP target is unaffected.)
- **Defence-in-depth.** Guard `startProtocol()` so any synchronous transport
  error is routed through the transfer Deferred and handled by the normal error
  path (artifact cleanup + failed event + clean exit) instead of escaping
  `listenUDP()`.

## Tests

`test_tftp.py` gains a synchronous test class (the existing async tests are
no-ops under the `unittest` runner CI uses):

- a non-numeric address reaching `transport.write` now yields a **failed
  Deferred** from `tftp_download_async()` instead of raising, and leaves **no
  orphaned temp file**;
- `tftp_download_async()` contacts the **resolved numeric IP**, not the hostname.

Both were red before the fix (they raised `InvalidAddressError`). Full tftp
suite passes; `mypy src` (266 files), `ruff check`, and `ruff format` are clean.

## Note

The reporter's attached `tftp.py` also carried a fix for a separate issue,
#40298 (already closed) — this PR is scoped to #40297 only.

https://claude.ai/code/session_011JLD6oA2s38WmQxKNUmWZK