### PR TITLE
fix: don't crash on attacker-controlled bytes that aren't valid UTF-8

### DIFF
--- a/src/cowrie/commands/awk.py
+++ b/src/cowrie/commands/awk.py
@@ -107,7 +107,8 @@ class Command_awk(HoneyPotCommand):
         This is the awk output.
         """
         if inb:
-            inp = inb.decode("utf-8")
+            # Piped input is attacker bytes and need not be valid UTF-8.
+            inp = inb.decode("utf-8", errors="replace")
         else:
             return
 

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -946,7 +946,8 @@ class Command_history(HoneyPotCommand):
                 return
             count = 1
             for line in self.protocol.historyLines:
-                self.write(f" {count:4d}  {line.decode()}\n")
+                # A typed line need not be valid UTF-8.
+                self.write(f" {count:4d}  {line.decode(errors='replace')}\n")
                 count += 1
         except Exception:
             # Non-interactive shell, do nothing

--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -274,7 +274,9 @@ class Command_curl(HoneyPotCommand):
                 self.exit(23)
                 return
 
-        self.url = url.encode("ascii")
+        # The URL is attacker input and can contain non-ASCII characters;
+        # encoding it as ASCII raised UnicodeEncodeError.
+        self.url = url.encode("utf8")
 
         parsed = parse.urlparse(url)
         scheme = parsed.scheme
@@ -372,11 +374,17 @@ class Command_curl(HoneyPotCommand):
         if self.head_request:
             reason = responses.get(response.code, "")
             self.write(f"HTTP/1.1 {response.code} {reason}\n")
+            # Header bytes come from an attacker-directed server and need
+            # not be valid UTF-8.
             for key, values in response.headers.getAllRawHeaders():
-                decoded_key = key.decode() if isinstance(key, bytes) else key
+                decoded_key = (
+                    key.decode(errors="replace") if isinstance(key, bytes) else key
+                )
                 for value in values:
                     decoded_value = (
-                        value.decode() if isinstance(value, bytes) else value
+                        value.decode(errors="replace")
+                        if isinstance(value, bytes)
+                        else value
                     )
                     self.write(f"{decoded_key}: {decoded_value}\n")
             self.exit()

--- a/src/cowrie/commands/finger.py
+++ b/src/cowrie/commands/finger.py
@@ -21,7 +21,8 @@ class Command_finger(HoneyPotCommand):
         user_data = []
         # Get all user data and convert to string
         all_users_byte = self.fs.file_contents("/etc/passwd")
-        all_users = all_users_byte.decode("utf-8")
+        # An attacker can overwrite /etc/passwd with arbitrary bytes.
+        all_users = all_users_byte.decode("utf-8", errors="replace")
         # Convert all new lines to : character
         all_users = all_users.replace("\n", ":")
         # Convert into list by splitting string

--- a/src/cowrie/commands/tee.py
+++ b/src/cowrie/commands/tee.py
@@ -91,7 +91,8 @@ class Command_tee(HoneyPotCommand):
         This is the tee output, if no file supplied
         """
         if inb:
-            inp = inb.decode("utf-8")
+            # Piped input is attacker bytes and need not be valid UTF-8.
+            inp = inb.decode("utf-8", errors="replace")
         else:
             return
 

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -501,8 +501,12 @@ class Command_wget(HoneyPotCommand):
         """
         successful treq get
         """
+        # Response metadata comes from an attacker-directed server and need
+        # not be valid UTF-8.
         if response.headers.hasHeader(b"content-type"):
-            contenttype = response.headers.getRawHeaders(b"content-type")[0].decode()
+            contenttype = response.headers.getRawHeaders(b"content-type")[0].decode(
+                errors="replace"
+            )
         else:
             contenttype = "text/whatever"
 
@@ -512,7 +516,7 @@ class Command_wget(HoneyPotCommand):
         if code is not None:
             if phrase:
                 if isinstance(phrase, bytes):
-                    phrase = phrase.decode()
+                    phrase = phrase.decode(errors="replace")
                 status_line = f"{code} {phrase}"
             else:
                 status_line = str(code)

--- a/src/cowrie/core/utils.py
+++ b/src/cowrie/core/utils.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import ipaddress
+from hashlib import md5
 from typing import TYPE_CHECKING, BinaryIO
 
 from twisted.application import internet
@@ -32,6 +33,40 @@ def escape_nonprintable(data: bytes) -> str:
         else:
             out.append(f"\\x{b:02x}")
     return "".join(out)
