### PR TITLE
perf: share the honeyfs tree across sessions (copy-on-write)

### DIFF
--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -402,9 +402,10 @@ or available locally via: info '(coreutils) rm invocation'\n"""
 
         for f in args:
             pname = self.fs.resolve_path(f, self.protocol.cwd)
+            parent = "/".join(pname.split("/")[:-1])
             try:
                 # verify path to file exists
-                directory = self.fs.get_path("/".join(pname.split("/")[:-1]))
+                directory = self.fs.get_path(parent)
                 # verify that the file itself exists
                 self.fs.get_path(pname)
             except (IndexError, fs.FileNotFound):
@@ -421,7 +422,7 @@ or available locally via: info '(coreutils) rm invocation'\n"""
                             f"rm: cannot remove `{i[fs.A_NAME]}': Is a directory\n"
                         )
                     else:
-                        directory.remove(i)
+                        self.fs.unlink_entry(i, parent)
                         if verbose:
                             if i[fs.A_TYPE] == fs.T_DIR:
                                 self.write(f"removed directory '{i[fs.A_NAME]}'\n")
@@ -495,15 +496,13 @@ class Command_cp(HoneyPotCommand):
                 continue
             s = copy.deepcopy(self.fs.getfile(resolv(src)))
             if isdir:
-                directory = self.fs.get_path(resolv(dest))
+                destdir = resolv(dest)
                 outfile = os.path.basename(src)
             else:
-                directory = self.fs.get_path(os.path.dirname(resolv(dest)))
+                destdir = os.path.dirname(resolv(dest))
                 outfile = os.path.basename(dest.rstrip("/"))
-            if outfile in [x[fs.A_NAME] for x in directory]:
-                directory.remove(next(x for x in directory if x[fs.A_NAME] == outfile))
             s[fs.A_NAME] = outfile
-            directory.append(s)
+            self.fs.link_entry(s, destdir)
 
 
 commands["/bin/cp"] = Command_cp
@@ -566,18 +565,15 @@ class Command_mv(HoneyPotCommand):
                 continue
             s = self.fs.getfile(resolv(src))
             if isdir:
-                directory = self.fs.get_path(resolv(dest))
+                destdir = resolv(dest)
                 outfile = os.path.basename(src)
             else:
-                directory = self.fs.get_path(os.path.dirname(resolv(dest)))
+                destdir = os.path.dirname(resolv(dest))
                 outfile = os.path.basename(dest)
-            if directory != os.path.dirname(resolv(src)):
-                s[fs.A_NAME] = outfile
-                directory.append(s)
-                sdir = self.fs.get_path(os.path.dirname(resolv(src)))
-                sdir.remove(s)
-            else:
-                s[fs.A_NAME] = outfile
+            srcdir = os.path.dirname(resolv(src))
+            s[fs.A_NAME] = outfile
+            self.fs.link_entry(s, destdir, replace=False)
+            self.fs.unlink_entry(s, srcdir)
 
 
 commands["/bin/mv"] = Command_mv

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -571,9 +571,9 @@ class Command_mv(HoneyPotCommand):
                 destdir = os.path.dirname(resolv(dest))
                 outfile = os.path.basename(dest)
             srcdir = os.path.dirname(resolv(src))
-            s[fs.A_NAME] = outfile
-            self.fs.link_entry(s, destdir, replace=False)
             self.fs.unlink_entry(s, srcdir)
+            s[fs.A_NAME] = outfile
+            self.fs.link_entry(s, destdir)
 
 
 commands["/bin/mv"] = Command_mv

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -402,32 +402,24 @@ or available locally via: info '(coreutils) rm invocation'\n"""
 
         for f in args:
             pname = self.fs.resolve_path(f, self.protocol.cwd)
-            parent = "/".join(pname.split("/")[:-1])
-            try:
-                # verify path to file exists
-                directory = self.fs.get_path(parent)
-                # verify that the file itself exists
-                self.fs.get_path(pname)
-            except (IndexError, fs.FileNotFound):
+            node = self.fs.getfile(pname, follow_symlinks=False)
+            if node is None:
                 if not force:
                     self.errorWrite(
                         f"rm: cannot remove `{f}': No such file or directory\n"
                     )
                 continue
-            basename = pname.split("/")[-1]
-            for i in directory[:]:
-                if i[fs.A_NAME] == basename:
-                    if i[fs.A_TYPE] == fs.T_DIR and not recursive:
-                        self.errorWrite(
-                            f"rm: cannot remove `{i[fs.A_NAME]}': Is a directory\n"
-                        )
-                    else:
-                        self.fs.unlink_entry(i, parent)
-                        if verbose:
-                            if i[fs.A_TYPE] == fs.T_DIR:
-                                self.write(f"removed directory '{i[fs.A_NAME]}'\n")
-                            else:
-                                self.write(f"removed '{i[fs.A_NAME]}'\n")
+            if node[fs.A_TYPE] == fs.T_DIR and not recursive:
+                self.errorWrite(
+                    f"rm: cannot remove `{node[fs.A_NAME]}': Is a directory\n"
+                )
+                continue
+            self.fs.remove(pname)
+            if verbose:
+                if node[fs.A_TYPE] == fs.T_DIR:
+                    self.write(f"removed directory '{node[fs.A_NAME]}'\n")
+                else:
+                    self.write(f"removed '{node[fs.A_NAME]}'\n")
 
 
 commands["/bin/rm"] = Command_rm
@@ -560,20 +552,15 @@ class Command_mv(HoneyPotCommand):
                 return
 
         for src in sources:
-            if not self.fs.exists(resolv(src)):
+            srcpath = resolv(src)
+            if not self.fs.exists(srcpath):
                 self.errorWrite(f"mv: cannot stat `{src}': No such file or directory\n")
                 continue
-            s = self.fs.getfile(resolv(src))
             if isdir:
-                destdir = resolv(dest)
-                outfile = os.path.basename(src)
+                destpath = os.path.join(resolv(dest), os.path.basename(src))
             else:
-                destdir = os.path.dirname(resolv(dest))
-                outfile = os.path.basename(dest)
-            srcdir = os.path.dirname(resolv(src))
-            self.fs.unlink_entry(s, srcdir)
-            s[fs.A_NAME] = outfile
-            self.fs.link_entry(s, destdir)
+                destpath = resolv(dest)
+            self.fs.rename(srcpath, destpath)
 
 
 commands["/bin/mv"] = Command_mv

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -15,7 +15,7 @@ import stat
 import sys
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from twisted.logger import Logger
 
@@ -39,6 +39,11 @@ if TYPE_CHECKING:
     A_REALFILE,
 ) = list(range(0, 10))
 T_LINK, T_DIR, T_FILE, T_BLK, T_CHR, T_SOCK, T_FIFO = list(range(0, 7))
+
+# A filesystem entry: the positional 10-field list indexed by the A_* constants
+# above — [name, type, uid, gid, size, mode, ctime, contents, target, realfile].
+# contents is a list of child Nodes for a directory, or bytes for a file.
+Node: TypeAlias = list[Any]
 
 
 SPECIAL_PATHS: list[str] = ["/sys", "/proc", "/dev/pts"]
@@ -116,7 +121,7 @@ class HoneyPotFilesystem:
 
     def __init__(self, arch: str, home: str) -> None:
         try:
-            self.fs: list[Any] = honeyfs.get_tree()
+            self.fs: Node = honeyfs.get_tree()
         except Exception:
             self._log.failure("ERROR: Failed to load filesystem")
             sys.exit(2)
@@ -154,7 +159,7 @@ class HoneyPotFilesystem:
                 realfile_path: str = os.path.join(path, filename)
                 virtual_path: str = "/" + os.path.relpath(realfile_path, honeyfs_path)
 
-                f: list[Any] | None = self.getfile(virtual_path, follow_symlinks=False)
+                f: Node | None = self.getfile(virtual_path, follow_symlinks=False)
                 if f and f[A_TYPE] == T_FILE:
                     self.update_realfile(f, realfile_path)
 
@@ -191,23 +196,22 @@ class HoneyPotFilesystem:
 
         return "/{}".format("/".join(cwdpieces))
 
-    def get_path(self, path: str, follow_symlinks: bool = True) -> Any:
+    def get_path(self, path: str, follow_symlinks: bool = True) -> Node:
         """
