### PR TITLE
fix: refuse an out-of-sequence keyboard-interactive INFO_RESPONSE

### DIFF
--- a/src/cowrie/ssh/userauth.py
+++ b/src/cowrie/ssh/userauth.py
@@ -211,7 +211,17 @@ class HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer):
             ...
             string response n
         """
-        assert self._pamDeferred is not None
+        if self._pamDeferred is None:
+            # A client can send this at any point during userauth. With no
+            # INFO_REQUEST outstanding it is either unsolicited or a repeat of
+            # a response already consumed, so refuse it the way the other
+            # sequence violations here do.
+            self.transport.sendDisconnect(  # type: ignore
+                DISCONNECT_PROTOCOL_ERROR,
+                "unexpected keyboard interactive response",
+            )
+            return
+
         d: defer.Deferred = self._pamDeferred
         self._pamDeferred = None
         resp: list

--- a/src/cowrie/test/test_ssh_userauth.py
+++ b/src/cowrie/test/test_ssh_userauth.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: An out-of-sequence keyboard-interactive INFO_RESPONSE must be
+# ABOUTME: refused with a protocol-error disconnect, not raise.
+
+from __future__ import annotations
+
+import os
+import struct
+import unittest
+from unittest.mock import MagicMock
+
+from twisted.conch.ssh.common import NS
+from twisted.conch.ssh.transport import DISCONNECT_PROTOCOL_ERROR
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+from cowrie.ssh.userauth import HoneyPotSSHUserAuthServer
+
+
+def _response_packet(*responses: bytes) -> bytes:
+    return struct.pack(">L", len(responses)) + b"".join(NS(r) for r in responses)
+
+
+class InfoResponseOutOfSequenceTests(unittest.TestCase):
+    def _server(self) -> HoneyPotSSHUserAuthServer:
+        server = HoneyPotSSHUserAuthServer()
+        # Kept as an attribute so assertions do not go through the
+        # protocol's typed transport.
+        self.transport = MagicMock()
+        server.transport = self.transport
+        # No keyboard-interactive round is in progress.
+        server._pamDeferred = None
+        return server
+
+    def test_unsolicited_response_disconnects_cleanly(self) -> None:
+        """A client can send message 61 at any time during userauth; with no
+        INFO_REQUEST outstanding this must not raise."""
+        server = self._server()
+
+        server.ssh_USERAUTH_INFO_RESPONSE(_response_packet(b"secret"))
+
+        self.transport.sendDisconnect.assert_called_once()
+        self.assertEqual(
+            self.transport.sendDisconnect.call_args[0][0], DISCONNECT_PROTOCOL_ERROR
+        )
+
+    def test_second_response_to_one_request_disconnects_cleanly(self) -> None:
+        """The deferred is cleared once consumed, so a repeat response is the
+        same out-of-sequence case."""
+        from twisted.internet import defer
+
+        server = self._server()
+        server._pamDeferred = defer.Deferred()
+        server._pamDeferred.addCallback(lambda _: None)
+
+        server.ssh_USERAUTH_INFO_RESPONSE(_response_packet(b"first"))
+        self.transport.sendDisconnect.assert_not_called()
+
+        server.ssh_USERAUTH_INFO_RESPONSE(_response_packet(b"second"))
+
+        self.transport.sendDisconnect.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #40384. This is a Cowrie bug, not a Twisted one — see below.

`ssh_USERAUTH_INFO_RESPONSE` opened with `assert self._pamDeferred is not None`. That deferred is only set while a keyboard-interactive round is in progress and is cleared as soon as a response is consumed, but a client may send `SSH_MSG_USERAUTH_INFO_RESPONSE` (message 61) at any point during userauth. An unsolicited response, or a second one after the first was consumed, therefore raised an unhandled `AssertionError` — the `try/except Exception` that guards malformed packet *content* starts below the assert, so it never applied. Under `python -O` the assert is stripped and the next line fails instead, just with a different exception.

It now sends `DISCONNECT_PROTOCOL_ERROR`, matching how `auth_keyboard_interactive` in the same class already refuses a concurrent attempt.

Worth noting: the handler is defined on the class unconditionally, while `[ssh] auth_keyboard_interactive_enabled` only controls whether keyboard-interactive is *offered* in `interfaceToMethod`. Twisted's dispatch reaches any `ssh_*` method that exists, so this was reachable in the **default** configuration where the feature is off.

### Why this is Cowrie's bug and not Twisted's

- Twisted's `SSHUserAuthServer` has no `ssh_USERAUTH_INFO_RESPONSE`, no `_pamDeferred`, and no `auth_keyboard_interactive`. Server-side keyboard-interactive/PAM support is entirely Cowrie's addition in `HoneyPotSSHUserAuthServer`; Twisted only implements INFO_RESPONSE on the *client* side, in `SSHUserAuthClient`.
- The `assert` is Cowrie's own line.
- Twisted's only involvement is dispatch: `conch/ssh/service.py`'s `packetReceived` maps message 61 to `ssh_USERAUTH_INFO_RESPONSE` and calls it when the attribute exists, otherwise logging "couldn't handle". Dispatching without tracking protocol sequence is normal and correct for a generic service base — validating sequence is the handler's job, and Cowrie's handler assumed instead of checking.

Two tests cover it: an unsolicited response, and a repeat response after one was already consumed. Both raised `AssertionError` before the change.

Thanks @vbontchev for the report.