### PR TITLE
fix: treat a bare = as a command name, not an assignment

### DIFF
--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -10,6 +10,7 @@ import copy
 import enum
 import fnmatch
 import os
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -44,6 +45,10 @@ from cowrie.shell.pipe import PipeProtocol
 # ceilings are far above that yet keep a `while true` from running forever.
 MAX_WHILE_ITERATIONS = 1000
 MAX_FOR_ITEMS = 10000
+
+# A word is a variable assignment only when a valid shell identifier precedes
+# the =; bash treats words like "=", "=foo" or "1x=5" as command names.
+ASSIGNMENT_WORD = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=")
 
 
 class LoopSignal(enum.Enum):
@@ -622,7 +627,7 @@ class HoneyPotShell:
         cmd_array: list[dict[str, Any]] = []
         while cmdAndArgs:
             piece = cmdAndArgs.pop(0)
-            if piece.count("="):
+            if ASSIGNMENT_WORD.match(piece):
                 key, val = piece.split("=", 1)
                 environ[key] = val
                 continue

--- a/src/cowrie/test/test_shell_variables.py
+++ b/src/cowrie/test/test_shell_variables.py
@@ -117,6 +117,22 @@ class ShellVariableTests(unittest.TestCase):
         self.assertEqual(self.run_line(b"whoami"), b"root\n")
         self.assertIn(b"command not found", self.run_line(b"definitelynotacommand"))
 
+    # A word only counts as an assignment when a valid identifier precedes the
+    # =; bash treats "=", "=foo" and "1x=5" as command names and reports them
+    # as not found
+    def test_bare_equals_is_command_not_found(self) -> None:
+        self.assertEqual(self.run_line(b"="), b"-bash: =: command not found\n")
+
+    def test_equals_prefixed_word_is_command_not_found(self) -> None:
+        self.assertEqual(self.run_line(b"=foo"), b"-bash: =foo: command not found\n")
+
+    def test_invalid_identifier_assignment_is_command_not_found(self) -> None:
+        self.assertEqual(self.run_line(b"1x=5"), b"-bash: 1x=5: command not found\n")
+
+    def test_underscore_identifier_assignment_persists(self) -> None:
+        self.proto.lineReceived(b"_x=hi")
+        self.assertEqual(self.run_line(b"echo $_x"), b"hi\n")
+
     # unset removes a variable from both scopes; afterwards a bare reference to
     # it drops the word, like any other unset name
     def test_unset_removes_variable(self) -> None:


### PR DESCRIPTION
## Problem

The leading-word loop in `HoneyPotShell.runCommand()` classified any word containing `=` as a variable assignment. A bare `=` (or `=foo`, `1x=5`) was silently consumed as `environ[''] = ''` and the shell returned success. Bash only treats a word as an assignment when a valid identifier precedes the `=`, and reports words like `=` as `command not found` — a checkable fingerprint distinguishing the emulated shell from real bash.

## Fix

Replace the `piece.count("=")` check with a match against bash's assignment-word grammar (`[A-Za-z_][A-Za-z0-9_]*=`); anything else falls through to command lookup and gets the normal `command not found` handling.

## Test

Four tests added to `test_shell_variables.py`: `=`, `=foo` and `1x=5` each report `command not found` (all three failed before the fix), and `_x=hi` still persists as an assignment.

Closes #40348

Thanks to @vbontchev for the report and analysis.