### PR TITLE
ci: add pip-audit dependency vulnerability scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,23 +14,31 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
     cooldown:
       default-days: 7
   - package-ecosystem: "pip"
     directory: "/docs"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
     cooldown:
       default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
     cooldown:
       default-days: 7
   - package-ecosystem: "docker"
     directory: "/docker"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
     cooldown:
       default-days: 7

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+---
+name: Security Audit
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+
+  pull_request:
+
+  schedule:
+    # Run weekly on Wednesdays at 06:00 UTC
+    - cron: '0 6 * * 3'
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip -q install --upgrade pip setuptools setuptools-scm wheel
+          python -m pip -q install -e .
+          python -m pip -q install pip-audit
+
+      - name: Run pip-audit on core dependencies
+        run: pip-audit -r requirements.txt
+
+      - name: Run pip-audit on output dependencies
+        # Continue on error since output deps may have known issues
+        continue-on-error: true
+        run: pip-audit -r requirements-output.txt

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,8 +13,9 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
 
   schedule:
-    # Run weekly on Wednesdays at 06:00 UTC
-    - cron: '0 6 * * 3'
+    # Run every Monday at 03:00 UTC, after the weekly release and before
+    # Dependabot, so audit warnings arrive early in the week.
+    - cron: '0 3 * * 1'
 
   workflow_dispatch:
 

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -9,8 +9,9 @@ name: Weekly Release
 
 on:  # yamllint disable-line rule:truthy
   schedule:
-    # Run every Monday at 09:00 UTC
-    - cron: '0 9 * * 1'
+    # Run every Monday at 00:00 UTC.
+    # First stage of the weekly cycle: release, then audit, then Dependabot.
+    - cron: '0 0 * * 1'
 
   workflow_dispatch:
     inputs:

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ clean: ## Clean temporary files
 	rm -rf _trial_temp build dist src/_trial_temp src/Cowrie.egg-info
 	make -C docs clean
 
+.PHONY: audit
+audit: ## Run dependency security audit
+	tox -e audit
+
 .PHONY: pre-commit
 pre-commit: ## Run pre-commit checks
 	pre-commit run --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ dev = [
 "mypy-zope==1.0.16; platform_python_implementation=='CPython'",
 "mypy==2.3.0; platform_python_implementation=='CPython'",
 "pathspec==1.1.1",
+"pip-audit==2.10.1",
 "pipdeptree==4.0.0",
 "pre-commit==4.6.0",
 "pylint==4.0.6",
@@ -302,6 +303,13 @@ legacy_tox_ini = """
         - pyre --noninteractive analyze
         - pyright {posargs:src}
     basepython = python3.10
+
+    [testenv:audit]
+    description = run dependency security audit
+    extras =
+        dev
+    commands =
+        pip-audit -r {toxinidir}/requirements.txt
 
     [testenv:coverage-report]
     deps = coverage


### PR DESCRIPTION
Adds dependency vulnerability scanning with [pip-audit](https://github.com/pypa/pip-audit), split out from #2911.

## What

- **New `security.yml` workflow** (`Security Audit`): runs `pip-audit` against the pinned core `requirements.txt` on push to main, on PRs, and weekly (Wed 06:00 UTC). Output-plugin deps (`requirements-output.txt`) are audited as a non-blocking step since they carry known upstream issues. Actions are SHA-pinned.
- **Local parity**: a tox `audit` environment and a `make audit` target so the same check runs locally.
- **Dev dependency**: `pip-audit==2.10.1`.

## Notes

- No CodeQL here — CodeQL is handled by GitHub's default setup in repo settings, and a workflow-defined CodeQL job conflicts with that.
- Scoped to pip-audit only; the container-scanning idea from #2911 is intentionally left out pending a separate evaluation.