### PR TITLE
fix: harden telnet subsystem against malformed client input

### DIFF
--- a/src/cowrie/telnet/session.py
+++ b/src/cowrie/telnet/session.py
@@ -38,7 +38,10 @@ class HoneyPotTelnetSession(TelnetBootstrapProtocol):
         # to be populated by HoneyPotTelnetAuthProtocol after auth
         self.transportId = None
         self.windowSize = [40, 80]
-        self.username = username.decode()
+        # The username is raw attacker input from the login prompt and need
+        # not be valid UTF-8; decode it the same way the login flow already
+        # decodes attacker-supplied credentials.
+        self.username = username.decode("utf-8", errors="replace")
         self.server = server
 
         try:

--- a/src/cowrie/telnet/session.py
+++ b/src/cowrie/telnet/session.py
@@ -166,14 +166,20 @@ class TelnetSessionProcessProtocol(protocol.ProcessProtocol):
 
     def getHost(self):
         """
-        Return the host from my session's transport.
+        Return the host from my session's transport, or None once
+        connectionLost() has cleared the session.
         """
+        if self.session is None:
+            return None
         return self.session.transport.getHost()
 
     def getPeer(self):
         """
-        Return the peer from my session's transport.
+        Return the peer from my session's transport, or None once
+        connectionLost() has cleared the session.
         """
+        if self.session is None:
+            return None
         return self.session.transport.getPeer()
 
     def write(self, data):

--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -285,7 +285,10 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
         each one floods the log, so identical repeats within a connection are
         suppressed after the first.
         """
-        option_byte = option[0] if option else 0
+        # -1 is a sentinel distinct from every real option byte: 0 is the
+        # real BINARY option, so using it for an empty option made the two
+        # collide in the log line and in the dedup key below.
+        option_byte = option[0] if option else -1
         key = (command, option_byte)
         if key in self._logged_options:
             return

--- a/src/cowrie/telnet/userauth.py
+++ b/src/cowrie/telnet/userauth.py
@@ -48,6 +48,12 @@ NEW_ENVIRON_VALUE = 1  # Variable value follows
 NEW_ENVIRON_ESC = 2  # Escape byte for literal VAR/VALUE/USERVAR bytes in data
 NEW_ENVIRON_USERVAR = 3  # User-defined variable name follows
 
+# The subnegotiation payload is attacker-controlled and Twisted buffers it
+# between IAC SB and IAC SE without a length limit of its own, so bound how
+# much of it the per-byte environment parser will accept. Real clients send
+# at most a few hundred bytes of environment variables.
+MAX_NEW_ENVIRON_SIZE = 4096
+
 
 class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
     """
@@ -208,6 +214,13 @@ class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
         # Join the data bytes
         raw_data = b"".join(data)
         if len(raw_data) < 1:
+            return
+
+        if len(raw_data) > MAX_NEW_ENVIRON_SIZE:
+            self._log.info(
+                "Telnet NEW-ENVIRON subnegotiation too large ({size} bytes), ignoring",
+                size=len(raw_data),
+            )
             return
 
         command = raw_data[0]

