### PR TITLE
fix: bind outbound downloads to out_addr so they don't leak the server IP

### DIFF
--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -11,14 +11,15 @@ from http.client import responses
 from urllib import parse
 
 import treq
-from twisted.internet import error
+from twisted.internet import error, reactor
 from twisted.internet.defer import inlineCallbacks
 from twisted.logger import Logger
 from twisted.python import failure
+from twisted.web.client import Agent
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
-from cowrie.core.network import communication_allowed
+from cowrie.core.network import communication_allowed, outbound_bind_address
 from cowrie.core.rate_limiter import RateLimiter
 from cowrie.shell.command import HoneyPotCommand
 
@@ -340,17 +341,16 @@ class Command_curl(HoneyPotCommand):
         """
         headers = {"User-Agent": ["curl/7.38.0"]}
 
-        # TODO: use designated outbound interface
-        # out_addr = None
-        # if CowrieConfig.has_option("honeypot", "out_addr"):
-        #     out_addr = (CowrieConfig.get("honeypot", "out_addr"), 0)
+        # Bind the outbound connection to the configured source address so the
+        # download does not leak the honeypot's real interface IP.
+        agent = Agent(reactor, bindAddress=(outbound_bind_address(), 0))
         if self.head_request:
             deferred = treq.head(
-                url=url, allow_redirects=False, headers=headers, timeout=10
+                url=url, agent=agent, allow_redirects=False, headers=headers, timeout=10
             )
         else:
             deferred = treq.get(
-                url=url, allow_redirects=False, headers=headers, timeout=10
+                url=url, agent=agent, allow_redirects=False, headers=headers, timeout=10
             )
         return deferred
 

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -15,7 +15,7 @@ from twisted.logger import Logger
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
-from cowrie.core.network import communication_allowed
+from cowrie.core.network import communication_allowed, outbound_bind_address
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.customparser import CustomParser, ExitException, OptionNotFound
 
@@ -326,8 +326,11 @@ class Command_tftp(HoneyPotCommand):
             self.host_ip, self.port, self.file_to_get, self.artifactFile
         )
 
-        # Listen on random UDP port
-        self.udp_port = reactor.listenUDP(0, self.tftp_client)  # type: ignore[attr-defined]
+        # Listen on a random UDP port, bound to the configured outbound source
+        # address so the transfer does not leak the honeypot's real IP.
+        self.udp_port = reactor.listenUDP(  # type: ignore[attr-defined]
+            0, self.tftp_client, interface=outbound_bind_address()
+        )
 
         # Clean up port when done
         def cleanup(result: Any) -> Any:

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -19,11 +19,12 @@ from twisted.internet.protocol import ClientCreator, Protocol
 from twisted.logger import Logger
 from twisted.protocols.ftp import CommandFailed, FTPClient
 from twisted.python import failure
+from twisted.web.client import Agent
 from twisted.web.iweb import UNKNOWN_LENGTH
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
-from cowrie.core.network import communication_allowed
+from cowrie.core.network import communication_allowed, outbound_bind_address
 from cowrie.core.rate_limiter import RateLimiter
 from cowrie.shell.command import HoneyPotCommand
 
@@ -328,12 +329,12 @@ class Command_wget(HoneyPotCommand):
             "User-Agent": [f"Wget/{self.wget_version} (linux-gnu)"]
         }
 
-        # TODO: use designated outbound interface
-        # out_addr = None
-        # if CowrieConfig.has_option("honeypot", "out_addr"):
-        #     out_addr = (CowrieConfig.get("honeypot", "out_addr"), 0)
-
-        deferred = treq.get(url=url, allow_redirects=True, headers=headers, timeout=10)
+        # Bind the outbound connection to the configured source address so the
+        # download does not leak the honeypot's real interface IP.
+        agent = Agent(reactor, bindAddress=(outbound_bind_address(), 0))
+        deferred = treq.get(
+            url=url, agent=agent, allow_redirects=True, headers=headers, timeout=10
+        )
         return deferred
 
     def ftpDownload(self, urldata: parse.ParseResult) -> Any:
@@ -364,7 +365,12 @@ class Command_wget(HoneyPotCommand):
         self.ftp_client = None
 
         creator = ClientCreator(reactor, FTPClient, username, password, passive=True)
-        deferred = creator.connectTCP(self.host, self.port, timeout=30)
+        deferred = creator.connectTCP(
+            self.host,
+            self.port,
+            timeout=30,
+            bindAddress=(outbound_bind_address(), 0),
+        )
         deferred.addCallback(self._ftp_connected)
         return deferred
 

--- a/src/cowrie/core/network.py
+++ b/src/cowrie/core/network.py
@@ -11,6 +11,8 @@ from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.logger import Logger
 from twisted.names import client, dns
 
+from cowrie.core.config import CowrieConfig
+
 _log = Logger()
 
 BLOCKED_IPS = [
@@ -96,6 +98,16 @@ PORT_PATTERN = re.compile(
 def is_valid_port(port: str) -> bool:
     """Check if port string is a valid TCP/UDP port number (1-65535)"""
     return bool(PORT_PATTERN.match(port))
+
+
+def outbound_bind_address() -> str:
+    """Source IP to bind outbound connections to, from ``[honeypot] out_addr``.
+
+    Defaults to ``0.0.0.0`` (let the OS pick the source address). Binding
+    downloads (wget, curl, tftp) to a configured address keeps the honeypot's
+    real interface IP out of traffic that would otherwise reveal it.
+    """
+    return CowrieConfig.get("honeypot", "out_addr", fallback="0.0.0.0")
 
 
 def is_ip_address(

--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -163,8 +163,9 @@ timezone = UTC
 # ============================================================================
 
 
-# IP address to bind to when opening outgoing connections. Used by wget and
-# curl commands.
+# IP address to bind to when opening outgoing connections. Used by the wget,
+# curl, tftp and nc commands. Binding to a dedicated address keeps the
+# honeypot's real interface IP out of outbound traffic that would leak it.
 #
 # (default: not specified)
 #out_addr = 0.0.0.0

--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -12,11 +12,13 @@ import tempfile
 import unittest
 from unittest import mock
 
-from twisted.internet import error
+from twisted.internet import defer, error
 from twisted.python.failure import Failure
 
+from cowrie.commands import curl as curl_module
 from cowrie.commands.curl import Command_curl
 from cowrie.core.artifact import Artifact
+from cowrie.core.config import CowrieConfig
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.eventcapture import capture_events
@@ -168,3 +170,40 @@ class CurlArtifactCleanupTests(unittest.TestCase):
             [],
             "late download callbacks reported events for an exited command",
         )
+
+
+class CurlOutboundBindTests(unittest.TestCase):
+    """Downloads must bind to the configured out_addr so they do not leak the
+    honeypot's real interface IP (issue #752)."""
+
+    def tearDown(self) -> None:
+        CowrieConfig.remove_option("honeypot", "out_addr")
+
+    def _capture_agent(self, head_request: bool, verb: str) -> object:
+        cmd = Command_curl.__new__(Command_curl)
+        cmd.head_request = head_request
+
+        captured: dict[str, object] = {}
+
+        def fake_verb(url: str, agent: object = None, **kwargs: object) -> object:
+            captured["agent"] = agent
+            return defer.succeed(None)
+
+        with mock.patch.object(curl_module.treq, verb, fake_verb):
+            cmd.treqDownload("http://198.51.100.1/x")
+
+        return captured["agent"]
+
+    def test_get_binds_agent_to_out_addr(self) -> None:
+        CowrieConfig.set("honeypot", "out_addr", "127.0.0.1")
+        agent = self._capture_agent(head_request=False, verb="get")
+        self.assertEqual(agent._endpointFactory._bindAddress, ("127.0.0.1", 0))
+
+    def test_head_binds_agent_to_out_addr(self) -> None:
+        CowrieConfig.set("honeypot", "out_addr", "127.0.0.1")
+        agent = self._capture_agent(head_request=True, verb="head")
+        self.assertEqual(agent._endpointFactory._bindAddress, ("127.0.0.1", 0))
+
+    def test_default_bind_is_wildcard(self) -> None:
+        agent = self._capture_agent(head_request=False, verb="get")
+        self.assertEqual(agent._endpointFactory._bindAddress, ("0.0.0.0", 0))

