### PR TITLE
feat: support the HAProxy PROXY protocol

### DIFF
--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -674,6 +674,12 @@ compression = zlib@openssh.com,zlib,none
 # Listening on multiple endpoints is supported with a single space separator
 # e.g listen_endpoints = "tcp:2222:interface=0.0.0.0 tcp:1022:interface=0.0.0.0" will result listening both on ports 2222 and 1022
 # use authbind for port numbers under 1024
+# When Cowrie sits behind a load balancer or proxy that speaks the HAProxy
+# PROXY protocol (HAProxy, AWS/GCP network load balancers, ...), prefix the
+# endpoint with "haproxy:" so the real client address is recorded instead of
+# the proxy's, e.g. listen_endpoints = haproxy:tcp:2222:interface=0.0.0.0
+# Every connection must then be prefixed with a PROXY header; a direct
+# connection without one is dropped.
 
 listen_endpoints = tcp:2222:interface=0.0.0.0
 
@@ -755,6 +761,9 @@ enabled = false
 # Listening on multiple endpoints is supported with a single space separator
 # e.g "listen_endpoints = tcp:2223:interface=0.0.0.0 tcp:2323:interface=0.0.0.0" will result listening both on ports 2223 and 2323
 # use authbind for port numbers under 1024
+# To accept the HAProxy PROXY protocol behind a load balancer or proxy,
+# prefix the endpoint with "haproxy:", e.g.
+# listen_endpoints = haproxy:tcp:2223:interface=0.0.0.0
 
 listen_endpoints = tcp:2223:interface=0.0.0.0
 

--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -23,7 +23,7 @@ from twisted.conch.ssh import transport
 from twisted.conch.ssh.common import getNS
 from twisted.internet.protocol import connectionDone
 from twisted.logger import Logger
-from twisted.protocols.policies import TimeoutMixin
+from twisted.protocols.policies import ProtocolWrapper, TimeoutMixin
 from twisted.python import failure, randbytes
 
 from cowrie.core.config import CowrieConfig
@@ -37,9 +37,14 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
     gotVersion: bool = False
     buf: bytes
     transportId: str
-    # The session's event emitter, bound in connectionMade when the running
-    # application provides a dispatcher.
+    # The session's event emitter, bound in connectionMade (or, under the
+    # PROXY protocol, on the first dataReceived) when the running application
+    # provides a dispatcher.
     events: EventLog | None = None
+    # Set when running behind a PROXY-protocol proxy: cowrie.session.connect is
+    # held back until the PROXY header has been parsed and getPeer() reflects
+    # the real client.
+    _emit_connect_pending: bool = False
     ipv4rex = re.compile(r"^::ffff:(\d+\.\d+\.\d+\.\d+)$")
     auth_timeout: int = CowrieConfig.getint(
         "honeypot", "authentication_timeout", fallback=120
@@ -69,8 +74,32 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         self.buf = b""
 
         self.transportId = uuid.uuid4().hex[:12]
-        src_ip: str = self.transport.getPeer().host
 
+        if isinstance(self.transport, ProtocolWrapper):
+            # A protocol wrapper in front of us (the haproxy: endpoint's PROXY
+            # parser) only resolves the real client address once it has read
+            # the header, which happens on the first dataReceived(). Defer
+            # cowrie.session.connect until then so it carries the real IP
+            # rather than the proxy's.
+            self._emit_connect_pending = True
+        else:
+            self._emit_connect()
+
+        self.transport.write(self.ourVersionString + b"\r\n")
+        self.currentEncryptions = transport.SSHCiphers(
+            b"none", b"none", b"none", b"none"
+        )
+        self.currentEncryptions.setKeys(b"", b"", b"", b"", b"", b"")
+
+        self.startTime = time.time()
+        self.setTimeout(self.auth_timeout)
+
+    def _emit_connect(self) -> None:
+        """
+        Bind the session event log and announce cowrie.session.connect using
+        the current (possibly PROXY-resolved) peer address.
+        """
+        src_ip: str = self.transport.getPeer().host
         ipv4_search = self.ipv4rex.search(src_ip)
         if ipv4_search is not None:
             src_ip = ipv4_search.group(1)
@@ -82,15 +111,6 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             protocol="ssh",
             src_ip=src_ip,
         )
