### PR TITLE
fix: harden scp upload parsing against crashes and file floods

### DIFF
--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -27,6 +27,12 @@ class Command_scp(HoneyPotCommand):
     download_path_uniq = CowrieConfig.get(
         "honeypot", "download_path_uniq", fallback=download_path
     )
+    # Every uploaded file costs a real temp-file write, a sha256 hash and a
+    # rename on the host filesystem, so cap how many files one upload session
+    # can save regardless of how small each file is.
+    max_files_per_session: int = CowrieConfig.getint(
+        "shell", "scp_max_files_per_session", fallback=20
+    )
 
     out_dir: str = ""
 
@@ -229,8 +235,17 @@ class Command_scp(HoneyPotCommand):
             # as content only. The raw stdin log still holds the framing (header,
             # body and trailing ACK), so remove it to avoid saving it again as a
             # download.
+            filecount = 0
             while data:
+                if filecount >= self.max_files_per_session:
+                    self._log.info(
+                        "scp: session reached scp_max_files_per_session "
+                        "({max_files}), ignoring the remaining files",
+                        max_files=self.max_files_per_session,
+                    )
+                    break
                 data = self.parse_scp_data(data)
+                filecount += 1
 
             terminal.stdinlogOpen = False
             os.remove(terminal.stdinlogFile)

--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -142,17 +142,33 @@ class Command_scp(HoneyPotCommand):
                 r = re.search(rb"C(0[\d]{3}) ([\d]+) ([^\s]+)", header)
 
                 if r and r.group(1) and r.group(2) and r.group(3):
-                    dend = pos + int(r.group(2))
+                    # Both fields are attacker-controlled: the filesize can
+                    # exceed int()'s digit limit (~4300, the CVE-2020-10735
+                    # mitigation) and the permissions regex admits non-octal
+                    # digits. Treat either conversion failing as a malformed
+                    # header rather than raising out of eofReceived().
+                    try:
+                        filesize = int(r.group(2))
+                        fileperm = int(r.group(1), 8)
+                    except ValueError:
+                        return b""
+
+                    dend = pos + filesize
 
                     if dend > len(data):
                         dend = len(data)
 
                     d = data[pos:dend]
 
+                    # The filename is attacker-controlled and need not be
+                    # valid UTF-8; still capture the upload under a
+                    # best-effort name.
+                    scpname = r.group(3).decode(errors="replace")
+
                     if self.out_dir:
-                        fname = posixpath.join(self.out_dir, r.group(3).decode())
+                        fname = posixpath.join(self.out_dir, scpname)
                     else:
-                        fname = r.group(3).decode()
+                        fname = scpname
 
                     outfile = self.fs.resolve_path(fname, self.protocol.cwd)
 
@@ -161,8 +177,8 @@ class Command_scp(HoneyPotCommand):
                             outfile,
                             self.current_user["uid"],
                             self.current_user["gid"],
-                            int(r.group(2)),
-                            int(r.group(1), 8),
+                            filesize,
+                            fileperm,
                         )
                     except fs.FileNotFound:
                         # The outfile locates at a non-existing directory.

--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -189,7 +189,23 @@ class Command_scp(HoneyPotCommand):
                         self.errorWrite(f"-scp: {outfile}: Permission denied\n")
                         return b""
 
-                    self.save_file(d, outfile)
+                    try:
+                        self.save_file(d, outfile)
+                    except OSError as e:
+                        # A real filesystem failure (disk full, missing or
+                        # unwritable download_path) while writing the temp
+                        # file or renaming it into place. Log it and stop the
+                        # upload cleanly instead of raising out of
+                        # eofReceived() and leaving the temp file behind.
+                        self._log.error(
+                            "scp: error saving upload {fname}: {error!r}",
+                            fname=fname,
+                            error=e,
+                        )
+                        safeoutfile = getattr(self, "safeoutfile", None)
+                        if safeoutfile and os.path.exists(safeoutfile):
+                            os.remove(safeoutfile)
+                        return b""
 
                     data = data[dend + 1 :]  # cut saved data + \x00
             else:

--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -576,6 +576,14 @@ ssh_version = OpenSSH_7.9p1, OpenSSL 1.1.1a  20 Nov 2018
 #ftpget_rate_limit_window = 60
 #ftpget_rate_limit_max_hosts = 1000
 
+# Maximum number of files one scp upload session will save. Every uploaded
+# file costs a real temp-file write, a sha256 hash and a rename on the host
+# filesystem, so a session uploading many tiny files can otherwise force a
+# disproportionate amount of real disk I/O. Files beyond the limit are
+# ignored.
+# (default: 20)
+#scp_max_files_per_session = 20
+
 
 # ============================================================================
 # SSH Specific Options