--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from typing import Any
 from unittest import mock
 
 from twisted.internet import defer, error
 from twisted.python.failure import Failure
 
-from cowrie.commands import curl as curl_module
 from cowrie.commands.curl import Command_curl
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
@@ -179,17 +179,17 @@ class CurlOutboundBindTests(unittest.TestCase):
     def tearDown(self) -> None:
         CowrieConfig.remove_option("honeypot", "out_addr")
 
-    def _capture_agent(self, head_request: bool, verb: str) -> object:
+    def _capture_agent(self, head_request: bool, verb: str) -> Any:
         cmd = Command_curl.__new__(Command_curl)
         cmd.head_request = head_request
 
-        captured: dict[str, object] = {}
+        captured: dict[str, Any] = {}
 
-        def fake_verb(url: str, agent: object = None, **kwargs: object) -> object:
+        def fake_verb(url: str, agent: Any = None, **kwargs: Any) -> Any:
             captured["agent"] = agent
             return defer.succeed(None)
 
-        with mock.patch.object(curl_module.treq, verb, fake_verb):
+        with mock.patch(f"cowrie.commands.curl.treq.{verb}", fake_verb):
             cmd.treqDownload("http://198.51.100.1/x")
 
         return captured["agent"]

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -24,6 +24,7 @@ from cowrie.commands.tftp import (
     Command_tftp,
 )
 from cowrie.core.artifact import Artifact
