### PR TITLE
build: add changelog and issues project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ dependencies = [
 homepage = "https://www.cowrie.org/"
 documentation = "https://docs.cowrie.org/"
 repository = "https://github.com/cowrie/cowrie"
+changelog = "https://github.com/cowrie/cowrie/blob/main/CHANGELOG.rst"
+issues = "https://github.com/cowrie/cowrie/issues"
 
 [project.scripts]
 cowrie = "cowrie.scripts.cowrie:run"


### PR DESCRIPTION
Split out from #2911. Adds two entries to `[project.urls]` in `pyproject.toml`:

```toml
changelog = "https://github.com/cowrie/cowrie/blob/main/CHANGELOG.rst"
issues = "https://github.com/cowrie/cowrie/issues"
```

These render as "Changelog" and "Issues" links in the sidebar of the [PyPI project page](https://pypi.org/project/cowrie/), which currently only shows homepage/documentation/repository. `CHANGELOG.rst` exists at the repo root, so the link resolves.