### PR TITLE
fix: flush buffered frontend packets in proxy mode

### DIFF
--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -468,6 +468,13 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             self.delayedPackets.append([messageNum, payload])
         else:
             if len(self.delayedPackets) > 0:
+                # Flush the queued packets in order, then this one; leaving them
+                # queued would strand a frontend request (e.g. the channel open
+                # that follows login) and hang the session. Mirrors the backend
+                # side in BackendSSHTransport.packet_buffer.
                 self.delayedPackets.append([messageNum, payload])
+                for packet in self.delayedPackets:
+                    self.sshParse.parse_num_packet("[SERVER]", packet[0], packet[1])
+                self.delayedPackets = []
             else:
                 self.sshParse.parse_num_packet("[SERVER]", messageNum, payload)

--- a/src/cowrie/test/test_proxy_packet_buffer.py
+++ b/src/cowrie/test/test_proxy_packet_buffer.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: The proxy frontend must flush buffered frontend->backend packets once
+# ABOUTME: the backend is connected, not strand them (issue #1788).
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+from cowrie.ssh_proxy.server_transport import FrontendSSHTransport
+
+
+def _make(backend_connected: bool, queued: list[list[Any]]) -> Any:
+    """A minimal stand-in exposing just what packet_buffer touches."""
+    parsed: list[tuple[str, int, bytes]] = []
+    sshParse = Mock()
+    sshParse.parse_num_packet = lambda ctx, num, payload: parsed.append(
+        (ctx, num, payload)
+    )
+    return SimpleNamespace(
+        backendConnected=backend_connected,
+        delayedPackets=queued,
+        sshParse=sshParse,
+        parsed=parsed,
+        _log=Mock(),
+    )
+
+
+class ProxyFrontendPacketBufferTests(unittest.TestCase):
+    def test_buffers_while_backend_not_connected(self) -> None:
+        s = _make(backend_connected=False, queued=[])
+        FrontendSSHTransport.packet_buffer(s, 90, b"open")
+        self.assertEqual(s.delayedPackets, [[90, b"open"]])
+        self.assertEqual(s.parsed, [])
+
+    def test_parses_immediately_when_connected_and_queue_empty(self) -> None:
+        s = _make(backend_connected=True, queued=[])
+        FrontendSSHTransport.packet_buffer(s, 90, b"open")
+        self.assertEqual(s.parsed, [("[SERVER]", 90, b"open")])
+        self.assertEqual(s.delayedPackets, [])
+
+    def test_flushes_queue_when_connected(self) -> None:
+        # The bug (#1788): with the backend connected but packets still queued,
+        # a new packet must flush the whole queue in order, not strand it.
+        s = _make(backend_connected=True, queued=[[80, b"a"], [81, b"b"]])
+        FrontendSSHTransport.packet_buffer(s, 90, b"open")
+        self.assertEqual(
+            s.parsed,
+            [("[SERVER]", 80, b"a"), ("[SERVER]", 81, b"b"), ("[SERVER]", 90, b"open")],
+        )
+        self.assertEqual(s.delayedPackets, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses #1788 (PuTTY login through proxy mode hangs, then the client times out).

## Root cause (code review)
In proxy mode the frontend transport buffers frontend→backend packets in `delayedPackets` until the backend connection is ready, then flushes them. The two directions were **asymmetric**:

- `BackendSSHTransport.packet_buffer()` (backend→frontend), when the far side is ready and packets are queued, appends the new packet **and flushes the whole queue**, then clears it.
- `FrontendSSHTransport.packet_buffer()` (frontend→backend), in the same case, appended the packet and **never flushed** — the frontend queue was only ever drained once, by the one-shot flush in `authenticateBackend()`.

So a frontend→backend packet that lands in `delayedPackets` via that else-branch is stranded. When it's the channel-open/session request that follows a successful login, the session never glues, and the client (PuTTY in the report) hangs and times out — matching the log in the issue (auth succeeds, then `buffering packet from frontend`, then `Connection lost`).

## Fix
Make the frontend flush the queue in order, mirroring the backend side.

## Tests
`test_proxy_packet_buffer.py` exercises `FrontendSSHTransport.packet_buffer` in isolation: buffers while the backend isn't connected, parses immediately when connected with an empty queue, and — the regression for #1788 — **flushes the whole queue in order** when connected with packets still queued. Full suite (834), ruff, and mypy pass.

## ⚠️ Validation note
This is a **code-review fix**. The unit test covers the buffering logic directly, but I could not reproduce #1788 end-to-end — that needs a full proxy + pool + QEMU backend-VM setup. The issue's log also shows a pathologically slow backend SSH handshake (~37s), which may be an independent environmental factor that this fix does not address. Please validate against a real proxy/pool deployment before merge.