### PR TITLE
fix: handle GreyNoise request failures instead of erroring

### DIFF
--- a/src/cowrie/output/greynoise.py
+++ b/src/cowrie/output/greynoise.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import treq
 from twisted.internet import defer, error
 from twisted.logger import Logger
+from twisted.web.client import ResponseFailed
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -83,8 +84,12 @@ class Output(cowrie.core.output.Output):
             defer.CancelledError,
             error.ConnectingCancelledError,
             error.DNSLookupError,
+            ResponseFailed,
         ):
-            self._log.info("GreyNoise requests timeout")
+            # ResponseFailed (its subclass ResponseNeverReceived wraps the
+            # CancelledError treq raises on a request timeout) would otherwise
+            # escape as an unhandled Deferred error (issue #1711).
+            self._log.info("GreyNoise request failed (timeout or connection error)")
             return
 
         if response.code == 404:

--- a/src/cowrie/test/test_greynoise.py
+++ b/src/cowrie/test/test_greynoise.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests that the greynoise output plugin swallows treq request
+# ABOUTME: failures instead of leaving an unhandled Deferred error (issue #1711).
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from twisted.internet import defer, error
+from twisted.python.failure import Failure
+from twisted.web.client import ResponseNeverReceived
+
+from cowrie.output.greynoise import Output
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+CONNECT_EVENT = {
+    "eventid": "cowrie.session.connect",
+    "session": "0000000000000000",
+    "src_ip": "1.2.3.4",
+    "protocol": "ssh",
+}
+
+
+class GreyNoiseRequestFailureTests(unittest.TestCase):
+    """A failed GreyNoise lookup must be handled, not left unhandled."""
+
+    def setUp(self) -> None:
+        self.output = Output()
+        self.output.apiKey = "test-key"
+        self.output.debug = False
+
+    def _assert_handled(self, failure: Exception) -> None:
+        with patch(
+            "cowrie.output.greynoise.treq.get", return_value=defer.fail(failure)
+        ):
+            d = self.output.scanip(CONNECT_EVENT)
+        results: list = []
+        d.addBoth(results.append)
+        # The Deferred fired, and not with a lingering Failure.
+        self.assertEqual(len(results), 1)
+        self.assertNotIsInstance(results[0], Failure)
+
+    def test_response_never_received_is_handled(self) -> None:
+        # treq wraps a request timeout as ResponseNeverReceived([CancelledError]);
+        # this is the exact failure reported in issue #1711.
+        self._assert_handled(ResponseNeverReceived([Failure(defer.CancelledError())]))
+
+    def test_cancelled_error_is_handled(self) -> None:
+        self._assert_handled(defer.CancelledError())
+
+    def test_dns_lookup_error_is_handled(self) -> None:
+        self._assert_handled(error.DNSLookupError())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1711.

## Bug
`greynoise`'s `scanip()` wraps `treq.get()` in a `try/except` for `defer.CancelledError`, `ConnectingCancelledError`, and `DNSLookupError`. But a **request timeout** doesn't surface as `CancelledError` — treq raises `twisted.web._newclient.ResponseNeverReceived`, which *wraps* the `CancelledError`:

```
twisted.web._newclient.ResponseNeverReceived: [<Failure twisted.internet.defer.CancelledError: >]
```

That type isn't in the except tuple, so it escapes `scanip()` — a fire-and-forget `inlineCallbacks` Deferred — and is logged as a `[twisted.internet.defer#critical] Unhandled error in Deferred` (the exact symptom in the issue, open since 2022).

## Fix
Add `ResponseFailed` to the except. It's the parent class of `ResponseNeverReceived` (and of the partial-response `ResponseFailed`), so a timed-out or reset GreyNoise lookup is now logged and skipped like the other network errors already are — no behaviour change for successful lookups.

## Tests
New `test_greynoise.py` drives `scanip()` with a failing `treq.get` and asserts the returned Deferred is left **handled** (no lingering `Failure`) for `ResponseNeverReceived` (the reported case), `CancelledError`, and `DNSLookupError`. Full suite (827), ruff, and mypy pass.

## Note
This targets the reported failure precisely. A broader hardening — an `addErrback` safety net on the fire-and-forget `scanip()` Deferred (as `virustotal` does) so *any* stray error, e.g. a malformed 200-response body, can't spam the critical log — would be a reasonable follow-up but is out of scope here.