-        This returns the contents of the Cowrie filesystem node at path — a
-        list of child entries for a directory, or the embedded bytes for a
-        file. Raises FileNotFound if the path does not resolve.
+        This returns the children of the directory node at path. Raises
+        FileNotFound if the path does not resolve.
         """
         node = self.getfile(path, follow_symlinks=follow_symlinks)
         if node is None:
             raise FileNotFound
-        return node[A_CONTENTS]
+        return node[A_CONTENTS]  # type: ignore[no-any-return]
 
     def exists(self, path: str) -> bool:
         """
         Return True if path refers to an existing path.
         Returns False for broken symbolic links.
         """
-        f: list[Any] | None = self.getfile(path, follow_symlinks=True)
+        f: Node | None = self.getfile(path, follow_symlinks=True)
         if f is not None:
             return True
         return False
@@ -217,12 +221,14 @@ class HoneyPotFilesystem:
         Return True if path refers to an existing path.
         Returns True for broken symbolic links.
         """
-        f: list[Any] | None = self.getfile(path, follow_symlinks=False)
+        f: Node | None = self.getfile(path, follow_symlinks=False)
         if f is not None:
             return True
         return False
 
-    def update_realfile(self, f: Any, realfile: str) -> None:
+    def update_realfile(self, f: Node | None, realfile: str) -> None:
+        if f is None:
+            return
         if (
             not f[A_REALFILE]
             and os.path.exists(realfile)
@@ -232,7 +238,7 @@ class HoneyPotFilesystem:
         ):
             f[A_REALFILE] = realfile
 
-    def getfile(self, path: str, follow_symlinks: bool = True) -> list[Any] | None:
+    def getfile(self, path: str, follow_symlinks: bool = True) -> Node | None:
         """
         This returns the Cowrie file system object for a path
         """
@@ -240,7 +246,7 @@ class HoneyPotFilesystem:
             return self.fs
         pieces: list[str] = [piece for piece in path.strip("/").split("/") if piece]
         cwd: str = ""
-        p: list[Any] | None = self.fs
+        p: Node | None = self.fs
         for piece in pieces:
             if not isinstance(p, list) or not isinstance(p[A_CONTENTS], list):
                 # missing, or an attempt to descend into a non-directory
@@ -284,7 +290,9 @@ class HoneyPotFilesystem:
         path: str = self.resolve_path(target, os.path.dirname(target))
         if not path or not self.exists(path):
             raise FileNotFound
-        f: Any = self.getfile(path)
+        f: Node | None = self.getfile(path)
+        if f is None:
+            raise FileNotFound
         if f[A_TYPE] == T_DIR:
             raise IsADirectoryError
         if f[A_TYPE] == T_FILE and f[A_REALFILE]:
@@ -300,7 +308,7 @@ class HoneyPotFilesystem:
             return read_data_bytes("arch", self.arch)
         return b""
 
-    def link_entry(self, entry: list[Any], dirpath: str) -> None:
+    def link_entry(self, entry: Node, dirpath: str) -> None:
         """Insert entry into the directory at dirpath, replacing any existing
         entry with the same name so a directory never holds two entries under
         one name.
@@ -314,7 +322,7 @@ class HoneyPotFilesystem:
             directory.remove(existing)
         directory.append(entry)
 
-    def unlink_entry(self, entry: list[Any], dirpath: str) -> None:
+    def unlink_entry(self, entry: Node, dirpath: str) -> None:
         """Remove entry from the directory at dirpath."""
         self.get_path(dirpath).remove(entry)
 
@@ -374,7 +382,7 @@ class HoneyPotFilesystem:
         links, so both islink() and isfile() can be true for the same path.
         """
         try:
-            f: list[Any] | None = self.getfile(path)
+            f: Node | None = self.getfile(path)
         except Exception:
             return False
         if f is None:
