### PR TITLE
fix: run a shell reading channel stdin when bash is the exec command

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,24 @@
+<!--
+SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
+# TODO
+
+- Double `processEnded` on late channel EOF: after a session's process has
+  ended (exec command finished, `exit` in a shell), a channel EOF arriving
+  afterwards delivers a second `processEnded` through the leftover shell on
+  the cmdstack. `HoneyPotExecProtocol.eofReceived` guards only the
+  stdin-line-mode instance. Root-cause fix: a fire-once process-end helper
+  on the protocol, used by `HoneyPotShell._finish` / `_terminate` /
+  `eofReceived`, `HoneyPotCommand.exit`, and `timeoutConnection`.
+
+- Exec-channel stdin line mode treats control bytes (CTRL-C, CTRL-D,
+  backspace/delete) as a tty would even when the client requested no pty;
+  in a plain pipe real bash sees them as literal bytes. Make the handling
+  conditional on the pty request if the fidelity gap ever matters.
+
+- `ruff format` would reformat 20 files outside the exec-shell work
+  (`ruff format --check src/cowrie` lists them); run it tree-wide in a
+  formatting-only commit.

--- a/src/cowrie/commands/bash.py
+++ b/src/cowrie/commands/bash.py
@@ -76,15 +76,36 @@ class Command_sh(HoneyPotCommand):
         # command, not this shell.
 
     def interactive_shell(self) -> None:
+        from cowrie.shell.protocol import HoneyPotExecProtocol
+
         parentshell = self.protocol.cmdstack[-2]
-        # A sub-shell launched from a non-interactive parent (pipe, redirect, or
-        # command substitution) will never have a terminal feeding its stdin, so
-        # spawning an interactive shell would leak it on the cmdstack and write a
-        # prompt into captured output via showPrompt(). Behave like EOF instead.
-        if not getattr(parentshell, "interactive", True):
+        if (
+            isinstance(self.protocol, HoneyPotExecProtocol)
+            and len(self.protocol.cmdstack) == 2
+            and self.input_data is None
+            and not getattr(self.protocol.pp, "stdin_from_pipe", False)
+        ):
+            # The shell was exec'd as the SSH command (`ssh host bash`): its
+            # stdin is the live channel, so keep reading command lines from it
+            # until EOF. A pty request (TERM set by getPty) makes the shell
+            # interactive, with a prompt.
+            interactive = "TERM" in self.protocol.environ
+            reads_stdin = True
+            self.protocol.stdin_line_mode = True
+        elif not getattr(parentshell, "interactive", True):
+            # A sub-shell launched from a non-interactive parent (pipe,
+            # redirect, or command substitution) will never have a terminal
+            # feeding its stdin, so spawning an interactive shell would leak it
+            # on the cmdstack and write a prompt into captured output via
+            # showPrompt(). Behave like EOF instead.
             self.exit()
             return
-        shell = HoneyPotShell(self.protocol, interactive=True)
+        else:
+            interactive = True
+            reads_stdin = False
+        shell = HoneyPotShell(
+            self.protocol, interactive=interactive, reads_stdin=reads_stdin
+        )
         # TODO: copy more variables, but only exported variables
         try:
             shell.environ["SHLVL"] = str(int(parentshell.environ["SHLVL"]) + 1)

--- a/src/cowrie/commands/bash.py
+++ b/src/cowrie/commands/bash.py
@@ -75,16 +75,24 @@ class Command_sh(HoneyPotCommand):
         # for a `-c` command that launched an async wget/curl is the in-flight
         # command, not this shell.
 
-    def interactive_shell(self) -> None:
+    def exec_channel_stdin(self) -> bool:
+        """Whether this shell is the SSH exec command itself, with the live
+        channel as its stdin: nothing on the cmdstack beneath it but the exec
+        parser shell, and no pipe or buffered input feeding it."""
+        # Imported here: cowrie.shell.protocol loads the command modules while
+        # its module body is still executing, so a top-level import is circular.
         from cowrie.shell.protocol import HoneyPotExecProtocol
 
