### PR TITLE
docker: reproducible build metadata and runtime hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,14 @@
 .git
 .github
 .eggs
+.mypy_cache
+.pyre
+.pytype
+.ruff_cache
+__pycache__
+*.egg-info
+*.pyc
+dist
+build
+docs
+_trial_temp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,6 +65,8 @@ COPY --chown=${COWRIE_USER}:${COWRIE_GROUP} . ${COWRIE_HOME}/cowrie-git
 FROM gcr.io/distroless/python3-debian13:latest AS runtime
 #FROM gcr.io/distroless/python3-debian13:debug AS runtime
 
+ARG SOURCE_DATE_EPOCH
+
 LABEL org.opencontainers.image.authors="Michel Oosterhof <michel@oosterhof.net>"
 LABEL org.opencontainers.image.url="https://cowrie.org/"
 LABEL org.opencontainers.image.documentation="https://docs.cowrie.org"
@@ -74,6 +76,7 @@ LABEL org.opencontainers.image.vendor="Cowrie"
 LABEL org.opencontainers.image.licenses="BSD-3-Clause"
 LABEL org.opencontainers.image.title="Cowrie SSH/Telnet Honeypot"
 LABEL org.opencontainers.image.description="Cowrie SSH/Telnet Honeypot"
+LABEL org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"
 #LABEL org.opencontainers.image.base.digest="7beb0248fd81"
 LABEL org.opencontainers.image.base.name="gcr.io/distroless/python3-debian13"
 
@@ -102,7 +105,7 @@ COPY --from=builder --chown=0:0 /etc/passwd /etc/group /etc/
 
 COPY --from=builder --chown=${COWRIE_USER}:${COWRIE_GROUP} ${COWRIE_HOME} ${COWRIE_HOME}
 
-RUN [ "python3", "-m", "compileall", "-q", "/cowrie/cowrie-git/src", "/cowrie/cowrie-env/", "/usr/lib/python3.13"]
+RUN [ "python3", "-c", "import sys, compileall; v=str(sys.version_info.major)+'.'+str(sys.version_info.minor); compileall.compile_dir('/cowrie/cowrie-git/src', quiet=1); compileall.compile_dir('/cowrie/cowrie-env/', quiet=1); compileall.compile_dir('/usr/lib/python'+v, quiet=1)" ]
 
 VOLUME [ "/cowrie/cowrie-git/var", "/cowrie/cowrie-git/etc" ]
 
@@ -116,6 +119,8 @@ ENV PYTHONUNBUFFERED=1
 RUN [ "python3", "/cowrie/cowrie-git/bin/regen-dropin.cache" ]
 
 EXPOSE 2222 2223
+
+STOPSIGNAL SIGTERM
 
 ENTRYPOINT [ "/cowrie/cowrie-env/bin/python3" ]
 CMD [ "/cowrie/cowrie-env/bin/twistd", "-n", "--umask=0022", "--pidfile=", "--logger", "cowrie.python.logfile.stdoutLogger", "cowrie" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -105,6 +105,9 @@ COPY --from=builder --chown=0:0 /etc/passwd /etc/group /etc/
 
 COPY --from=builder --chown=${COWRIE_USER}:${COWRIE_GROUP} ${COWRIE_HOME} ${COWRIE_HOME}
 
+# Exec form runs python directly with no shell; the -c argument is Python,
+# not shell, so ShellCheck's SC1088 parse error on its parentheses is spurious.
+# hadolint ignore=SC1088
 RUN [ "python3", "-c", "import sys, compileall; v=str(sys.version_info.major)+'.'+str(sys.version_info.minor); compileall.compile_dir('/cowrie/cowrie-git/src', quiet=1); compileall.compile_dir('/cowrie/cowrie-env/', quiet=1); compileall.compile_dir('/usr/lib/python'+v, quiet=1)" ]
 
 VOLUME [ "/cowrie/cowrie-git/var", "/cowrie/cowrie-git/etc" ]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,13 +9,18 @@ volumes:
 
 services:
   cowrie:
-    restart: always
+    restart: unless-stopped
     build:
       context: ..
       dockerfile: docker/Dockerfile
     ports:
-      - "2222:2222"
-      - "2223:2223"
+      - "${COWRIE_SSH_PORT:-2222}:2222"    # SSH honeypot
+      - "${COWRIE_TELNET_PORT:-2223}:2223"  # Telnet honeypot
     volumes:
       - cowrie-etc:/cowrie/cowrie-git/etc
       - cowrie-var:/cowrie/cowrie-git/var
+    cap_drop:
+      - ALL
+    read_only: true
+    security_opt:
+      - no-new-privileges:true


### PR DESCRIPTION
Ports the Docker improvements from #2911 as a focused change (no CI/scanner changes here).

## Dockerfile
- Re-declare `ARG SOURCE_DATE_EPOCH` in the runtime stage (build args don't cross `FROM` boundaries) and stamp it into `org.opencontainers.image.created` for reproducible build metadata.
- Derive the stdlib path in the `compileall` step from the running interpreter (`sys.version_info`) instead of hardcoding `python3.13`, so a base-image Python bump doesn't fail the build on a missing path. (The exec-form `python -c` trips a spurious ShellCheck SC1088 in the CI hadolint 2.12.x; suppressed inline since the RUN never touches a shell.)
- Add `STOPSIGNAL SIGTERM` for a clean Twisted shutdown.

## docker-compose.yml
- `restart: unless-stopped` (a manual stop stays stopped).
- Host ports parameterised via `COWRIE_SSH_PORT` / `COWRIE_TELNET_PORT` (defaults unchanged).
- Container hardening: `cap_drop: [ALL]`, `read_only: true`, `no-new-privileges:true`.

## .dockerignore
- Exclude caches (`.mypy_cache`, `.ruff_cache`, `__pycache__`, …), build artifacts (`dist`, `build`, `*.egg-info`), and `docs` from the build context.

## Verification
Built the image locally and ran it with the full hardening set (`--cap-drop=ALL --read-only --security-opt no-new-privileges:true`, named volumes for `etc`/`var`). Cowrie starts cleanly — "Ready to accept SSH connections" / "Ready to accept Telnet connections" — so the read-only rootfs needs no extra `tmpfs`. This matches the existing `make docker-start`, which already runs `--read-only`.