+
+
+def hassh_client(
+    kexAlgs: list[bytes],
+    encCS: list[bytes],
+    macCS: list[bytes],
+    compCS: list[bytes],
+) -> tuple[str, str]:
+    """Return the hassh algorithm string and fingerprint for a client's
+    KEXINIT name-lists.
+
+    hassh identifies an SSH client by the algorithms it offers.
+    https://github.com/salesforce/hassh
+
+    MD5 is the digest the hassh specification defines, so the fingerprint is
+    only comparable to other tools' hassh values when computed this way; it is
+    an identifier, not a security control.
+
+    backslashreplace, not escape_nonprintable: for every byte sequence that
+    decodes as valid UTF-8 (all real clients) this is identical to a plain
+    decode, so the hassh fingerprint is unchanged; it only avoids crashing on
+    a malformed name-list that is not valid UTF-8.
+    """
+
+    def name_list(algs: list[bytes]) -> str:
+        return ",".join(alg.decode("utf-8", "backslashreplace") for alg in algs)
+
+    algorithms = (
+        f"{name_list(kexAlgs)};{name_list(encCS)};"
+        f"{name_list(macCS)};{name_list(compCS)}"
+    )
+    encoded = algorithms.encode("utf-8")
+    digest = md5(encoded, usedforsecurity=False)  # NOSONAR - hassh format
+    return algorithms, digest.hexdigest()
 
 
 def durationHuman(duration: float) -> str:

--- a/src/cowrie/llm/avatar.py
+++ b/src/cowrie/llm/avatar.py
@@ -24,7 +24,9 @@ class CowrieUser(avatar.ConchUser):
 
     def __init__(self, username: bytes, server: server.CowrieServer) -> None:
         avatar.ConchUser.__init__(self)
-        self.username: str = username.decode("utf-8")
+        # The username is attacker input from SSH userauth and need not be
+        # valid UTF-8.
+        self.username: str = username.decode("utf-8", errors="replace")
         self.server = server
         self.channelLookup[b"session"] = sshsession.HoneyPotSSHSession
 

--- a/src/cowrie/llm/session.py
+++ b/src/cowrie/llm/session.py
@@ -36,7 +36,9 @@ class SSHSessionForCowrieUser:
         processprotocol.makeConnection(session.wrapProtocol(self.protocol))
 
     def getPty(self, terminal, windowSize, attrs):
