### PR TITLE
chore: make pyright usable, then fix everything it finds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,22 @@ reportOptionalOperand = "information"
 reportPossiblyUnboundVariable = "information"
 reportUnsupportedDunderAll = "information"
 
+# Twisted/zope base classes are untyped (mypy uses the mypy-zope plugin;
+# pyright has no equivalent), so in strict mode every attribute access on a
+# Twisted subclass resolves to "Unknown". That noise (~89% of all findings)
+# buries the checks that are actually useful on the pure-Python parts of the
+# codebase, so silence the Unknown/untyped-decorator/missing-annotation
+# families and keep the rest of strict mode.
+reportUnknownMemberType = "none"
+reportUnknownArgumentType = "none"
+reportUnknownVariableType = "none"
+reportUnknownParameterType = "none"
+reportUnknownLambdaType = "none"
+reportMissingParameterType = "none"
+reportMissingTypeArgument = "none"
+reportUntypedClassDecorator = "none"
+reportUntypedFunctionDecorator = "none"
+
 # Tests legitimately exercise protected methods of the code under test.
 [[tool.pyright.executionEnvironments]]
 root = "src/cowrie/test"

--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -267,11 +267,7 @@ class Command_curl(HoneyPotCommand):
                 self.outfile = opt[1]
             if opt[0] == "-O":
                 self.outfile = urldata.path.split("/")[-1]
-                if (
-                    self.outfile is None
-                    or not len(self.outfile.strip())
-                    or not urldata.path.count("/")
-                ):
+                if not len(self.outfile.strip()) or not urldata.path.count("/"):
                     self.errorWrite("curl: Remote file name has no length!\n")
                     self.exit(23)
                     return

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -401,13 +401,12 @@ class Command_wget(HoneyPotCommand):
             if self.ftp_client:
                 try:
                     quit_deferred = self.ftp_client.quit()