+from cowrie.core.config import CowrieConfig
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.eventcapture import capture_events
 from cowrie.test.fake_server import FakeAvatar, FakeServer
@@ -392,6 +393,36 @@ class TFTPHostnameResolutionTests(unittest.TestCase):
             d.addErrback(lambda _f: None)
             d.cancel()
             cmd.artifactFile.close()
+
+    def _bound_host(self, cmd: Command_tftp) -> str:
+        d = cmd.tftp_download_async()
+        try:
+            assert cmd.udp_port is not None
+            host: str = cmd.udp_port.getHost().host
+            return host
+        finally:
+            client = cmd.tftp_client
+            if client and client.timeout_call and client.timeout_call.active():
+                client.timeout_call.cancel()
+            if cmd.udp_port:
+                cmd.udp_port.stopListening()
+            d.addErrback(lambda _f: None)
+            d.cancel()
+            cmd.artifactFile.close()
+
+    def test_download_binds_to_out_addr(self) -> None:
+        # The UDP socket must bind to the configured out_addr so the transfer
+        # does not leak the honeypot's real interface IP (issue #752).
+        self.addCleanup(CowrieConfig.remove_option, "honeypot", "out_addr")
+        CowrieConfig.set("honeypot", "out_addr", "127.0.0.1")
+        cmd = self._make_command(host_ip="127.0.0.1")
+        self.assertEqual(self._bound_host(cmd), "127.0.0.1")
+
+    def test_download_defaults_to_wildcard_bind(self) -> None:
+        # With no out_addr configured, the OS chooses the source address.
+        CowrieConfig.remove_option("honeypot", "out_addr")
+        cmd = self._make_command(host_ip="127.0.0.1")
+        self.assertEqual(self._bound_host(cmd), "0.0.0.0")
 
 
 class TFTPProtocolTests(unittest.TestCase):

--- a/src/cowrie/test/test_wget.py
+++ b/src/cowrie/test/test_wget.py
@@ -11,12 +11,13 @@ import os
 import tempfile
 import time
 import unittest
+from typing import Any
 from unittest import mock
+from urllib.parse import urlparse
 
 from twisted.internet import defer, error
 from twisted.python.failure import Failure
 
-from cowrie.commands import wget as wget_module
 from cowrie.commands.wget import Command_wget
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
@@ -191,36 +192,27 @@ class WgetOutboundBindTests(unittest.TestCase):
     def tearDown(self) -> None:
         CowrieConfig.remove_option("honeypot", "out_addr")
 
-    def test_http_download_binds_agent_to_out_addr(self) -> None:
-        CowrieConfig.set("honeypot", "out_addr", "127.0.0.1")
+    def _captured_agent(self) -> Any:
+        """Run httpDownload with treq.get stubbed and return the agent it used.
+        The agent's endpoint factory carries the source address it binds to."""
         cmd = Command_wget.__new__(Command_wget)
+        captured: dict[str, Any] = {}
 
