### PR TITLE
fix: handle failed HTTP requests in output plugins

### DIFF
--- a/src/cowrie/output/axiom.py
+++ b/src/cowrie/output/axiom.py
@@ -52,13 +52,21 @@ class Output(cowrie.core.output.Output):
             self._log.error("jsonlog: Can't serialize: '{event!r}'", event=event)
             return
 
-        resp = yield treq.post(
-            self.url,
-            data=b"[" + msg + b"]",
-            headers=self.headers,
-            allow_redirects=False,
-        )
+        try:
+            resp = yield treq.post(
+                self.url,
+                data=b"[" + msg + b"]",
+                headers=self.headers,
+                allow_redirects=False,
+            )
 
-        if resp.code != 200:
-            error = yield resp.text()
-            self._log.error("jsonlog: Can't submit to Axiom: '{error!r}'", error=error)
+            if resp.code != 200:
+                error = yield resp.text()
+                self._log.error(
+                    "jsonlog: Can't submit to Axiom: '{error!r}'", error=error
+                )
+        except Exception as e:
+            # A timed-out or reset request surfaces here (treq raises
+            # ResponseNeverReceived, ...); log it rather than leave it as an
+            # unhandled Deferred error.
+            self._log.info("axiom: request to Axiom failed: {error}", error=repr(e))

--- a/src/cowrie/output/datadog.py
+++ b/src/cowrie/output/datadog.py
@@ -71,4 +71,12 @@ class Output(cowrie.core.output.Output):
         }
         headers = http_headers.Headers(base_headers)
         body = FileBodyProducer(BytesIO(json.dumps(entry).encode("utf8")))
-        self.agent.request(b"POST", self.url, headers, body)
+        d = self.agent.request(b"POST", self.url, headers, body)
+        d.addErrback(self._request_failed)
+
+    def _request_failed(self, failure):
+        # Best-effort telemetry: log a failed request (timeout, DNS, reset,
+        # ...) rather than leave it as an unhandled Deferred error.
+        self._log.info(
+            "Datadog request failed: {error}", error=failure.getErrorMessage()
+        )

--- a/src/cowrie/output/graylog.py
+++ b/src/cowrie/output/graylog.py
@@ -14,6 +14,7 @@ import time
 from io import BytesIO
 
 from twisted.internet import reactor, ssl
+from twisted.logger import Logger
 from twisted.web import client, http_headers
 from twisted.web.client import FileBodyProducer
 from twisted.web.iweb import IPolicyForHTTPS
@@ -24,6 +25,8 @@ from cowrie.core.config import CowrieConfig
 
 
 class Output(cowrie.core.output.Output):
+    _log = Logger()
+
     def start(self) -> None:
         self.url = CowrieConfig.get("output_graylog", "url").encode("utf8")
         contextFactory = WhitelistContextFactory()
@@ -56,7 +59,15 @@ class Output(cowrie.core.output.Output):
         )
 
         body = FileBodyProducer(BytesIO(json.dumps(entry).encode("utf8")))
-        self.agent.request(b"POST", self.url, headers, body)
+        d = self.agent.request(b"POST", self.url, headers, body)
+        d.addErrback(self._request_failed)
+
+    def _request_failed(self, failure):
+        # Best-effort telemetry: log a failed request (timeout, DNS, reset,
+        # ...) rather than leave it as an unhandled Deferred error.
+        self._log.info(
+            "Graylog request failed: {error}", error=failure.getErrorMessage()
+        )
 
 
 @implementer(IPolicyForHTTPS)

--- a/src/cowrie/output/telegram.py
+++ b/src/cowrie/output/telegram.py
@@ -60,15 +60,21 @@ class Output(cowrie.core.output.Output):
 
     def send_message(self, message):
         self._log.info("Telegram plugin will try to call TelegramBot")
-        try:
-            treq.get(
-                "https://api.telegram.org/bot" + self.bot_token + "/sendMessage",
-                params=[
-                    ("chat_id", str(self.chat_id)),
-                    ("parse_mode", "HTML"),
-                    ("text", message),
-                ],
-                allow_redirects=False,
-            )
-        except Exception:
-            self._log.info("Telegram plugin request error")
+        # treq.get returns a Deferred; a network failure surfaces there, not as
+        # a synchronous exception, so it needs an errback rather than a
+        # try/except to avoid an unhandled Deferred error.
+        d = treq.get(
+            "https://api.telegram.org/bot" + self.bot_token + "/sendMessage",
+            params=[
+                ("chat_id", str(self.chat_id)),
+                ("parse_mode", "HTML"),
+                ("text", message),
+            ],
+            allow_redirects=False,
+        )
+        d.addErrback(self._request_failed)
+
+    def _request_failed(self, failure):
+        self._log.info(
+            "Telegram plugin request error: {error}", error=failure.getErrorMessage()
+        )

