### PR TITLE
fix: use posixpath for emulated-filesystem paths (Windows support)

### DIFF
--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import getopt
-import os
+import posixpath
 from http.client import responses
 from urllib import parse
 
@@ -274,7 +274,7 @@ class Command_curl(HoneyPotCommand):
 
         if self.outfile:
             self.outfile = self.fs.resolve_path(self.outfile, self.protocol.cwd)
-            path = os.path.dirname(self.outfile) if self.outfile else ""
+            path = posixpath.dirname(self.outfile) if self.outfile else ""
             if not path or not self.fs.exists(path) or not self.fs.isdir(path):
                 self.errorWrite(
                     f"curl: {self.outfile}: Cannot open: No such file or directory\n"

--- a/src/cowrie/commands/du.py
+++ b/src/cowrie/commands/du.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-import os
+import posixpath
 
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.fs import A_NAME
@@ -119,7 +119,7 @@ or available locally via: info '(coreutils) du invocation'\n"""
             return
         for filename in filenames:
             if showall:
-                isdir = self.protocol.fs.isdir(os.path.join(path, filename))
+                isdir = self.protocol.fs.isdir(posixpath.join(path, filename))
                 if isdir:
                     filename = f"4       ./{filename}\n"
                     self.write(filename)

--- a/src/cowrie/commands/find.py
+++ b/src/cowrie/commands/find.py
@@ -10,7 +10,7 @@ find command
 from __future__ import annotations
 
 import fnmatch
-import os
+import posixpath
 
 from cowrie.shell.command import HoneyPotCommand
 
@@ -94,13 +94,13 @@ class Command_find(HoneyPotCommand):
                 for entry in self.fs.listdir(path):
                     if entry in (".", ".."):
                         continue
-                    full_path = os.path.join(path, entry)
+                    full_path = posixpath.join(path, entry)
                     self.find_recursive(full_path, depth + 1)
         except Exception as e:
             self.errorWrite(f"find: error accessing {path}: {e}\n")
 
     def _match(self, path: str) -> bool:
-        basename = os.path.basename(path)
+        basename = posixpath.basename(path)
 
         if self.name_pattern and not fnmatch.fnmatch(basename, self.name_pattern):
             return False

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import copy
 import getopt
 import os.path
+import posixpath
 import re
 from typing import TYPE_CHECKING
 
@@ -471,7 +472,7 @@ class Command_cp(HoneyPotCommand):
             isdir = True
         else:
             isdir = False
-            parent = os.path.dirname(resolv(dest))
+            parent = posixpath.dirname(resolv(dest))
             if not self.fs.exists(parent):
                 self.errorWrite(
                     "cp: cannot create regular file "
@@ -489,10 +490,10 @@ class Command_cp(HoneyPotCommand):
             s = copy.deepcopy(self.fs.getfile(resolv(src)))
             if isdir:
                 destdir = resolv(dest)
-                outfile = os.path.basename(src)
+                outfile = posixpath.basename(src)
             else:
-                destdir = os.path.dirname(resolv(dest))
-                outfile = os.path.basename(dest.rstrip("/"))
+                destdir = posixpath.dirname(resolv(dest))
+                outfile = posixpath.basename(dest.rstrip("/"))
             s[fs.A_NAME] = outfile
             self.fs.link_entry(s, destdir)
 
@@ -543,7 +544,7 @@ class Command_mv(HoneyPotCommand):
             isdir = True
         else:
             isdir = False
-            parent = os.path.dirname(resolv(dest))
+            parent = posixpath.dirname(resolv(dest))
             if not self.fs.exists(parent):
                 self.errorWrite(
                     "mv: cannot create regular file "
@@ -557,7 +558,7 @@ class Command_mv(HoneyPotCommand):
                 self.errorWrite(f"mv: cannot stat `{src}': No such file or directory\n")
                 continue
             if isdir:
-                destpath = os.path.join(resolv(dest), os.path.basename(src))
+                destpath = posixpath.join(resolv(dest), posixpath.basename(src))
             else:
                 destpath = resolv(dest)
             self.fs.rename(srcpath, destpath)
@@ -610,7 +611,7 @@ class Command_rmdir(HoneyPotCommand):
                 directory = self.fs.get_path("/".join(pname.split("/")[:-1]))
             except (IndexError, fs.FileNotFound):
                 directory = None
-            fname = os.path.basename(f)
+            fname = posixpath.basename(f)
             if not directory or fname not in [x[fs.A_NAME] for x in directory]:
                 self.errorWrite(
                     f"rmdir: failed to remove `{f}': No such file or directory\n"
@@ -656,7 +657,7 @@ class Command_touch(HoneyPotCommand):
             return
         for f in self.args:
             pname = self.fs.resolve_path(f, self.protocol.cwd)
-            if not self.fs.exists(os.path.dirname(pname)):
+            if not self.fs.exists(posixpath.dirname(pname)):
                 self.errorWrite(
                     f"touch: cannot touch `{pname}`: No such file or directory\n"
                 )

--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import getopt
 import os
+import posixpath
 from typing import TYPE_CHECKING
 
 from twisted.internet import defer, reactor
@@ -117,13 +118,13 @@ Download a file via FTP
         elif len(args) >= 3:
             self.host, self.local_file, self.remote_path = args[:3]
 
-        self.remote_dir = os.path.dirname(self.remote_path)
-        self.remote_file = os.path.basename(self.remote_path)
+        self.remote_dir = posixpath.dirname(self.remote_path)
+        self.remote_file = posixpath.basename(self.remote_path)
         if not self.local_file:
             self.local_file = self.remote_file
 
         fakeoutfile = self.fs.resolve_path(self.local_file, self.protocol.cwd)
-        path = os.path.dirname(fakeoutfile)
+        path = posixpath.dirname(fakeoutfile)
         if not path or not self.fs.exists(path) or not self.fs.isdir(path):
             self.errorWrite(
                 f"ftpget: can't open '{self.local_file}': No such file or directory"

--- a/src/cowrie/commands/ls.py
+++ b/src/cowrie/commands/ls.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import getopt
-import os.path
+import posixpath
 import stat
 import time
 
@@ -81,7 +81,7 @@ class Command_ls(HoneyPotCommand):
                     dot = self.protocol.fs.getfile(path)[:]
                     dot[fs.A_NAME] = "."
                     files.append(dot)
-                    dotdot = self.protocol.fs.getfile(os.path.split(path)[0])[:]
+                    dotdot = self.protocol.fs.getfile(posixpath.split(path)[0])[:]
                     if not dotdot:
                         dotdot = self.protocol.fs.getfile(path)[:]
                     dotdot[fs.A_NAME] = ".."

--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import getopt
 import hashlib
 import os
+import posixpath
 import re
 import time
 
@@ -109,7 +110,7 @@ class Command_scp(HoneyPotCommand):
             self.protocol.events.dispatch(
                 "cowrie.session.file_upload",
                 'SCP Uploaded file "%(filename)s" to %(outfile)s',
-                filename=os.path.basename(fname),
+                filename=posixpath.basename(fname),
                 duplicate=duplicate,
                 url=fname,
                 outfile=shasum,
@@ -149,7 +150,7 @@ class Command_scp(HoneyPotCommand):
                     d = data[pos:dend]
 
                     if self.out_dir:
-                        fname = os.path.join(self.out_dir, r.group(3).decode())
+                        fname = posixpath.join(self.out_dir, r.group(3).decode())
                     else:
                         fname = r.group(3).decode()
 

--- a/src/cowrie/commands/tar.py
+++ b/src/cowrie/commands/tar.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-import os
+import posixpath
 import tarfile
 
 from twisted.logger import Logger
@@ -90,7 +90,7 @@ class Command_tar(HoneyPotCommand):
                     f.mtime,
                 )
             elif f.isfile():
-                self.mkfullpath(os.path.dirname(dest), f)
+                self.mkfullpath(posixpath.dirname(dest), f)
                 self.fs.mkfile(
                     dest,
                     self.current_user["uid"],

--- a/src/cowrie/commands/tee.py
+++ b/src/cowrie/commands/tee.py
@@ -10,7 +10,7 @@ tee command
 from __future__ import annotations
 
 import getopt
-import os
+import posixpath
 
 from twisted.logger import Logger
 
@@ -62,7 +62,7 @@ class Command_tee(HoneyPotCommand):
                 self.errorWrite(f"tee: {arg}: Is a directory\n")
                 continue
 
-            folder_path = os.path.dirname(pname)
+            folder_path = posixpath.dirname(pname)
             fname = self.fs.resolve_path(folder_path, self.protocol.cwd)
             if not self.fs.isdir(fname):
                 self.errorWrite(f"tee: {arg}: No such file or directory\n")

--- a/src/cowrie/commands/unzip.py
+++ b/src/cowrie/commands/unzip.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-import os
+import posixpath
 import zipfile
 
 from twisted.logger import Logger
@@ -123,7 +123,7 @@ class Command_unzip(HoneyPotCommand):
                     33188,
                 )
             elif not f.is_dir():
-                self.mkfullpath(os.path.dirname(dest))
+                self.mkfullpath(posixpath.dirname(dest))
                 self.fs.mkfile(
                     dest,
                     self.current_user["uid"],

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import getopt
-import os
 import posixpath
 import time
 from typing import Any
@@ -289,7 +288,7 @@ class Command_wget(HoneyPotCommand):
 
         elif self.outfile != "-":
             self.outfile = self.fs.resolve_path(self.outfile, self.protocol.cwd)
-            path = os.path.dirname(self.outfile)
+            path = posixpath.dirname(self.outfile)
             if not path or not self.fs.exists(path) or not self.fs.isdir(path):
                 self.errorWrite(
                     f"wget: {self.outfile}: Cannot open: No such file or directory\n"

--- a/src/cowrie/shell/filetransfer.py
+++ b/src/cowrie/shell/filetransfer.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import errno
 import functools
 import os
+import posixpath
 from collections.abc import Callable
 from typing import Any, TypeVar, cast
 
@@ -166,8 +167,10 @@ class CowrieSFTPDirectory:
             attrs = self.server._getAttrs(s)
             return (f, longname, attrs)
         else:
-            s = self.server.fs.lstat(os.path.join(self.dir, f))
-            s2 = self.server.fs.lstat(os.path.join(self.dir, f))
+            # Virtual (emulated-Linux) paths always join with "/", never the
+            # host separator — os.path.join would use "\" on Windows.
+            s = self.server.fs.lstat(posixpath.join(self.dir, f))
+            s2 = self.server.fs.lstat(posixpath.join(self.dir, f))
             s2.st_uid = pwd.Passwd().getpwuid(s.st_uid)["pw_name"]
             s2.st_gid = pwd.Group().getgrgid(s.st_gid)["gr_name"]
             longname = twisted.conch.ls.lsLine(f, s2)
@@ -191,7 +194,9 @@ class SFTPServerForCowrieUser:
 
     def _absPath(self, path):
         home = self.avatar.home
-        return os.path.abspath(os.path.join(nativeString(home), nativeString(path)))
+        # Emulated-Linux path: normalise with posix semantics so the host OS
+        # separator (e.g. "\" on Windows) never leaks into a virtual path.
+        return posixpath.abspath(posixpath.join(nativeString(home), nativeString(path)))
 
     def _setAttrs(self, path, attrs):
         if "uid" in attrs and "gid" in attrs:

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -11,6 +11,7 @@ import copy
 import errno
 import hashlib
 import os
+import posixpath
 import re
 import stat
 import sys
@@ -302,7 +303,7 @@ class HoneyPotFilesystem:
         2) built-in contents (A_CONTENTS) from the pickle file
         3) a generic binary header
         """
-        path: str = self.resolve_path(target, os.path.dirname(target))
+        path: str = self.resolve_path(target, posixpath.dirname(target))
         if not path or not self.exists(path):
             raise FileNotFound
         f: Node | None = self.getfile(path)
@@ -356,14 +357,14 @@ class HoneyPotFilesystem:
             return False
         if ctime is None:
             ctime = time.time()
-        _path: str = os.path.dirname(path)
+        _path: str = posixpath.dirname(path)
 
         if any([_path.startswith(_p) for _p in SPECIAL_PATHS]):
             raise PermissionDenied
 
         self._ensure_private_fs()
         _dir = self.get_path(_path)
-        outfile: str = os.path.basename(path)
+        outfile: str = posixpath.basename(path)
         if outfile in [x[A_NAME] for x in _dir]:
             _dir.remove(next(x for x in _dir if x[A_NAME] == outfile))
         _dir.append([outfile, T_FILE, uid, gid, size, mode, ctime, [], None, None])
@@ -387,11 +388,22 @@ class HoneyPotFilesystem:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT), path)
         self._ensure_private_fs()
         try:
-            directory = self.get_path(os.path.dirname(path.strip("/")))
+            directory = self.get_path(posixpath.dirname(path.strip("/")))
         except (IndexError, FileNotFound):
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT), path) from None
         directory.append(
-            [os.path.basename(path), T_DIR, uid, gid, size, mode, ctime, [], None, None]
+            [
+                posixpath.basename(path),
+                T_DIR,
+                uid,
+                gid,
+                size,
+                mode,
+                ctime,
+                [],
+                None,
+                None,
+            ]
         )
         self.newcount += 1
 
@@ -505,7 +517,7 @@ class HoneyPotFilesystem:
         self.events.dispatch(
             "cowrie.session.file_upload",
             'SFTP Uploaded file "%(filename)s" to %(outfile)s',
-            filename=os.path.basename(self.filenames[fd]),
+            filename=posixpath.basename(self.filenames[fd]),
             outfile=shasumfile,
             shasum=shasum,
         )
@@ -529,8 +541,8 @@ class HoneyPotFilesystem:
 
     def rmdir(self, path: str) -> bool:
         p: str = path.rstrip("/")
-        name: str = os.path.basename(p)
-        parent: str = os.path.dirname(p)
+        name: str = posixpath.basename(p)
+        parent: str = posixpath.dirname(p)
         directory: Node | None = self.getfile(p, follow_symlinks=False)
         if not directory:
             raise OSError(errno.EEXIST, os.strerror(errno.EEXIST), p)