-        self.environ["TERM"] = terminal.decode("utf-8")
+        # The terminal type is attacker input from the pty request and need
+        # not be valid UTF-8.
+        self.environ["TERM"] = terminal.decode("utf-8", errors="replace")
         self.avatar.conn.transport.events.dispatch(
             "cowrie.client.size",
             "Terminal Size: %(width)s %(height)s",

--- a/src/cowrie/llm/telnet.py
+++ b/src/cowrie/llm/telnet.py
@@ -33,7 +33,9 @@ class HoneyPotTelnetSession(TelnetBootstrapProtocol):
     def __init__(self, username, server):
         self.transportId = None
         self.windowSize = [40, 80]
-        self.username = username.decode()
+        # The username is raw attacker input from the login prompt and need
+        # not be valid UTF-8.
+        self.username = username.decode("utf-8", errors="replace")
         self.server = server
 
         self.environ = {

--- a/src/cowrie/shell/avatar.py
+++ b/src/cowrie/shell/avatar.py
@@ -28,7 +28,9 @@ class CowrieUser(avatar.ConchUser):
 
     def __init__(self, username: bytes, server: server.CowrieServer) -> None:
         avatar.ConchUser.__init__(self)
-        self.username: str = username.decode("utf-8")
+        # The username is attacker input from SSH userauth and need not be
+        # valid UTF-8.
+        self.username: str = username.decode("utf-8", errors="replace")
         self.server = server
 
         self.channelLookup[b"session"] = sshsession.HoneyPotSSHSession

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -266,7 +266,8 @@ class HoneyPotShell:
         self.cmdpending.append(command)
         self.runCommand()
         pp = self.protocol.pp
-        return pp.redirected_data.decode() if pp is not None else ""
+        # The captured output is attacker bytes and need not be valid UTF-8.
+        return pp.redirected_data.decode(errors="replace") if pp is not None else ""
 
     def _finish(self) -> None:
         """The command queue is drained: do the shell's idle action.

--- a/src/cowrie/shell/session.py
+++ b/src/cowrie/shell/session.py
@@ -89,7 +89,9 @@ class SSHSessionForCowrieUser:
         processprotocol.makeConnection(ProtocolTransport(self.protocol))
 
     def getPty(self, terminal, windowSize, attrs):
-        self.environ["TERM"] = terminal.decode("utf-8")
+        # The terminal type is attacker input from the pty request and need
+        # not be valid UTF-8.
+        self.environ["TERM"] = terminal.decode("utf-8", errors="replace")
         self.avatar.conn.transport.events.dispatch(
             "cowrie.client.size",
             "Terminal Size: %(width)s %(height)s",

--- a/src/cowrie/ssh/session.py
+++ b/src/cowrie/ssh/session.py
@@ -34,15 +34,19 @@ class HoneyPotSSHSession(session.SSHSession):
             self._log.info("Extra data in request_env: {rest!r}", rest=rest)
             return 1
 
+        # Name and value are attacker input from the env request and need
+        # not be valid UTF-8.
+        name_str = name.decode("utf-8", errors="replace")
+        value_str = value.decode("utf-8", errors="replace")
         self.conn.transport.events.dispatch(
             "cowrie.client.var",
             "request_env: %(name)s=%(value)s",
-            name=name.decode("utf-8"),
-            value=value.decode("utf-8"),
+            name=name_str,
+            value=value_str,
         )
         # FIXME: This only works for shell, not for exec command
         if self.session:
-            self.session.environ[name.decode("utf-8")] = value.decode("utf-8")
+            self.session.environ[name_str] = value_str
         return 0
 
     def request_agent(self, data: bytes) -> int:

--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -16,7 +16,6 @@ import struct
 import time
 import uuid
 import zlib
-from hashlib import md5
 from typing import Any
 
 from twisted.conch.ssh import transport
@@ -28,7 +27,7 @@ from twisted.python import failure, randbytes
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.events import EventLog, transport_events
-from cowrie.core.utils import escape_nonprintable
+from cowrie.core.utils import escape_nonprintable, hassh_client
 
 
 class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
@@ -247,20 +246,7 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             s.split(b",") for s in strings
         )
 
-        # hassh SSH client fingerprint
-        # https://github.com/salesforce/hassh
-        # backslashreplace, not escape_nonprintable: for every byte sequence
-        # that decodes as valid UTF-8 (all real clients) this is identical to a
-        # plain decode, so the hassh fingerprint is unchanged; it only avoids
-        # crashing on a malformed name-list that is not valid UTF-8.
-        ckexAlgs = ",".join(
-            [alg.decode("utf-8", "backslashreplace") for alg in kexAlgs]
-        )
-        cencCS = ",".join([alg.decode("utf-8", "backslashreplace") for alg in encCS])
-        cmacCS = ",".join([alg.decode("utf-8", "backslashreplace") for alg in macCS])
-        ccompCS = ",".join([alg.decode("utf-8", "backslashreplace") for alg in compCS])
-        hasshAlgorithms = f"{ckexAlgs};{cencCS};{cmacCS};{ccompCS}"
-        hassh = md5(hasshAlgorithms.encode("utf-8")).hexdigest()
+        hasshAlgorithms, hassh = hassh_client(kexAlgs, encCS, macCS, compCS)
 
         if self.events:
             self.events.dispatch(

--- a/src/cowrie/ssh_proxy/protocols/sftp.py
+++ b/src/cowrie/ssh_proxy/protocols/sftp.py
@@ -227,7 +227,9 @@ class SFTP(base_protocol.BaseProtocol):
                     # TODO: should use artifact functions
                     shasum = hashlib.sha256(self.theFile).hexdigest()
                     outfile = os.path.join(self.downloadPath, shasum)
-                    fname = self.command.decode().split(" ")[-1]
+                    # The command line is client bytes and need not be valid
+                    # UTF-8.
+                    fname = self.command.decode(errors="replace").split(" ")[-1]
                     duplicate = os.path.exists(outfile)
 
                     if not duplicate:

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -10,7 +10,6 @@ import struct
 import time
 import uuid
 import zlib
-from hashlib import md5
 
 from twisted.conch.ssh import transport
 from twisted.conch.ssh.common import getNS
@@ -22,7 +21,7 @@ from twisted.python import failure, randbytes
 
 from cowrie.core.config import CowrieConfig
 from cowrie.core.events import EventLog, transport_events
-from cowrie.core.utils import escape_nonprintable
+from cowrie.core.utils import escape_nonprintable, hassh_client
 from cowrie.ssh_proxy import client_transport
 from cowrie.ssh_proxy.protocols import ssh
 
@@ -317,17 +316,7 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             s.split(b",") for s in strings
         )
 
-        # hassh SSH client fingerprint
-        # https://github.com/salesforce/hassh
-        # The algorithm names are client bytes and need not be valid UTF-8.
-        ckexAlgs = ",".join(
-            [alg.decode("utf-8", "backslashreplace") for alg in kexAlgs]
-        )
-        cencCS = ",".join([alg.decode("utf-8", "backslashreplace") for alg in encCS])
-        cmacCS = ",".join([alg.decode("utf-8", "backslashreplace") for alg in macCS])
-        ccompCS = ",".join([alg.decode("utf-8", "backslashreplace") for alg in compCS])
-        hasshAlgorithms = f"{ckexAlgs};{cencCS};{cmacCS};{ccompCS}"
-        hassh = md5(hasshAlgorithms.encode("utf-8")).hexdigest()
+        hasshAlgorithms, hassh = hassh_client(kexAlgs, encCS, macCS, compCS)
 
         if self.events:
             self.events.dispatch(

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -319,10 +319,13 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
 
         # hassh SSH client fingerprint
         # https://github.com/salesforce/hassh
-        ckexAlgs = ",".join([alg.decode("utf-8") for alg in kexAlgs])
-        cencCS = ",".join([alg.decode("utf-8") for alg in encCS])
-        cmacCS = ",".join([alg.decode("utf-8") for alg in macCS])
-        ccompCS = ",".join([alg.decode("utf-8") for alg in compCS])
+        # The algorithm names are client bytes and need not be valid UTF-8.
+        ckexAlgs = ",".join(
+            [alg.decode("utf-8", "backslashreplace") for alg in kexAlgs]
+        )
+        cencCS = ",".join([alg.decode("utf-8", "backslashreplace") for alg in encCS])
+        cmacCS = ",".join([alg.decode("utf-8", "backslashreplace") for alg in macCS])
+        ccompCS = ",".join([alg.decode("utf-8", "backslashreplace") for alg in compCS])
         hasshAlgorithms = f"{ckexAlgs};{cencCS};{cmacCS};{ccompCS}"
         hassh = md5(hasshAlgorithms.encode("utf-8")).hexdigest()
 

--- a/src/cowrie/test/test_attacker_bytes.py
+++ b/src/cowrie/test/test_attacker_bytes.py
@@ -8,9 +8,12 @@
 from __future__ import annotations
 
 import os
+import shutil
+import tempfile
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from twisted.conch.ssh import filetransfer
 from twisted.conch.ssh.common import NS
 from twisted.web.http_headers import Headers
 
@@ -27,6 +30,9 @@ from cowrie.shell import avatar as shell_avatar
 from cowrie.shell import session as shell_session
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.ssh import session as ssh_session
+from cowrie.ssh_proxy import server_transport as proxy_transport
+from cowrie.ssh_proxy.protocols import base_protocol
+from cowrie.ssh_proxy.protocols import sftp as proxy_sftp
 from cowrie.test.eventcapture import capture_events
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
@@ -155,6 +161,66 @@ class HttpResponseMetadataTests(unittest.TestCase):
         (url.encode('ascii') raised UnicodeEncodeError)."""
         self.proto.lineReceived("curl http://192.168.1.1/päth\n".encode())
         self.assertTrue(self.tr.value().endswith(self.PROMPT))
+
+
+class ProxyModeTests(unittest.TestCase):
+    """In proxy mode the client's raw protocol bytes reach these handlers
+    directly; non-UTF-8 bytes in them must not crash the connection."""
+
+    def test_kexinit_non_utf8_algorithm_name(self) -> None:
+        """The hassh fingerprint decodes the client's algorithm lists; the
+        shell backend already tolerates invalid UTF-8 there."""
+        t = proxy_transport.FrontendSSHTransport.__new__(
+            proxy_transport.FrontendSSHTransport
+        )
+        capture_events(t)
+        with patch.object(
+            proxy_transport.transport.SSHServerTransport,
+            "ssh_KEXINIT",
+            lambda s, p: None,
+        ):
+            t.ssh_KEXINIT(
+                b"\x00" * 16
+                + b"".join(
+                    NS(field)
+                    for field in (
+                        b"curve25519-sha256\xff",  # kexAlgs
+                        b"ssh-rsa",  # keyAlgs
+                        b"aes128-ctr\xff",  # encCS
+                        b"aes128-ctr",  # encSC
+                        b"hmac-sha2-256\xff",  # macCS
+                        b"hmac-sha2-256",  # macSC
+                        b"none\xff",  # compCS
+                        b"none",  # compSC
+                        b"",  # langCS
+                        b"",  # langSC
+                    )
+                )
+                + b"\x00\x00\x00\x00\x00"
+            )
+
+    def test_sftp_upload_non_utf8_command(self) -> None:
+        """The sftp command line is client bytes; deriving the uploaded
+        filename from it must not raise UnicodeDecodeError."""
+        sftp = proxy_sftp.SFTP.__new__(proxy_sftp.SFTP)
+        sftp.events = None
+        sftp.downloadPath = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, sftp.downloadPath, True)
+        sftp.command = b"put /tmp/ev\xffil"
+        sftp.path = b"/tmp/ev\xffil"
+        sftp.theFile = b"uploaded-content"
+        sftp.handle = b"h"
+        # An FXP_CLOSE packet for that handle: type, request id, handle.
+        sftp.parentPacket = base_protocol.BaseProtocol()
+        sftp.parentPacket.data = (
+            bytes([filetransfer.FXP_CLOSE]) + b"\x00\x00\x00\x01" + NS(b"h")
+        )
+        sftp.parentPacket.packetSize = len(sftp.parentPacket.data)
+
+        sftp.handle_packet("[CLIENT]")
+
+        saved = os.listdir(sftp.downloadPath)
+        self.assertEqual(len(saved), 1)
 
 
 if __name__ == "__main__":

--- a/src/cowrie/test/test_attacker_bytes.py
+++ b/src/cowrie/test/test_attacker_bytes.py
@@ -12,11 +12,14 @@ import unittest
 from unittest.mock import MagicMock
 
 from twisted.conch.ssh.common import NS
+from twisted.web.http_headers import Headers
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
+from cowrie.commands.curl import Command_curl
+from cowrie.commands.wget import Command_wget
 from cowrie.llm import avatar as llm_avatar
 from cowrie.llm import session as llm_session
 from cowrie.llm import telnet as llm_telnet
@@ -95,6 +98,62 @@ class ShellPipelineTests(unittest.TestCase):
 
     def test_non_utf8_bytes_in_command_substitution(self) -> None:
         self.proto.lineReceived(b"echo $(echo -e '\\xff')\n")
+        self.assertTrue(self.tr.value().endswith(self.PROMPT))
+
+
+class HttpResponseMetadataTests(unittest.TestCase):
+    """Response metadata comes from an attacker-directed server; non-UTF-8
+    bytes in it must not crash download handling."""
+
+    PROMPT = b"root@unitTest:~# "
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def test_wget_non_utf8_content_type_and_phrase(self) -> None:
+        cmd = Command_wget.__new__(Command_wget)
+        cmd.protocol = self.proto
+        begun: list = []
+        cmd._begin_download = (  # type: ignore[method-assign]
+            lambda *args: begun.append(args) or False
+        )
+        response = MagicMock()
+        response.headers = Headers({b"content-type": [b"text\xff/html"]})
+        response.code = 200
+        response.phrase = b"O\xffK"
+        response.length = 10
+
+        cmd.success(response)
+
+        self.assertEqual(begun[0][1], "text�/html")
+        self.assertIn("O�K", begun[0][2])
+
+    def test_curl_head_non_utf8_headers(self) -> None:
+        cmd = Command_curl.__new__(Command_curl)
+        cmd.protocol = self.proto
+        writes: list[str] = []
+        cmd.write = writes.append  # type: ignore[assignment]
+        cmd.exit = lambda code=None: None  # type: ignore[method-assign]
+        cmd.head_request = True
+        response = MagicMock()
+        response.length = 0
+        response.code = 200
+        response.headers = Headers({b"X-Evil": [b"v\xffal"]})
+
+        cmd.success(response)
+
+        self.assertIn("v�al", "".join(writes))
+
+    def test_curl_non_ascii_url(self) -> None:
+        """A non-ASCII URL typed by the attacker must not crash curl
+        (url.encode('ascii') raised UnicodeEncodeError)."""
+        self.proto.lineReceived("curl http://192.168.1.1/päth\n".encode())
         self.assertTrue(self.tr.value().endswith(self.PROMPT))
 
 

--- a/src/cowrie/test/test_attacker_bytes.py
+++ b/src/cowrie/test/test_attacker_bytes.py
@@ -80,9 +80,8 @@ class SessionSetupTests(unittest.TestCase):
         self.assertEqual(sess.session.environ, {"LA�NG": "C�"})
 
 
-class ShellPipelineTests(unittest.TestCase):
-    """The attacker can produce arbitrary bytes inside the shell (echo -e
-    escapes); piping or substituting them must not crash the session."""
+class ShellSessionTestCase(unittest.TestCase):
+    """A live interactive shell session to run attacker input through."""
 
     PROMPT = b"root@unitTest:~# "
 
@@ -95,17 +94,27 @@ class ShellPipelineTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.proto.connectionLost()
 
+    def assertSessionAlive(self) -> None:
+        """The shell returned to its prompt, so the command did not raise out
+        of the session."""
+        self.assertTrue(self.tr.value().endswith(self.PROMPT))
+
+
+class ShellPipelineTests(ShellSessionTestCase):
+    """The attacker can produce arbitrary bytes inside the shell (echo -e
+    escapes); piping or substituting them must not crash the session."""
+
     def test_non_utf8_bytes_piped_to_awk(self) -> None:
         self.proto.lineReceived(b"echo -e '\\xff' | awk '{ print $0 }'\n")
-        self.assertTrue(self.tr.value().endswith(self.PROMPT))
+        self.assertSessionAlive()
 
     def test_non_utf8_bytes_piped_to_tee(self) -> None:
         self.proto.lineReceived(b"echo -e '\\xff' | tee /tmp/out\n")
-        self.assertTrue(self.tr.value().endswith(self.PROMPT))
+        self.assertSessionAlive()
 
     def test_non_utf8_bytes_in_command_substitution(self) -> None:
         self.proto.lineReceived(b"echo $(echo -e '\\xff')\n")
-        self.assertTrue(self.tr.value().endswith(self.PROMPT))
+        self.assertSessionAlive()
 
     def test_history_with_non_utf8_command(self) -> None:
         """A typed line need not be valid UTF-8; history must still list the
@@ -130,23 +139,12 @@ class ShellPipelineTests(unittest.TestCase):
         ):
             self.proto.lineReceived(b"finger\n")
 
-        self.assertTrue(self.tr.value().endswith(self.PROMPT))
+        self.assertSessionAlive()
 
 
-class HttpResponseMetadataTests(unittest.TestCase):
+class HttpResponseMetadataTests(ShellSessionTestCase):
     """Response metadata comes from an attacker-directed server; non-UTF-8
     bytes in it must not crash download handling."""
-
-    PROMPT = b"root@unitTest:~# "
-
-    def setUp(self) -> None:
-        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-        self.tr = FakeTransport("", "31337")
-        self.proto.makeConnection(self.tr)
-        self.tr.clear()
-
-    def tearDown(self) -> None:
-        self.proto.connectionLost()
 
     def test_wget_non_utf8_content_type_and_phrase(self) -> None:
         cmd = Command_wget.__new__(Command_wget)
@@ -189,7 +187,7 @@ class HttpResponseMetadataTests(unittest.TestCase):
         """A non-ASCII URL typed by the attacker must not crash curl
         (url.encode('ascii') raised UnicodeEncodeError)."""
         self.proto.lineReceived("curl http://192.168.1.1/päth\n".encode())
-        self.assertTrue(self.tr.value().endswith(self.PROMPT))
+        self.assertSessionAlive()
 
 
 class ProxyModeTests(unittest.TestCase):

--- a/src/cowrie/test/test_attacker_bytes.py
+++ b/src/cowrie/test/test_attacker_bytes.py
@@ -200,7 +200,7 @@ class ProxyModeTests(unittest.TestCase):
         t = proxy_transport.FrontendSSHTransport.__new__(
             proxy_transport.FrontendSSHTransport
         )
-        capture_events(t)
+        dispatched = capture_events(t)
         with patch.object(
             SSHServerTransport,
             "ssh_KEXINIT",
@@ -225,6 +225,13 @@ class ProxyModeTests(unittest.TestCase):
                 )
                 + b"\x00\x00\x00\x00\x00"
             )
+
+        kex = [e for e in dispatched if e["eventid"] == "cowrie.client.kex"]
+        self.assertEqual(len(kex), 1)
+        self.assertEqual(
+            kex[0]["hasshAlgorithms"],
+            "curve25519-sha256\\xff;aes128-ctr\\xff;hmac-sha2-256\\xff;none\\xff",
+        )
 
     def test_sftp_upload_non_utf8_command(self) -> None:
         """The sftp command line is client bytes; deriving the uploaded

--- a/src/cowrie/test/test_attacker_bytes.py
+++ b/src/cowrie/test/test_attacker_bytes.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 
 from twisted.conch.ssh import filetransfer
 from twisted.conch.ssh.common import NS
+from twisted.conch.ssh.transport import SSHServerTransport
 from twisted.web.http_headers import Headers
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
@@ -43,11 +44,11 @@ class SessionSetupTests(unittest.TestCase):
     right after the honeypot has accepted the login."""
 
     def test_ssh_username(self) -> None:
-        user = shell_avatar.CowrieUser(b"admin\xff", FakeServer())
+        user = shell_avatar.CowrieUser(b"admin\xff", FakeServer())  # type: ignore[arg-type]
         self.assertEqual(user.username, "admin�")
 
     def test_llm_ssh_username(self) -> None:
-        user = llm_avatar.CowrieUser(b"admin\xff", FakeServer())
+        user = llm_avatar.CowrieUser(b"admin\xff", FakeServer())  # type: ignore[arg-type]
         self.assertEqual(user.username, "admin�")
 
     def test_llm_telnet_username(self) -> None:
@@ -106,6 +107,31 @@ class ShellPipelineTests(unittest.TestCase):
         self.proto.lineReceived(b"echo $(echo -e '\\xff')\n")
         self.assertTrue(self.tr.value().endswith(self.PROMPT))
 
+    def test_history_with_non_utf8_command(self) -> None:
+        """A typed line need not be valid UTF-8; history must still list the
+        commands rather than silently producing nothing."""
+        self.proto.historyLines = [b"ls", b"cat /tmp/\xff", b"id"]
+        self.tr.clear()
+
+        self.proto.lineReceived(b"history\n")
+
+        out = self.tr.value()
+        self.assertIn(b"ls", out)
+        self.assertIn(b"id", out)
+
+    def test_finger_with_non_utf8_passwd(self) -> None:
+        """An attacker can overwrite /etc/passwd with binary content; finger
+        reads it and must not crash the session."""
+        self.proto.fs.mkfile("/etc/passwd", 0, 0, 100, 0o644)
+        with patch.object(
+            self.proto.fs,
+            "file_contents",
+            return_value=b"root:x:0:0:r\xffot:/root:/bin/sh\n",
+        ):
+            self.proto.lineReceived(b"finger\n")
+
+        self.assertTrue(self.tr.value().endswith(self.PROMPT))
+
 
 class HttpResponseMetadataTests(unittest.TestCase):
     """Response metadata comes from an attacker-directed server; non-UTF-8
@@ -126,9 +152,12 @@ class HttpResponseMetadataTests(unittest.TestCase):
         cmd = Command_wget.__new__(Command_wget)
         cmd.protocol = self.proto
         begun: list = []
-        cmd._begin_download = (  # type: ignore[method-assign]
-            lambda *args: begun.append(args) or False
-        )
+
+        def record(*args: object) -> bool:
+            begun.append(args)
+            return False
+
+        cmd._begin_download = record  # type: ignore[assignment]
         response = MagicMock()
         response.headers = Headers({b"content-type": [b"text\xff/html"]})
         response.code = 200
@@ -175,7 +204,7 @@ class ProxyModeTests(unittest.TestCase):
         )
         capture_events(t)
         with patch.object(
-            proxy_transport.transport.SSHServerTransport,
+            SSHServerTransport,
             "ssh_KEXINIT",
             lambda s, p: None,
         ):

