### PR TITLE
fix: treat an empty symlink target as a broken link

### DIFF
--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -273,6 +273,10 @@ class HoneyPotFilesystem:
                     if piece == pieces[-1] and not follow_symlinks:
                         p = x
                     elif x[A_TYPE] == T_LINK:
+                        if not x[A_TARGET]:
+                            # Empty target (e.g. a /proc/<pid>/cwd link
+                            # captured with no destination): a broken link.
+                            return None
                         if x[A_TARGET][0] == "/":
                             # Absolute link
                             fileobj = self.getfile(

--- a/src/cowrie/test/test_fs.py
+++ b/src/cowrie/test/test_fs.py
@@ -182,6 +182,12 @@ class WalkerTests(unittest.TestCase):
     def test_getfile_broken_symlink_returns_none(self) -> None:
         self.assertIsNone(self.fs.getfile("/broken"))
 
+    def test_getfile_empty_target_symlink_returns_none(self) -> None:
+        # Some /proc/<pid>/cwd links ship with an empty target; resolving them
+        # must not crash on target[0] (issue: IndexError in getfile).
+        self.fs.fs[fs.A_CONTENTS].append(_link_entry("emptylink", ""))
+        self.assertIsNone(self.fs.getfile("/emptylink"))
+
     def test_getfile_follows_intermediate_symlink(self) -> None:
         self.assertEqual(self._getfile("/dirlink/passwd")[fs.A_CONTENTS], b"root:x")
 


### PR DESCRIPTION
## Bug

`HoneyPotFilesystem.getfile()` decides absolute-vs-relative for a symlink by
indexing the target's first character:

```python
elif x[A_TYPE] == T_LINK:
    if x[A_TARGET][0] == "/":
```

When the target is an empty string this raises `IndexError: string index out of
range`, crashing path resolution.

The bundled `fs.pickle` ships four such links — `/proc/1/cwd`, `/proc/1/root`,
`/proc/969/cwd`, `/proc/969/root` (PID cwd/root links captured with no
destination). So an attacker (or any code) touching one of them — e.g.
`cat /proc/1/cwd` — hits the crash.

This is long-standing; it predates the recent filesystem refactors.

## Fix

Treat an empty target as a broken link — return `None` before indexing it, the
same result as any other dangling symlink.

## Testing

- New unit test resolves an empty-target link to `None` instead of raising.
- Verified the four real `/proc/*/{cwd,root}` links now return `None`.
- Full suite passes; ruff and mypy clean.