--- a/src/cowrie/test/test_scp_exec.py
+++ b/src/cowrie/test/test_scp_exec.py
@@ -156,5 +156,77 @@ class ScpExecPushTests(unittest.TestCase):
         self.assertIn("cowrie.session.file_upload", [e.get("eventid") for e in events])
 
 
+class ScpExecHardeningTests(unittest.TestCase):
+    """Malformed or abusive SCP wire data must not crash the upload handler."""
+
+    def setUp(self) -> None:
+        for name in os.listdir(_DOWNLOAD_DIR):
+            full = os.path.join(_DOWNLOAD_DIR, name)
+            if os.path.isfile(full):
+                os.remove(full)
+
+    def test_oversized_filesize_header(self) -> None:
+        """A filesize field longer than int()'s digit limit (~4300) must be
+        treated as a malformed header, not raise ValueError out of the EOF
+        handler."""
+        framed = b"C0644 " + b"9" * 5000 + b" evil.txt\n" + b"x" * 16 + b"\x00"
+
+        saved, _events = run_exec_scp_push(framed)
+
+        self.assertEqual(saved, [])
+
+    def test_non_octal_permissions_header(self) -> None:
+        """The permissions regex admits non-octal digits; int('0999', 8) must
+        be treated as a malformed header, not raise ValueError."""
+        framed = b"C0999 1 f\n" + b"x\x00"
+
+        saved, _events = run_exec_scp_push(framed)
+
+        self.assertEqual(saved, [])
+
+    def test_undecodable_filename_still_captured(self) -> None:
+        """A filename that is not valid UTF-8 must not raise
+        UnicodeDecodeError; the upload content is still captured."""
+        body = b"payload"
+        framed = b"C0644 %d \xff\xfe\n" % len(body) + body + b"\x00"
+
+        saved, events = run_exec_scp_push(framed)
+
+        self.assertEqual(saved, [body])
+        self.assertIn("cowrie.session.file_upload", [e.get("eventid") for e in events])
+
+    def test_max_files_per_session_caps_saves(self) -> None:
+        """One session must not be able to force an unbounded number of real
+        file writes by uploading many tiny files."""
+        orig = scp.Command_scp.max_files_per_session
+        scp.Command_scp.max_files_per_session = 3
+        self.addCleanup(setattr, scp.Command_scp, "max_files_per_session", orig)
+
+        framed = b"".join(
+            b"C0644 1 f%d\n%d\x00" % (i, i)
+            for i in range(10)  # distinct bodies
+        )
+
+        saved, _events = run_exec_scp_push(framed)
+
+        self.assertEqual(len(saved), 3)
+
+    def test_unwritable_download_path_does_not_crash(self) -> None:
+        """A real filesystem error while saving the upload (download_path
+        missing) must be handled, not raise OSError out of the EOF handler."""
+        orig = scp.Command_scp.download_path
+        scp.Command_scp.download_path = os.path.join(_DOWNLOAD_DIR, "missing", "dir")
+        self.addCleanup(setattr, scp.Command_scp, "download_path", orig)
+
+        framed = b"C0644 1 f\n" + b"x\x00"
+
+        saved, events = run_exec_scp_push(framed)
+
+        self.assertEqual(saved, [])
+        self.assertNotIn(
+            "cowrie.session.file_upload", [e.get("eventid") for e in events]
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #40399.

`parse_scp_data()` trusted several attacker-controlled fields of the SCP wire header, and `eofReceived()` had no bound on per-session work:

- A **filesize field with more than ~4300 digits** made `int()` raise `ValueError` (the CVE-2020-10735 digit-limit mitigation). Uncaught, it propagated out of `eofReceived()`, breaking the upload and leaving the stdin log and temp file behind.
- The **permissions regex `0[\d]{3}` admits non-octal digits**, so a header like `C0999 ...` crashed `int(.., 8)` the same way (found while writing the fix; same class as the reported crash).
- A **filename that is not valid UTF-8** raised `UnicodeDecodeError` the same way. It is now decoded with `errors=replace` so the upload is still captured under a best-effort name.
- A **real filesystem failure in `save_file()`** (disk full, unwritable `download_path`) raised `OSError` uncaught. It is now logged, any leftover temp file removed, and the upload ended cleanly.
- The parse loop **saved unboundedly many files per session** — each one a real temp-file write, sha256 hash, rename and event dispatch — letting an attacker trade a few bytes of upload bandwidth per file for disproportionate host disk I/O. The loop is now bounded by the new `scp_max_files_per_session` option (default 20), documented in the `[shell]` section of `cowrie.cfg.dist`.

Unparseable size/permission fields end parsing the same way an already-malformed header does. All five cases are covered by new exec-channel tests that drive the real `scp -t` path.

Thanks @vbontchev for the detailed report.
