### PR TITLE
ci: dispatch docker and pypi publish workflows from weekly release

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
 
     steps:
       - name: Checkout
@@ -108,6 +109,18 @@ jobs:
             --title "${NEXT_VERSION}" \
             --generate-notes \
             --notes-start-tag "${LATEST_TAG}"
+
+      - name: Publish release artifacts
+        if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEXT_VERSION="${{ steps.next_version.outputs.next_version }}"
+
+          # Tags created with GITHUB_TOKEN do not trigger tag-push
+          # workflows, so dispatch the publish workflows explicitly.
+          gh workflow run docker.yml --ref "${NEXT_VERSION}"
+          gh workflow run pypi.yml --ref "${NEXT_VERSION}"
 
       - name: Dry run summary
         if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run == 'true'


### PR DESCRIPTION
## Problem

No Docker image has been published since docker.yml was gated on release tags (4146a276, June 23), and no PyPI package since v3.0.0 in May.

Root cause: the weekly release creates tags via `gh release create` with the workflow's `GITHUB_TOKEN`, and GitHub never triggers workflows from events created with `GITHUB_TOKEN` (recursion prevention). The `v*` tag pushes therefore fired neither `docker.yml` nor `pypi.yml` — every release since v3.0.1 was silently skipped by both publish pipelines.

## Fix

`workflow_dispatch` is exempt from that restriction, so after creating the release, dispatch both publish workflows on the new tag ref explicitly. Both workflows already gate their publish steps on `startsWith(github.ref, 'refs/tags/v')`, which holds under a dispatch on a tag ref. Needs `actions: write` on the job.

v3.0.10 was backfilled with manual dispatches of both workflows on the tag ref.