@@ -389,7 +397,7 @@ class HoneyPotFilesystem:
         link.
         """
         try:
-            f: list[Any] | None = self.getfile(path)
+            f: Node | None = self.getfile(path)
         except Exception:
             return False
         if f is None:
@@ -498,7 +506,7 @@ class HoneyPotFilesystem:
         """
         FIXME mkdir() name conflicts with existing mkdir
         """
-        directory: list[Any] | None = self.getfile(path)
+        directory: Node | None = self.getfile(path)
         if directory:
             raise OSError(errno.EEXIST, os.strerror(errno.EEXIST), path)
         self.mkdir(path, 0, 0, 4096, 16877)
@@ -507,7 +515,7 @@ class HoneyPotFilesystem:
         p: str = path.rstrip("/")
         name: str = os.path.basename(p)
         parent: str = os.path.dirname(p)
-        directory: Any = self.getfile(p, follow_symlinks=False)
+        directory: Node | None = self.getfile(p, follow_symlinks=False)
         if not directory:
             raise OSError(errno.EEXIST, os.strerror(errno.EEXIST), p)
         if directory[A_TYPE] != T_DIR:
@@ -522,19 +530,19 @@ class HoneyPotFilesystem:
         return False
 
     def utime(self, path: str, _atime: float, mtime: float) -> None:
-        p: list[Any] | None = self.getfile(path)
+        p: Node | None = self.getfile(path)
         if not p:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
         p[A_CTIME] = mtime
 
     def chmod(self, path: str, perm: int) -> None:
-        p: list[Any] | None = self.getfile(path)
+        p: Node | None = self.getfile(path)
         if not p:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
         p[A_MODE] = stat.S_IFMT(p[A_MODE]) | perm
 
     def chown(self, path: str, uid: int, gid: int) -> None:
-        p: list[Any] | None = self.getfile(path)
+        p: Node | None = self.getfile(path)
         if not p:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
         if uid != -1:
@@ -543,13 +551,13 @@ class HoneyPotFilesystem:
             p[A_GID] = gid
 
     def remove(self, path: str) -> None:
-        p: list[Any] | None = self.getfile(path, follow_symlinks=False)
+        p: Node | None = self.getfile(path, follow_symlinks=False)
         if not p:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
         self.unlink_entry(p, os.path.dirname(path))
 
     def readlink(self, path: str) -> str:
-        p: list[Any] | None = self.getfile(path, follow_symlinks=False)
+        p: Node | None = self.getfile(path, follow_symlinks=False)
         if not p:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
         if not p[A_MODE] & stat.S_IFLNK:
@@ -563,7 +571,7 @@ class HoneyPotFilesystem:
         """Move oldpath to newpath, replacing newpath if it already exists —
         the rename(2) semantics real mv(1) and the SFTP client rely on.
         """
-        old: list[Any] | None = self.getfile(oldpath)
+        old: Node | None = self.getfile(oldpath)
         if not old:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
         self.unlink_entry(old, os.path.dirname(oldpath))
@@ -578,7 +586,7 @@ class HoneyPotFilesystem:
         return self.stat(path, follow_symlinks=False)
 
     def stat(self, path: str, follow_symlinks: bool = True) -> _statobj:
-        p: list[Any] | None
+        p: Node | None
         if path == "/":
             p = ["/", T_DIR, 0, 0, 4096, 16877, time.time(), [], None, None]
         else:
@@ -604,7 +612,7 @@ class HoneyPotFilesystem:
         return path
 
     def update_size(self, filename: str, size: int) -> None:
-        f: list[Any] | None = self.getfile(filename)
+        f: Node | None = self.getfile(filename)
         if not f:
             return
         if f[A_TYPE] != T_FILE:

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -347,6 +347,28 @@ class HoneyPotFilesystem:
             return read_data_bytes("arch", self.arch)
         return b""
 
+    def link_entry(self, entry: list[Any], dirpath: str, replace: bool = True) -> None:
+        """Insert entry into the directory at dirpath.
+
+        When replace is True (the default) any existing entry with the same
+        name is removed first, so directory names stay unique — cp semantics.
+        When False the entry is appended unconditionally, which can leave two
+        entries sharing a name; this preserves mv's historical behaviour.
+
+        The caller owns entry: it must not still be linked elsewhere in the
+        tree (move callers unlink_entry it from its old parent).
+        """
+        directory = self.get_path(dirpath)
+        if replace:
+            name = entry[A_NAME]
+            for existing in [x for x in directory if x[A_NAME] == name]:
+                directory.remove(existing)
+        directory.append(entry)
+
+    def unlink_entry(self, entry: list[Any], dirpath: str) -> None:
+        """Remove entry from the directory at dirpath."""
+        self.get_path(dirpath).remove(entry)
+
     def mkfile(
         self,
         path: str,

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -223,32 +223,14 @@ class HoneyPotFilesystem:
 
     def get_path(self, path: str, follow_symlinks: bool = True) -> Any:
         """
-        This returns the Cowrie file system objects for a directory
+        This returns the contents of the Cowrie filesystem node at path — a
+        list of child entries for a directory, or the embedded bytes for a
+        file. Raises FileNotFound if the path does not resolve.
         """
-        cwd: list[Any] = self.fs
-        for part in path.split("/"):
-            if not part:
-                continue
-            if not isinstance(cwd[A_CONTENTS], list):
-                # walked into a non-directory entry (e.g. a file's bytes)
-                raise FileNotFound
-            ok = False
-            for c in cwd[A_CONTENTS]:
-                if c[A_NAME] == part:
-                    if c[A_TYPE] == T_LINK:
-                        f = self.getfile(c[A_TARGET], follow_symlinks=follow_symlinks)
-                        if f is None:
-                            ok = False
-                            break
-                        else:
-                            cwd = f
-                    else:
-                        cwd = c
-                    ok = True
-                    break
-            if not ok:
-                raise FileNotFound
-        return cwd[A_CONTENTS]
+        node = self.getfile(path, follow_symlinks=follow_symlinks)
+        if node is None:
+            raise FileNotFound
+        return node[A_CONTENTS]
 
     def exists(self, path: str) -> bool:
         """
