### PR TITLE
feat: read stdin in grep when no files are given

### DIFF
--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -30,6 +30,9 @@ class Command_grep(HoneyPotCommand):
     grep command
     """
 
+    interactive: bool = False
+    matched: bool = False
+
     def grep_get_contents(self, filename: str, match: str) -> None:
         try:
             contents = self.fs.file_contents(filename)
@@ -39,10 +42,10 @@ class Command_grep(HoneyPotCommand):
 
     def grep_application(self, contents: bytes, match: str) -> None:
         bmatch = os.path.basename(match).replace('"', "").encode("utf8")
-        matches = re.compile(bmatch)
-        contentsplit = contents.split(b"\n")
-        for line in contentsplit:
-            if matches.search(line):
+        matcher = re.compile(bmatch)
+        for line in contents.split(b"\n"):
+            if matcher.search(line):
+                self.matched = True
                 self.writeBytes(line + b"\n")
 
     def help(self) -> None:
@@ -63,44 +66,49 @@ class Command_grep(HoneyPotCommand):
             self.exit()
             return
 
-        self.n = 10
-        optlist: list[tuple[str, str]] = []
-        args = self.args
-        if self.args[0] == ">":
-            pass
-        else:
-            try:
-                optlist, args = getopt.getopt(
-                    self.args,
-                    "abcDEFGHhIiJLlmnOoPqRSsUVvwxZA:B:C:e:f:",
-                    [
-                        "binary-files=",
-                        "color=",
-                        "color",
-                        "context=",
-                        "directories=",
-                        "label",
-                        "line-buffered",
-                    ],
-                )
-            except getopt.GetoptError as err:
-                self.errorWrite(f"grep: invalid option -- {err.opt}\n")
+        try:
+            optlist, args = getopt.getopt(
+                self.args,
+                "abcDEFGHhIiJLlmnOoPqRSsUVvwxZA:B:C:e:f:",
+                [
+                    "binary-files=",
+                    "color=",
+                    "color",
+                    "context=",
+                    "directories=",
+                    "label",
+                    "line-buffered",
+                ],
+            )
+        except getopt.GetoptError as err:
+            self.errorWrite(f"grep: invalid option -- {err.opt}\n")
+            self.help()
+            self.exit()
+            return
+
+        for opt, _arg in optlist:
+            if opt == "-h":
                 self.help()
-                self.exit()
-                return
 
-            for opt, _arg in optlist:
-                if opt == "-h":
-                    self.help()
+        if not args:
+            # Options only, no pattern (e.g. `grep -h`).
+            self.exit()
+            return
 
-        if not self.input_data:
-            files = self.check_arguments("grep", args[1:])
-            for pname in files:
-                self.grep_get_contents(pname, args[0])
+        self.match = args[0]
+        files = args[1:]
+
+        if self.input_data is not None:
+            self.grep_application(self.input_data, self.match)
+        elif files:
+            for pname in self.check_arguments("grep", files):
+                self.grep_get_contents(pname, self.match)
         else:
-            self.grep_application(self.input_data, args[0])
+            # No file and no pipe: read stdin until EOF.
+            self.interactive = True
+            return
 
-        self.exit()
+        self.exit(0 if self.matched else 1)
 
     def lineReceived(self, line: str) -> None:
         self.protocol.events.dispatch(
@@ -109,9 +117,23 @@ class Command_grep(HoneyPotCommand):
             realm="grep",
             input=line,
         )
+        if self.interactive:
+            self.grep_application(line.encode("utf8"), self.match)
 
     def eofReceived(self) -> None:
-        self.exit()
+        if self.interactive:
+            terminal = self.protocol.terminal
+            if (
+                getattr(terminal, "stdinlogOpen", False)
+                and getattr(terminal, "stdinlogFile", "")
+                and os.path.exists(terminal.stdinlogFile)
+            ):
+                # Live exec-channel stdin (e.g. `grep foo < file` over an ssh
+                # exec): the bytes were streamed to the stdin log rather than
+                # arriving via lineReceived, so match against them now.
+                with open(terminal.stdinlogFile, "rb") as f:
+                    self.grep_application(f.read(), self.match)
+        self.exit(0 if self.matched else 1)
 
 
 commands["/bin/grep"] = Command_grep

--- a/src/cowrie/test/test_grep.py
+++ b/src/cowrie/test/test_grep.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import os
+import unittest
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+
+class ShellGrepCommandTests(unittest.TestCase):
+    """Test for the grep command in cowrie/commands/fs.py."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def test_grep_pipe_match(self) -> None:
+        self.proto.lineReceived(b"echo hello | grep hell\n")
+        self.assertEqual(self.tr.value(), b"hello\n" + PROMPT)
+
+    def test_grep_pipe_no_match(self) -> None:
+        self.proto.lineReceived(b"echo hello | grep zzz\n")
+        self.assertEqual(self.tr.value(), PROMPT)
+
+    def test_grep_pipe_exit_code_match(self) -> None:
+        self.proto.lineReceived(b"echo hello | grep hell; echo $?\n")
+        self.assertEqual(self.tr.value(), b"hello\n0\n" + PROMPT)
+
+    def test_grep_pipe_exit_code_no_match(self) -> None:
+        # grep returns 1 when nothing matched (issue: previously always 0).
+        self.proto.lineReceived(b"echo hello | grep zzz; echo $?\n")
+        self.assertEqual(self.tr.value(), b"1\n" + PROMPT)
+
+    def test_grep_file(self) -> None:
+        self.proto.lineReceived(b"grep root /etc/passwd\n")
+        self.assertEqual(self.tr.value(), b"root:x:0:0:root:/root:/bin/bash\n" + PROMPT)
+
+    def test_grep_stdin_match_then_ctrl_c(self) -> None:
+        # With no file and no pipe, grep reads stdin: matching lines echo back,
+        # non-matching lines are silent. CTRL-C interrupts.
+        self.proto.lineReceived(b"grep foo\n")
+        self.proto.lineReceived(b"foobar\n")
+        self.proto.lineReceived(b"baz\n")
+        self.proto.handle_CTRL_C()
+        self.assertEqual(self.tr.value(), b"foobar\n^C\n" + PROMPT)
+
+    def test_grep_stdin_ctrl_d_exit_code_match(self) -> None:
+        self.proto.lineReceived(b"grep foo\n")
+        self.proto.lineReceived(b"foobar\n")
+        self.proto.handle_CTRL_D()
+        self.proto.lineReceived(b"echo $?\n")
+        self.assertEqual(self.tr.value(), b"foobar\n" + PROMPT + b"0\n" + PROMPT)
+
+    def test_grep_stdin_ctrl_d_exit_code_no_match(self) -> None:
+        self.proto.lineReceived(b"grep foo\n")
+        self.proto.lineReceived(b"bar\n")
+        self.proto.handle_CTRL_D()
+        self.proto.lineReceived(b"echo $?\n")
+        self.assertEqual(self.tr.value(), PROMPT + b"1\n" + PROMPT)
+
+    def test_grep_no_args_shows_usage(self) -> None:
+        self.proto.lineReceived(b"grep\n")
+        value = self.tr.value()
+        self.assertIn(b"usage: grep", value)
+        self.assertTrue(value.endswith(PROMPT))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A fresh, rebased take on #2553 (scoped to the stdin behaviour; recursive `-r` dropped for now).

## What
`grep PATTERN` with **no file and no pipe** now reads from stdin until EOF and prints matching lines, instead of exiting immediately (previously the typed lines fell through to the shell as "command not found"). It works for:
- an **interactive terminal** — type lines, matches echo back, `Ctrl-D`/`Ctrl-C` to stop;
- **stdin streamed over an ssh exec channel** (mirrors how `cat` handles the live stdin log).

Piped (`echo x | grep x`) and file (`grep x file`) modes are unchanged.

## Also
grep now returns its **standard exit status** — `0` if a line matched, `1` if not — so `$?` and `&&`/`||` chains behave. Previously it always returned `0`.

## Notes
- Uses the existing redirection handling — the shell parser strips `>`/pipes before the command runs, so the old `if self.args[0] == ">"` guard is gone.
- Keeps the current long-option set (`--color`, `--context=`, …) intact.
- Interactive lines route through the same `grep_application` matcher as files/pipes (no duplicated logic).

## Tests
New `test_grep.py`: file match, pipe match/no-match, exit codes (match/no-match), interactive stdin with Ctrl-C and Ctrl-D, and usage output. Full suite (815 tests), ruff, and mypy all pass.

Credit to @Onder7994, who proposed the stdin behaviour in #2553.