--- a/src/cowrie/test/test_output_network_errors.py
+++ b/src/cowrie/test/test_output_network_errors.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Output plugins that make HTTP requests must handle a failed request
+# ABOUTME: instead of leaving an unhandled Deferred error (issue #1711 class).
+
+from __future__ import annotations
+
+import os
+import unittest
+from typing import Any
+from unittest.mock import Mock, patch
+
+from twisted.internet import defer
+from twisted.python.failure import Failure
+from twisted.web.client import ResponseNeverReceived
+
+from cowrie.output import axiom, datadog, graylog, telegram
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+def _network_failure() -> Failure:
+    # What treq raises when a request times out (issue #1711).
+    return Failure(ResponseNeverReceived([Failure(defer.CancelledError())]))
+
+
+def _make(module: Any) -> Any:
+    """Construct a plugin without running its config-reading start()."""
+    with patch.object(module.Output, "start", lambda self: None):
+        return module.Output()
+
+
+def _assert_handled(test: unittest.TestCase, deferred: defer.Deferred) -> None:
+    seen: list = []
+    deferred.addBoth(seen.append)
+    test.assertEqual(len(seen), 1)
+    test.assertNotIsInstance(seen[0], Failure)
+
+
+class OutputNetworkErrorTests(unittest.TestCase):
+    """A failed HTTP request must be handled, not left as an unhandled Deferred."""
+
+    def test_axiom_request_failure_is_handled(self) -> None:
+        out = _make(axiom)
+        out.url = b"https://example.invalid"
+        out.headers = {}
+        d_fail: defer.Deferred = defer.fail(_network_failure())
+        with patch("cowrie.output.axiom.treq.post", return_value=d_fail):
+            written = out.write({"timestamp": "2026-01-01T00:00:00Z", "eventid": "t"})
+        _assert_handled(self, written)
+
+    def test_datadog_request_failure_is_handled(self) -> None:
+        out = _make(datadog)
+        out.agent = Mock()
+        d_fail: defer.Deferred = defer.fail(_network_failure())
+        out.agent.request.return_value = d_fail
+        out.url = b"https://example.invalid"
+        out.ddsource = "cowrie"
+        out.ddtags = "env:test"
+        out.service = "honeypot"
+        out.hostname = "unitTest"
+        out.api_key = b""
+        out.write({"eventid": "t", "session": "s"})
+        _assert_handled(self, d_fail)
+
+    def test_graylog_request_failure_is_handled(self) -> None:
+        out = _make(graylog)
+        out.agent = Mock()
+        d_fail: defer.Deferred = defer.fail(_network_failure())
+        out.agent.request.return_value = d_fail
+        out.url = b"https://example.invalid"
+        out.write({"sensor": "unitTest", "eventid": "t"})
+        _assert_handled(self, d_fail)
+
+    def test_telegram_request_failure_is_handled(self) -> None:
+        out = _make(telegram)
+        out.bot_token = "token"
+        out.chat_id = "123"
+        d_fail: defer.Deferred = defer.fail(_network_failure())
+        with patch("cowrie.output.telegram.treq.get", return_value=d_fail):
+            out.send_message("hello")
+        _assert_handled(self, d_fail)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up to #40374 (greynoise). Audited all 13 network-using output plugins for the same class of bug — an HTTP request whose failure is left unhandled, surfacing as a `[twisted.internet.defer#critical] Unhandled error in Deferred` on a timeout/reset (issue #1711). Four had it:

| Plugin | Problem | Fix |
|---|---|---|
| **axiom** | the awaited `treq.post()` sat **outside** the `try/except` (which only caught the `json.dumps` `TypeError`) | wrap the request + response handling so a failed post is logged |
| **datadog** | `agent.request()` fired and its Deferred dropped | attach an errback that logs the failure |
| **graylog** | same as datadog | same (also gained a `Logger` for the error path) |
| **telegram** | `send_message()` called `treq.get()` with no `yield`/errback; the surrounding `except` only caught *synchronous* errors, so the async failure was orphaned | capture the Deferred and errback it |

## Already correct (unchanged)
- **crashreporter, dshield, cuckoo, malshare** — `yield treq…` inside a broad `except Exception`.
- **signal, discord, splunk, virustotal** — `addErrback` on the request Deferred.
- **greynoise** — fixed separately in #40374.

All fixes follow the conventions already in the codebase (errback for fire-and-forget Deferreds; broad except around a yielded `treq` in `inlineCallbacks`). No change to the success path of any plugin.

## Tests
New `test_output_network_errors.py`: injects a `ResponseNeverReceived` (the treq timeout failure) into each plugin's request and asserts the Deferred is left **handled**, not lingering as a `Failure`. Full suite (828), ruff, and mypy pass.