-
-        self.transport.write(self.ourVersionString + b"\r\n")
-        self.currentEncryptions = transport.SSHCiphers(
-            b"none", b"none", b"none", b"none"
-        )
-        self.currentEncryptions.setKeys(b"", b"", b"", b"", b"", b"")
-
-        self.startTime: float = time.time()
-        self.setTimeout(self.auth_timeout)
 
     def sendKexInit(self) -> None:
         """
@@ -122,6 +142,13 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
 
         @type data: C{str}
         """
+        if self._emit_connect_pending:
+            # First bytes have arrived, which under the PROXY protocol means
+            # the header has been parsed and getPeer() now reflects the real
+            # client. Announce the connection before processing the data.
+            self._emit_connect_pending = False
+            self._emit_connect()
+
         self.buf = self.buf + data
         if not self.gotVersion:
             if b"\n" not in self.buf:
@@ -283,7 +310,13 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         """
         self.setTimeout(None)
         transport.SSHServerTransport.connectionLost(self, reason)
-        self.transport.connectionLost(reason)
+        if self._emit_connect_pending:
+            # A proxied connection whose PROXY header carried no trailing data
+            # never reached dataReceived(), so the deferred announce never
+            # fired. getPeer() is resolved by now; announce it before closing
+            # so the connection is still logged (as a direct one would be).
+            self._emit_connect_pending = False
+            self._emit_connect()
         self.transport = None
         duration_ms = round((time.time() - self.startTime) * 1000)
         if self.events is not None:

--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 from twisted.conch.telnet import AlreadyNegotiating, TelnetTransport
 from twisted.internet.protocol import connectionDone
 from twisted.logger import Logger
-from twisted.protocols.policies import TimeoutMixin
+from twisted.protocols.policies import ProtocolWrapper, TimeoutMixin
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.events import EventLog, transport_events
@@ -52,9 +52,14 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
 
     _log = Logger()
 
-    # The session's event emitter, bound in connectionMade when the running
-    # application provides a dispatcher.
+    # The session's event emitter, bound in connectionMade (or, under the
+    # PROXY protocol, on the first dataReceived) when the running application
+    # provides a dispatcher.
     events: EventLog | None = None
+    # Set when running behind a PROXY-protocol proxy: cowrie.session.connect is
+    # held back until the PROXY header has been parsed and getPeer() reflects
+    # the real client.
+    _emit_connect_pending: bool = False
 
     # Set while the connection is being torn down. Telnet.connectionLost()
     # iterates self.options and errbacks pending negotiations; our retry
@@ -72,14 +77,29 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
             CowrieConfig.getint("honeypot", "authentication_timeout", fallback=120)
         )
 
+        if isinstance(self.transport, ProtocolWrapper):
+            # A protocol wrapper in front of us (the haproxy: endpoint's PROXY
+            # parser) only resolves the real client address once it has read
+            # the header, which happens on the first dataReceived(). Defer
+            # cowrie.session.connect until then so it carries the real IP
+            # rather than the proxy's.
+            self._emit_connect_pending = True
+        else:
+            self._emit_connect()
+
+        TelnetTransport.connectionMade(self)
+
+    def _emit_connect(self) -> None:
+        """
+        Bind the session event log and announce cowrie.session.connect using
+        the current (possibly PROXY-resolved) peer address.
+        """
         self.events = transport_events(
             self.factory,
             self.transport,
             session=self.transportId,
             protocol="telnet",
         )
-
-        TelnetTransport.connectionMade(self)
 
     def write(self, data):
         """
