### PR TITLE
fix: harden DB output plugins against error-handler crashes and NULL-string rows

### DIFF
--- a/src/cowrie/output/mongodb.py
+++ b/src/cowrie/output/mongodb.py
@@ -58,7 +58,8 @@ class Output(cowrie.core.output.Output):
             self._log.info("output_mongodb: Error: {error}", error=e)
 
     def stop(self):
-        self.mongo_client.close()
+        if hasattr(self, "mongo_client"):
+            self.mongo_client.close()
 
     def write(self, event):
         for i in list(event):

--- a/src/cowrie/output/mysql.py
+++ b/src/cowrie/output/mysql.py
@@ -89,26 +89,23 @@ class Output(cowrie.core.output.Output):
         # except (MySQLdb.Error, MySQLdb._exceptions.Error) as e:
         except Exception as e:
             self._log.info(
-                "output_mysql: Error {errno}: {errmsg}",
-                errno=e.args[0],
-                errmsg=e.args[1],
+                "output_mysql: Error connecting to database: {error!r}", error=e
             )
 
     def stop(self):
-        self.db.close()
+        if hasattr(self, "db"):
+            self.db.close()
 
     def sqlerror(self, error):
         """
         1146, "Table '...' doesn't exist"
         1406, "Data too long for column '...' at row ..."
         """
-        if error.value.args[0] in (1146, 1406):
-            self._log.info("output_mysql: MySQL Error: {args!r}", args=error.value.args)
+        self._log.info("output_mysql: MySQL Error: {args!r}", args=error.value.args)
+        if error.value.args and error.value.args[0] in (1146, 1406):
             self._log.info(
                 "output_mysql: MySQL schema maybe misconfigured, doublecheck database!"
             )