@@ -286,11 +268,12 @@ class HoneyPotFilesystem:
         """
         if path == "/":
             return self.fs
-        pieces: list[str] = path.strip("/").split("/")
+        pieces: list[str] = [piece for piece in path.strip("/").split("/") if piece]
         cwd: str = ""
         p: list[Any] | None = self.fs
         for piece in pieces:
-            if not isinstance(p, list):
+            if not isinstance(p, list) or not isinstance(p[A_CONTENTS], list):
+                # missing, or an attempt to descend into a non-directory
                 return None
             if piece not in [x[A_NAME] for x in p[A_CONTENTS]]:
                 return None

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -347,22 +347,18 @@ class HoneyPotFilesystem:
             return read_data_bytes("arch", self.arch)
         return b""
 
-    def link_entry(self, entry: list[Any], dirpath: str, replace: bool = True) -> None:
-        """Insert entry into the directory at dirpath.
-
-        When replace is True (the default) any existing entry with the same
-        name is removed first, so directory names stay unique — cp semantics.
-        When False the entry is appended unconditionally, which can leave two
-        entries sharing a name; this preserves mv's historical behaviour.
+    def link_entry(self, entry: list[Any], dirpath: str) -> None:
+        """Insert entry into the directory at dirpath, replacing any existing
+        entry with the same name so a directory never holds two entries under
+        one name.
 
         The caller owns entry: it must not still be linked elsewhere in the
-        tree (move callers unlink_entry it from its old parent).
+        tree (move callers unlink_entry it from its old parent first).
         """
         directory = self.get_path(dirpath)
-        if replace:
-            name = entry[A_NAME]
-            for existing in [x for x in directory if x[A_NAME] == name]:
-                directory.remove(existing)
+        name = entry[A_NAME]
+        for existing in [x for x in directory if x[A_NAME] == name]:
+            directory.remove(existing)
         directory.append(entry)
 
     def unlink_entry(self, entry: list[Any], dirpath: str) -> None:

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -593,7 +593,7 @@ class HoneyPotFilesystem:
         p: list[Any] | None = self.getfile(path, follow_symlinks=False)
         if not p:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
-        self.get_path(os.path.dirname(path)).remove(p)
+        self.unlink_entry(p, os.path.dirname(path))
 
     def readlink(self, path: str) -> str:
         p: list[Any] | None = self.getfile(path, follow_symlinks=False)
@@ -607,16 +607,15 @@ class HoneyPotFilesystem:
         raise NotImplementedError
 
     def rename(self, oldpath: str, newpath: str) -> None:
+        """Move oldpath to newpath, replacing newpath if it already exists —
+        the rename(2) semantics real mv(1) and the SFTP client rely on.
+        """
         old: list[Any] | None = self.getfile(oldpath)
         if not old:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
-        new = self.getfile(newpath)
-        if new:
-            raise OSError(errno.EEXIST, os.strerror(errno.EEXIST))
-
-        self.get_path(os.path.dirname(oldpath)).remove(old)
+        self.unlink_entry(old, os.path.dirname(oldpath))
         old[A_NAME] = os.path.basename(newpath)
-        self.get_path(os.path.dirname(newpath)).append(old)
+        self.link_entry(old, os.path.dirname(newpath))
 
     def listdir(self, path: str) -> list[str]:
         names: list[str] = [x[A_NAME] for x in self.get_path(path)]

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import errno
-import fnmatch
 import hashlib
 import os
 import re
@@ -191,35 +190,6 @@ class HoneyPotFilesystem:
             cwdpieces.append(piece)
 
         return "/{}".format("/".join(cwdpieces))
-
-    def resolve_path_wc(self, path: str, cwd: str) -> list[str]:
-        """
-        Resolve_path with wildcard support (globbing)
-        """
-        pieces: list[str] = path.rstrip("/").split("/")
-        cwdpieces: list[str]
-        if len(pieces[0]):
-            cwdpieces = [x for x in cwd.split("/") if len(x)]
-            path = path[1:]
-        else:
-            cwdpieces, pieces = [], pieces[1:]
-        found: list[str] = []
-
-        def foo(p, cwd):
-            if not p:
-                found.append("/{}".format("/".join(cwd)))
-            elif p[0] == ".":
-                foo(p[1:], cwd)
-            elif p[0] == "..":
-                foo(p[1:], cwd[:-1])
-            else:
-                names = [x[A_NAME] for x in self.get_path("/".join(cwd))]
-                matches = [x for x in names if fnmatch.fnmatchcase(x, p[0])]
-                for match in matches:
-                    foo(p[1:], [*cwd, match])
-
-        foo(pieces, cwdpieces)
-        return found
 
     def get_path(self, path: str, follow_symlinks: bool = True) -> Any:
         """

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import copy
 import errno
 import hashlib
 import os
@@ -121,10 +122,13 @@ class HoneyPotFilesystem:
 
     def __init__(self, arch: str, home: str) -> None:
         try:
+            # Shared with every other session until this session first mutates
+            # the tree, at which point _ensure_private_fs() copies it.
             self.fs: Node = honeyfs.get_tree()
         except Exception:
             self._log.failure("ERROR: Failed to load filesystem")
             sys.exit(2)
+        self._private_fs: bool = False
 
         # Keep track of arch so we can return appropriate binary
         self.arch: str = arch
@@ -148,12 +152,23 @@ class HoneyPotFilesystem:
             except Exception as e:
                 self._log.info("Failed to load honeyfs {error!r}", error=e)
 
+    def _ensure_private_fs(self) -> None:
+        """Copy the shared base tree the first time this session mutates it.
+
+        Every mutating method calls this before fetching the node it will
+        change, so writes land on a private copy and the base tree stays
+        pristine for other sessions. Read-only sessions never copy.
+        """
+        if not self._private_fs:
+            self.fs = copy.deepcopy(self.fs)
+            self._private_fs = True
+
     def init_honeyfs(self, honeyfs_path: str) -> None:
         """
         Explore the honeyfs at 'honeyfs_path' and set all A_REALFILE attributes on
         the virtual filesystem.
         """
-
+        self._ensure_private_fs()
         for path, _directories, filenames in os.walk(honeyfs_path):
             for filename in filenames:
                 realfile_path: str = os.path.join(path, filename)
@@ -316,6 +331,7 @@ class HoneyPotFilesystem:
         The caller owns entry: it must not still be linked elsewhere in the
         tree (move callers unlink_entry it from its old parent first).
         """