--- a/src/cowrie/test/test_telnet_new_environ.py
+++ b/src/cowrie/test/test_telnet_new_environ.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 
 from cowrie.telnet.transport import TELNET_OPTIONS, CowrieTelnetTransport
 from cowrie.telnet.userauth import (
+    MAX_NEW_ENVIRON_SIZE,
     NEW_ENVIRON,
     NEW_ENVIRON_ESC,
     NEW_ENVIRON_IS,
@@ -256,6 +257,51 @@ class TestCVE2026_24061Detection(unittest.TestCase):
                 var_logged = True
                 break
         self.assertFalse(var_logged, "SEND command should be ignored")
+
+
+class TestNewEnvironSizeCap(unittest.TestCase):
+    """An oversized NEW-ENVIRON subnegotiation must be ignored, not parsed."""
+
+    def setUp(self) -> None:
+        mock_portal = MagicMock()
+        self.protocol = HoneyPotTelnetAuthProtocol(mock_portal)
+        self.protocol.environ_received = {}
+        self.protocol.transport = MagicMock()
+        self.dispatched = capture_events(self.protocol.transport)
+
+    @patch("cowrie.telnet.userauth.HoneyPotTelnetAuthProtocol._log")
+    def test_oversized_subnegotiation_ignored(self, mock_log: MagicMock) -> None:
+        """A payload larger than MAX_NEW_ENVIRON_SIZE must be dropped before
+        any per-byte parsing work, storing and logging nothing."""
+        payload = (
+            bytes([NEW_ENVIRON_IS, NEW_ENVIRON_VAR])
+            + b"USER"
+            + bytes([NEW_ENVIRON_VALUE])
+            + b"A" * (MAX_NEW_ENVIRON_SIZE + 1)
+        )
+        self.protocol.telnet_NEW_ENVIRON([payload])
+
+        self.assertEqual(self.protocol.environ_received, {})
+        self.assertEqual(
+            [e for e in self.dispatched if e.get("eventid") == "cowrie.client.var"],
+            [],
+        )
+
+    @patch("cowrie.telnet.userauth.HoneyPotTelnetAuthProtocol._log")
+    def test_payload_at_limit_still_parsed(self, mock_log: MagicMock) -> None:
+        """A payload exactly at the limit is still parsed normally."""
+        prefix = (
+            bytes([NEW_ENVIRON_IS, NEW_ENVIRON_VAR])
+            + b"USER"
+            + bytes([NEW_ENVIRON_VALUE])
+        )
+        payload = prefix + b"A" * (MAX_NEW_ENVIRON_SIZE - len(prefix))
+        self.protocol.telnet_NEW_ENVIRON([payload])
+
+        self.assertEqual(
+            self.protocol.environ_received,
+            {"USER": "A" * (MAX_NEW_ENVIRON_SIZE - len(prefix))},
+        )
 
 
 class TestTelnetOptionLogging(unittest.TestCase):

--- a/src/cowrie/test/test_telnet_session.py
+++ b/src/cowrie/test/test_telnet_session.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Telnet session setup must survive attacker-controlled input:
+# ABOUTME: a non-UTF-8 username and transport queries after teardown.
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from cowrie.telnet.session import HoneyPotTelnetSession
+from cowrie.test.fake_server import FakeServer
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class TelnetSessionUsernameTests(unittest.TestCase):
+    def test_non_utf8_username_does_not_crash(self) -> None:
+        """The username comes raw from the login prompt and need not be valid
+        UTF-8; session construction must not raise UnicodeDecodeError."""
+        session = HoneyPotTelnetSession(b"admin\xff", FakeServer())
+
+        self.assertEqual(session.username, "admin�")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_telnet_session.py
+++ b/src/cowrie/test/test_telnet_session.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import os
 import unittest
+from unittest.mock import MagicMock
 
-from cowrie.telnet.session import HoneyPotTelnetSession
+from cowrie.telnet.session import HoneyPotTelnetSession, TelnetSessionProcessProtocol
 from cowrie.test.fake_server import FakeServer
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
@@ -24,6 +25,17 @@ class TelnetSessionUsernameTests(unittest.TestCase):
         session = HoneyPotTelnetSession(b"admin\xff", FakeServer())
 
         self.assertEqual(session.username, "admin�")
+
+
+class TelnetSessionProcessProtocolTests(unittest.TestCase):
+    def test_getpeer_gethost_after_connection_lost(self) -> None:
+        """connectionLost() clears the session; getPeer()/getHost() must then
+        return None instead of raising AttributeError."""
+        pp = TelnetSessionProcessProtocol(MagicMock())
+        pp.connectionLost(None)
+
+        self.assertIsNone(pp.getPeer())
+        self.assertIsNone(pp.getHost())
 
 
 if __name__ == "__main__":

--- a/src/cowrie/test/test_telnet_transport.py
+++ b/src/cowrie/test/test_telnet_transport.py
@@ -430,5 +430,24 @@ class TestLoginLineEndings(unittest.TestCase):
         session.dataReceived.assert_called_once_with(b"x")
 
 
+class TestNegotiationLogging(unittest.TestCase):
+    """Option negotiation logging must keep distinct options distinct."""
+
+    def test_empty_option_does_not_collide_with_binary(self) -> None:
+        """An empty option must not share a dedup key with BINARY (option
+        byte 0): logging one previously suppressed the other."""
+        transport = CowrieTelnetTransport()
+        transport._logged_options = set()
+        dispatched = capture_events(transport)
+
+        transport._log_negotiation("DO", bytes([0]))  # real BINARY
+        transport._log_negotiation("DO", b"")  # empty option
+
+        logged = [e for e in dispatched if e["eventid"] == "cowrie.telnet.option"]
+        self.assertEqual(len(logged), 2)
+        self.assertEqual(logged[0]["option_name"], "BINARY")
+        self.assertNotEqual(logged[1]["option_byte"], logged[0]["option_byte"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #40401.

Four independent robustness fixes in the Telnet subsystem, one commit each:

- **userauth.py**: `telnet_NEW_ENVIRON()` handed the whole subnegotiation payload to the per-byte environment parser with no size check, and Twisted buffers subnegotiation bytes with no length limit of its own — a client could force unbounded parsing work and list allocation. Payloads over `MAX_NEW_ENVIRON_SIZE` (4096 bytes) are now logged and ignored before any parsing; real clients send at most a few hundred bytes.
- **session.py**: `HoneyPotTelnetSession.__init__()` decoded the attacker-supplied username as strict UTF-8, so an invalid byte sequence raised `UnicodeDecodeError` right after the honeypot accepted the login. Now decoded with `errors=replace`, matching how the login flow already decodes attacker credentials.
- **session.py**: `TelnetSessionProcessProtocol.getPeer()`/`getHost()` dereferenced `self.session` after `connectionLost()` set it to `None`, raising `AttributeError`; they now return `None`.
- **transport.py**: `_log_negotiation()` mapped an empty option byte to `0`, the real wire value of `BINARY`, so the log line was wrong and the per-connection dedup key collided — logging one could suppress the other. `-1` is now used as a sentinel distinct from every real option byte.

Each fix has a unit test that failed before the change.

Thanks @vbontchev for the detailed report.