-        else:
-            self._log.info("output_mysql: MySQL Error: {args!r}", args=error.value.args)
 
     def simpleQuery(self, sql, args):
         """
@@ -217,7 +214,7 @@ class Output(cowrie.core.output.Output):
             self.simpleQuery(
                 "INSERT INTO `downloads` (`session`, `timestamp`, `url`, `outfile`, `shasum`) "
                 "VALUES (%s, FROM_UNIXTIME(%s), %s, %s, %s)",
-                (event["session"], event["time"], event.get("url", ""), "NULL", "NULL"),
+                (event["session"], event["time"], event.get("url", ""), None, None),
             )
 
         elif event["eventid"] == "cowrie.session.file_upload":

--- a/src/cowrie/output/postgresql.py
+++ b/src/cowrie/output/postgresql.py
@@ -75,13 +75,12 @@ class Output(cowrie.core.output.Output):
             )
         except Exception as e:
             self._log.info(
-                "output_mysql: Error {errno}: {errmsg}",
-                errno=e.args[0],
-                errmsg=e.args[1],
+                "output_postgresql: Error connecting to database: {error!r}", error=e
             )
 
     def stop(self):
-        self.db.close()
+        if hasattr(self, "db"):
+            self.db.close()
 
     def sqlerror(self, error):
         self._log.info(

--- a/src/cowrie/output/rethinkdblog.py
+++ b/src/cowrie/output/rethinkdblog.py
@@ -39,7 +39,8 @@ class Output(cowrie.core.output.Output):
             pass
 
     def stop(self):
-        self.connection.close()
+        if hasattr(self, "connection"):
+            self.connection.close()
 
     def write(self, event):
         for i in list(event):

--- a/src/cowrie/output/sqlite.py
+++ b/src/cowrie/output/sqlite.py
@@ -35,16 +35,16 @@ class Output(cowrie.core.output.Output):
             self.db = adbapi.ConnectionPool(
                 "sqlite3", database=sqliteFilename, check_same_thread=False
             )
+            self.db.start()
         except sqlite3.OperationalError as e:
             self._log.info("{error}", error=e)
-
-        self.db.start()
 
     def stop(self):
         """
         Close connection to db
         """
-        self.db.close()
+        if hasattr(self, "db"):
+            self.db.close()
 
     def sqlerror(self, error):
         self._log.failure("sqlite error", failure=error)
@@ -141,7 +141,7 @@ class Output(cowrie.core.output.Output):
             self.simpleQuery(
                 "INSERT INTO `downloads` (`session`, `timestamp`, `url`, `outfile`, `shasum`) "
                 "VALUES (?, ?, ?, ?, ?)",
-                (event["session"], event["timestamp"], event["url"], "NULL", "NULL"),
+                (event["session"], event["timestamp"], event["url"], None, None),
             )
 
         elif event["eventid"] == "cowrie.client.version":

--- a/src/cowrie/test/test_output_mongodb.py
+++ b/src/cowrie/test/test_output_mongodb.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: The mongodb output plugin must shut down cleanly when start()
+# ABOUTME: never connected to the database.
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+try:
+    import pymongo  # noqa: F401
+except ImportError:
+    # The driver is an optional dependency; stub it so the plugin imports.
+    sys.modules["pymongo"] = types.ModuleType("pymongo")
+
+from cowrie.output import mongodb
+
+
+def _make() -> Any:
+    """Construct the plugin without running its config-reading start()."""
+    with patch.object(mongodb.Output, "start", lambda self: None):
+        return mongodb.Output()
+
+
+class OutputMongodbHardeningTests(unittest.TestCase):
+    def test_stop_without_successful_start(self) -> None:
+        """stop() must not raise when start() never connected."""
+        out = _make()
+        out.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_output_mysql.py
+++ b/src/cowrie/test/test_output_mysql.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: The mysql output plugin must survive exceptions with unusual args
+# ABOUTME: and record failed downloads with SQL NULL, not the string "NULL".
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+import unittest
+from typing import Any
+from unittest.mock import Mock, patch
+
+from twisted.internet import defer
+from twisted.python.failure import Failure
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+try:
+    import mysql.connector  # noqa: F401
+except ImportError:
+    # The driver is an optional dependency; stub it so the plugin imports.
+    _mysql = types.ModuleType("mysql")
+    _connector = types.ModuleType("mysql.connector")
+    _connector.Error = type("Error", (Exception,), {})  # type: ignore[attr-defined]
+    _connector.errorcode = types.SimpleNamespace(  # type: ignore[attr-defined]
+        CR_CONN_HOST_ERROR=2003,
+        CR_SERVER_GONE_ERROR=2006,
+        CR_SERVER_LOST=2013,
+        ER_LOCK_DEADLOCK=1213,
+    )
+    _mysql.connector = _connector  # type: ignore[attr-defined]
+    sys.modules["mysql"] = _mysql
+    sys.modules["mysql.connector"] = _connector
+
+from cowrie.output import mysql as mysql_output
+
+
+def _make() -> Any:
+    """Construct the plugin without running its config-reading start()."""
+    with patch.object(mysql_output.Output, "start", lambda self: None):
+        return mysql_output.Output()
+
+
+class OutputMysqlHardeningTests(unittest.TestCase):
+    def test_start_failure_with_argless_exception_is_logged(self) -> None:
+        """A pool construction error without two args must not raise IndexError."""
+        out = _make()
+        config = Mock()
+        config.getboolean.return_value = False
+        config.getint.return_value = 3306
+        config.get.return_value = "example.invalid"
+        with (
+            patch.object(mysql_output, "CowrieConfig", config),
+            patch.object(
+                mysql_output,
+                "ReconnectingConnectionPool",
+                side_effect=TypeError(),
+            ),
+        ):
+            out.start()
+
+    def test_stop_without_successful_start(self) -> None:
+        """stop() must not raise when start() never created the pool."""
+        out = _make()
+        out.stop()
+
+    def test_sqlerror_with_empty_args(self) -> None:
+        """An errback whose exception has no args must not raise IndexError."""
+        out = _make()
+        out.sqlerror(Failure(Exception()))
+
+    def test_sqlerror_with_schema_error(self) -> None:
+        out = _make()
+        out.sqlerror(Failure(Exception(1146, "Table 'auth' doesn't exist")))
+
+    def test_failed_download_records_sql_null(self) -> None:
+        """file_download.failed must store NULL, not the string 'NULL'."""
+        out = _make()
+        out.db = Mock()
+        out.db.runQuery.return_value = defer.succeed(None)
+        out.write(
+            {
+                "eventid": "cowrie.session.file_download.failed",
+                "session": "s1",
+                "time": 1234567890,
+                "url": "http://example.invalid/x",
+            }
+        )
+        args = out.db.runQuery.call_args[0][1]
+        self.assertEqual(args[-2:], (None, None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_output_postgresql.py
+++ b/src/cowrie/test/test_output_postgresql.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: The postgresql output plugin must survive connection errors with
+# ABOUTME: unusual args and shut down cleanly when start() never connected.
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+import unittest
+from typing import Any
+from unittest.mock import Mock, patch
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+try:
+    import psycopg2  # noqa: F401
+except ImportError:
+    # The driver is an optional dependency; stub it so the plugin imports.
+    _psycopg2 = types.ModuleType("psycopg2")
+    _psycopg2.OperationalError = type(  # type: ignore[attr-defined]
+        "OperationalError", (Exception,), {}
+    )
+    sys.modules["psycopg2"] = _psycopg2
+
+from cowrie.output import postgresql
+
+
+def _make() -> Any:
+    """Construct the plugin without running its config-reading start()."""
+    with patch.object(postgresql.Output, "start", lambda self: None):
+        return postgresql.Output()
+
+
+class OutputPostgresqlHardeningTests(unittest.TestCase):
+    def test_start_failure_with_argless_exception_is_logged(self) -> None:
+        """A pool construction error without two args must not raise IndexError."""
+        out = _make()
+        config = Mock()
+        config.getboolean.return_value = False
+        config.getint.return_value = 5432
+        config.get.return_value = "example.invalid"
+        with (
+            patch.object(postgresql, "CowrieConfig", config),
+            patch.object(
+                postgresql,
+                "ReconnectingPostgreSQLConnectionPool",
+                side_effect=TypeError(),
+            ),
+        ):
+            out.start()
+
+    def test_stop_without_successful_start(self) -> None:
+        """stop() must not raise when start() never created the pool."""
+        out = _make()
+        out.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_output_rethinkdblog.py
+++ b/src/cowrie/test/test_output_rethinkdblog.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: The rethinkdblog output plugin must shut down cleanly when start()
+# ABOUTME: never connected to the database.
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+try:
+    import rethinkdb  # noqa: F401
+except ImportError:
+    # The driver is an optional dependency; stub it so the plugin imports.
+    sys.modules["rethinkdb"] = types.ModuleType("rethinkdb")
+
+from cowrie.output import rethinkdblog
+
+
+def _make() -> Any:
+    """Construct the plugin without running its config-reading start()."""
+    with patch.object(rethinkdblog.Output, "start", lambda self: None):
+        return rethinkdblog.Output()
+
+
+class OutputRethinkdblogHardeningTests(unittest.TestCase):
+    def test_stop_without_successful_start(self) -> None:
+        """stop() must not raise when start() never connected."""
+        out = _make()
+        out.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_output_sqlite.py
+++ b/src/cowrie/test/test_output_sqlite.py
@@ -13,6 +13,7 @@ import unittest
 from typing import Any
 from unittest.mock import Mock, patch
 
+from twisted.enterprise import adbapi
 from twisted.internet import defer
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
@@ -37,7 +38,7 @@ class OutputSqliteHardeningTests(unittest.TestCase):
         with (
             patch.object(sqlite_output, "CowrieConfig", config),
             patch.object(
-                sqlite_output.adbapi,
+                adbapi,
                 "ConnectionPool",
                 side_effect=sqlite3.OperationalError(),
             ),

--- a/src/cowrie/test/test_output_sqlite.py
+++ b/src/cowrie/test/test_output_sqlite.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: The sqlite output plugin must survive a failed pool construction
+# ABOUTME: and record failed downloads with SQL NULL, not the string "NULL".
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import unittest
+from typing import Any
+from unittest.mock import Mock, patch
+
+from twisted.internet import defer
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+from cowrie.output import sqlite as sqlite_output
+
+
+def _make() -> Any:
+    """Construct the plugin without running its config-reading start()."""
+    with patch.object(sqlite_output.Output, "start", lambda self: None):
+        return sqlite_output.Output()
+
+
+class OutputSqliteHardeningTests(unittest.TestCase):
+    def test_start_failure_is_logged(self) -> None:
+        """A pool construction error must not raise from start() itself."""
+        out = _make()
+        config = Mock()
+        config.get.return_value = "/nonexistent/cowrie.db"
+        with (
+            patch.object(sqlite_output, "CowrieConfig", config),
+            patch.object(
+                sqlite_output.adbapi,
+                "ConnectionPool",
+                side_effect=sqlite3.OperationalError(),
+            ),
+        ):
+            out.start()
+
+    def test_stop_without_successful_start(self) -> None:
+        """stop() must not raise when start() never created the pool."""
+        out = _make()
+        out.stop()
+
+    def test_failed_download_records_sql_null(self) -> None:
+        """file_download.failed must store NULL, not the string 'NULL'."""
+        out = _make()
+        out.db = Mock()
+        out.db.runQuery.return_value = defer.succeed(None)
+        out.write(
+            {
+                "eventid": "cowrie.session.file_download.failed",
+                "session": "s1",
+                "timestamp": "2026-01-01T00:00:00.000000Z",
+                "url": "http://example.invalid/x",
+            }
+        )
+        args = out.db.runQuery.call_args[0][1]
+        self.assertEqual(args[-2:], (None, None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #40404.

The mysql output plugin had four robustness defects, and the plugins derived from it inherited several of them:

- **`start()` indexed `e.args[0]`/`e.args[1]`** in its connection error handler. An exception with fewer than two args raised `IndexError` from inside the handler, replacing the real connection error in the logs. Fixed in mysql and postgresql (which also logged under the `output_mysql` prefix).
- **`stop()` called `close()` unguarded.** The base class registers the shutdown trigger before `start()` runs, so when `start()` failed (or swallowed its error), `stop()` raised `AttributeError` at reactor shutdown. Fixed in mysql, postgresql, sqlite, mongodb, and rethinkdblog.
- **`sqlerror()` indexed `error.value.args[0]` unconditionally** — an errback for an exception with empty `args` raised `IndexError` from inside the errback. Fixed in mysql (postgresql/sqlite were already safe).
- **A failed download stored the string `"NULL"`** in the nullable `outfile`/`shasum` columns instead of SQL `NULL`, breaking `WHERE outfile IS NULL` queries. Fixed in mysql and sqlite (postgresql already used `None`).
- sqlite additionally called `self.db.start()` outside the `try`, so a failed pool construction crashed one line after being logged.

Each plugin's fix is a separate commit with unit tests; the optional DB drivers are stubbed at import time so the tests run without them installed.

Thanks @vbontchev for the detailed report.