+        self._ensure_private_fs()
         directory = self.get_path(dirpath)
         name = entry[A_NAME]
         for existing in [x for x in directory if x[A_NAME] == name]:
@@ -324,6 +340,7 @@ class HoneyPotFilesystem:
 
     def unlink_entry(self, entry: Node, dirpath: str) -> None:
         """Remove entry from the directory at dirpath."""
+        self._ensure_private_fs()
         self.get_path(dirpath).remove(entry)
 
     def mkfile(
@@ -344,6 +361,7 @@ class HoneyPotFilesystem:
         if any([_path.startswith(_p) for _p in SPECIAL_PATHS]):
             raise PermissionDenied
 
+        self._ensure_private_fs()
         _dir = self.get_path(_path)
         outfile: str = os.path.basename(path)
         if outfile in [x[A_NAME] for x in _dir]:
@@ -367,6 +385,7 @@ class HoneyPotFilesystem:
             ctime = time.time()
         if not path.strip("/"):
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT), path)
+        self._ensure_private_fs()
         try:
             directory = self.get_path(os.path.dirname(path.strip("/")))
         except (IndexError, FileNotFound):
@@ -522,6 +541,7 @@ class HoneyPotFilesystem:
             raise OSError(errno.ENOTDIR, os.strerror(errno.ENOTDIR), p)
         if len(self.get_path(p)) > 0:
             raise OSError(errno.ENOTEMPTY, os.strerror(errno.ENOTEMPTY), p)
+        self._ensure_private_fs()
         pdir = self.get_path(parent, follow_symlinks=True)
         for i in pdir[:]:
             if i[A_NAME] == name:
@@ -530,18 +550,21 @@ class HoneyPotFilesystem:
         return False
 
     def utime(self, path: str, _atime: float, mtime: float) -> None:
+        self._ensure_private_fs()
         p: Node | None = self.getfile(path)
         if not p:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
         p[A_CTIME] = mtime
 
     def chmod(self, path: str, perm: int) -> None:
+        self._ensure_private_fs()
         p: Node | None = self.getfile(path)
         if not p:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
         p[A_MODE] = stat.S_IFMT(p[A_MODE]) | perm
 
     def chown(self, path: str, uid: int, gid: int) -> None:
+        self._ensure_private_fs()
         p: Node | None = self.getfile(path)
         if not p:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
@@ -551,6 +574,7 @@ class HoneyPotFilesystem:
             p[A_GID] = gid
 
     def remove(self, path: str) -> None:
+        self._ensure_private_fs()
         p: Node | None = self.getfile(path, follow_symlinks=False)
         if not p:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
@@ -571,6 +595,7 @@ class HoneyPotFilesystem:
         """Move oldpath to newpath, replacing newpath if it already exists —
         the rename(2) semantics real mv(1) and the SFTP client rely on.
         """
+        self._ensure_private_fs()
         old: Node | None = self.getfile(oldpath)
         if not old:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
@@ -612,6 +637,7 @@ class HoneyPotFilesystem:
         return path
 
     def update_size(self, filename: str, size: int) -> None:
+        self._ensure_private_fs()
         f: Node | None = self.getfile(filename)
         if not f:
             return

--- a/src/cowrie/shell/honeyfs.py
+++ b/src/cowrie/shell/honeyfs.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import configparser
-import copy
 import functools
 import pickle
 from pathlib import Path
@@ -96,13 +95,14 @@ def _tree() -> list[Any]:
 
 
 def get_tree() -> list[Any]:
-    """Return a fresh deep copy of the cached filesystem tree.
+    """Return the shared cached filesystem tree.
 