--- a/src/cowrie/test/test_attacker_bytes.py
+++ b/src/cowrie/test/test_attacker_bytes.py
@@ -22,9 +22,11 @@ from cowrie.llm import session as llm_session
 from cowrie.llm import telnet as llm_telnet
 from cowrie.shell import avatar as shell_avatar
 from cowrie.shell import session as shell_session
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.ssh import session as ssh_session
 from cowrie.test.eventcapture import capture_events
-from cowrie.test.fake_server import FakeServer
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
 
 
 class SessionSetupTests(unittest.TestCase):
@@ -66,6 +68,34 @@ class SessionSetupTests(unittest.TestCase):
 
         self.assertEqual(rc, 0)
         self.assertEqual(sess.session.environ, {"LA�NG": "C�"})
+
+
+class ShellPipelineTests(unittest.TestCase):
+    """The attacker can produce arbitrary bytes inside the shell (echo -e
+    escapes); piping or substituting them must not crash the session."""
+
+    PROMPT = b"root@unitTest:~# "
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def test_non_utf8_bytes_piped_to_awk(self) -> None:
+        self.proto.lineReceived(b"echo -e '\\xff' | awk '{ print $0 }'\n")
+        self.assertTrue(self.tr.value().endswith(self.PROMPT))
+
+    def test_non_utf8_bytes_piped_to_tee(self) -> None:
+        self.proto.lineReceived(b"echo -e '\\xff' | tee /tmp/out\n")
+        self.assertTrue(self.tr.value().endswith(self.PROMPT))
+
+    def test_non_utf8_bytes_in_command_substitution(self) -> None:
+        self.proto.lineReceived(b"echo $(echo -e '\\xff')\n")
+        self.assertTrue(self.tr.value().endswith(self.PROMPT))
 
 
 if __name__ == "__main__":