-        captured: dict[str, object] = {}
-
-        def fake_get(url: str, agent: object = None, **kwargs: object) -> object:
+        def fake_get(url: str, agent: Any = None, **kwargs: Any) -> Any:
             captured["agent"] = agent
             return defer.succeed(None)
 
-        with mock.patch.object(wget_module.treq, "get", fake_get):
+        with mock.patch("cowrie.commands.wget.treq.get", fake_get):
             cmd.httpDownload("http://198.51.100.1/x")
+        return captured["agent"]
 
-        # The agent's endpoint factory carries the source address it binds to.
-        agent = captured["agent"]
+    def test_http_download_binds_agent_to_out_addr(self) -> None:
+        CowrieConfig.set("honeypot", "out_addr", "127.0.0.1")
+        agent = self._captured_agent()
         self.assertEqual(agent._endpointFactory._bindAddress, ("127.0.0.1", 0))
 
     def test_http_download_default_bind_is_wildcard(self) -> None:
-        cmd = Command_wget.__new__(Command_wget)
-
-        captured: dict[str, object] = {}
-
-        def fake_get(url: str, agent: object = None, **kwargs: object) -> object:
-            captured["agent"] = agent
-            return defer.succeed(None)
-
-        with mock.patch.object(wget_module.treq, "get", fake_get):
-            cmd.httpDownload("http://198.51.100.1/x")
-
-        agent = captured["agent"]
+        agent = self._captured_agent()
         self.assertEqual(agent._endpointFactory._bindAddress, ("0.0.0.0", 0))
 
     def test_ftp_download_binds_to_out_addr(self) -> None:
@@ -229,20 +221,20 @@ class WgetOutboundBindTests(unittest.TestCase):
         cmd.host = "198.51.100.1"
         cmd.port = 21
 
-        captured: dict[str, object] = {}
+        captured: dict[str, Any] = {}
 
         class FakeCreator:
-            def __init__(self, *a: object, **k: object) -> None:
+            def __init__(self, *a: Any, **k: Any) -> None:
                 pass
 
-            def connectTCP(self, host: str, port: int, **kwargs: object) -> object:
+            def connectTCP(self, host: str, port: int, **kwargs: Any) -> Any:
                 captured["bindAddress"] = kwargs.get("bindAddress")
                 # A pending Deferred: capture the bind address without driving
                 # the FTP callback chain (which would need a live client).
                 return defer.Deferred()
 
-        urldata = wget_module.parse.urlparse("ftp://198.51.100.1/dir/file")
-        with mock.patch.object(wget_module, "ClientCreator", FakeCreator):
+        urldata = urlparse("ftp://198.51.100.1/dir/file")
+        with mock.patch("cowrie.commands.wget.ClientCreator", FakeCreator):
             cmd.ftpDownload(urldata)
 
         self.assertEqual(captured["bindAddress"], ("127.0.0.1", 0))

--- a/src/cowrie/test/test_wget.py
+++ b/src/cowrie/test/test_wget.py
@@ -13,11 +13,13 @@ import time
 import unittest
 from unittest import mock
 
-from twisted.internet import error
+from twisted.internet import defer, error
 from twisted.python.failure import Failure
 
+from cowrie.commands import wget as wget_module
 from cowrie.commands.wget import Command_wget
 from cowrie.core.artifact import Artifact
+from cowrie.core.config import CowrieConfig
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.eventcapture import capture_events
@@ -180,3 +182,67 @@ class WgetArtifactCleanupTests(unittest.TestCase):
             [],
             "late download callbacks reported events for an exited command",
         )
