### PR TITLE
fix: cache reversedns results instead of spent Deferreds

### DIFF
--- a/src/cowrie/output/reversedns.py
+++ b/src/cowrie/output/reversedns.py
@@ -6,7 +6,8 @@
 from __future__ import annotations
 
 import ipaddress
-from functools import lru_cache
+from collections import OrderedDict
+from typing import Any
 
 from twisted.internet import defer
 from twisted.logger import Logger
@@ -30,6 +31,8 @@ class Output(cowrie.core.output.Output):
         Start Output Plugin
         """
         self.timeout = [CowrieConfig.getint("output_reversedns", "timeout", fallback=3)]
+        self.cache_size: int = 1000
+        self._cache: OrderedDict[str, Any] = OrderedDict()
 
     def stop(self):
         """
@@ -107,10 +110,12 @@ class Output(cowrie.core.output.Output):
                 d.addCallback(processForward)
                 d.addErrback(cbError)
 
-    @lru_cache(maxsize=1000)
     def reversedns(self, addr):
         """
-        Perform a reverse DNS lookup on an IP
+        Perform a reverse DNS lookup on an IP, serving repeat lookups
+        from a bounded cache of resolved results. A Deferred is single
+        use, so the cache holds DNS answers (None for NXDOMAIN), never
+        the Deferred itself.
 
         Arguments:
             addr -- IPv4 Address
@@ -119,5 +124,31 @@ class Output(cowrie.core.output.Output):
             ptr = ipaddress.ip_address(addr).reverse_pointer
         except ValueError:
             return None
+        if addr in self._cache:
+            self._cache.move_to_end(addr)
+            return defer.succeed(self._cache[addr])
         d = client.lookupPointer(ptr, timeout=self.timeout)
+        d.addCallbacks(
+            self._cacheResult,
+            self._cacheFailure,
+            callbackArgs=(addr,),
+            errbackArgs=(addr,),
+        )
         return d
+
+    def _cacheResult(self, result, addr):
+        self._cacheStore(addr, result)
+        return result
+
+    def _cacheFailure(self, failure, addr):
+        # NXDOMAIN is a definitive answer worth caching; timeouts and
+        # SERVFAIL are transient, so the next connect retries the lookup.
+        if failure.check(error.DNSNameError):
+            self._cacheStore(addr, None)
+        return failure
+
+    def _cacheStore(self, addr, result):
+        self._cache[addr] = result
+        self._cache.move_to_end(addr)
+        while len(self._cache) > self.cache_size:
+            self._cache.popitem(last=False)

--- a/src/cowrie/test/test_reversedns.py
+++ b/src/cowrie/test/test_reversedns.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests that the reversedns output plugin caches DNS results rather
+# ABOUTME: than spent Deferreds, so repeat connects still dispatch (issue #40416).
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from twisted.internet import defer
+from twisted.names import dns, error
+
+from cowrie.core.events import EventDispatcher
+from cowrie.output.reversedns import Output
+from cowrie.test.eventcapture import CaptureSink
+
+
+def connect_event(src_ip: str) -> dict[str, str]:
+    return {
+        "eventid": "cowrie.session.connect",
+        "session": "0000000000000000",
+        "src_ip": src_ip,
+        "protocol": "ssh",
+    }
+
+
+def forward_event(dst_ip: str) -> dict[str, str]:
+    return {
+        "eventid": "cowrie.direct-tcpip.request",
+        "session": "0000000000000000",
+        "src_ip": "9.9.9.9",
+        "dst_ip": dst_ip,
+        "protocol": "ssh",
+    }
+
+
+def ptr_result(
+    name: str = "host.example.com", ttl: int = 3600
+) -> tuple[list[dns.RRHeader], list, list]:
+    payload = dns.Record_PTR(name=name, ttl=ttl)
+    header = dns.RRHeader(
+        name="4.3.2.1.in-addr.arpa", type=dns.PTR, payload=payload, ttl=ttl
+    )
+    return ([header], [], [])
+
+
+class ReverseDnsCacheTests(unittest.TestCase):
+    """The plugin must cache DNS results, not single-use Deferreds."""
+
+    def setUp(self) -> None:
+        self.output = Output()
+        sink = CaptureSink()
+        self.dispatched = sink.events
+        self.output.dispatcher = EventDispatcher(
+            [sink], logmsg=lambda *args, **kwargs: None
+        )
+        self.lookups: list[str] = []
+
+    def patch_lookup(self, response):
+        """Patch lookupPointer to record calls and return a fresh Deferred
+        built by ``response`` on each call."""
+
+        def fake_lookup(ptr, timeout=None):
+            self.lookups.append(ptr)
+            return response()
+
+        return patch("cowrie.output.reversedns.client.lookupPointer", fake_lookup)
+
+    def test_second_connect_same_ip_dispatches_again(self) -> None:
+        with self.patch_lookup(lambda: defer.succeed(ptr_result())):
+            self.output.write(connect_event("1.2.3.4"))
+            self.output.write(connect_event("1.2.3.4"))
+        self.assertEqual(len(self.lookups), 1)
+        self.assertEqual(
+            [e["eventid"] for e in self.dispatched],
+            ["cowrie.reversedns.connect", "cowrie.reversedns.connect"],
+        )
+        self.assertEqual(self.dispatched[1]["ptr"], "host.example.com")
+
+    def test_forward_after_connect_same_ip_dispatches(self) -> None:
+        with self.patch_lookup(lambda: defer.succeed(ptr_result())):
+            self.output.write(connect_event("1.2.3.4"))
+            self.output.write(forward_event("1.2.3.4"))
+        self.assertEqual(len(self.lookups), 1)
+        self.assertEqual(
+            [e["eventid"] for e in self.dispatched],
+            ["cowrie.reversedns.connect", "cowrie.reversedns.forward"],
+        )
+
+    def test_nxdomain_is_cached(self) -> None:
+        with self.patch_lookup(lambda: defer.fail(error.DNSNameError())):
+            self.output.write(connect_event("1.2.3.4"))
+            self.output.write(connect_event("1.2.3.4"))
+        self.assertEqual(len(self.lookups), 1)
+        self.assertEqual(self.dispatched, [])
+
+    def test_timeout_is_not_cached(self) -> None:
+        with self.patch_lookup(lambda: defer.fail(defer.TimeoutError())):
+            self.output.write(connect_event("1.2.3.4"))
+            self.output.write(connect_event("1.2.3.4"))
+        self.assertEqual(len(self.lookups), 2)
+
+    def test_servfail_is_not_cached(self) -> None:
+        with self.patch_lookup(lambda: defer.fail(error.DNSServerError())):
+            self.output.write(connect_event("1.2.3.4"))
+            self.output.write(connect_event("1.2.3.4"))
+        self.assertEqual(len(self.lookups), 2)
+
+    def test_invalid_ip_does_no_lookup(self) -> None:
+        with self.patch_lookup(lambda: defer.succeed(ptr_result())):
+            self.output.write(connect_event("not-an-ip"))
+        self.assertEqual(self.lookups, [])
+        self.assertEqual(self.dispatched, [])
+
+    def test_cache_is_bounded(self) -> None:
+        self.output.cache_size = 2
+        with self.patch_lookup(lambda: defer.succeed(ptr_result())):
+            self.output.write(connect_event("1.1.1.1"))
+            self.output.write(connect_event("2.2.2.2"))
+            self.output.write(connect_event("3.3.3.3"))
+            self.output.write(connect_event("1.1.1.1"))
+        self.assertEqual(len(self.lookups), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #40416.

`functools.lru_cache` on `reversedns()` cached the Twisted `Deferred`, which is a single-use callback pipeline: every repeat connect from an IP chained `processConnect` onto the already-fired Deferred, received `None`, and silently dropped the `cowrie.reversedns.connect` event — exactly the traffic the cache exists to serve. The same spent Deferred also cross-contaminated connect/forward lookups, and transient failures (timeout, SERVFAIL) were cached for the process lifetime.

This replaces the decorator with a bounded LRU dict that stores the resolved DNS answer and returns `defer.succeed()` on a hit, so every caller gets a fresh Deferred. NXDOMAIN is cached as `None` (a definitive answer, and the common case for attacker IPs); timeouts and SERVFAIL are not cached, so the next connect retries. The bound keeps the previous `maxsize=1000` property against attacker-controlled src IPs.

Adds `test_reversedns.py` covering the second-connect-from-same-IP case (which the old code fails), connect/forward cache sharing, NXDOMAIN caching, timeout/SERVFAIL non-caching, invalid IPs, and the cache bound.