### PR TITLE
fix: apply rate limit, size limit and outbound bind to ftpget

### DIFF
--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -31,17 +31,13 @@ commands = {}
 # Per-host limiter on outbound FTP connections, matching wget/curl.
 ftpget_rate_limiter = RateLimiter(
     enabled=CowrieConfig.getboolean(
-        "honeypot", "ftpget_rate_limit_enabled", fallback=True
+        "shell", "ftpget_rate_limit_enabled", fallback=True
     ),
-    max_requests=CowrieConfig.getint(
-        "honeypot", "ftpget_rate_limit_requests", fallback=5
-    ),
+    max_requests=CowrieConfig.getint("shell", "ftpget_rate_limit_requests", fallback=5),
     window_seconds=CowrieConfig.getint(
-        "honeypot", "ftpget_rate_limit_window", fallback=60
+        "shell", "ftpget_rate_limit_window", fallback=60
     ),
-    max_keys=CowrieConfig.getint(
-        "honeypot", "ftpget_rate_limit_max_hosts", fallback=1000
-    ),
+    max_keys=CowrieConfig.getint("shell", "ftpget_rate_limit_max_hosts", fallback=1000),
 )
 
 

--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -19,7 +19,8 @@ from twisted.protocols.ftp import CommandFailed, FTPClient
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
-from cowrie.core.network import communication_allowed
+from cowrie.core.network import communication_allowed, outbound_bind_address
+from cowrie.core.rate_limiter import RateLimiter
 from cowrie.shell.command import HoneyPotCommand
 
 if TYPE_CHECKING:
@@ -27,19 +28,46 @@ if TYPE_CHECKING:
 
 commands = {}
 
+# Per-host limiter on outbound FTP connections, matching wget/curl.
+ftpget_rate_limiter = RateLimiter(
+    enabled=CowrieConfig.getboolean(
+        "honeypot", "ftpget_rate_limit_enabled", fallback=True
+    ),
+    max_requests=CowrieConfig.getint(
+        "honeypot", "ftpget_rate_limit_requests", fallback=5
+    ),
+    window_seconds=CowrieConfig.getint(
+        "honeypot", "ftpget_rate_limit_window", fallback=60
+    ),
+    max_keys=CowrieConfig.getint(
+        "honeypot", "ftpget_rate_limit_max_hosts", fallback=1000
+    ),
+)
+
 
 class FTPFileReceiver(Protocol):
     """
     Protocol to receive FTP file data
     """
 
-    def __init__(self, artifact: Artifact) -> None:
+    def __init__(self, artifact: Artifact, limit_size: int = 0) -> None:
         self.artifact = artifact
         self.bytes_received = 0
+        self.limit_size = limit_size
+        self.limit_exceeded = False
 
     def dataReceived(self, data: bytes) -> None:
+        if self.limit_exceeded:
+            # Already over the limit; drop late chunks and stop writing to disk.
+            return
         self.artifact.write(data)
         self.bytes_received += len(data)
+        if self.limit_size > 0 and self.bytes_received > self.limit_size:
+            # A misbehaving server must not be able to write unbounded data;
+            # stop writing and close the data connection to abort the transfer.
+            self.limit_exceeded = True
+            if self.transport is not None:
+                self.transport.loseConnection()
 
     def connectionLost(self, reason: Failure | None = None) -> None:
         # Transfer complete
