### PR TITLE
fix: ignore CHANNEL_WINDOW_ADJUST for already-closed channels

### DIFF
--- a/src/cowrie/ssh/connection.py
+++ b/src/cowrie/ssh/connection.py
@@ -46,10 +46,11 @@ class CowrieSSHConnection(connection.SSHConnection):
             d.addErrback(self._ebChannelRequest, localChannel)
         return d
 
-    # Some clients (observed: libssh2) send CHANNEL_EOF / CHANNEL_CLOSE for a
-    # channel whose close handshake already completed, often alongside the
-    # final DISCONNECT. Twisted's handlers look the channel up unguarded and
-    # raise KeyError to the reactor; ignore the stale message instead.
+    # Some clients (observed: libssh2) send CHANNEL_EOF / CHANNEL_CLOSE /
+    # CHANNEL_WINDOW_ADJUST for a channel whose close handshake already
+    # completed, often alongside the final DISCONNECT. Twisted's handlers look
+    # the channel up unguarded and raise KeyError to the reactor; ignore the
+    # stale message instead.
 
     def ssh_CHANNEL_EOF(self, packet):
         localChannel = struct.unpack(">L", packet[:4])[0]
@@ -70,3 +71,13 @@ class CowrieSSHConnection(connection.SSHConnection):
             )
             return
         connection.SSHConnection.ssh_CHANNEL_CLOSE(self, packet)
+
+    def ssh_CHANNEL_WINDOW_ADJUST(self, packet):
+        localChannel = struct.unpack(">L", packet[:4])[0]
+        if localChannel not in self.channels:
+            self._log.info(
+                "Ignoring CHANNEL_WINDOW_ADJUST for unknown channel {channel_id}",
+                channel_id=localChannel,
+            )
+            return
+        connection.SSHConnection.ssh_CHANNEL_WINDOW_ADJUST(self, packet)

--- a/src/cowrie/test/test_ssh_connection.py
+++ b/src/cowrie/test/test_ssh_connection.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# ABOUTME: Tests for CowrieSSHConnection channel message handling: stale EOF
-# ABOUTME: and CLOSE for an already-closed channel are ignored, not a crash.
+# ABOUTME: Tests for CowrieSSHConnection channel message handling: stale EOF,
+# ABOUTME: CLOSE, and WINDOW_ADJUST for a closed channel are ignored, not a crash.
 
 from __future__ import annotations
 
@@ -22,6 +22,7 @@ class _StubChannel:
     def __init__(self) -> None:
         self.gotEOF = False
         self.gotClose = False
+        self.windowBytesAdded = 0
 
     def eofReceived(self) -> None:
         self.gotEOF = True
@@ -29,14 +30,18 @@ class _StubChannel:
     def closeReceived(self) -> None:
         self.gotClose = True
 
+    def addWindowBytes(self, data: int) -> None:
+        self.windowBytesAdded += data
+
     def logPrefix(self) -> str:
         return "stub"
 
 
 class StaleChannelMessageTests(unittest.TestCase):
-    """A libssh2 client can send CHANNEL_EOF / CHANNEL_CLOSE for a channel
-    whose close handshake already completed (issue #40296); the connection
-    must ignore them instead of raising KeyError to the reactor."""
+    """A client can send CHANNEL_EOF / CHANNEL_CLOSE / CHANNEL_WINDOW_ADJUST
+    for a channel whose close handshake already completed (issues #40296,
+    #40314); the connection must ignore them instead of raising KeyError to
+    the reactor."""
 
     def setUp(self) -> None:
         self.conn = CowrieSSHConnection()
@@ -58,3 +63,12 @@ class StaleChannelMessageTests(unittest.TestCase):
         self.conn.channels[0] = channel
         self.conn.ssh_CHANNEL_CLOSE(struct.pack(">L", 0))
         self.assertTrue(channel.gotClose)
+
+    def test_window_adjust_for_unknown_channel_is_ignored(self) -> None:
+        self.conn.ssh_CHANNEL_WINDOW_ADJUST(struct.pack(">2L", 0, 1024))
+
+    def test_window_adjust_for_known_channel_is_delivered(self) -> None:
+        channel = _StubChannel()
+        self.conn.channels[0] = channel
+        self.conn.ssh_CHANNEL_WINDOW_ADJUST(struct.pack(">2L", 0, 1024))
+        self.assertEqual(channel.windowBytesAdded, 1024)


### PR DESCRIPTION
## Problem

`CowrieSSHConnection` guards `ssh_CHANNEL_EOF` and `ssh_CHANNEL_CLOSE` against stale messages for channels that already completed their close handshake, but not `ssh_CHANNEL_WINDOW_ADJUST`. A client sending a window adjust for a closed channel hit Twisted's unguarded `self.channels[localChannel]` lookup, raising an unhandled `KeyError` to the reactor:

```
File ".../twisted/conch/ssh/connection.py", line 235, in ssh_CHANNEL_WINDOW_ADJUST
    channel = self.channels[localChannel]
builtins.KeyError: 0
```

## Fix

Override `ssh_CHANNEL_WINDOW_ADJUST` with the same guard already used for EOF and CLOSE: log and ignore the message when the channel is no longer in `self.channels`.

## Test

Two tests added to `test_ssh_connection.py` alongside the existing EOF/CLOSE coverage: a window adjust for an unknown channel is ignored (reproduces the exact `KeyError: 0` before the fix), and one for a live channel still reaches `addWindowBytes` with the right byte count.

Closes #40314

Thanks to @vbontchev for the report and proposed fix.