### PR TITLE
fix: stop logging a traceback for malformed telnet IAC traffic

### DIFF
--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -128,8 +128,9 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         Telnet.dataReceived() also re-enters the application stack
         (applicationDataReceived -> protocol.dataReceived, negotiate,
         commandReceived), so a ValueError raised by downstream honeypot code is
-        caught here too. Log the full traceback as well so a genuine bug is not
-        silently reduced to a one-line protocol error.
+        caught here too. That is a genuine bug, so log the full traceback for
+        it -- but not for the parser's own protocol error, which is expected
+        garbage traffic (see below).
         """
         try:
             TelnetTransport.dataReceived(self, data)
@@ -140,7 +141,20 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
                     "Telnet protocol error %(error)s; dropping connection",
                     error=str(e),
                 )
-            self._log.failure("Telnet protocol error; dropping connection")
+            # Twisted's parser raises ValueError("Stumped", byte) for a byte
+            # that is not a valid command after IAC: a non-telnet or malformed
+            # client (scanners, binary garbage) probing the port. That is
+            # expected honeypot traffic, already recorded by the event above,
+            # so drop it without a traceback. Any other ValueError comes from
+            # re-entrant honeypot code and is a real bug worth the traceback.
+            stumped = bool(e.args) and e.args[0] == "Stumped"
+            if not stumped:
+                self._log.failure("Telnet protocol error; dropping connection")
+            elif not self.events:
+                self._log.info(
+                    "Telnet protocol error {error}; dropping connection",
+                    error=str(e),
+                )
             if self.transport:
                 self.transport.loseConnection()
             return

--- a/src/cowrie/test/test_telnet_transport.py
+++ b/src/cowrie/test/test_telnet_transport.py
@@ -278,6 +278,30 @@ class TestInvalidIACSequence(unittest.TestCase):
         self.tcp.loseConnection.assert_not_called()
         self.assertEqual(errors, [])
 
+    def test_protocol_error_logs_no_traceback(self) -> None:
+        # A byte the telnet parser rejects after IAC is expected garbage from a
+        # non-telnet client (scanners). The error event records it; a full
+        # traceback would just be log noise, so none is logged.
+        self.transport._log = MagicMock()
+        errors = self._capture(lambda: self.transport.dataReceived(b"\xff\x18"))
+
+        self.assertEqual(len(errors), 1)
+        self.tcp.loseConnection.assert_called_once_with()
+        self.transport._log.failure.assert_not_called()
+
+    def test_unexpected_valueerror_logs_traceback(self) -> None:
+        # A ValueError from downstream honeypot code (not the telnet parser) is
+        # a genuine bug and must still be logged with a full traceback.
+        self.transport._log = MagicMock()
+        protocol = MagicMock()
+        protocol.dataReceived.side_effect = ValueError("boom")
+        self.transport.protocol = protocol  # type: ignore[assignment]
+
+        self.transport.dataReceived(b"hello")
+
+        self.transport._log.failure.assert_called_once()
+        self.tcp.loseConnection.assert_called_once_with()
+
 
 class TestOptionLoggingDeduplication(unittest.TestCase):
     """A scanner flooding the same option negotiation is logged once."""


### PR DESCRIPTION
Honeypots on the telnet port get a steady stream of non-telnet and malformed traffic (scanners, binary garbage). When such a client sends a byte that is not a valid command after IAC (`0xFF`), Twisted's parser raises `ValueError("Stumped", byte)`. The transport already catches this, records a `cowrie.telnet.error` event, and drops the connection — but it *also* logs a full Python traceback for every one:

```
[telnet,81e7ba0d31ea,118.175.134.141] Telnet protocol error ('Stumped', b'\x18'); dropping connection
[CowrieTelnetTransport,2641,118.175.134.141] Telnet protocol error; dropping connection
        Traceback (most recent call last):
          File ".../telnet/transport.py", line 111, in dataReceived
            TelnetTransport.dataReceived(self, data)
          File ".../twisted/conch/telnet.py", line 548, in dataReceived
            raise ValueError("Stumped", b)
        builtins.ValueError: ('Stumped', b'\x18')
```

That traceback is noise — it's expected garbage traffic, not a bug.

## Fix

The traceback was there deliberately: the same `try/except` also catches `ValueError`s raised by re-entrant honeypot code, which are genuine bugs worth a traceback. So distinguish the two: Twisted's parser marks its own protocol error with `args[0] == "Stumped"`. For that case, rely on the already-dispatched error event and drop the connection without a traceback; keep the full traceback for any other `ValueError`.

## Testing

- New tests: the parser protocol error (`IAC` + invalid byte) dispatches the event and drops the connection but logs **no** traceback; an unrelated downstream `ValueError` still logs a traceback.
- Full suite green; ruff and mypy clean.
- Verified live: sending `0xFF 0x18` to a running telnet honeypot now produces a single `cowrie.telnet.error` event line with the session/IP context and zero tracebacks in the log.