-        parentshell = self.protocol.cmdstack[-2]
-        if (
+        return (
             isinstance(self.protocol, HoneyPotExecProtocol)
             and len(self.protocol.cmdstack) == 2
             and self.input_data is None
             and not getattr(self.protocol.pp, "stdin_from_pipe", False)
-        ):
+        )
+
+    def interactive_shell(self) -> None:
+        parentshell = self.protocol.cmdstack[-2]
+        if self.exec_channel_stdin():
             # The shell was exec'd as the SSH command (`ssh host bash`): its
             # stdin is the live channel, so keep reading command lines from it
             # until EOF. A pty request (TERM set by getPty) makes the shell

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -279,6 +279,7 @@ class HoneyPotShell:
         if self.interactive:
             self.showPrompt()
         elif self.reads_stdin:
+            # Idle, not done: the channel will deliver more lines or EOF.
             pass
         elif len(self.protocol.cmdstack) == 1:
             # Top-level non-interactive shell (an exec session): end the process

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -874,10 +874,13 @@ class HoneyPotShell:
 
     def eofReceived(self) -> None:
         """
-        EOF with the shell as the active reader (no command running) logs out.
+        EOF with the shell as the active reader (no command running) logs out,
+        exiting with the last command's status ($?) as bash does.
         """
         self._log.info("received eof, logging out")
-        self.protocol.terminal.transport.processEnded(process_status(0))
+        self.protocol.terminal.transport.processEnded(
+            process_status(self.last_exit_code)
+        )
 
     def handle_CTRL_C(self) -> None:
         self.protocol.lineBuffer = []

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -81,10 +81,14 @@ class HoneyPotShell:
         interactive: bool = True,
         redirect: bool = False,
         effective_user: dict[str, Any] | None = None,
+        reads_stdin: bool = False,
     ) -> None:
         self.protocol = protocol
         self.interactive: bool = interactive
         self.redirect: bool = redirect  # to support output redirection
+        # The shell's commands arrive over a live stdin (an SSH exec channel
+        # running `bash`): a drained queue means idle, not done, until EOF.
+        self.reads_stdin: bool = reads_stdin
         self.effective_user = effective_user  # For su: {uid, gid, username, home}
         # Parsed-but-not-yet-evaluated statements; each is expanded against the
         # live environment only when it is about to run (see runCommand). A
@@ -262,16 +266,20 @@ class HoneyPotShell:
     def _finish(self) -> None:
         """The command queue is drained: do the shell's idle action.
 
-        An interactive shell shows the next prompt. A top-level non-interactive
-        shell (an exec session) ends the process. A nested non-interactive shell
-        that runs a script or ``-c`` commands (sh/bash/su) removes itself from
-        the cmdstack and resumes the command that launched it -- this is what
-        hands control back once the script's async commands (wget/curl) have all
-        finished. A command-substitution / redirect capture shell is left alone:
-        its creator pops it in a finally when capture returns.
+        An interactive shell shows the next prompt. A shell reading commands
+        from live stdin stays resident awaiting the next line or EOF. A
+        top-level non-interactive shell (an exec session) ends the process. A
+        nested non-interactive shell that runs a script or ``-c`` commands
+        (sh/bash/su) removes itself from the cmdstack and resumes the command
+        that launched it -- this is what hands control back once the script's
+        async commands (wget/curl) have all finished. A command-substitution /
+        redirect capture shell is left alone: its creator pops it in a finally
+        when capture returns.
         """
         if self.interactive:
             self.showPrompt()
+        elif self.reads_stdin:
+            pass
         elif len(self.protocol.cmdstack) == 1:
             # Top-level non-interactive shell (an exec session): end the process
             # with the last command's status so the SSH channel reports a real

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -315,6 +315,13 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
         except UnicodeDecodeError:
             self._log.error("Unusual execcmd: {execcmd!r}", execcmd=execcmd)
 
