### PR TITLE
fix: move wget/curl/nc rate-limit options to [shell] and document them

### DIFF
--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -32,18 +32,10 @@ commands = {}
 
 # Initialize rate limiter
 curl_rate_limiter = RateLimiter(
-    enabled=CowrieConfig.getboolean(
-        "honeypot", "curl_rate_limit_enabled", fallback=True
-    ),
-    max_requests=CowrieConfig.getint(
-        "honeypot", "curl_rate_limit_requests", fallback=5
-    ),
-    window_seconds=CowrieConfig.getint(
-        "honeypot", "curl_rate_limit_window", fallback=60
-    ),
-    max_keys=CowrieConfig.getint(
-        "honeypot", "curl_rate_limit_max_hosts", fallback=1000
-    ),
+    enabled=CowrieConfig.getboolean("shell", "curl_rate_limit_enabled", fallback=True),
+    max_requests=CowrieConfig.getint("shell", "curl_rate_limit_requests", fallback=5),
+    window_seconds=CowrieConfig.getint("shell", "curl_rate_limit_window", fallback=60),
+    max_keys=CowrieConfig.getint("shell", "curl_rate_limit_max_hosts", fallback=1000),
 )
 
 CURL_HELP = """Usage: curl [options...] <url>

--- a/src/cowrie/commands/nc.py
+++ b/src/cowrie/commands/nc.py
@@ -23,10 +23,10 @@ commands = {}
 
 # Initialize rate limiter
 nc_rate_limiter = RateLimiter(
-    enabled=CowrieConfig.getboolean("honeypot", "nc_rate_limit_enabled", fallback=True),
-    max_requests=CowrieConfig.getint("honeypot", "nc_rate_limit_requests", fallback=5),
-    window_seconds=CowrieConfig.getint("honeypot", "nc_rate_limit_window", fallback=60),
-    max_keys=CowrieConfig.getint("honeypot", "nc_rate_limit_max_hosts", fallback=1000),
+    enabled=CowrieConfig.getboolean("shell", "nc_rate_limit_enabled", fallback=True),
+    max_requests=CowrieConfig.getint("shell", "nc_rate_limit_requests", fallback=5),
+    window_seconds=CowrieConfig.getint("shell", "nc_rate_limit_window", fallback=60),
+    max_keys=CowrieConfig.getint("shell", "nc_rate_limit_max_hosts", fallback=1000),
 )
 
 

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -36,18 +36,10 @@ commands = {}
 
 # Initialize rate limiter
 wget_rate_limiter = RateLimiter(
-    enabled=CowrieConfig.getboolean(
-        "honeypot", "wget_rate_limit_enabled", fallback=True
-    ),
-    max_requests=CowrieConfig.getint(
-        "honeypot", "wget_rate_limit_requests", fallback=5
-    ),
-    window_seconds=CowrieConfig.getint(
-        "honeypot", "wget_rate_limit_window", fallback=60
-    ),
-    max_keys=CowrieConfig.getint(
-        "honeypot", "wget_rate_limit_max_hosts", fallback=1000
-    ),
+    enabled=CowrieConfig.getboolean("shell", "wget_rate_limit_enabled", fallback=True),
+    max_requests=CowrieConfig.getint("shell", "wget_rate_limit_requests", fallback=5),
+    window_seconds=CowrieConfig.getint("shell", "wget_rate_limit_window", fallback=60),
+    max_keys=CowrieConfig.getint("shell", "wget_rate_limit_max_hosts", fallback=1000),
 )
 
 

--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -565,12 +565,25 @@ operating_system = GNU/Linux
 # SSH Version as printed by "ssh -V" in shell emulation
 ssh_version = OpenSSH_7.9p1, OpenSSL 1.1.1a  20 Nov 2018
 
-# Rate limiting for outbound FTP connections made by the ftpget command.
-# Limits the number of connections per unique host within a time window.
-# ftpget_rate_limit_enabled: enable/disable the rate limiter (default: true)
-# ftpget_rate_limit_requests: max connections per host per window (default: 5)
-# ftpget_rate_limit_window: window length in seconds (default: 60)
-# ftpget_rate_limit_max_hosts: max hosts tracked simultaneously (default: 1000)
+# Rate limiting for outbound connections made by the wget, curl, nc and
+# ftpget commands. Limits the number of connections per unique host within a
+# time window.
+# *_rate_limit_enabled: enable/disable the rate limiter (default: true)
+# *_rate_limit_requests: max connections per host per window (default: 5)
+# *_rate_limit_window: window length in seconds (default: 60)
+# *_rate_limit_max_hosts: max hosts tracked simultaneously (default: 1000)
+#wget_rate_limit_enabled = true
+#wget_rate_limit_requests = 5
+#wget_rate_limit_window = 60
+#wget_rate_limit_max_hosts = 1000
+#curl_rate_limit_enabled = true
+#curl_rate_limit_requests = 5
+#curl_rate_limit_window = 60
+#curl_rate_limit_max_hosts = 1000
+#nc_rate_limit_enabled = true
+#nc_rate_limit_requests = 5
+#nc_rate_limit_window = 60
+#nc_rate_limit_max_hosts = 1000
 #ftpget_rate_limit_enabled = true
 #ftpget_rate_limit_requests = 5
 #ftpget_rate_limit_window = 60


### PR DESCRIPTION
The `wget_rate_limit_*`, `curl_rate_limit_*` and `nc_rate_limit_*` options
were read from the `[honeypot]` section and were not documented in
`cowrie.cfg.dist`. Command-emulation settings belong in `[shell]` (same
change as #40407 makes for `ftpget`).

## Changes

- `wget`, `curl` and `nc` now read their `*_rate_limit_*` options from
  `[shell]` instead of `[honeypot]`. `nc` wasn't explicitly requested but
  follows the identical pattern, so it is included to leave no per-command
  rate-limit options behind in `[honeypot]`.
- All twelve options documented (commented out, with defaults) in the
  `[shell]` section of `cowrie.cfg.dist`.

Anyone who had overridden these options under `[honeypot]` needs to move
the overrides to `[shell]`; the old location is no longer read.

Note: will conflict trivially with #40407 in `cowrie.cfg.dist` — whichever
merges second needs a rebase.

## Testing

Full suite passes; ruff and mypy clean.