### PR TITLE
fix: re-authenticate returning attackers in AuthRandom

### DIFF
--- a/src/cowrie/core/auth.py
+++ b/src/cowrie/core/auth.py
@@ -206,7 +206,12 @@ class AuthRandom:
         """
 
         auth: bool = False
-        userpass: str = str(thelogin) + ":" + str(thepasswd)
+        # Decode once and store/compare the text form everywhere, so an
+        # attacker's stored credentials always match on return (and the JSON
+        # state file stays readable instead of holding "b'root'").
+        login: str = thelogin.decode("utf-8", errors="replace")
+        passwd: str = thepasswd.decode("utf-8", errors="replace")
+        userpass: str = login + ":" + passwd
 
         if "cache" not in self.uservar:
             self.uservar["cache"] = []
@@ -224,8 +229,8 @@ class AuthRandom:
                     userpass=userpass,
                 )
                 ipinfo["max"] = 1
-                ipinfo["user"] = str(thelogin)
-                ipinfo["pw"] = str(thepasswd)
+                ipinfo["user"] = login
+                ipinfo["pw"] = passwd
                 auth = True
                 self.savevars()
                 return auth
@@ -240,8 +245,8 @@ class AuthRandom:
                 ipinfo = self.uservar[src_ip]
                 self._log.info("Found cached: {userpass}", userpass=userpass)
                 ipinfo["max"] = 1
-                ipinfo["user"] = str(thelogin)
-                ipinfo["pw"] = str(thepasswd)
+                ipinfo["user"] = login
+                ipinfo["pw"] = passwd
                 auth = True
                 self.savevars()
                 return auth
@@ -271,8 +276,8 @@ class AuthRandom:
         if attempts < need:
             self.uservar[src_ip]["tried"].append(userpass)
         elif attempts == need:
-            ipinfo["user"] = str(thelogin)
-            ipinfo["pw"] = str(thepasswd)
+            ipinfo["user"] = login
+            ipinfo["pw"] = passwd
             cache.append(userpass)
             if len(cache) > self.maxcache:
                 cache.pop(0)
@@ -289,7 +294,7 @@ class AuthRandom:
                     user=ipinfo["user"],
                     pw=ipinfo["pw"],
                 )
-                if thelogin == ipinfo["user"] and str(thepasswd) == ipinfo["pw"]:
+                if login == ipinfo["user"] and passwd == ipinfo["pw"]:
                     auth = True
         self.savevars()
         return auth

--- a/src/cowrie/test/test_auth.py
+++ b/src/cowrie/test/test_auth.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for cowrie/core/auth.py authentication classes.
+# ABOUTME: Covers AuthRandom's returning-attacker fast path.
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+
+from cowrie.core import auth
+from cowrie.core.config import CowrieConfig
+
+
+class AuthRandomReturningLoginTests(unittest.TestCase):
+    """Once an IP has earned access, presenting the same credentials again
+    must be accepted immediately (the attempts > need branch)."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self._had = CowrieConfig.has_option("honeypot", "state_path")
+        self._old = (
+            CowrieConfig.get("honeypot", "state_path") if self._had else None
+        )
+        CowrieConfig.set("honeypot", "state_path", self.tmp)
+        self.addCleanup(self._restore)
+        self.auth = auth.AuthRandom()
+
+    def _restore(self) -> None:
+        if self._had and self._old is not None:
+            CowrieConfig.set("honeypot", "state_path", self._old)
+        else:
+            CowrieConfig.remove_option("honeypot", "state_path")
+
+    def _earned(self, user: bytes, passwd: bytes, src_ip: str) -> None:
+        """Seed the state left behind after this IP has already succeeded."""
+        self.auth.uservar[src_ip] = {
+            "max": 2,
+            "try": 2,
+            "tried": [],
+            "user": user.decode("utf-8", errors="replace"),
+            "pw": passwd.decode("utf-8", errors="replace"),
+        }
+
+    def test_returning_attacker_reauthenticates(self) -> None:
+        self._earned(b"root", b"secret", "1.2.3.4")
+        self.assertTrue(self.auth.checklogin(b"root", b"secret", "1.2.3.4"))
+
+    def test_returning_attacker_with_different_user_is_not_authed(self) -> None:
+        self._earned(b"root", b"secret", "1.2.3.4")
+        self.assertFalse(self.auth.checklogin(b"admin", b"secret", "1.2.3.4"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #40382.

## Bug

With `auth_class = AuthRandom`, `checklogin()` is meant to let an attacker who has
already earned access from a source IP straight back in (the `attempts > need`
branch). It never fired, because the username was stored and compared with
different types:

```python
ipinfo["user"] = str(thelogin)          # thelogin is bytes -> "b'root'"
...
if thelogin == ipinfo["user"] and str(thepasswd) == ipinfo["pw"]:
```

`thelogin` is `bytes` (`b"root"`) and `ipinfo["user"]` is the string `"b'root'"`;
in Python 3 `bytes` never equals `str`, so the username comparison was always
`False`. The password side already used `str(thepasswd)`, which is why only the
username side was broken. A returning attacker therefore re-earned a random
threshold on every reconnect.

## Fix

Rather than sprinkle `str()` conversions (which produce the ugly `"b'root'"`),
decode the credentials once with `.decode("utf-8", errors="replace")` — the
convention already used for credentials in `telnet/userauth.py` — and store and
compare that text form everywhere. A single decoded value can't drift between
storage and comparison, so the class of bug goes away, and the `auth_random.json`
state file becomes readable (`"root"` instead of `"b'root'"`).

`errors="replace"` keeps it safe for the non-UTF8 bytes attackers routinely send.

**State-file note:** existing `auth_random.json` files hold the old `str(bytes)`
form, so an attacker recorded before this change re-earns their threshold once.
That state is ephemeral honeypot data and self-heals on the next login — no
migration needed.

## Testing

- New `test_auth.py`: a returning attacker with the same credentials is now
  authenticated immediately, and one presenting a different username is not.
- Full suite passes; ruff and mypy clean.

Thanks to @vbontchev for the report and the diagnosis.