+        # When the exec'd command is a shell reading commands from the channel
+        # (`ssh host bash`), stdin is delivered to the cmdstack line by line
+        # instead of being buffered raw in input_data.
+        self.stdin_line_mode: bool = False
+        self._stdin_line = bytearray()
+        self._stdin_last_cr: bool = False
+
         HoneyPotBaseProtocol.__init__(self, avatar)
 
     def connectionMade(self) -> None:
@@ -326,7 +333,47 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
         self.cmdstack[0].lineReceived(self.execcmd)
 
     def keystrokeReceived(self, keyID, modifier):
-        self.input_data += keyID
+        if not self.stdin_line_mode:
+            self.input_data += keyID
+            return
+        if not isinstance(keyID, bytes):
+            # A function key parsed from an escape sequence has no place in a
+            # line-based stdin stream.
+            return
+        last_cr = self._stdin_last_cr
+        self._stdin_last_cr = keyID == b"\r"
+        if keyID == b"\n" and last_cr:
+            # The \n of a \r\n pair; the \r already dispatched the line.
+            return
+        if keyID in (b"\r", b"\n"):
+            line = bytes(self._stdin_line)
+            self._stdin_line = bytearray()
+            self.lineReceived(line)
+        elif keyID == b"\x04" and not self._stdin_line:
+            # CTRL-D on an empty line is EOF for the shell reading stdin.
+            HoneyPotBaseProtocol.eofReceived(self)
+        else:
+            self._stdin_line += keyID
+
+    def setInsertMode(self) -> None:
+        """Insert-mode toggle requested when an interactive shell resumes; an
+        exec channel has no recvline editor, so there is no mode to switch."""
+
+    def eofReceived(self) -> None:
+        if self.stdin_line_mode:
+            if self._stdin_line:
+                # A final line without a terminator still runs, as bash does
+                # when its stdin ends without a newline.
+                line = bytes(self._stdin_line)
+                self._stdin_line = bytearray()
+                self.lineReceived(line)
+            if not any(
+                getattr(item, "reads_stdin", False) for item in self.cmdstack
+            ):
+                # The stdin-reading shell already exited (e.g. `exit`) and
+                # ended the process; nothing is left to deliver EOF to.
+                return
+        HoneyPotBaseProtocol.eofReceived(self)
 
 
 class HoneyPotInteractiveProtocol(HoneyPotBaseProtocol, recvline.HistoricRecvLine):

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -234,8 +234,12 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         IMPORTANT
         Before this, all data is 'bytes'. Here it converts to 'string' and
         commands work with string rather than bytes.
+
+        Invalid UTF-8 (binary piped or pasted into the shell) becomes
+        replacement characters: the line must not raise out of the protocol
+        and kill the session.
         """
-        string = line.decode("utf8")
+        string = line.decode("utf8", errors="replace")
 
         if self.cmdstack:
             self.cmdstack[-1].lineReceived(string)
@@ -304,6 +308,11 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
     # input_data is static buffer for stdin received from remote client
     input_data = b""
 
+    # Longest accepted stdin line in line mode, bash's per-argument limit
+    # (MAX_ARG_STRLEN). Bytes beyond it are dropped so an endless
+    # unterminated stream cannot grow memory without bound.
+    STDIN_LINE_MAX = 131072
+
     def __init__(self, avatar, execcmd):
         """
         IMPORTANT
@@ -345,12 +354,21 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
         if keyID == b"\n" and last_cr:
             # The \n of a \r\n pair; the \r already dispatched the line.
             return
+        # Control bytes are handled as a tty would, which is only strictly
+        # right when the client requested a pty; in a plain pipe they are
+        # rare enough that the difference does not matter.
         if keyID in (b"\r", b"\n"):
             self._dispatch_stdin_line()
         elif keyID == b"\x04" and not self._stdin_line:
             # CTRL-D on an empty line is EOF for the shell reading stdin.
             HoneyPotBaseProtocol.eofReceived(self)