@@ -575,7 +587,7 @@ class HoneyPotFilesystem:
         p: Node | None = self.getfile(path, follow_symlinks=False)
         if not p:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
-        self.unlink_entry(p, os.path.dirname(path))
+        self.unlink_entry(p, posixpath.dirname(path))
 
     def readlink(self, path: str) -> str:
         p: Node | None = self.getfile(path, follow_symlinks=False)
@@ -596,9 +608,9 @@ class HoneyPotFilesystem:
         old: Node | None = self.getfile(oldpath)
         if not old:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
-        self.unlink_entry(old, os.path.dirname(oldpath))
-        old[A_NAME] = os.path.basename(newpath)
-        self.link_entry(old, os.path.dirname(newpath))
+        self.unlink_entry(old, posixpath.dirname(oldpath))
+        old[A_NAME] = posixpath.basename(newpath)
+        self.link_entry(old, posixpath.dirname(newpath))
 
     def listdir(self, path: str) -> list[str]:
         names: list[str] = [x[A_NAME] for x in self.get_path(path)]

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import copy
 import enum
 import fnmatch
-import os
+import posixpath
 import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -908,7 +908,7 @@ class HoneyPotShell:
 
         # clue now contains the string to complete or is empty.
         # line contains the buffer as bytes
-        basedir = os.path.dirname(clue)
+        basedir = posixpath.dirname(clue)
         if basedir and basedir[-1] != "/":
             basedir += "/"
 
