### PR TITLE
fix: run long pipelines flat instead of recursing per stage

### DIFF
--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -68,6 +68,12 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         self.data = None
         self.password_input = False
         self.cmdstack = []
+        # Trampoline state for call_command. A pipeline stage starts the next
+        # one from its PipeProtocol.outConnectionLost(); that re-entrant call is
+        # queued (see _advancing_pipe) and drained by a flat loop, so a long
+        # pipeline runs without recursing one Python frame per stage (#40352).
+        self._advancing_pipe: bool = False
+        self._call_queue: list = []
 
     def getProtoTransport(self):
         """
@@ -249,6 +255,34 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
             self.terminal.transport.processEnded(stat)
 
     def call_command(self, pp, cmd, *args):
+        """
+        Run a command, then drain any pipeline stages it queued.
+
+        A pipeline stage starts the next one from its
+        ``PipeProtocol.outConnectionLost()``, which calls back here. A naive
+        recursive design grows the Python stack by one frame per stage, so a
+        long ``a | b | c | ...`` line overflows it (issue #40352). Only that
+        pipeline advancement is flattened (``_advancing_pipe``): the next stage
+        is queued and run by this flat loop instead of recursed into. A command
+        that runs another synchronously during ``start()`` (``su -c``,
+        ``sh -c``, a nested shell) is not pipeline advancement and still
+        executes inline, draining its own pipeline before returning.
+        """
+        if self._advancing_pipe:
+            self._call_queue.append((pp, cmd, args))
+            return
+
+        # Drain only the stages this call queues. A command run synchronously
+        # here (su -c, sh -c, a nested shell) may itself reach call_command and
+        # drive its own pipeline; scoping to `base` keeps that nested drive from
+        # consuming a stage the enclosing pipeline has already queued.
+        base = len(self._call_queue)
+        self._run_command(pp, cmd, *args)
+        while len(self._call_queue) > base:
+            next_pp, next_cmd, next_args = self._call_queue.pop(base)
+            self._run_command(next_pp, next_cmd, *next_args)
+
+    def _run_command(self, pp, cmd, *args):
         self.pp = pp
         obj = cmd(self, *args)
         obj.set_input_data(pp.input_data)
@@ -256,7 +290,13 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         obj.start()
 
         if self.pp:
-            self.pp.outConnectionLost()
+            # Advancing to the next pipeline stage: flatten the callback so a
+            # long pipeline does not recurse (see call_command).
+            self._advancing_pipe = True
+            try:
+                self.pp.outConnectionLost()
+            finally:
+                self._advancing_pipe = False
 
         # Mirror ProcessProtocol.transport.closeStdin(): if the command parked
         # waiting for stdin but nothing will ever write to it, signal EOF so it

--- a/src/cowrie/test/test_pipe_recursion.py
+++ b/src/cowrie/test/test_pipe_recursion.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: A long pipeline (a | b | c | ...) must not exhaust the Python stack.
+# ABOUTME: Guards issue #40352 where each pipe stage recursed call_command.
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+
+class LongPipelineTests(unittest.TestCase):
+    """A pipeline of many stages must run flat, not recurse per stage."""
+
+    def test_long_pipeline_does_not_crash(self) -> None:
+        proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        tr = FakeTransport("", "31337")
+        proto.makeConnection(tr)
+        tr.clear()
+
+        # Far more stages than the recursive design could handle before hitting
+        # Python's default recursion limit; the data passes through each `cat`.
+        line = ("echo hi" + " | cat" * 600 + "\n").encode()
+        proto.lineReceived(line)
+
+        self.assertEqual(tr.value(), b"hi\n" + PROMPT)
+        # The whole pipeline drained: nothing left parked on the stack.
+        self.assertEqual(len(proto.cmdstack), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #40352.

## Bug
A pipeline stage starts the next one from its `PipeProtocol.outConnectionLost()`, which calls back into `HoneyPotBaseProtocol.call_command()`. That makes `call_command() → outConnectionLost() → call_command()` a recursive cycle **one Python frame deep per stage**, with no cap on pipe stages. A command line of a few hundred `|`-separated stages hits Python's recursion limit and crashes the session with an unhandled `RecursionError` (reproduced here with `echo hi | cat × 600`).

## Fix
Flatten **only** the pipeline advancement: while a stage emits its `outConnectionLost()` (guarded by `_advancing_pipe`), the next stage is queued instead of recursed into, and `call_command()` drains the queued stages in a flat loop. This mirrors the trampoline `HoneyPotShell._advance()` already uses for `;`-separated statement lists.

Two scoping details keep it correct:
- A command that runs another **synchronously** during `start()` — `su -c`, `sh -c`, a nested shell — is *not* pipeline advancement (`_advancing_pipe` is false there) and still executes inline. A broad version that queued every re-entrant `call_command` broke exactly those (e.g. `su -c 'whoami' phil` printed `root`).
- Each `call_command()` drains only the stages it queued, tracked by a base index into the shared queue, so a nested drive (e.g. `sh` executing piped input from its `eofReceived()`) cannot consume a stage the enclosing pipeline already queued.

## Behaviour note
Each stage's post-`start()` stdin-EOF check now runs in pipeline order rather than after the whole chain has been set up (the recursion previously ran them in reverse at unwind). This only differs when two or more stages stay parked on `cmdstack` without exiting, which a normal command doesn't do (its `start()` calls `exit()` before returning).

## Tests
New `test_pipe_recursion.py`: a 600-stage pipeline runs to completion (`hi\n` + prompt) with nothing left on the stack. Full suite (824), ruff, and mypy pass — including the `su`/`sh -c`/nested-shell/exit-status/async-script tests that exercise synchronous nested execution, and `sh`-in-a-pipe cases (`echo whoami | sh | cat` → `root`).

Reported with a thorough analysis (and a patch along the same lines) by @vbontchev.