### PR TITLE
feat: kafka output based on aiokafka

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ rethinkdblog = ["rethinkdb"]
 s3 = ["botocore"]
 slack = ["slackclient"]
 influxdb = ["influxdb"]
+kafka = ["aiokafka==0.14"]
 dev = [
 "build==1.5.0",
 "coverage==7.14.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ rethinkdblog = ["rethinkdb"]
 s3 = ["botocore"]
 slack = ["slackclient"]
 influxdb = ["influxdb"]
-kafka = ["aiokafka==0.14"]
+kafka = ["aiokafka"]
 dev = [
 "build==1.5.0",
 "coverage==7.14.3",

--- a/requirements-output.txt
+++ b/requirements-output.txt
@@ -57,3 +57,6 @@ pika==1.4.1
 
 # prometheus
 prometheus_client==0.25.0
+
+# kafka
+aiokafka==0.14

--- a/requirements-output.txt
+++ b/requirements-output.txt
@@ -59,4 +59,4 @@ pika==1.4.1
 prometheus_client==0.25.0
 
 # kafka
-aiokafka==0.14
+aiokafka==0.14.0

--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -1103,6 +1103,11 @@ port = 8086
 database_name = cowrie
 retention_policy_duration = 12w
 
+# Kafka output. Requires Twisted to run the asyncio reactor:
+#   cowrie start -- --reactor=asyncio
+# The plugin disables itself with an error when another reactor is in use.
+# Connections are plaintext and unauthenticated (no TLS/SASL support),
+# so only use a broker on a trusted network.
 [output_kafka]
 enabled = false
 host = 127.0.0.1

--- a/src/cowrie/output/kafka.py
+++ b/src/cowrie/output/kafka.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2015-2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from aiokafka import AIOKafkaProducer
+from twisted.internet import reactor
+from twisted.logger import Logger
+
+import cowrie.core.output
+import cowrie.python.logfile
+from cowrie.core.config import CowrieConfig
+
+
+class NotAsyncioError(Exception):
+    def __init__(self):
+        super().__init__(
+            "asyncio loop is not running. This plugin requires Twisted to run an asyncio reactor."
+        )
+
+
+class Output(cowrie.core.output.Output):
+    """
+    Kafka output
+    """
+
+    _log = Logger()
+
+    def start(self):
+        self._host = CowrieConfig.get("output_kafka", "host", fallback="127.0.0.1")
+        self._port = CowrieConfig.getint("output_kafka", "port", fallback=9092)
+        self._topic = CowrieConfig.get("output_kafka", "topic", fallback="cowrie")
+
+        # References to pending asyncio tasks.
+        # https://docs.astral.sh/ruff/rules/asyncio-dangling-task/
+        self._background_tasks = set()
+
+        # Initialization must be delayed - it requires an asyncio loop to be running, which only
+        # happens after the reactor starts.
+        self._producer = None
+        self._ready = asyncio.Event()
+
+        # Start initialization when the asyncio reactor is already running
+        reactor.callLater(0, self._start)
+
+    def _start(self):
+        """
+        Initialize the Kafka producer in a background task.
+        Must be called when the asyncio loop is already running.
+        """
+        self._assert_asyncio_running()
+
+        async def _do_start():
+            try:
+                self._producer = AIOKafkaProducer(
+                    bootstrap_servers=f"{self._host}:{self._port}"
+                )
+                await self._producer.start()
+            except Exception as e:
+                self._log.error(f"kafka: Can't connect: {e}")
+            finally:
+                # Set the event even in case of failure to unblock waiting tasks.
+                # They'll fail anyway, but at least they won't build up.
+                self._ready.set()
+
+        task = asyncio.ensure_future(_do_start())
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    def _assert_asyncio_running(self):
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError as e:
+            raise NotAsyncioError() from e
+
+    def stop(self):
+        if not self._producer:
+            return
+
+        async def _do_stop():
+            await self._producer.stop()
+
+        task = asyncio.ensure_future(_do_stop())
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    def write(self, event):
+        for i in list(event):
+            # Remove twisted 15 legacy keys
+            if i.startswith("log_") or i == "time" or i == "system":
+                del event[i]
+
+        task = asyncio.ensure_future(self._write(json.dumps(event).encode("utf-8")))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    async def _write(self, content):
+        try:
+            await self._ready.wait()
+            await self._producer.send_and_wait(self._topic, content)
+        except Exception as e:
+            self._log.error(f"kafka: Can't write: {e}")

--- a/src/cowrie/output/kafka.py
+++ b/src/cowrie/output/kafka.py
@@ -35,6 +35,11 @@ class Output(cowrie.core.output.Output):
 
     # How long shutdown may wait for pending events to reach the broker.
     FLUSH_TIMEOUT: float = 5.0
+    # Delay between connection attempts while the broker is unreachable.
+    RECONNECT_INTERVAL: float = 30.0
+    # Events buffer while disconnected (or the broker is slow); beyond
+    # this backlog, writes are dropped and counted.
+    MAX_PENDING: int = 1000
 
     def start(self) -> None:
         self._enabled: bool = False
@@ -45,6 +50,7 @@ class Output(cowrie.core.output.Output):
         # https://docs.astral.sh/ruff/rules/asyncio-dangling-task/
         self._background_tasks: set[asyncio.Task[None]] = set()
         self._ready = asyncio.Event()
+        self._dropped: int = 0
 
         # The reactor's static type is an interface; widen it so mypy
         # accepts the concrete-class check.
@@ -80,26 +86,34 @@ class Output(cowrie.core.output.Output):
 
     def _start(self) -> None:
         """
-        Initialize the Kafka producer in a background task.
+        Start connecting in a background task.
         Must be called when the asyncio loop is already running.
         """
-
-        async def _do_start() -> None:
-            try:
-                self._producer = AIOKafkaProducer(
-                    bootstrap_servers=f"{self._host}:{self._port}"
-                )
-                await self._producer.start()
-            except Exception as e:
-                self._log.error(f"kafka: Can't connect: {e}")
-            finally:
-                # Set the event even in case of failure to unblock waiting tasks.
-                # They'll fail anyway, but at least they won't build up.
-                self._ready.set()
-
-        task = asyncio.ensure_future(_do_start())
+        task = asyncio.ensure_future(self._connect())
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
+
+    async def _connect(self) -> None:
+        """
+        Connect the producer, retrying while the broker is unreachable.
+        Writes buffer against _ready until the connection succeeds.
+        """
+        while self._producer is None:
+            producer = self._create_producer()
+            try:
+                await producer.start()
+            except Exception as e:
+                self._log.error(
+                    f"kafka: Can't connect, retrying in {self.RECONNECT_INTERVAL}s: {e}"
+                )
+                await producer.stop()
+                await asyncio.sleep(self.RECONNECT_INTERVAL)
+                continue
+            self._producer = producer
+            self._ready.set()
+
+    def _create_producer(self) -> Any:
+        return AIOKafkaProducer(bootstrap_servers=f"{self._host}:{self._port}")
 
     def _flush(self) -> Deferred[None] | None:
         if self._producer is None:
@@ -133,6 +147,14 @@ class Output(cowrie.core.output.Output):
 
     def write(self, event: dict[str, Any]) -> None:
         if not self._enabled:
+            return
+
+        if len(self._background_tasks) >= self.MAX_PENDING:
+            self._dropped += 1
+            if self._dropped == 1 or self._dropped % 100 == 0:
+                self._log.error(
+                    f"kafka: backlog full, {self._dropped} events dropped so far"
+                )
             return
 
         for i in list(event):

--- a/src/cowrie/output/kafka.py
+++ b/src/cowrie/output/kafka.py
@@ -6,55 +6,75 @@ from __future__ import annotations
 
 import asyncio
 import json
+from typing import Any, cast
 
-from aiokafka import AIOKafkaProducer
-from twisted.internet import reactor
+from twisted.internet import asyncioreactor, reactor
 from twisted.logger import Logger
 
 import cowrie.core.output
-import cowrie.python.logfile
 from cowrie.core.config import CowrieConfig
 
-
-class NotAsyncioError(Exception):
-    def __init__(self):
-        super().__init__(
-            "asyncio loop is not running. This plugin requires Twisted to run an asyncio reactor."
-        )
+try:
+    from aiokafka import AIOKafkaProducer
+except ImportError:
+    AIOKafkaProducer = None
 
 
 class Output(cowrie.core.output.Output):
     """
-    Kafka output
+    Kafka output.
+
+    aiokafka drives Kafka I/O on the asyncio event loop, so this plugin
+    only works when Twisted runs the asyncio reactor
+    (cowrie start -- --reactor=asyncio). Under any other reactor the
+    plugin disables itself with an error message.
     """
 
     _log = Logger()
 
-    def start(self):
-        self._host = CowrieConfig.get("output_kafka", "host", fallback="127.0.0.1")
-        self._port = CowrieConfig.getint("output_kafka", "port", fallback=9092)
-        self._topic = CowrieConfig.get("output_kafka", "topic", fallback="cowrie")
-
+    def start(self) -> None:
+        self._enabled: bool = False
+        # AIOKafkaProducer, or None until the producer has connected
+        # (aiokafka is untyped for mypy, so no annotation with it).
+        self._producer: Any = None
         # References to pending asyncio tasks.
         # https://docs.astral.sh/ruff/rules/asyncio-dangling-task/
-        self._background_tasks = set()
-
-        # Initialization must be delayed - it requires an asyncio loop to be running, which only
-        # happens after the reactor starts.
-        self._producer = None
+        self._background_tasks: set[asyncio.Task[None]] = set()
         self._ready = asyncio.Event()
 
-        # Start initialization when the asyncio reactor is already running
+        # The reactor's static type is an interface; widen it so mypy
+        # accepts the concrete-class check.
+        if not isinstance(
+            cast("object", reactor), asyncioreactor.AsyncioSelectorReactor
+        ):
+            self._log.error(
+                "kafka: this plugin requires the asyncio reactor,"
+                " start cowrie with: cowrie start -- --reactor=asyncio."
+                " Kafka output disabled."
+            )
+            return
+
+        if AIOKafkaProducer is None:
+            self._log.error("kafka: aiokafka is not installed. Kafka output disabled.")
+            return
+
+        self._host: str = CowrieConfig.get("output_kafka", "host", fallback="127.0.0.1")
+        self._port: int = CowrieConfig.getint("output_kafka", "port", fallback=9092)
+        self._topic: str = CowrieConfig.get("output_kafka", "topic", fallback="cowrie")
+
+        self._enabled = True
+
+        # Producer initialization must be delayed - it requires an asyncio
+        # loop to be running, which only happens after the reactor starts.
         reactor.callLater(0, self._start)
 
-    def _start(self):
+    def _start(self) -> None:
         """
         Initialize the Kafka producer in a background task.
         Must be called when the asyncio loop is already running.
         """
-        self._assert_asyncio_running()
 
-        async def _do_start():
+        async def _do_start() -> None:
             try:
                 self._producer = AIOKafkaProducer(
                     bootstrap_servers=f"{self._host}:{self._port}"
@@ -71,24 +91,22 @@ class Output(cowrie.core.output.Output):
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
-    def _assert_asyncio_running(self):
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError as e:
-            raise NotAsyncioError() from e
-
-    def stop(self):
-        if not self._producer:
+    def stop(self) -> None:
+        producer = self._producer
+        if not producer:
             return
 
-        async def _do_stop():
-            await self._producer.stop()
+        async def _do_stop() -> None:
+            await producer.stop()
 
         task = asyncio.ensure_future(_do_stop())
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
-    def write(self, event):
+    def write(self, event: dict[str, Any]) -> None:
+        if not self._enabled:
+            return
+
         for i in list(event):
             # Remove twisted 15 legacy keys
             if i.startswith("log_") or i == "time" or i == "system":
@@ -98,9 +116,12 @@ class Output(cowrie.core.output.Output):
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
-    async def _write(self, content):
+    async def _write(self, content: bytes) -> None:
+        await self._ready.wait()
+        if self._producer is None:
+            self._log.error("kafka: Can't write: not connected")
+            return
         try:
-            await self._ready.wait()
             await self._producer.send_and_wait(self._topic, content)
         except Exception as e:
             self._log.error(f"kafka: Can't write: {e}")

--- a/src/cowrie/output/kafka.py
+++ b/src/cowrie/output/kafka.py
@@ -9,6 +9,7 @@ import json
 from typing import Any, cast
 
 from twisted.internet import asyncioreactor, reactor
+from twisted.internet.defer import Deferred
 from twisted.logger import Logger
 
 import cowrie.core.output
@@ -31,6 +32,9 @@ class Output(cowrie.core.output.Output):
     """
 
     _log = Logger()
+
+    # How long shutdown may wait for pending events to reach the broker.
+    FLUSH_TIMEOUT: float = 5.0
 
     def start(self) -> None:
         self._enabled: bool = False
@@ -64,6 +68,12 @@ class Output(cowrie.core.output.Output):
 
         self._enabled = True
 
+        # Flush before reactor shutdown: Twisted waits for Deferreds from
+        # "before" shutdown triggers while the asyncio loop still runs. By
+        # the time the base class calls stop() (after shutdown) the loop no
+        # longer executes tasks, so nothing can be delivered there.
+        reactor.addSystemEventTrigger("before", "shutdown", self._flush)
+
         # Producer initialization must be delayed - it requires an asyncio
         # loop to be running, which only happens after the reactor starts.
         reactor.callLater(0, self._start)
@@ -91,17 +101,35 @@ class Output(cowrie.core.output.Output):
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
-    def stop(self) -> None:
-        producer = self._producer
-        if not producer:
-            return
+    def _flush(self) -> Deferred[None] | None:
+        if self._producer is None:
+            return None
+        return Deferred.fromFuture(asyncio.ensure_future(self._shutdown_flush()))
 
-        async def _do_stop() -> None:
+    async def _shutdown_flush(self) -> None:
+        """
+        Wait for pending sends, then stop the producer, which flushes its
+        internal buffer. Bounded so an unreachable broker can't hang shutdown.
+        """
+        producer = self._producer
+
+        async def _drain() -> None:
+            if self._background_tasks:
+                await asyncio.gather(*self._background_tasks, return_exceptions=True)
             await producer.stop()
 
-        task = asyncio.ensure_future(_do_stop())
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        try:
+            await asyncio.wait_for(_drain(), timeout=self.FLUSH_TIMEOUT)
+        except Exception as e:
+            self._log.error(f"kafka: Can't flush on shutdown: {e}")
+        finally:
+            self._producer = None
+
+    def stop(self) -> None:
+        """
+        Producer teardown happens in _flush before reactor shutdown; once
+        this runs (after shutdown) the asyncio loop no longer executes tasks.
+        """
 
     def write(self, event: dict[str, Any]) -> None:
         if not self._enabled:

--- a/src/cowrie/test/test_kafka.py
+++ b/src/cowrie/test/test_kafka.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for the kafka output plugin: it requires the asyncio
+# ABOUTME: reactor and must disable itself under any other reactor.
+
+from __future__ import annotations
+
+import os
+import unittest
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class KafkaReactorGateTests(unittest.TestCase):
+    """Under a non-asyncio reactor the plugin must disable itself:
+    write() must not schedule asyncio tasks and stop() must be a no-op."""
+
+    def test_disabled_under_default_reactor(self) -> None:
+        from cowrie.output.kafka import Output
+
+        output = Output()
+        self.assertFalse(output._enabled)
+
+        # A write on a disabled plugin must not create tasks on an
+        # asyncio loop that will never run.
+        output.write({"eventid": "cowrie.test", "msg": "hello"})
+        self.assertEqual(output._background_tasks, set())
+
+        output.stop()

--- a/src/cowrie/test/test_kafka.py
+++ b/src/cowrie/test/test_kafka.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# ABOUTME: Tests for the kafka output plugin: reactor gating, and the
-# ABOUTME: shutdown flush that delivers pending events before the loop stops.
+# ABOUTME: Tests for the kafka output plugin: reactor gating, the shutdown
+# ABOUTME: flush of pending events, broker reconnection and write buffering.
 
 from __future__ import annotations
 
@@ -103,3 +103,57 @@ class KafkaShutdownFlushTests(unittest.TestCase):
         self.assertIsNone(output._producer)
         self.assertEqual(len(output._log.errors), 1)
         self.assertIn("flush", output._log.errors[0])
+
+
+class KafkaReconnectTests(unittest.TestCase):
+    """A broker that is down at startup must not kill the plugin: connecting
+    retries until it succeeds, and writes buffer up to a bounded backlog."""
+
+    def test_connect_retries_until_broker_available(self) -> None:
+        output = make_output()
+        attempts: list[object] = []
+
+        class FlakyProducer:
+            def __init__(self, ok: bool) -> None:
+                self.ok = ok
+
+            async def start(self) -> None:
+                if not self.ok:
+                    raise ConnectionError
+
+            async def stop(self) -> None:
+                pass
+
+        def create() -> FlakyProducer:
+            attempts.append(object())
+            return FlakyProducer(ok=len(attempts) >= 3)
+
+        output._create_producer = create
+        output.RECONNECT_INTERVAL = 0
+        asyncio.run(output._connect())
+
+        self.assertEqual(len(attempts), 3)
+        self.assertTrue(output._ready.is_set())
+        self.assertIsNotNone(output._producer)
+        self.assertEqual(len(output._log.errors), 2)
+        for message in output._log.errors:
+            self.assertIn("Can't connect", message)
+
+    def test_write_drops_events_when_backlog_is_full(self) -> None:
+        output = make_output()
+
+        async def scenario() -> None:
+            output._enabled = True
+            output.MAX_PENDING = 2
+            for n in range(5):
+                output.write({"eventid": "cowrie.test", "n": n})
+
+            self.assertEqual(len(output._background_tasks), 2)
+            self.assertEqual(output._dropped, 3)
+
+            for task in list(output._background_tasks):
+                task.cancel()
+
+        asyncio.run(scenario())
+        self.assertEqual(len(output._log.errors), 1)
+        self.assertIn("dropped", output._log.errors[0])

--- a/src/cowrie/test/test_kafka.py
+++ b/src/cowrie/test/test_kafka.py
@@ -2,17 +2,36 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# ABOUTME: Tests for the kafka output plugin: it requires the asyncio
-# ABOUTME: reactor and must disable itself under any other reactor.
+# ABOUTME: Tests for the kafka output plugin: reactor gating, and the
+# ABOUTME: shutdown flush that delivers pending events before the loop stops.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import unittest
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class LogRecorder:
+    """Captures Logger.error calls so tests can assert on error output."""
+
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+
+    def error(self, message: str) -> None:
+        self.errors.append(message)
+
+
+def make_output():
+    from cowrie.output.kafka import Output
+
+    output = Output()
+    output._log = LogRecorder()
+    return output
 
 
 class KafkaReactorGateTests(unittest.TestCase):
@@ -31,3 +50,56 @@ class KafkaReactorGateTests(unittest.TestCase):
         self.assertEqual(output._background_tasks, set())
 
         output.stop()
+
+
+class KafkaShutdownFlushTests(unittest.TestCase):
+    """The before-shutdown flush must deliver pending sends and stop the
+    producer while the asyncio loop still runs, bounded by a timeout so a
+    dead broker cannot hang shutdown."""
+
+    def test_flush_is_noop_without_a_producer(self) -> None:
+        output = make_output()
+        self.assertIsNone(output._flush())
+
+    def test_flush_waits_for_pending_sends_then_stops_producer(self) -> None:
+        output = make_output()
+        calls: list[str] = []
+
+        class FakeProducer:
+            async def stop(self) -> None:
+                calls.append("stop")
+
+        async def scenario() -> None:
+            output._producer = FakeProducer()
+
+            async def pending_send() -> None:
+                await asyncio.sleep(0)
+                calls.append("send")
+
+            task = asyncio.ensure_future(pending_send())
+            output._background_tasks.add(task)
+            task.add_done_callback(output._background_tasks.discard)
+
+            await output._shutdown_flush()
+
+        asyncio.run(scenario())
+        self.assertEqual(calls, ["send", "stop"])
+        self.assertIsNone(output._producer)
+        self.assertEqual(output._log.errors, [])
+
+    def test_flush_gives_up_when_the_broker_hangs(self) -> None:
+        output = make_output()
+
+        class HangingProducer:
+            async def stop(self) -> None:
+                await asyncio.Event().wait()
+
+        async def scenario() -> None:
+            output._producer = HangingProducer()
+            output.FLUSH_TIMEOUT = 0.05
+            await output._shutdown_flush()
+
+        asyncio.run(scenario())
+        self.assertIsNone(output._producer)
+        self.assertEqual(len(output._log.errors), 1)
+        self.assertIn("flush", output._log.errors[0])


### PR DESCRIPTION
Supersedes #40326 — this branch keeps @rwakulszowa's original commit as-is and stacks review fixes on top. Please merge without squashing so the original authorship is preserved.

The kafka output plugin uses aiokafka, which requires Twisted to run the asyncio reactor (`cowrie start -- --reactor=asyncio`).

On top of the original implementation:

- **Clean reactor gating**: the plugin checks the reactor class in `start()` and disables itself with one clear error under any other reactor. Previously the check ran from a `callLater` callback (surfacing as an unhandled traceback) while `write()` kept scheduling one task per event on a loop that never runs.
- **Shutdown flush**: a before-shutdown trigger returns a Deferred that drains pending sends and stops the producer while the asyncio loop still runs, bounded by a timeout so an unreachable broker can't hang shutdown. Previously the producer-stop task was scheduled after shutdown and never executed, dropping all buffered events.
- **Reconnect**: connecting retries at a fixed interval instead of giving up forever when the broker is down at startup. Writes buffer until connected, with a capped backlog and throttled drop accounting.
- **Unit tests** for the reactor gate, flush ordering and timeout, retry loop, and backlog cap — runnable without aiokafka or a broker (the import is guarded like rmq's).
- Dependency pinning follows conventions (unpinned extra in pyproject.toml, pinned in requirements-output.txt), and `cowrie.cfg.dist` documents the asyncio-reactor requirement and the current plaintext/no-TLS/no-SASL limitation.

https://claude.ai/code/session_013fJv8ViZCFiQ7W3qzeALbP