-                    if isinstance(quit_deferred, defer.Deferred):
-                        quit_deferred.addErrback(
-                            lambda f: self._log.info(
-                                "FTP quit failed during abort: {error}",
-                                error=f.getErrorMessage(),
-                            )
+                    quit_deferred.addErrback(
+                        lambda f: self._log.info(
+                            "FTP quit failed during abort: {error}",
+                            error=f.getErrorMessage(),
                         )
+                    )
                 except Exception as e:  # pragma: no cover - defensive
                     self._log.info(
                         "FTP quit raised exception during abort: {error}", error=e
@@ -431,12 +430,11 @@ class Command_wget(HoneyPotCommand):
         if self.ftp_client:
             try:
                 quit_deferred = self.ftp_client.quit()
-                if isinstance(quit_deferred, defer.Deferred):
-                    quit_deferred.addErrback(
-                        lambda f: self._log.info(
-                            "FTP quit failed: {error}", error=f.getErrorMessage()
-                        )
+                quit_deferred.addErrback(
+                    lambda f: self._log.info(
+                        "FTP quit failed: {error}", error=f.getErrorMessage()
                     )
+                )
             except Exception as e:  # pragma: no cover - defensive
                 self._log.info("FTP quit raised exception: {error}", error=e)
             finally:

--- a/src/cowrie/core/cef.py
+++ b/src/cowrie/core/cef.py
@@ -60,6 +60,8 @@ def formatCef(logentry: dict[str, str]) -> str:
             cefExtensions["filehash"] = logentry["filehash"]
             cefExtensions["filePath"] = logentry["filename"]
             cefExtensions["fsize"] = logentry["size"]
+        case _:
+            pass
 
     # 'out' 'outcome'  request, rt
 

--- a/src/cowrie/scripts/fsctl.py
+++ b/src/cowrie/scripts/fsctl.py
@@ -27,6 +27,7 @@ import cmd
 import copy
 import os
 import pickle
+import subprocess
 import sys
 import time
 from stat import (
@@ -837,7 +838,7 @@ class fseditCmd(cmd.Cmd):
         """
         Clears the screen
         """
-        os.system("clear")
+        subprocess.run(["clear"], check=False)
 
     def emptyline(self) -> bool:
         """

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -181,12 +181,15 @@ class ShellContext(Protocol):
 
     def get_variable(self, name: str) -> str | None:
         """Return the value of a shell variable, or None if unset."""
+        ...
 
     def get_status(self) -> str:
         """Return ``$?`` -- the last command's exit status, as a string."""
+        ...
 
     def command_substitution(self, source: str) -> str:
         """Execute ``source`` and return its captured stdout (newlines stripped)."""
+        ...
 
 
 @dataclass

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -73,9 +73,8 @@ class HoneyPotCommand:
         self.exported = self.protocol.cmdstack[-1].exported
         self.fs = self.protocol.fs
         self.data: bytes = b""  # output data
-        self.input_data: None | (
-            bytes
-        ) = None  # used to store STDIN data passed via PIPE
+        # used to store STDIN data passed via PIPE
+        self.input_data: bytes | None = None
         pp: Any = getattr(self.protocol, "pp", None)
         self.writefn: Callable[[bytes], None]
         self.errorWritefn: Callable[[bytes], None]

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -494,26 +494,23 @@ class HoneyPotFilesystem:
     def close(self, fd: int) -> None:
         if not fd:
             return
-        if self.tempfiles[fd] is not None:
-            with open(self.tempfiles[fd], "rb") as f:
-                shasum: str = hashlib.sha256(f.read()).hexdigest()
-            shasumfile: str = (
-                CowrieConfig.get("honeypot", "download_path") + "/" + shasum
-            )
-            if os.path.exists(shasumfile):
-                os.remove(self.tempfiles[fd])
-            else:
-                os.rename(self.tempfiles[fd], shasumfile)
-            self.update_realfile(self.getfile(self.filenames[fd]), shasumfile)
-            self.events.dispatch(
-                "cowrie.session.file_upload",
-                'SFTP Uploaded file "%(filename)s" to %(outfile)s',
-                filename=os.path.basename(self.filenames[fd]),
-                outfile=shasumfile,
-                shasum=shasum,
-            )
-            del self.tempfiles[fd]
-            del self.filenames[fd]
+        with open(self.tempfiles[fd], "rb") as f:
+            shasum: str = hashlib.sha256(f.read()).hexdigest()
+        shasumfile: str = CowrieConfig.get("honeypot", "download_path") + "/" + shasum
+        if os.path.exists(shasumfile):
+            os.remove(self.tempfiles[fd])
+        else:
+            os.rename(self.tempfiles[fd], shasumfile)
+        self.update_realfile(self.getfile(self.filenames[fd]), shasumfile)
+        self.events.dispatch(
+            "cowrie.session.file_upload",
+            'SFTP Uploaded file "%(filename)s" to %(outfile)s',
+            filename=os.path.basename(self.filenames[fd]),
+            outfile=shasumfile,
+            shasum=shasum,
+        )
+        del self.tempfiles[fd]
+        del self.filenames[fd]
         os.close(fd)
 
     def lseek(self, fd: int, offset: int, whence: int) -> int:

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -167,12 +167,12 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         from cowrie.shell.script import run_script_file
 
         class Command_scriptcmd(command.HoneyPotCommand):
-            def call(self_cmd):
+            def call(self):
                 # Running ./file or /path/file: the kernel rejects a binary with
                 # ENOEXEC ("cannot execute binary file"); a shell script is run
                 # through the parser (the shebang is parsed as a comment).
                 run_script_file(
-                    self_cmd,
+                    self,
                     path,
                     not_found_message=f"-bash: {path}: No such file or directory\n",
                     binary_message=(

--- a/src/cowrie/ssh_proxy/protocols/sftp.py
+++ b/src/cowrie/ssh_proxy/protocols/sftp.py
@@ -56,7 +56,7 @@ from cowrie.ssh_proxy.protocols import base_protocol
 class SFTP(base_protocol.BaseProtocol):
     _log = Logger()
     prevID: int = 0
-    ID: int = 0
+    packetID: int = 0
     handle: bytes = b""
     path: bytes = b""
     command: bytes = b""
@@ -118,8 +118,8 @@ class SFTP(base_protocol.BaseProtocol):
 
         sftp_num: int = self.extract_int(1)
 
-        self.prevID: int = self.ID
-        self.ID: int = self.extract_int(4)
+        self.prevID = self.packetID
+        self.packetID = self.extract_int(4)
 
         self.path: bytes = b""
 
@@ -170,7 +170,7 @@ class SFTP(base_protocol.BaseProtocol):
                 self.theFile = self.theFile[: self.offset] + self.extract_data()
 
         elif sftp_num == filetransfer.FXP_HANDLE:
-            if self.ID == self.prevID:
+            if self.packetID == self.prevID:
                 self.handle = self.extract_string()
 
         elif sftp_num == filetransfer.FXP_READDIR:
@@ -271,7 +271,7 @@ class SFTP(base_protocol.BaseProtocol):
             self.command = b"rmdir " + self.extract_string()
 
         elif sftp_num == filetransfer.FXP_STATUS:
-            if self.ID == self.prevID:
+            if self.packetID == self.prevID:
                 code = self.extract_int(4)
                 if code in [0, 1]:
                     if b"get" not in self.command and b"put" not in self.command:

--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -272,7 +272,7 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
     def _get_option_name(self, option: bytes) -> str:
         """Get human-readable name for a telnet option byte."""
         if option:
-            option_byte = option[0] if isinstance(option, bytes) else option
+            option_byte = option[0]
             return TELNET_OPTIONS.get(option_byte, f"UNKNOWN-{option_byte}")
         return "UNKNOWN"
 

--- a/src/cowrie/telnet/userauth.py
+++ b/src/cowrie/telnet/userauth.py
@@ -123,9 +123,7 @@ class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
                     if isinstance(password, bytes)
                     else password,
                 )
-            username = (
-                exploit_user.encode() if isinstance(exploit_user, str) else exploit_user
-            )
+            username = exploit_user.encode()
             password = b""  # Exploit bypasses password
             self.cve_2026_24061_user = None  # Clear the flag
 


### PR DESCRIPTION
## Motivation

Pyright ran in `strict` mode, but Twisted/zope base classes are untyped for it
(mypy uses the `mypy-zope` plugin; pyright has no equivalent). So every attribute
access on a Twisted subclass — `self.protocol.fs`, etc. — resolved to `Unknown`,
producing **7320 errors, 89% of them the `reportUnknown*` family**. That noise
buried the handful of checks that are actually useful on the pure-Python parts of
the tree, so pyright's output was effectively unreadable.

## What this does

**1. Make pyright usable.** Silence the strict-only families that Twisted/zope
untyped bases trigger (the `Unknown*` group, plus untyped-decorator and
missing-annotation checks — all near-zero signal here) while keeping the rest of
strict mode. Pyright drops from **7320 → 12** findings.

**2. Fix all 12 remaining findings**, each root-caused rather than suppressed:

| finding | fix |
|---|---|
| `reportUnnecessaryComparison` / `reportUnnecessaryIsInstance` | remove provably-dead checks: `fs.close`'s `is not None` on a `dict[int, str]`; `curl -O`'s `outfile is None` right after `str.split()`; a `bytes`/`str` `isinstance` on already-typed params in telnet; `isinstance(_, Deferred)` on `FTPClient.quit()` which always returns a `Deferred` |
| `reportConstantRedefinition` | rename SFTP `ID` → `packetID` — it's a per-packet id that's reassigned every packet, not a constant |
| `reportReturnType` | give the `bashparse.ShellContext` `Protocol` methods explicit `...` stub bodies (docstring-only bodies read as "returns `None`") |
| `reportMatchNotExhaustive` | add an explicit `case _: pass` to the CEF event-id `match` |
| `reportSelfClsParameterName` | name the nested `scriptcmd.call` parameter `self` (its body never uses the enclosing `self`) |
| `reportDeprecated` | `os.system` → `subprocess.run` in the `fsctl` dev tool |

None of the fixes change behavior. After them, `pyright src` reports **0 errors**.

Also fixes a pre-existing ruff **RUF036** in `command.py` (`None | bytes` reordered
to `bytes | None`).

## Why this matters

The pure-Python parts of cowrie — parsers, the filesystem/tree logic, CEF, base
commands — can now be meaningfully type-checked by pyright instead of drowning in
7300 lines of `Unknown`. CI still runs pyright advisorily (`- pyright`); with the
noise gone and the tree at zero, it could later be made a gate, but that policy
change is intentionally left out of this PR.

## Testing

- `pyright src` → 0 errors (was 7320).
- `PYTHONPATH=src python -m unittest discover src` → all tests pass.
- `ruff` and `mypy` clean on the changed files.