+
+
+class WgetOutboundBindTests(unittest.TestCase):
+    """Downloads must bind to the configured out_addr so they do not leak the
+    honeypot's real interface IP (issue #752)."""
+
+    def tearDown(self) -> None:
+        CowrieConfig.remove_option("honeypot", "out_addr")
+
+    def test_http_download_binds_agent_to_out_addr(self) -> None:
+        CowrieConfig.set("honeypot", "out_addr", "127.0.0.1")
+        cmd = Command_wget.__new__(Command_wget)
+
+        captured: dict[str, object] = {}
+
+        def fake_get(url: str, agent: object = None, **kwargs: object) -> object:
+            captured["agent"] = agent
+            return defer.succeed(None)
+
+        with mock.patch.object(wget_module.treq, "get", fake_get):
+            cmd.httpDownload("http://198.51.100.1/x")
+
+        # The agent's endpoint factory carries the source address it binds to.
+        agent = captured["agent"]
+        self.assertEqual(agent._endpointFactory._bindAddress, ("127.0.0.1", 0))
+
+    def test_http_download_default_bind_is_wildcard(self) -> None:
+        cmd = Command_wget.__new__(Command_wget)
+
+        captured: dict[str, object] = {}
+
+        def fake_get(url: str, agent: object = None, **kwargs: object) -> object:
+            captured["agent"] = agent
+            return defer.succeed(None)
+
+        with mock.patch.object(wget_module.treq, "get", fake_get):
+            cmd.httpDownload("http://198.51.100.1/x")
+
+        agent = captured["agent"]
+        self.assertEqual(agent._endpointFactory._bindAddress, ("0.0.0.0", 0))
+
+    def test_ftp_download_binds_to_out_addr(self) -> None:
+        CowrieConfig.set("honeypot", "out_addr", "127.0.0.1")
+        cmd = Command_wget.__new__(Command_wget)
+        cmd.host = "198.51.100.1"
+        cmd.port = 21
+
+        captured: dict[str, object] = {}
+
+        class FakeCreator:
+            def __init__(self, *a: object, **k: object) -> None:
+                pass
+
+            def connectTCP(self, host: str, port: int, **kwargs: object) -> object:
+                captured["bindAddress"] = kwargs.get("bindAddress")
+                # A pending Deferred: capture the bind address without driving
+                # the FTP callback chain (which would need a live client).
+                return defer.Deferred()
+
+        urldata = wget_module.parse.urlparse("ftp://198.51.100.1/dir/file")
+        with mock.patch.object(wget_module, "ClientCreator", FakeCreator):
+            cmd.ftpDownload(urldata)
+
+        self.assertEqual(captured["bindAddress"], ("127.0.0.1", 0))


### PR DESCRIPTION
Fixes #752. Also fixes #754.

#754 reported that a **redirect** leaks the real IP: even with `out_addr` set, the redirect hop went out the default interface. treq wraps the bound `Agent` in a `RedirectAgent`, which reuses that single agent for every hop, so the redirect connection is bound too. Verified at runtime with a spy agent over a real 302: both the original and the redirected request went through the agent bound to `out_addr`.

The `tftp`, `wget`, and `curl` commands opened outbound connections without binding to the configured `[honeypot] out_addr`, so transfers used the host's real interface address and leaked the honeypot's IP.

The original #752 was about the `tftpy` library. That dependency is long gone — `tftp` is now a native Twisted `DatagramProtocol` — but the rewrite never wired `out_addr` in (`listenUDP(0, client)` binds `0.0.0.0`), and `wget`/`curl` had their `out_addr` handling commented out since the treq/Agent rewrite. So the leak is still live across all three, HTTP downloads included. `nc` already honored `out_addr`.

## What changed

- New shared helper `cowrie.core.network.outbound_bind_address()` reads `[honeypot] out_addr` (default `0.0.0.0`).
- `tftp`: `reactor.listenUDP(0, client, interface=out_addr)`.
- `wget` / `curl`: build `Agent(reactor, bindAddress=(out_addr, 0))` and pass it to `treq`.
- `wget` FTP path: `connectTCP(..., bindAddress=(out_addr, 0))`.
- Updated the `out_addr` config comment (it claimed wget/curl already used it).

Binding to `0.0.0.0` is a no-op, so behavior is unchanged unless `out_addr` is set.

## Testing

- New unit tests per command asserting the bound interface / agent bindAddress reflects `out_addr`, plus the wildcard default.
- Full suite green; ruff and mypy clean.
- Verified end-to-end: with `out_addr=127.0.0.1`, `wget` fetched from a local HTTP server (200 OK); with `out_addr` set to an address not on any interface, the connect failed with "Can't assign requested address" — confirming the bind reaches the socket rather than being silently ignored.

## Not addressed here

DNS resolution (`reactor.resolve`, the `communication_allowed` lookup) still queries via the system resolver from the real IP — inherent to hostname resolution and out of scope for `out_addr`.