@@ -930,7 +930,7 @@ class HoneyPotShell:
             if clue == "":
                 files.append(x)
                 continue
-            if not x[fs.A_NAME].startswith(os.path.basename(clue)):
+            if not x[fs.A_NAME].startswith(posixpath.basename(clue)):
                 continue
             files.append(x)
 
@@ -953,8 +953,8 @@ class HoneyPotShell:
                 newbuf += " "
             newbyt = newbuf.encode("utf8")
         else:
-            if os.path.basename(clue):
-                prefix = os.path.commonprefix([x[fs.A_NAME] for x in files])
+            if posixpath.basename(clue):
+                prefix = posixpath.commonprefix([x[fs.A_NAME] for x in files])
             else:
                 prefix = ""
             first = line.decode("utf8").split(" ")[:-1]

--- a/src/cowrie/test/test_filetransfer.py
+++ b/src/cowrie/test/test_filetransfer.py
@@ -58,5 +58,23 @@ class SFTPErrorTranslationTests(unittest.TestCase):
         self.assertEqual(ctx.exception.errno, errno.ENOENT)
 
 
+class SFTPPathJoinTests(unittest.TestCase):
+    """Virtual SFTP paths must be joined with "/" regardless of host OS;
+    os.path.join would use "\\" on Windows (issue #40388)."""
+
+    def setUp(self) -> None:
+        self.server = SFTPServerForCowrieUser.__new__(SFTPServerForCowrieUser)
+        self.server.fs = fs.HoneyPotFilesystem("linux-x64-lsb", "/root")
+        self.server.avatar = SimpleNamespace(home="/home/phil")
+
+    def test_abspath_joins_with_forward_slash(self) -> None:
+        result = self.server._absPath("file.txt")
+        self.assertEqual(result, "/home/phil/file.txt")
+        self.assertNotIn("\\", result)
+
+    def test_abspath_of_absolute_path_is_unchanged(self) -> None:
+        self.assertEqual(self.server._absPath("/etc/passwd"), "/etc/passwd")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #40388.