--- a/src/cowrie/test/test_attacker_bytes.py
+++ b/src/cowrie/test/test_attacker_bytes.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Attacker-controlled bytes that are not valid UTF-8 must not crash
+# ABOUTME: session setup, the shell pipeline, or download handling.
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import MagicMock
+
+from twisted.conch.ssh.common import NS
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+from cowrie.llm import avatar as llm_avatar
+from cowrie.llm import session as llm_session
+from cowrie.llm import telnet as llm_telnet
+from cowrie.shell import avatar as shell_avatar
+from cowrie.shell import session as shell_session
+from cowrie.ssh import session as ssh_session
+from cowrie.test.eventcapture import capture_events
+from cowrie.test.fake_server import FakeServer
+
+
+class SessionSetupTests(unittest.TestCase):
+    """A non-UTF-8 username, TERM or env var must not crash session setup
+    right after the honeypot has accepted the login."""
+
+    def test_ssh_username(self) -> None:
+        user = shell_avatar.CowrieUser(b"admin\xff", FakeServer())
+        self.assertEqual(user.username, "admin�")
+
+    def test_llm_ssh_username(self) -> None:
+        user = llm_avatar.CowrieUser(b"admin\xff", FakeServer())
+        self.assertEqual(user.username, "admin�")
+
+    def test_llm_telnet_username(self) -> None:
+        session = llm_telnet.HoneyPotTelnetSession(b"admin\xff", FakeServer())
+        self.assertEqual(session.username, "admin�")
+
+    def test_term_from_pty_request(self) -> None:
+        for mod in (shell_session, llm_session):
+            with self.subTest(module=mod.__name__):
+                sess = mod.SSHSessionForCowrieUser.__new__(mod.SSHSessionForCowrieUser)
+                sess.environ = {}
+                sess.avatar = MagicMock()
+                capture_events(sess.avatar.conn.transport)
+
+                sess.getPty(b"xterm\xff", (24, 80, 0, 0), None)
+
+                self.assertEqual(sess.environ["TERM"], "xterm�")
+
+    def test_env_from_env_request(self) -> None:
+        sess = ssh_session.HoneyPotSSHSession.__new__(ssh_session.HoneyPotSSHSession)
+        sess.conn = MagicMock()
+        capture_events(sess.conn.transport)
+        sess.session = MagicMock()
+        sess.session.environ = {}
+
+        rc = sess.request_env(NS(b"LA\xffNG") + NS(b"C\xff"))
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(sess.session.environ, {"LA�NG": "C�"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A sweep for the bug class behind the telnet username crash in #40401: attacker-controlled bytes decoded as strict UTF-8, where an invalid byte sequence raises `UnicodeDecodeError` out of a live session. Five commits, grouped by subsystem, each with tests that failed beforehand.

**Session setup** (`shell/avatar.py`, `llm/avatar.py`, `llm/telnet.py`, `shell/session.py`, `llm/session.py`, `ssh/session.py`) — the SSH username, the LLM backend's telnet username, the pty request's `TERM`, and env-request name/value pairs. These crash right after the honeypot has accepted the login, i.e. exactly when the attacker is most interesting.

**Shell pipeline** (`commands/awk.py`, `commands/tee.py`, `shell/honeypot.py`) — the attacker can produce arbitrary bytes inside the shell with `echo -e '\xff'`; piping them to awk or tee, or capturing them via command substitution, crashed the session.

**Download handling** (`commands/wget.py`, `commands/curl.py`) — the content-type header, HTTP status phrase and HEAD-request header values come from a server the attacker chose. Also `curl` encoded the attacker-typed URL as ASCII, so a non-ASCII URL raised `UnicodeEncodeError` before the download started; it now matches wget's UTF-8.

**Proxy mode** (`ssh_proxy/server_transport.py`, `ssh_proxy/protocols/sftp.py`) — the hassh fingerprint decoded the client's KEXINIT algorithm lists strictly, and the sftp upload handler decoded the client's command line to derive a filename. The shell backend's transport already used `backslashreplace` for algorithm names; the proxy twin was never updated.

**finger and history** (`commands/finger.py`, `commands/base.py`) — an attacker can overwrite `/etc/passwd` with binary content, which crashed `finger`. `history` decoded typed lines strictly too, and there a broad `except` swallowed the error, so the listing silently stopped at the first non-UTF-8 command instead of showing the rest.

Deliberately left strict: operator-provided data (`shell/pwd.py`, `core/auth.py` reading `etc/passwd`/`userdb.txt` from disk) and `shell/script.py`'s binary sniffing, which catches `UnicodeDecodeError` on purpose.