@@ -52,6 +80,7 @@ class Command_ftpget(HoneyPotCommand):
     """
 
     download_path = CowrieConfig.get("honeypot", "download_path", fallback=".")
+    limit_size: int = CowrieConfig.getint("honeypot", "download_limit_size", fallback=0)
     verbose: bool
     host: str
     port: int
@@ -62,6 +91,7 @@ class Command_ftpget(HoneyPotCommand):
     remote_file: str
     artifactFile: Artifact
     ftp_client: FTPClient | None
+    receiver: FTPFileReceiver | None = None
 
     def help(self) -> None:
         self.errorWrite(
@@ -123,6 +153,20 @@ Download a file via FTP
         if not self.local_file:
             self.local_file = self.remote_file
 
+        # Rate-limit outbound FTP connections per host (matching wget/curl).
+        if not ftpget_rate_limiter.check(self.host):
+            self._log.info(
+                "ftpget: rate limit exceeded for host: {host}. "
+                "Simulating connection timeout",
+                host=self.host,
+            )
+            self.errorWrite(
+                f"ftpget: can't connect to remote host ({self.host}): "
+                "Connection timed out\n"
+            )
+            self.exit(1)
+            return
+
         fakeoutfile = self.fs.resolve_path(self.local_file, self.protocol.cwd)
         path = posixpath.dirname(fakeoutfile)
         if not path or not self.fs.exists(path) or not self.fs.isdir(path):
@@ -175,7 +219,12 @@ Download a file via FTP
         if self.verbose:
             self.write(f"Connecting to {self.host}\n")
 
-        d = creator.connectTCP(self.host, self.port, timeout=30)
+        d = creator.connectTCP(
+            self.host,
+            self.port,
+            timeout=30,
+            bindAddress=(outbound_bind_address(), 0),
+        )
         d.addCallback(self._ftp_connected)
         return d  # type: ignore[no-any-return]
 
@@ -213,7 +262,8 @@ Download a file via FTP
             self.write(f"ftpget: cmd RETR {self.remote_path}\n")
 
         # Create receiver protocol
-        receiver = FTPFileReceiver(self.artifactFile)
+        receiver = FTPFileReceiver(self.artifactFile, self.limit_size)
+        self.receiver = receiver
 
         # Retrieve file
         if self.ftp_client:
@@ -240,11 +290,29 @@ Download a file via FTP
         else:
             return defer.succeed(None)
 
+    def _log_size_limit_exceeded(self) -> None:
+        """
+        Log that the download was aborted for exceeding download_limit_size.
+        """
+        size = self.receiver.bytes_received if self.receiver else 0
+        self._log.info(
+            "Not saving URL ({url}) (size: {size}) exceeds file size limit ({limit})",
+            url=self.url_log,
+            size=size,
+            limit=self.limit_size,
+        )
+        self.errorWrite("ftpget: file exceeds download size limit\n")
+
     def _download_success(self, result: None) -> None:
         """
         Called when download completes successfully
         """
         self.artifactFile.close()
+
+        if self.receiver is not None and self.receiver.limit_exceeded:
+            self._log_size_limit_exceeded()
+            self.exit()
+            return
 
         # log to cowrie.log
         self.protocol.events.dispatch(
@@ -276,9 +344,16 @@ Download a file via FTP
         """
         Called when download fails
         """
-        self.exit_code = 1
         self.artifactFile.close()
 
+        # Aborting the transfer at the size limit surfaces here as a connection
+        # error; report it as the limit hit, not a spurious network failure.
+        if self.receiver is not None and self.receiver.limit_exceeded:
+            self._log_size_limit_exceeded()
+            self.exit()
+            return
+
+        self.exit_code = 1
         error_msg = "Connection error"
 
         if failure.check(CommandFailed):

--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -565,6 +565,17 @@ operating_system = GNU/Linux
 # SSH Version as printed by "ssh -V" in shell emulation
 ssh_version = OpenSSH_7.9p1, OpenSSL 1.1.1a  20 Nov 2018
 
+# Rate limiting for outbound FTP connections made by the ftpget command.
+# Limits the number of connections per unique host within a time window.
+# ftpget_rate_limit_enabled: enable/disable the rate limiter (default: true)
+# ftpget_rate_limit_requests: max connections per host per window (default: 5)
+# ftpget_rate_limit_window: window length in seconds (default: 60)
+# ftpget_rate_limit_max_hosts: max hosts tracked simultaneously (default: 1000)
+#ftpget_rate_limit_enabled = true
+#ftpget_rate_limit_requests = 5
+#ftpget_rate_limit_window = 60
+#ftpget_rate_limit_max_hosts = 1000
+
 
 # ============================================================================
 # SSH Specific Options

--- a/src/cowrie/test/test_ftpget.py
+++ b/src/cowrie/test/test_ftpget.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
+from unittest import mock
 
 from twisted.cred.checkers import InMemoryUsernamePasswordDatabaseDontUse
 from twisted.cred.portal import Portal
@@ -15,6 +17,7 @@ from twisted.internet import defer
 from twisted.internet import reactor as _reactor
 from twisted.protocols.ftp import FTPFactory, FTPRealm
 
+from cowrie.commands.ftpget import FTPFileReceiver, ftpget_rate_limiter
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
@@ -26,6 +29,8 @@ if TYPE_CHECKING:
         IReactorTCP,
         IReactorTime,
     )
+
+    from cowrie.core.artifact import Artifact
 
     class _Reactor(IReactorTime, IReactorTCP):
         pass
@@ -56,6 +61,8 @@ class ShellFtpGetCommandTests(unittest.TestCase):
 
     def setUp(self) -> None:
         self.tr.clear()
+        # The limiter is a module-level singleton; keep tests isolated.
+        ftpget_rate_limiter.reset()
 
     def test_help_command(self) -> defer.Deferred[None]:
         usage = (
@@ -141,6 +148,35 @@ class ShellFtpGetCommandTests(unittest.TestCase):
         return d
 
 
+class FTPFileReceiverSizeLimitTests(unittest.TestCase):
+    """The receiver must stop writing and abort the data connection once the
+    download exceeds download_limit_size, so a rogue server can't write
+    unbounded data to disk."""
+
+    def _make(self, limit: int) -> tuple[FTPFileReceiver, list[bytes]]:
+        written: list[bytes] = []
+        artifact = SimpleNamespace(write=written.append)
+        receiver = FTPFileReceiver(cast("Artifact", artifact), limit_size=limit)
+        receiver.makeConnection(mock.Mock())
+        return receiver, written
+
+    def test_aborts_and_stops_writing_past_the_limit(self) -> None:
+        receiver, written = self._make(10)
+        receiver.dataReceived(b"12345")
+        self.assertFalse(receiver.limit_exceeded)
+        receiver.dataReceived(b"67890AB")  # total 12 > 10
+        self.assertTrue(receiver.limit_exceeded)
+        cast("mock.Mock", receiver.transport).loseConnection.assert_called_once()
+        receiver.dataReceived(b"dropped")  # ignored once over the limit
+        self.assertEqual(b"".join(written), b"1234567890AB")
+
+    def test_no_limit_writes_everything(self) -> None:
+        receiver, written = self._make(0)
+        receiver.dataReceived(b"x" * 5000)
+        self.assertFalse(receiver.limit_exceeded)
+        self.assertEqual(len(b"".join(written)), 5000)
+
+
 class ShellFtpGetAsyncTests(unittest.TestCase):
     """Async tests for ftpget with mock FTP server"""
 
@@ -183,6 +219,8 @@ class ShellFtpGetAsyncTests(unittest.TestCase):
 
     def setUp(self) -> None:
         self.tr.clear()
+        # The limiter is a module-level singleton; keep tests isolated.
+        ftpget_rate_limiter.reset()
 
     def test_successful_download_anonymous(self) -> defer.Deferred[None]:
         """Test successful FTP download with anonymous login"""


### PR DESCRIPTION
Fixes #40393.

## Problem

`ftpget` makes real outbound FTP connections to an attacker-specified host but,
unlike `wget`/`curl`/`tftp`, applied none of the protections those commands were
hardened with. This brings it to parity on three of them:

## Changes

1. **Per-host rate limiter.** Adds an `ftpget_rate_limit_*`-configured
   `RateLimiter` (same pattern/config shape as `wget`/`curl`) checked before
   connecting, so the number of outbound FTP connections per host is bounded.

2. **Download size limit.** `FTPFileReceiver` now enforces
   `[honeypot] download_limit_size`: once exceeded it stops writing to the
   artifact and closes the data connection, and the command logs the limit hit
   and does not save the truncated file — so a rogue/misbehaving FTP server can't
   write unbounded data to disk (previously `dataReceived` wrote every byte).

3. **Outbound bind address.** The connection is bound to `[honeypot] out_addr`
   via `outbound_bind_address()`, keeping the honeypot's real interface IP out of
   traffic to attacker-controlled hosts.

## Not addressed: DNS-rebinding TOCTOU

The report also raised the double-resolution TOCTOU (validate one lookup, then
let `connectTCP` re-resolve). With public DNS the two lookups can't be reliably
timed apart by an attacker, so it isn't a practical concern; leaving it out to
keep this focused.

## Testing

- New deterministic `FTPFileReceiver` tests: the receiver stops writing and
  aborts the data connection once the size limit is exceeded, and writes
  everything when no limit is set.
- Existing ftpget tests reset the now-module-level rate limiter in `setUp` for
  isolation.
- Full suite passes; ruff and mypy clean.

Thanks to @vbontchev for the report.