-        else:
+        elif keyID in (b"\x08", b"\x7f"):
+            # Backspace / delete: drop the last byte of the pending line.
+            del self._stdin_line[-1:]
+        elif keyID == b"\x03":
+            # CTRL-C: discard the pending line.
+            self._stdin_line.clear()
+        elif len(self._stdin_line) < self.STDIN_LINE_MAX:
             self._stdin_line += keyID
 
     def _dispatch_stdin_line(self) -> None:

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -346,14 +346,18 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
             # The \n of a \r\n pair; the \r already dispatched the line.
             return
         if keyID in (b"\r", b"\n"):
-            line = bytes(self._stdin_line)
-            self._stdin_line = bytearray()
-            self.lineReceived(line)
+            self._dispatch_stdin_line()
         elif keyID == b"\x04" and not self._stdin_line:
             # CTRL-D on an empty line is EOF for the shell reading stdin.
             HoneyPotBaseProtocol.eofReceived(self)
         else:
             self._stdin_line += keyID
+
+    def _dispatch_stdin_line(self) -> None:
+        """Run the accumulated stdin line through the command stack."""
+        line = bytes(self._stdin_line)
+        self._stdin_line.clear()
+        self.lineReceived(line)
 
     def setInsertMode(self) -> None:
         """Insert-mode toggle requested when an interactive shell resumes; an
@@ -364,12 +368,8 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
             if self._stdin_line:
                 # A final line without a terminator still runs, as bash does
                 # when its stdin ends without a newline.
-                line = bytes(self._stdin_line)
-                self._stdin_line = bytearray()
-                self.lineReceived(line)
-            if not any(
-                getattr(item, "reads_stdin", False) for item in self.cmdstack
-            ):
+                self._dispatch_stdin_line()
+            if not any(getattr(item, "reads_stdin", False) for item in self.cmdstack):
                 # The stdin-reading shell already exited (e.g. `exit`) and
                 # ended the process; nothing is left to deliver EOF to.
                 return

--- a/src/cowrie/test/test_exec_shell_stdin.py
+++ b/src/cowrie/test/test_exec_shell_stdin.py
@@ -131,6 +131,13 @@ class ExecShellStdinTests(unittest.TestCase):
         self.assertEqual(bytes(out), b"hi\n")
         self.assertEqual(ended.get("code"), 0)
 
+    def test_eof_reports_last_command_status(self) -> None:
+        # bash exits with the last command's status when stdin hits EOF.
+        lsp, _out, ended = self.drive(b"bash")
+        lsp.dataReceived(b"false\n")
+        lsp.eofReceived()
+        self.assertEqual(ended.get("code"), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/cowrie/test/test_exec_shell_stdin.py
+++ b/src/cowrie/test/test_exec_shell_stdin.py
@@ -138,6 +138,35 @@ class ExecShellStdinTests(unittest.TestCase):
         lsp.eofReceived()
         self.assertEqual(ended.get("code"), 1)
 
+    def test_binary_garbage_does_not_kill_session(self) -> None:
+        # Invalid UTF-8 piped into the shell must not raise out of the
+        # protocol; the shell reports garbage and keeps reading.
+        lsp, out, ended = self.drive(b"bash")
+        lsp.dataReceived(b"\xff\xfe\x01garbage\n")
+        self.assertEqual(ended, {})
+        out.clear()
+        lsp.dataReceived(b"echo ok\n")
+        self.assertEqual(bytes(out), b"ok\n")
+
+    def test_backspace_edits_line(self) -> None:
+        lsp, out, _ended = self.drive(b"bash", term="xterm")
+        out.clear()
+        lsp.dataReceived(b"echo hix\x7f\r")
+        self.assertEqual(bytes(out), b"hi\n" + PROMPT)
+
+    def test_ctrl_c_discards_pending_line(self) -> None:
+        lsp, out, _ended = self.drive(b"bash", term="xterm")
+        out.clear()
+        lsp.dataReceived(b"echo dropped\x03echo kept\r")
+        self.assertEqual(bytes(out), b"kept\n" + PROMPT)
+
+    def test_overlong_line_is_capped(self) -> None:
+        cap = protocol.HoneyPotExecProtocol.STDIN_LINE_MAX
+        lsp, out, ended = self.drive(b"bash")
+        lsp.dataReceived(b"echo " + b"A" * cap + b"\n")
+        self.assertEqual(ended, {})
+        self.assertEqual(bytes(out), b"A" * (cap - len(b"echo ")) + b"\n")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/cowrie/test/test_exec_shell_stdin.py
+++ b/src/cowrie/test/test_exec_shell_stdin.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests `bash` exec'd as the SSH command reading commands from channel
+# ABOUTME: stdin until EOF, with a prompt only when the client requested a pty.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from twisted.internet.protocol import connectionDone
+
+from cowrie.insults import insults
+from cowrie.shell import protocol
+from cowrie.test.eventcapture import CaptureSink, make_exec_transport
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+
+_DOWNLOAD_DIR = tempfile.mkdtemp(prefix="cowrie_exec_shell_")
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = _DOWNLOAD_DIR
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+insults.LoggingServerProtocol.downloadPath = _DOWNLOAD_DIR
+
+PROMPT = b"root@unitTest:~# "
+
+
+def start_exec_session(
+    cmd: bytes, term: str | None = None
+) -> tuple[insults.LoggingServerProtocol, bytearray, dict[str, int]]:
+    """Open an SSH exec channel running `cmd`.
+
+    Returns the logging protocol, a buffer collecting channel output, and a
+    dict that gains a "code" key once the session reports its exit status.
+    A pty request is simulated by `term`, which sets TERM in the session
+    environment as SSHSessionForCowrieUser.getPty does.
+    """
+    avatar = FakeAvatar(FakeServer())
+    if term is not None:
+        avatar.environ["TERM"] = term
+
+    out = bytearray()
+    ended: dict[str, int] = {}
+
+    def process_ended(reason: object = None) -> None:
+        value = getattr(reason, "value", None)
+        ended["code"] = getattr(value, "exitCode", 0) if value is not None else 0
+
+    transport = make_exec_transport(CaptureSink(), processEnded=process_ended)
+    transport.write = out.extend
+    lsp = insults.LoggingServerProtocol(protocol.HoneyPotExecProtocol, avatar, cmd)
+    lsp.makeConnection(transport)
+    return lsp, out, ended
+
+
+class ExecShellStdinTests(unittest.TestCase):
+    """`ssh host bash` runs a shell fed by channel stdin, as real sshd does."""
+
+    def drive(
+        self, cmd: bytes, term: str | None = None
+    ) -> tuple[insults.LoggingServerProtocol, bytearray, dict[str, int]]:
+        lsp, out, ended = start_exec_session(cmd, term)
+        self.addCleanup(lsp.connectionLost, connectionDone)
+        return lsp, out, ended
+
+    def test_bash_waits_for_stdin(self) -> None:
+        _lsp, out, ended = self.drive(b"bash")
+        self.assertEqual(ended, {})
+        self.assertEqual(bytes(out), b"")
+
+    def test_lines_run_as_commands_and_eof_exits(self) -> None:
+        lsp, out, ended = self.drive(b"bash")
+        lsp.dataReceived(b"echo hello\n")
+        self.assertEqual(bytes(out), b"hello\n")
+        lsp.eofReceived()
+        self.assertEqual(ended.get("code"), 0)
+
+    def test_sh_behaves_like_bash(self) -> None:
+        lsp, out, ended = self.drive(b"sh")
+        lsp.dataReceived(b"echo hello\n")
+        self.assertEqual(bytes(out), b"hello\n")
+        lsp.eofReceived()
+        self.assertEqual(ended.get("code"), 0)
+
+    def test_variables_persist_across_lines(self) -> None:
+        lsp, out, _ended = self.drive(b"bash")
+        lsp.dataReceived(b"A=5\n")
+        lsp.dataReceived(b"echo $A\n")
+        self.assertEqual(bytes(out), b"5\n")
+
+    def test_final_line_without_newline_runs_at_eof(self) -> None:
+        lsp, out, ended = self.drive(b"bash")
+        lsp.dataReceived(b"echo done")
+        lsp.eofReceived()
+        self.assertEqual(bytes(out), b"done\n")
+        self.assertEqual(ended.get("code"), 0)
+
+    def test_exit_reports_status(self) -> None:
+        lsp, _out, ended = self.drive(b"bash")
+        lsp.dataReceived(b"exit 3\n")
+        self.assertEqual(ended.get("code"), 3)
+
+    def test_cr_and_crlf_line_endings(self) -> None:
+        lsp, out, _ended = self.drive(b"bash")
+        lsp.dataReceived(b"echo one\r\necho two\r")
+        self.assertEqual(bytes(out), b"one\ntwo\n")
+
+    def test_prompt_with_pty(self) -> None:
+        lsp, out, _ended = self.drive(b"bash", term="xterm")
+        self.assertEqual(bytes(out), PROMPT)
+        out.clear()
+        lsp.dataReceived(b"echo hi\r")
+        self.assertEqual(bytes(out), b"hi\n" + PROMPT)
+
+    def test_ctrl_d_on_empty_line_exits(self) -> None:
+        lsp, _out, ended = self.drive(b"bash", term="xterm")
+        lsp.dataReceived(b"\x04")
+        self.assertEqual(ended.get("code"), 0)
+
+    def test_empty_pipe_into_bash_still_exits(self) -> None:
+        # `true | bash`: stdin is the (empty) pipe, not the channel, so the
+        # shell sees immediate EOF and the session ends.
+        _lsp, _out, ended = self.drive(b"true | bash")
+        self.assertEqual(ended.get("code"), 0)
+
+    def test_bash_dash_c_still_exits(self) -> None:
+        _lsp, out, ended = self.drive(b"bash -c 'echo hi'")
+        self.assertEqual(bytes(out), b"hi\n")
+        self.assertEqual(ended.get("code"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #141.

A client that execs `bash` or `sh` (`ssh host bash`, paramiko/pwntools `exec_command("bash")`) had its channel closed immediately: `Command_sh` treated the non-interactive exec parent shell as a pipe source and exited before any stdin arrived. Real sshd leaves the shell reading commands from the channel until EOF, with a prompt when a pty was requested.

## What changed

- `Command_sh` exec'd as the top-level SSH command now pushes a resident `HoneyPotShell` fed by channel stdin. A pty request (TERM set by `getPty`) makes it interactive with a prompt; without one it reads silently, like bash on a pipe.
- `HoneyPotExecProtocol` gains a line mode: incoming bytes are assembled into lines (`\r`, `\n`, and `\r\n` endings), dispatched to the cmdstack, and an unterminated final line still runs at channel EOF. CTRL-D on an empty line is EOF; backspace/delete and CTRL-C edit or discard the pending line instead of polluting command telemetry.
- Piped stdin (`true | bash`), `-c`, and script-file invocations keep their existing behavior.

Robustness/fidelity fixes that fell out of review:

- Invalid UTF-8 on a command line raised `UnicodeDecodeError` out of the protocol and killed the session with a traceback (also reachable interactively); lines now decode with replacement characters.
- The pending-line buffer is capped at bash's per-argument limit (128 KiB) so an endless unterminated stream cannot grow memory without bound.
- The shell exits with the last command's status on stdin EOF, as bash does (`printf 'false' | ssh host bash` now returns 1).

## Testing

- 16 unit tests in `test_exec_shell_stdin.py`, written failing first; full suite green.
- Verified end-to-end against a running cowrie with the OpenSSH client: piped command streams, forced-pty interactive sessions (prompt, `whoami`, `exit`), exit-status propagation, binary garbage piped into the shell, and multiple exec channels multiplexed over one transport. Every received line appears as a `cowrie.command.input` event; exec-channel stdin is still captured as a download artifact.