@@ -132,6 +152,13 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         it -- but not for the parser's own protocol error, which is expected
         garbage traffic (see below).
         """
+        if self._emit_connect_pending:
+            # First bytes have arrived, which under the PROXY protocol means
+            # the header has been parsed and getPeer() now reflects the real
+            # client. Announce the connection before processing the data.
+            self._emit_connect_pending = False
+            self._emit_connect()
+
         try:
             TelnetTransport.dataReceived(self, data)
         except ValueError as e:
@@ -183,6 +210,13 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         self._closing = True
         self.setTimeout(None)
         TelnetTransport.connectionLost(self, reason)
+        if self._emit_connect_pending:
+            # A proxied connection whose PROXY header carried no trailing data
+            # never reached dataReceived(), so the deferred announce never
+            # fired. getPeer() is resolved by now; announce it before closing
+            # so the connection is still logged (as a direct one would be).
+            self._emit_connect_pending = False
+            self._emit_connect()
         duration_ms = round((time.time() - self.startTime) * 1000)
         if self.events is not None:
             self.events.session_closed(duration_ms)

--- a/src/cowrie/test/test_proxy_protocol.py
+++ b/src/cowrie/test/test_proxy_protocol.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for HAProxy PROXY-protocol support: the session.connect event
+# ABOUTME: is deferred until the PROXY header is parsed so it carries the real IP.
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from twisted.internet import endpoints, reactor
+from twisted.protocols.policies import ProtocolWrapper
+
+from cowrie.core.events import EventDispatcher
+from cowrie.ssh import transport as ssh_transport
+from cowrie.telnet import transport as telnet_transport
+from cowrie.test.eventcapture import CaptureSink, events_of
+
+
+def _fake_factory(sink: CaptureSink) -> Any:
+    dispatcher = EventDispatcher([sink], logmsg=lambda *a, **k: None)
+    return SimpleNamespace(tac=SimpleNamespace(dispatcher=dispatcher))
+
+
+def _fake_transport(peer_host: str, *, wrapped: bool) -> Any:
+    # A PROXY-wrapped connection presents a policies.ProtocolWrapper as the
+    # protocol's transport; a direct connection does not.
+    tr = MagicMock(spec=ProtocolWrapper) if wrapped else MagicMock()
+    tr.getPeer.return_value = SimpleNamespace(host=peer_host, port=5555)
+    tr.getHost.return_value = SimpleNamespace(host="10.0.0.2", port=2222)
+    return tr
+
+
+class SSHProxyProtocolTests(unittest.TestCase):
+    def _make(
+        self, peer_host: str, *, wrapped: bool
+    ) -> tuple[ssh_transport.HoneyPotSSHTransport, CaptureSink]:
+        sink = CaptureSink()
+        t = ssh_transport.HoneyPotSSHTransport()
+        t.factory = _fake_factory(sink)
+        t.transport = _fake_transport(peer_host, wrapped=wrapped)
+        t.ourVersionString = b"SSH-2.0-OpenSSH_9.6"
+        return t, sink
+
+    def test_direct_connection_emits_connect_in_connection_made(self) -> None:
+        t, sink = self._make("9.9.9.9", wrapped=False)
+        with patch.object(ssh_transport.HoneyPotSSHTransport, "setTimeout"):
+            t.connectionMade()
+        connects = events_of(sink.events, "cowrie.session.connect")
+        self.assertEqual(len(connects), 1)
+        self.assertEqual(connects[0]["src_ip"], "9.9.9.9")
+
+    def test_proxied_connection_defers_connect_until_first_data(self) -> None:
+        # At connect time getPeer() still returns the proxy's address.
+        t, sink = self._make("10.0.0.9", wrapped=True)
+        with patch.object(ssh_transport.HoneyPotSSHTransport, "setTimeout"):
+            t.connectionMade()
+
+        self.assertEqual(events_of(sink.events, "cowrie.session.connect"), [])
+        self.assertIsNone(t.events)
+
+        # The wrapper parses the PROXY header before our dataReceived fires, so
+        # getPeer() now returns the real client. A newline-less banner triggers
+        # the deferred emit and returns before the SSH handshake.
+        t.transport.getPeer.return_value = SimpleNamespace(
+            host="203.0.113.7", port=5555
+        )
+        t.dataReceived(b"SSH-2.0-RealClient")
+
+        connects = events_of(sink.events, "cowrie.session.connect")
+        self.assertEqual(len(connects), 1)
+        self.assertEqual(connects[0]["src_ip"], "203.0.113.7")
+        self.assertIsNotNone(t.events)
+
+    def test_ipv4_mapped_real_client_is_normalized(self) -> None:
+        t, sink = self._make("10.0.0.9", wrapped=True)
+        with patch.object(ssh_transport.HoneyPotSSHTransport, "setTimeout"):
+            t.connectionMade()
+        t.transport.getPeer.return_value = SimpleNamespace(
+            host="::ffff:203.0.113.7", port=5555
+        )
+        t.dataReceived(b"SSH-2.0-RealClient")
+        connects = events_of(sink.events, "cowrie.session.connect")
+        self.assertEqual(connects[0]["src_ip"], "203.0.113.7")
+
+    def test_proxied_connection_closed_without_data_is_still_logged(self) -> None:
+        # A PROXY header with no trailing payload never reaches dataReceived();
+        # the connection must still be announced (and closed) at teardown, not
+        # vanish, as a direct no-data connection would be logged.
+        t, sink = self._make("203.0.113.7", wrapped=True)
+        with patch.object(ssh_transport.HoneyPotSSHTransport, "setTimeout"):
+            t.connectionMade()
+        self.assertEqual(events_of(sink.events, "cowrie.session.connect"), [])
+        with patch("twisted.conch.ssh.transport.SSHServerTransport.connectionLost"):
+            t.connectionLost()
+        connects = events_of(sink.events, "cowrie.session.connect")
+        self.assertEqual(len(connects), 1)
+        self.assertEqual(connects[0]["src_ip"], "203.0.113.7")
+        self.assertEqual(len(events_of(sink.events, "cowrie.session.closed")), 1)
+
+
+class TelnetProxyProtocolTests(unittest.TestCase):
+    def _make(
+        self, peer_host: str, *, wrapped: bool
+    ) -> tuple[telnet_transport.CowrieTelnetTransport, CaptureSink]:
+        sink = CaptureSink()
+        t = telnet_transport.CowrieTelnetTransport()
+        t.factory = _fake_factory(sink)
+        t.transport = _fake_transport(peer_host, wrapped=wrapped)
+        return t, sink
+
+    def test_direct_connection_emits_connect_in_connection_made(self) -> None:
+        t, sink = self._make("9.9.9.9", wrapped=False)
+        with (
+            patch.object(telnet_transport.CowrieTelnetTransport, "setTimeout"),
+            patch("twisted.conch.telnet.TelnetTransport.connectionMade"),
+        ):
+            t.connectionMade()
+        connects = events_of(sink.events, "cowrie.session.connect")
+        self.assertEqual(len(connects), 1)
+        self.assertEqual(connects[0]["src_ip"], "9.9.9.9")
+
+    def test_proxied_connection_defers_connect_until_first_data(self) -> None:
+        t, sink = self._make("10.0.0.9", wrapped=True)
+        with (
+            patch.object(telnet_transport.CowrieTelnetTransport, "setTimeout"),
+            patch("twisted.conch.telnet.TelnetTransport.connectionMade"),
+        ):
+            t.connectionMade()
+
+        self.assertEqual(events_of(sink.events, "cowrie.session.connect"), [])
+        self.assertIsNone(t.events)
+
+        # PROXY header parsed: getPeer() now reflects the real client.
+        t.transport = _fake_transport("203.0.113.7", wrapped=True)
+        with patch("twisted.conch.telnet.TelnetTransport.dataReceived"):
+            t.dataReceived(b"anything")
+
+        connects = events_of(sink.events, "cowrie.session.connect")
+        self.assertEqual(len(connects), 1)
+        self.assertEqual(connects[0]["src_ip"], "203.0.113.7")
+
+    def test_proxied_connection_closed_without_data_is_still_logged(self) -> None:
+        t, sink = self._make("203.0.113.7", wrapped=True)
+        with (
+            patch.object(telnet_transport.CowrieTelnetTransport, "setTimeout"),
+            patch("twisted.conch.telnet.TelnetTransport.connectionMade"),
+        ):
+            t.connectionMade()
+        self.assertEqual(events_of(sink.events, "cowrie.session.connect"), [])
+        with patch("twisted.conch.telnet.TelnetTransport.connectionLost"):
+            t.connectionLost()
+        connects = events_of(sink.events, "cowrie.session.connect")
+        self.assertEqual(len(connects), 1)
+        self.assertEqual(connects[0]["src_ip"], "203.0.113.7")
+        self.assertEqual(len(events_of(sink.events, "cowrie.session.closed")), 1)
+
+
+class HAProxyEndpointTests(unittest.TestCase):
+    def test_haproxy_endpoint_string_is_wrapped(self) -> None:
+        # Cowrie relies on Twisted's registered haproxy: endpoint plugin to do
+        # the PROXY parsing; a plain endpoint string is not wrapped.
+        wrapped = endpoints.serverFromString(
+            reactor, "haproxy:tcp:2222:interface=127.0.0.1"
+        )
+        plain = endpoints.serverFromString(reactor, "tcp:2222:interface=127.0.0.1")
+        self.assertEqual(type(wrapped).__name__, "_WrapperServerEndpoint")
+        self.assertNotEqual(type(plain).__name__, "_WrapperServerEndpoint")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds support for running Cowrie behind a load balancer or proxy that speaks the [HAProxy PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) (HAProxy, AWS/GCP network load balancers, sensor relays, …), so logs and events record the **real attacker IP** instead of the proxy's. Clean reimplementation in the current event-pipeline architecture (supersedes the stale #40089).

## Usage
Prefix the listener with Twisted's `haproxy:` endpoint — no new config:
```ini
[ssh]
listen_endpoints = haproxy:tcp:2222:interface=0.0.0.0
```
Same for `[telnet]`. Twisted's `haproxy:` endpoint plugin does the PROXY (v1/v2) header parsing and makes `getPeer()` return the real client — Cowrie adds no parser.

## What Cowrie actually changes
The only thing Cowrie must get right is **event timing**. The real client address isn't known until the PROXY header is parsed, which Twisted does on the first `dataReceived()`. So when the transport is fronted by a `twisted.protocols.policies.ProtocolWrapper` (what the `haproxy:` endpoint installs), Cowrie defers `cowrie.session.connect` — and binding the session's event log — from `connectionMade()` to the first `dataReceived()`, where `getPeer()` is authoritative. A direct (unwrapped) connection is unchanged: connect is emitted at connection time, so bare no-data probes are still logged. Applies to **SSH and Telnet**.

**Header-only connections:** if the PROXY header arrives with no trailing payload, Twisted never calls our `dataReceived()`, so the deferred announce is emitted from `connectionLost()` instead (`getPeer()` is resolved by then). This keeps parity with a direct connection, which logs a connect+closed pair even when the client sends nothing.

## Incidental fix
Removed the redundant `self.transport.connectionLost(reason)` in the SSH transport. Under a wrapper `self.transport` *is* the wrapper, whose `connectionLost()` re-enters ours → infinite recursion at close. The reactor already drives `connectionLost`, and the Telnet transport never made this call.

## Tests
`test_proxy_protocol.py`: connect deferred and carrying the real client IP once parsed (SSH + Telnet), IPv4-mapped (`::ffff:`) normalization, direct-connection behaviour, header-only connection still logged, and that the `haproxy:` endpoint string resolves to a wrapped endpoint. Full suite (823), ruff, mypy all pass.

## Notes
- No config flag and no Cowrie-side endpoint wrapping — rides on the `haproxy:` endpoint string Cowrie already accepts via `serverFromString`.
- With `haproxy:`, every connection must carry a PROXY header; a direct connection without one is dropped by Twisted's parser (standard PROXY-protocol behaviour).