## Problem

Cowrie's emulated filesystem is always `/`-separated, but many call sites
manipulate guest paths with `os.path.dirname` / `basename` / `join` / `split`.
`os.path` uses the **host** OS separator, so on Windows a virtual path like
`/home/phil` + `file` becomes `/home/phil\file`, which `HoneyPotFilesystem`
(which splits on `/` everywhere) can't resolve.

@vbontchev reported this for SFTP directory listings (#40388), but an audit
showed the same bug throughout the codebase — `fs.py`
(mkfile/mkdir/rmdir/remove/rename/file_contents), shell tab-completion, and the
command set (cp/mv/touch, find, tar, unzip, tee, du, ls, curl, wget, and the
scp/ftpget guest-side paths). Harmless on Linux/macOS (where `os.path` already
uses `/`), broken on Windows.

## Fix

Route every **emulated-filesystem** path operation through `posixpath`, which is
byte-identical to `os.path` on POSIX (so behaviour and CI are unchanged) and
always uses `/`. Remote FTP server paths (also `/`-separated) move to `posixpath`
too.

**Real host-filesystem** operations are deliberately left on `os.path`: the
download / honeyfs directories, ttylog and stdin-log files, downloaded artifacts,
and `os.walk()` results. These must follow the host OS. (One pre-existing oddity
— `grep` applying `os.path.basename` to a regex pattern — was left untouched;
it's not a path.)

Each site was individually classified as virtual vs host; the host sites and the
one non-path quirk keep `os.path`.

## Testing

- New `test_filetransfer.py` test: `_absPath` joins with `/` regardless of host OS.
- Full suite passes; ruff and mypy clean.

Note: the bug only manifests on a non-POSIX host, so the tests can't fail on the
Linux CI for the old code — but `posixpath` guarantees the correct behaviour on
every platform, and the change is a no-op on POSIX.
