### PR TITLE
fix: make the outbound rate limiter case-insensitive per host

### DIFF
--- a/src/cowrie/core/rate_limiter.py
+++ b/src/cowrie/core/rate_limiter.py
@@ -54,6 +54,10 @@ class RateLimiter:
         if not self.enabled:
             return True
 
+        # Hostnames (and IPv6 hex) are case-insensitive, so normalise the key;
+        # otherwise case variants of one host each get their own allowance.
+        key = key.lower()
+
         current_time = time.time()
 
         # Periodic global cleanup

--- a/src/cowrie/test/test_rate_limiter.py
+++ b/src/cowrie/test/test_rate_limiter.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: tests for cowrie/core/rate_limiter.py — the outbound per-host limiter.
+# ABOUTME: covers case-insensitive host keying so case variation can't bypass it.
+
+from __future__ import annotations
+
+import unittest
+
+from cowrie.core.rate_limiter import RateLimiter
+
+
+class RateLimiterCaseInsensitiveTests(unittest.TestCase):
+    """DNS hostnames are case-insensitive, so case variants of one host must
+    share a single bucket (otherwise the per-host limit is trivially bypassed)."""
+
+    def test_case_variants_share_one_bucket(self) -> None:
+        limiter = RateLimiter(max_requests=2, window_seconds=60)
+        self.assertTrue(limiter.check("example.com"))
+        self.assertTrue(limiter.check("EXAMPLE.com"))
+        # Third request for the same host (any case) exceeds max_requests=2.
+        self.assertFalse(limiter.check("Example.Com"))
+
+    def test_distinct_hosts_keep_separate_buckets(self) -> None:
+        limiter = RateLimiter(max_requests=1, window_seconds=60)
+        self.assertTrue(limiter.check("a.example.com"))
+        self.assertTrue(limiter.check("b.example.com"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #40395.

## Bug

`RateLimiter.check()` keys the per-destination request tracker on the host
string exactly as given. DNS hostnames are case-insensitive, so `example.com`,
`EXAMPLE.com` and `Example.CoM` name the same host but are tracked as three
separate buckets. An attacker can bypass the configured per-host `wget`/`curl`
request limit entirely by cycling the case of the hostname — the effective limit
becomes `max_requests` × (number of case variations sent).

## Fix

Normalise the key with `.lower()` inside `check()`.

The report proposed lowercasing at the `wget` and `curl` call sites; doing it in
`check()` instead fixes the third caller too — `nc` (`nc_rate_limiter`) has the
same bug — and keeps the normalisation in one place. `check()`'s key is always a
destination host/IP (per its docstring and all three callers), and lowercasing is
also correct for IPv6 literals, whose hex is case-insensitive.

## Testing

- New `test_rate_limiter.py`: case variants of one host share a single bucket
  (the third request is limited), and distinct hosts keep separate buckets.
- Full suite passes; ruff and mypy clean.

Thanks to @vbontchev for the report.
