### PR TITLE
fix: treat a bare "=" as a command word, not an assignment

### DIFF
--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -10,6 +10,7 @@ import copy
 import enum
 import fnmatch
 import os
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -70,6 +71,12 @@ class _Continuation:
     fn: Callable[[], None]
     is_loop_cont: bool = False
     op: str | None = None
+
+
+# A leading word only counts as a variable assignment when a valid shell
+# identifier precedes the "=", matching bash's assignment-word grammar. A bare
+# "=" (or "1=x") is a command name, not an assignment.
+ASSIGNMENT_WORD = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 
 
 class HoneyPotShell:
@@ -622,7 +629,7 @@ class HoneyPotShell:
         cmd_array: list[dict[str, Any]] = []
         while cmdAndArgs:
             piece = cmdAndArgs.pop(0)
-            if piece.count("="):
+            if ASSIGNMENT_WORD.match(piece):
                 key, val = piece.split("=", 1)
                 environ[key] = val
                 continue

--- a/src/cowrie/test/test_shell_variables.py
+++ b/src/cowrie/test/test_shell_variables.py
@@ -111,6 +111,14 @@ class ShellVariableTests(unittest.TestCase):
         self.proto.lineReceived(b"export x")
         self.assertIn(b"x=hi", self.run_line(b"env"))
 
+    # A word is only an assignment when a valid identifier precedes the "=";
+    # bash reports a bare "=" (or a non-identifier name) as a command instead.
+    def test_bare_equals_is_a_command(self) -> None:
+        self.assertIn(b"=: command not found", self.run_line(b"="))
+
+    def test_non_identifier_assignment_is_a_command(self) -> None:
+        self.assertIn(b"1=x: command not found", self.run_line(b"1=x"))
+
     # unset PATH must not crash later command dispatch
     def test_unset_path_does_not_crash(self) -> None:
         self.proto.lineReceived(b"unset PATH")


### PR DESCRIPTION
Closes #40348

`runCommand()` treated any leading word containing `=` as an assignment, so a bare `=` set `environ[""] = ""` and was silently consumed; bash requires a valid identifier before the `=` and reports `bash: =: command not found`. The check now uses an assignment-word regex matching bash's grammar, so `=` and `1=x` fall through to normal command lookup.

Two cases added to `src/cowrie/test/test_shell_variables.py`; they fail without the change and pass with it (full test suite: 799 passed).