### PR TITLE
fix: accept bare-CR line endings at the telnet login prompt (PuTTY)

### DIFF
--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -92,6 +92,30 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         """
         self.transport.write(data.replace(b"\r\n", b"\n"))
 
+    def _in_login_phase(self) -> bool:
+        """True until the login succeeds and the interactive session protocol
+        replaces the authentication protocol (see HoneyPotTelnetAuthProtocol.
+        _cbLogin). The CR handling below is scoped to login so the session's
+        raw keystroke input is left untouched."""
+        from cowrie.telnet.userauth import HoneyPotTelnetAuthProtocol
+
+        return isinstance(self.protocol, HoneyPotTelnetAuthProtocol)
+
+    def applicationDataReceived(self, data: bytes) -> None:
+        """
+        Deliver line-based login input the way a real telnetd does.
+
+        The login is read by a LineReceiver that only breaks on LF. Twisted's
+        NVT layer turns CR LF into LF but leaves any other carriage return as a
+        literal CR (CR NUL, or CR before the next line), so a client that ends
+        a line with a bare CR -- PuTTY with "Return sends ^M" -- would never
+        deliver the LF the login waits for (issue #1461). During login, treat a
+        CR as the line terminator too.
+        """
+        if self._in_login_phase():
+            data = data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+        TelnetTransport.applicationDataReceived(self, data)
+
     def dataReceived(self, data: bytes) -> None:
         """
         Twisted's Telnet.dataReceived() raises ValueError on an unrecognised
@@ -119,6 +143,15 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
             self._log.failure("Telnet protocol error; dropping connection")
             if self.transport:
                 self.transport.loseConnection()
+            return
+
+        # A line ending in a bare CR leaves Twisted parked in the "newline"
+        # state with the CR pending, so no terminator reaches the login reader
+        # until the next byte arrives. Flush it now as a newline so the prompt
+        # advances immediately, as a real telnetd does (issue #1461).
+        if self.state == "newline" and self._in_login_phase():
+            self.state = "data"
+            self.applicationDataReceived(b"\n")
 
     def timeoutConnection(self) -> None:
         """

--- a/src/cowrie/test/test_telnet_transport.py
+++ b/src/cowrie/test/test_telnet_transport.py
@@ -24,6 +24,7 @@ from twisted.python import failure, log
 from zope.interface import implementer
 
 from cowrie.telnet.transport import CowrieTelnetTransport
+from cowrie.telnet.userauth import HoneyPotTelnetAuthProtocol
 from cowrie.test.eventcapture import capture_events
 
 if TYPE_CHECKING:
@@ -316,6 +317,93 @@ class TestOptionLoggingDeduplication(unittest.TestCase):
         ):
             logs = self._capture(run)
         self.assertEqual(sorted(e["command"] for e in logs), ["WILL", "WONT"])
+
+
+class TestLoginLineEndings(unittest.TestCase):
+    """Login must accept the line endings a real telnetd does (issue #1461).
+
+    Twisted's NVT layer only turns CR LF into a newline; a client that ends a
+    line with a bare CR (PuTTY's "Return sends ^M"), CR NUL, or CR followed by
+    the next line never delivers the LF the login LineReceiver waits for, so
+    the login would stall at ``login:``.
+    """
+
+    def _harness(
+        self,
+    ) -> tuple[CowrieTelnetTransport, HoneyPotTelnetAuthProtocol, list[bytes]]:
+        transport = CowrieTelnetTransport()
+        transport.transport = MagicMock()
+        capture_events(transport)
+        auth = HoneyPotTelnetAuthProtocol(MagicMock())
+        auth.transport = transport  # type: ignore[assignment]
+        auth.factory = MagicMock()
+        auth.factory.banner = b"banner\n"
+        transport.protocol = auth  # type: ignore[assignment]
+        auth.state = "User"
+        lines: list[bytes] = []
+
+        def spy_user(line: bytes) -> str:
+            lines.append(line)
+            return "Password"
+
+        auth.telnet_User = spy_user  # type: ignore[method-assign]
+        return transport, auth, lines
+
+    def test_crlf_still_delivers_clean_line(self) -> None:
+        transport, _auth, lines = self._harness()
+        transport.dataReceived(b"root\r\n")
+        self.assertEqual(lines, [b"root"])
+
+    def test_bare_cr_delivers_clean_line(self) -> None:
+        transport, _auth, lines = self._harness()
+        transport.dataReceived(b"root\r")
+        self.assertEqual(lines, [b"root"])
+
+    def test_cr_nul_delivers_clean_line(self) -> None:
+        transport, _auth, lines = self._harness()
+        transport.dataReceived(b"root\r\x00")
+        self.assertEqual(lines, [b"root"])
+
+    def test_bare_cr_split_across_packets(self) -> None:
+        # A bare CR arriving in its own packet (character-at-a-time telnet)
+        # must terminate the line immediately, not wait for the next keystroke.
+        transport, _auth, lines = self._harness()
+        for byte in b"root":
+            transport.dataReceived(bytes([byte]))
+        self.assertEqual(lines, [])
+        transport.dataReceived(b"\r")
+        self.assertEqual(lines, [b"root"])
+
+    def test_full_login_with_bare_cr(self) -> None:
+        transport, auth, lines = self._harness()
+        passwords: list[bytes] = []
+
+        def spy_password(line: bytes) -> str:
+            passwords.append(line)
+            return "Discard"
+
+        auth.telnet_Password = spy_password  # type: ignore[method-assign]
+
+        transport.dataReceived(b"root\r")
+        auth.state = "Password"
+        transport.dataReceived(b"secret\r")
+        self.assertEqual(lines, [b"root"])
+        self.assertEqual(passwords, [b"secret"])
+
+    def test_held_cr_not_flushed_after_login(self) -> None:
+        # The CR handling is scoped to login. Once the interactive session
+        # protocol is in place, a bare CR is left for Twisted's normal NVT
+        # handling so the session's raw keystroke input is unaffected.
+        transport = CowrieTelnetTransport()
+        transport.transport = MagicMock()
+        capture_events(transport)
+        session = MagicMock()
+        transport.protocol = session  # type: ignore[assignment]
+
+        transport.dataReceived(b"x\r")
+
+        self.assertEqual(transport.state, "newline")
+        session.dataReceived.assert_called_once_with(b"x")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1461.

PuTTY in telnet mode with "Return sends ^M" (and some other clients / malware) ends a line with a bare CR (`0x0d`) instead of CR LF. Twisted's NVT layer only turns CR LF into a newline:

- a lone CR is parked in the `"newline"` state and never emitted until the next byte arrives;
- CR NUL and CR-before-the-next-line become a literal CR in the application data.

The login is read by a `LineReceiver` that only breaks on LF, so with any of these the login never sees a terminator and the session stalls at `login:` — matching the reported symptoms (echo suppressed on the first line, no newline after Enter). A real telnetd treats CR as end-of-line here.

## Fix

Scoped to the login phase (before the interactive session protocol replaces the auth protocol):

- `applicationDataReceived`: translate a carriage return in application data to LF, so CR NUL / CR-before-next-line terminate the line.
- `dataReceived`: if Twisted is left parked in the `"newline"` state at the end of a packet (a bare CR alone, as sent character-at-a-time), flush it as a newline so the prompt advances immediately instead of waiting for the next keystroke.

The interactive session's raw keystroke input is deliberately left untouched.

## Testing

- New `TestLoginLineEndings` cases: CR LF (regression), bare CR, CR NUL, bare CR split across packets, a full bare-CR login, and a guard that a held CR is **not** flushed once the session protocol is in place.
- Full suite green; ruff and mypy clean.
- Verified end-to-end against a running telnet honeypot with a raw client: before the fix, bare CR and CR NUL stalled at `login:`; after, all of bare CR, CR NUL, and CR LF complete the login to the shell prompt and log clean `[root/secret]` credentials with no tracebacks.