-    Each HoneyPotFilesystem instance gets its own copy so per-session
-    mutations (mkfile, init_honeyfs A_REALFILE markers, etc.) don't leak
-    across sessions.
+    Callers MUST NOT mutate the returned tree — it is shared by every
+    session. HoneyPotFilesystem deep-copies it on its first write
+    (see HoneyPotFilesystem._ensure_private_fs), so read-only sessions
+    never pay the copy.
     """
-    return copy.deepcopy(_tree())
+    return _tree()
 
 
 def read_file(virtual_path: str) -> bytes:

--- a/src/cowrie/test/test_fs.py
+++ b/src/cowrie/test/test_fs.py
@@ -2,18 +2,24 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# ABOUTME: tests for cowrie/shell/fs.py path resolution
-# ABOUTME: covers resolve_path normalization and empty-path robustness
+# ABOUTME: tests for cowrie/shell/fs.py path resolution and directory-entry linking
+# ABOUTME: covers resolve_path normalization, empty-path robustness, link/unlink_entry
 
 from __future__ import annotations
 
 import os
 import unittest
+from typing import Any
 
 from cowrie.shell import fs
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+def _file_entry(name: str) -> list[Any]:
+    """Build a minimal T_FILE directory entry."""
+    return [name, fs.T_FILE, 0, 0, 0, 0o644, 0, b"", None, None]
 
 
 class ResolvePathTests(unittest.TestCase):
@@ -36,6 +42,39 @@ class ResolvePathTests(unittest.TestCase):
         # from any command that forwards an unset shell variable, e.g. an
         # attacker's `[ -w "$mnt" ]` where $mnt expanded to nothing.
         self.assertEqual(self.fs.resolve_path("", "/home/user"), "/home/user")
+
+
+class EntryLinkingTests(unittest.TestCase):
+    """link_entry/unlink_entry are the encapsulated directory mutators that
+    cp, mv and rm use instead of poking get_path() lists directly."""
+
+    def setUp(self) -> None:
+        self.fs = fs.HoneyPotFilesystem("arch", "/root")
+
+    def test_link_entry_adds_file_to_directory(self) -> None:
+        self.fs.link_entry(_file_entry("cowrie_test_file"), "/")
+        self.assertIn("cowrie_test_file", self.fs.listdir("/"))
+        self.assertIsNotNone(self.fs.getfile("/cowrie_test_file"))
+
+    def test_link_entry_replaces_same_name_by_default(self) -> None:
+        self.fs.link_entry(_file_entry("dup"), "/")
+        self.fs.link_entry(_file_entry("dup"), "/")
+        self.assertEqual(self.fs.listdir("/").count("dup"), 1)
+
+    def test_link_entry_without_replace_allows_duplicate(self) -> None:
+        self.fs.link_entry(_file_entry("dup2"), "/", replace=False)
+        self.fs.link_entry(_file_entry("dup2"), "/", replace=False)
+        self.assertEqual(self.fs.listdir("/").count("dup2"), 2)
+
+    def test_unlink_entry_removes_file(self) -> None:
+        entry = _file_entry("to_remove")
+        self.fs.link_entry(entry, "/")
+        self.fs.unlink_entry(entry, "/")
+        self.assertNotIn("to_remove", self.fs.listdir("/"))
+
+    def test_link_entry_into_subdirectory(self) -> None:
+        self.fs.link_entry(_file_entry("in_tmp"), "/tmp")
+        self.assertIn("in_tmp", self.fs.listdir("/tmp"))
 
 
 if __name__ == "__main__":

--- a/src/cowrie/test/test_fs.py
+++ b/src/cowrie/test/test_fs.py
@@ -73,5 +73,47 @@ class EntryLinkingTests(unittest.TestCase):
         self.assertIn("in_tmp", self.fs.listdir("/tmp"))
 
 
+class RenameRemoveTests(unittest.TestCase):
+    """fs.rename/fs.remove model the rename(2)/unlink(2) syscalls and back
+    both the shell (mv, rm) and the SFTP server."""
+
+    def setUp(self) -> None:
+        self.fs = fs.HoneyPotFilesystem("arch", "/root")
+
+    def test_rename_moves_file_to_new_name(self) -> None:
+        self.fs.link_entry(_file_entry("r_old"), "/tmp")
+        self.fs.rename("/tmp/r_old", "/tmp/r_new")
+        names = self.fs.listdir("/tmp")
+        self.assertNotIn("r_old", names)
+        self.assertIn("r_new", names)
+
+    def test_rename_overwrites_existing_destination(self) -> None:
+        self.fs.link_entry(_file_entry("r_src"), "/tmp")
+        self.fs.link_entry(_file_entry("r_dst"), "/tmp")
+        self.fs.rename("/tmp/r_src", "/tmp/r_dst")
+        names = self.fs.listdir("/tmp")
+        self.assertNotIn("r_src", names)
+        self.assertEqual(names.count("r_dst"), 1)
+
+    def test_rename_across_directories(self) -> None:
+        self.fs.link_entry(_file_entry("x_move"), "/tmp")
+        self.fs.rename("/tmp/x_move", "/root/x_moved")
+        self.assertNotIn("x_move", self.fs.listdir("/tmp"))
+        self.assertIn("x_moved", self.fs.listdir("/root"))
+
+    def test_rename_missing_source_raises(self) -> None:
+        with self.assertRaises(OSError):
+            self.fs.rename("/tmp/nope_src_xyz", "/tmp/whatever")
+
+    def test_remove_deletes_file(self) -> None:
+        self.fs.link_entry(_file_entry("rm_me"), "/tmp")
+        self.fs.remove("/tmp/rm_me")
+        self.assertNotIn("rm_me", self.fs.listdir("/tmp"))
+
+    def test_remove_missing_raises(self) -> None:
+        with self.assertRaises(OSError):
+            self.fs.remove("/tmp/not_here_xyz")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/cowrie/test/test_fs.py
+++ b/src/cowrie/test/test_fs.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# ABOUTME: tests for cowrie/shell/fs.py path resolution and directory-entry linking
-# ABOUTME: covers resolve_path normalization, empty-path robustness, link/unlink_entry
+# ABOUTME: tests for cowrie/shell/fs.py path resolution, tree walking and mutation
+# ABOUTME: covers resolve_path, getfile/get_path, link/unlink_entry, rename/remove
 
 from __future__ import annotations
 
@@ -17,9 +17,19 @@ os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 
-def _file_entry(name: str) -> list[Any]:
+def _file_entry(name: str, contents: bytes = b"") -> list[Any]:
     """Build a minimal T_FILE directory entry."""
-    return [name, fs.T_FILE, 0, 0, 0, 0o644, 0, b"", None, None]
+    return [name, fs.T_FILE, 0, 0, len(contents), 0o644, 0, contents, None, None]
+
+
+def _dir_entry(name: str, children: list[Any]) -> list[Any]:
+    """Build a T_DIR directory entry."""
+    return [name, fs.T_DIR, 0, 0, 0, 0o755, 0, children, None, None]
+
+
+def _link_entry(name: str, target: str) -> list[Any]:
+    """Build a T_LINK entry pointing at an absolute in-tree path."""
+    return [name, fs.T_LINK, 0, 0, 0, 0o777, 0, [], target, None]
 
 
 class ResolvePathTests(unittest.TestCase):
@@ -113,6 +123,90 @@ class RenameRemoveTests(unittest.TestCase):
     def test_remove_missing_raises(self) -> None:
         with self.assertRaises(OSError):
             self.fs.remove("/tmp/not_here_xyz")
+
+
+class WalkerTests(unittest.TestCase):
+    """getfile() resolves a path to a node; get_path() returns that node's
+    contents. Both must agree on missing paths, walking through a file, and
+    symlink resolution."""
+
+    def setUp(self) -> None:
+        self.fs = fs.HoneyPotFilesystem("arch", "/root")
+        self.fs.fs = _dir_entry(
+            "/",
+            [
+                _dir_entry(
+                    "etc",
+                    [
+                        _file_entry("passwd", b"root:x"),
+                        _link_entry("plink", "/etc/passwd"),
+                    ],
+                ),
+                _dir_entry("tmp", []),
+                _link_entry("dirlink", "/etc"),
+                _link_entry("broken", "/nope"),
+            ],
+        )
+
+    def _getfile(self, path: str, follow_symlinks: bool = True) -> list[Any]:
+        """getfile() that asserts a node was found, for tests that inspect it."""
+        node = self.fs.getfile(path, follow_symlinks=follow_symlinks)
+        assert node is not None
+        return node
+
+    # --- getfile ---
+    def test_getfile_returns_file_node(self) -> None:
+        self.assertEqual(self._getfile("/etc/passwd")[fs.A_CONTENTS], b"root:x")
+
+    def test_getfile_missing_returns_none(self) -> None:
+        self.assertIsNone(self.fs.getfile("/etc/nope"))
+
+    def test_getfile_through_a_file_returns_none(self) -> None:
+        # Descending past a regular file must not crash — it is not a directory.
+        self.assertIsNone(self.fs.getfile("/etc/passwd/foo"))
+
+    def test_getfile_empty_path_is_root(self) -> None:
+        self.assertIs(self.fs.getfile(""), self.fs.fs)
+
+    def test_getfile_double_slash_is_ignored(self) -> None:
+        self.assertEqual(self._getfile("/etc//passwd")[fs.A_CONTENTS], b"root:x")
+
+    def test_getfile_follows_terminal_symlink(self) -> None:
+        self.assertEqual(self._getfile("/etc/plink")[fs.A_CONTENTS], b"root:x")
+
+    def test_getfile_no_follow_returns_link_node(self) -> None:
+        node = self._getfile("/etc/plink", follow_symlinks=False)
+        self.assertEqual(node[fs.A_TYPE], fs.T_LINK)
+
+    def test_getfile_broken_symlink_returns_none(self) -> None:
+        self.assertIsNone(self.fs.getfile("/broken"))
+
+    def test_getfile_follows_intermediate_symlink(self) -> None:
+        self.assertEqual(self._getfile("/dirlink/passwd")[fs.A_CONTENTS], b"root:x")
+
+    # --- get_path ---
+    def test_get_path_returns_directory_children(self) -> None:
+        names = [c[fs.A_NAME] for c in self.fs.get_path("/etc")]
+        self.assertEqual(sorted(names), ["passwd", "plink"])
+
+    def test_get_path_of_file_returns_its_bytes(self) -> None:
+        self.assertEqual(self.fs.get_path("/etc/passwd"), b"root:x")
+
+    def test_get_path_missing_raises(self) -> None:
+        with self.assertRaises(fs.FileNotFound):
+            self.fs.get_path("/etc/nope")
+
+    def test_get_path_through_a_file_raises(self) -> None:
+        with self.assertRaises(fs.FileNotFound):
+            self.fs.get_path("/etc/passwd/foo")
+
+    def test_get_path_empty_is_root_children(self) -> None:
+        names = [c[fs.A_NAME] for c in self.fs.get_path("")]
+        self.assertEqual(sorted(names), ["broken", "dirlink", "etc", "tmp"])
+
+    def test_get_path_follows_symlink_to_directory(self) -> None:
+        names = [c[fs.A_NAME] for c in self.fs.get_path("/dirlink")]
+        self.assertEqual(sorted(names), ["passwd", "plink"])
 
 
 if __name__ == "__main__":

--- a/src/cowrie/test/test_fs.py
+++ b/src/cowrie/test/test_fs.py
@@ -56,15 +56,11 @@ class EntryLinkingTests(unittest.TestCase):
         self.assertIn("cowrie_test_file", self.fs.listdir("/"))
         self.assertIsNotNone(self.fs.getfile("/cowrie_test_file"))
 
-    def test_link_entry_replaces_same_name_by_default(self) -> None:
+    def test_link_entry_replaces_same_name(self) -> None:
+        # A directory can never hold two entries under one name.
         self.fs.link_entry(_file_entry("dup"), "/")
         self.fs.link_entry(_file_entry("dup"), "/")
         self.assertEqual(self.fs.listdir("/").count("dup"), 1)
-
-    def test_link_entry_without_replace_allows_duplicate(self) -> None:
-        self.fs.link_entry(_file_entry("dup2"), "/", replace=False)
-        self.fs.link_entry(_file_entry("dup2"), "/", replace=False)
-        self.assertEqual(self.fs.listdir("/").count("dup2"), 2)
 
     def test_unlink_entry_removes_file(self) -> None:
         entry = _file_entry("to_remove")

--- a/src/cowrie/test/test_fs.py
+++ b/src/cowrie/test/test_fs.py
@@ -7,11 +7,12 @@
 
 from __future__ import annotations
 
+import copy
 import os
 import unittest
 from typing import Any
 
-from cowrie.shell import fs
+from cowrie.shell import fs, honeyfs
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
@@ -207,6 +208,44 @@ class WalkerTests(unittest.TestCase):
     def test_get_path_follows_symlink_to_directory(self) -> None:
         names = [c[fs.A_NAME] for c in self.fs.get_path("/dirlink")]
         self.assertEqual(sorted(names), ["passwd", "plink"])
+
+
+class CopyOnWriteTests(unittest.TestCase):
+    """Sessions share the base tree until they mutate it, then copy it once.
+    The shared base must never be mutated by a session."""
+
+    def setUp(self) -> None:
+        honeyfs._tree.cache_clear()
+        self.addCleanup(honeyfs._tree.cache_clear)
+
+    def test_new_session_shares_the_base_tree(self) -> None:
+        session = fs.HoneyPotFilesystem("arch", "/root")
+        self.assertIs(session.fs, honeyfs.get_tree())
+
+    def test_two_sessions_share_until_one_mutates(self) -> None:
+        a = fs.HoneyPotFilesystem("arch", "/root")
+        b = fs.HoneyPotFilesystem("arch", "/root")
+        self.assertIs(a.fs, b.fs)
+        a.mkfile("/tmp/only_in_a", 0, 0, 0, 0o644)
+        self.assertIsNot(a.fs, b.fs)
+        self.assertIn("only_in_a", a.listdir("/tmp"))
+        self.assertNotIn("only_in_a", b.listdir("/tmp"))
+
+    def test_second_mutation_does_not_copy_again(self) -> None:
+        a = fs.HoneyPotFilesystem("arch", "/root")
+        a.mkfile("/tmp/one", 0, 0, 0, 0o644)
+        private = a.fs
+        a.mkfile("/tmp/two", 0, 0, 0, 0o644)
+        self.assertIs(a.fs, private)
+
+    def test_base_tree_is_never_mutated(self) -> None:
+        base = honeyfs.get_tree()
+        snapshot = copy.deepcopy(base)
+        a = fs.HoneyPotFilesystem("arch", "/root")
+        a.mkfile("/tmp/x", 0, 0, 0, 0o644)
+        a.chmod("/etc/passwd", 0o600)
+        a.remove("/tmp/x")
+        self.assertEqual(base, snapshot)
 
 
 if __name__ == "__main__":

--- a/src/cowrie/test/test_honeyfs.py
+++ b/src/cowrie/test/test_honeyfs.py
@@ -41,18 +41,15 @@ def _root(children: list) -> list:
 
 
 class GetTreeTests(unittest.TestCase):
-    """get_tree() returns a deep copy of the cached tree."""
+    """get_tree() returns the shared cached tree; HoneyPotFilesystem copies
+    it on first write rather than get_tree() copying per call."""
 
     def test_returns_a_list(self) -> None:
         tree = honeyfs.get_tree()
         self.assertIsInstance(tree, list)
 
-    def test_returns_fresh_copy_each_call(self) -> None:
-        first = honeyfs.get_tree()
-        second = honeyfs.get_tree()
-        self.assertIsNot(first, second)
-        first.append("mutation")
-        self.assertNotIn("mutation", second)
+    def test_returns_the_same_shared_tree_each_call(self) -> None:
+        self.assertIs(honeyfs.get_tree(), honeyfs.get_tree())
 
 
 class ReadFileTests(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Every session deep-copied the entire honeyfs tree at startup. `honeyfs.get_tree()`
did `copy.deepcopy(_tree())` — for the bundled `fs.pickle` that's a **~10 MB
in-memory tree of ~58k `list` objects, ~6.9 MB per session**.

Under a telnet login flood (many concurrent, short-lived Mirai-style sessions that
only run something like `cd /proc/; cat self/cmdline`), those per-session copies
add up fast and the process allocator does not return the freed arenas, so RSS
ratchets up and stays high. On a small (1 GB) honeypot VM this drove sustained
swap thrash — the sessions were **read-only**, yet each paid for a full private
copy of the filesystem.

## What this does

Share one immutable base tree across all sessions and copy it **lazily, once**, the
first time a session actually mutates it (whole-tree copy-on-write):

- `honeyfs.get_tree()` now returns the shared cached tree instead of a deep copy.
- `HoneyPotFilesystem._ensure_private_fs()` deep-copies `self.fs` on the first
  write and flips a flag; it's called at the head of every mutator **before** it
  fetches the node it will change (that ordering matters — the copy invalidates any
  node reference fetched earlier).

Read-only sessions never copy. A mutating session pays exactly one copy and stays
isolated from the base tree and from other sessions.

### Measured

40 concurrent **read-only** telnet sessions, process footprint:

| | before | after |
|---|---|---|
| 40 sessions held open | +357 MB | **+4 MB** |
| per session | ~8.9 MB | ~0.1 MB |

The unit suite also runs much faster (~38 s → ~7 s) since tests no longer deep-copy
the tree on every `HoneyPotFilesystem`.

## Getting there safely

The copy-on-write step is only sound if all tree mutation goes through
`HoneyPotFilesystem` and no caller mutates a node fetched before the copy. Most of
this PR is the refactor that makes that true, each as its own commit:

1. **Encapsulate directory mutation** behind `link_entry`/`unlink_entry` — `cp`,
   `mv`, `rm` no longer poke the raw `get_path()` list.
2. **Fix `mv` to overwrite an existing destination** (it was appending a duplicate
   entry under the same name); a directory can never hold two entries with one name.
3. **Route shell `mv`/`rm` through `fs.rename`/`fs.remove`** and fix `fs.rename` to
   overwrite (`rename(2)` semantics). Previously the shell and the SFTP server had
   two divergent implementations that disagreed (SFTP `rename` raised `EEXIST`).
4. **Unify `get_path` onto the `getfile` resolver** — one path/symlink walk instead
   of two with subtly different behavior; `getfile` no longer crashes when a path
   descends through a regular file.
5. **Remove dead `resolve_path_wc`** (no callers; shell globbing lives elsewhere).
6. **Introduce a `Node` type alias and tighten `fs.py` annotations**, closing a
   couple of latent `NoneType` dereferences.
7. **The copy-on-write change itself.**

### Notes / follow-up

- `update_realfile` is the one mutator without a guard: it takes a caller-supplied
  node, and every caller (`open`, `close`, `wget`/`curl`/`tftp`/`ftpget`/`scp`/`gcc`)
  creates the file via `mkfile` first, which privatizes the tree. `init_honeyfs`
  guards explicitly.
- When `[honeypot] contents_path` is set, `init_honeyfs` still copies per session at
  startup because it marks `A_REALFILE` on the tree. Those markers are deterministic
  and could later be folded into the shared cached tree once — left as a follow-up
  so this PR stays focused.

## Testing

- `PYTHONPATH=src python -m unittest discover src` — 872 tests pass.
- New tests: `link_entry`/`unlink_entry`, `rename`/`remove` semantics, `getfile`/
  `get_path` walker edge cases, and copy-on-write (sessions share until mutation,
  mutations isolate, the shared base is never mutated).
- `ruff check` and `mypy` clean on the changed modules.
- End-to-end against a real SSH/OpenSSH client: `cp`/`mv` (rename, overwrite,
  move-into-dir), `rm` (file, missing with/without `-f`, dir with/without `-r`),
  `mkdir`, `chmod`, and read paths (`ls`/`cd`/`cat`).
