### PR TITLE
fix: drop OpenSSH host-key rotation requests in ssh proxy

### DIFF
--- a/src/cowrie/ssh_proxy/protocols/ssh.py
+++ b/src/cowrie/ssh_proxy/protocols/ssh.py
@@ -392,6 +392,22 @@ class SSH(base_protocol.BaseProtocol):
                 if not CowrieConfig.getboolean("ssh", "forwarding"):
                     self.sendOn = False
                     self.send_back(parent, 82, b"")
+            elif channel_type == b"hostkeys-00@openssh.com":
+                # The backend advertises its host keys for OpenSSH host-key
+                # rotation (UpdateHostKeys). The proxy cannot relay this: the
+                # prove-ownership signatures are bound to the backend's session
+                # id, which differs from the frontend's, so the attacker's
+                # client reports "bad signature" for each host key. Drop the
+                # advertisement so rotation is never attempted.
+                self.sendOn = False
+            elif channel_type == b"hostkeys-prove-00@openssh.com":
+                # A client that still asks the server to prove key ownership:
+                # drop it and fail the request if a reply was expected, so the
+                # client does not wait on a proof the proxy cannot produce.
+                want_reply = self.extract_bool()
+                self.sendOn = False
+                if want_reply:
+                    self.send_back(parent, 82, b"")
 
         else:
             self._log.debug(


### PR DESCRIPTION
Fixes #2177.

## Symptom

Logging in through proxy mode, OpenSSH clients print:

```
client_global_hostkeys_private_confirm: server gave bad signature for ECDSA key 1: incorrect signature
dispatch_protocol_error: type 7 seq 7
```

Non-fatal (the session continues), but noisy — and a **proxy fingerprint**: a real server never produces this.

## Root cause

This is OpenSSH's host-key rotation feature (`UpdateHostKeys`, default-on in modern OpenSSH). After auth the server advertises its host keys via a `hostkeys-00@openssh.com` global request and, on request, proves ownership by signing `"hostkeys-prove-00@openssh.com" || session_id || keyblob` for each key.

In proxy mode the frontend (attacker↔cowrie) and backend (cowrie↔backend) run **separate** key exchanges, so each hop has its own session id. `parse_num_packet` in `ssh_proxy/protocols/ssh.py` forwarded these global requests verbatim (only `tcpip-forward` was special-cased). So the backend signed the proof against the **backend** session id, while the attacker's client verified it against the **frontend** session id — they differ, so verification fails for every advertised host key. The session-id binding is exactly the anti-MITM property of `UpdateHostKeys`, so this cannot be relayed correctly through the proxy.

## Fix

Filter the two host-key-rotation global requests in `parse_num_packet`, mirroring the existing `tcpip-forward` drop:

- Drop the backend's `hostkeys-00@openssh.com` advertisement so the client never starts the rotation flow.
- Drop a client's `hostkeys-prove-00@openssh.com` request, and send `REQUEST_FAILURE` when a reply was expected so nothing waits on a proof the proxy cannot produce.

The `type 7` (`SSH_MSG_EXT_INFO`) `dispatch_protocol_error` looks like a separate forwarding-ordering artifact and is not addressed here.

## Testing

Proxy mode has little direct test coverage and needs a live backend to exercise end-to-end; this change is a targeted global-request filter verified by inspection (imports, `ruff`, and `mypy src` are clean).

https://claude.ai/code/session_011JLD6oA2s38WmQxKNUmWZK