### PR TITLE
fix: ignore CHANNEL_REQUEST for an unknown or closed channel

### DIFF
--- a/src/cowrie/ssh/connection.py
+++ b/src/cowrie/ssh/connection.py
@@ -27,6 +27,12 @@ class CowrieSSHConnection(connection.SSHConnection):
 
     def ssh_CHANNEL_REQUEST(self, packet):
         localChannel = struct.unpack(">L", packet[:4])[0]
+        if localChannel not in self.channels:
+            self._log.info(
+                "Ignoring CHANNEL_REQUEST for unknown channel {channel_id}",
+                channel_id=localChannel,
+            )
+            return None
         requestType, rest = common.getNS(packet[4:])
         wantReply = ord(rest[0:1])
         channel = self.channels[localChannel]

--- a/src/cowrie/test/test_ssh_connection.py
+++ b/src/cowrie/test/test_ssh_connection.py
@@ -3,12 +3,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # ABOUTME: Tests for CowrieSSHConnection channel message handling: stale EOF,
-# ABOUTME: CLOSE, and WINDOW_ADJUST for a closed channel are ignored, not a crash.
+# ABOUTME: CLOSE, WINDOW_ADJUST, and REQUEST for a closed channel are ignored.
 
 from __future__ import annotations
 
 import struct
 import unittest
+
+from twisted.conch.ssh import common
 
 from cowrie.ssh.connection import CowrieSSHConnection
 
@@ -23,6 +25,7 @@ class _StubChannel:
         self.gotEOF = False
         self.gotClose = False
         self.windowBytesAdded = 0
+        self.requests: list[tuple[bytes, bytes]] = []
 
     def eofReceived(self) -> None:
         self.gotEOF = True
@@ -32,6 +35,10 @@ class _StubChannel:
 
     def addWindowBytes(self, data: int) -> None:
         self.windowBytesAdded += data
+
+    def requestReceived(self, requestType: bytes, data: bytes) -> bool:
+        self.requests.append((requestType, data))
+        return True
 
     def logPrefix(self) -> str:
         return "stub"
@@ -72,3 +79,16 @@ class StaleChannelMessageTests(unittest.TestCase):
         self.conn.channels[0] = channel
         self.conn.ssh_CHANNEL_WINDOW_ADJUST(struct.pack(">2L", 0, 1024))
         self.assertEqual(channel.windowBytesAdded, 1024)
+
+    def test_request_for_unknown_channel_is_ignored(self) -> None:
+        # Issue #40383: a CHANNEL_REQUEST for a never-opened or already
+        # closed channel must not raise KeyError.
+        packet = struct.pack(">L", 0) + common.NS(b"env") + b"\x00"
+        self.conn.ssh_CHANNEL_REQUEST(packet)
+
+    def test_request_for_known_channel_is_delivered(self) -> None:
+        channel = _StubChannel()
+        self.conn.channels[0] = channel
+        packet = struct.pack(">L", 0) + common.NS(b"env") + b"\x00" + b"payload"
+        self.conn.ssh_CHANNEL_REQUEST(packet)
+        self.assertEqual(channel.requests, [(b"env", b"payload")])


### PR DESCRIPTION
Fixes #40383.

`ssh_CHANNEL_REQUEST()` looked up `self.channels[localChannel]` unguarded, so a `SSH_MSG_CHANNEL_REQUEST` referencing a channel that was never opened — or whose close handshake already completed — raised an unhandled `KeyError` to the reactor.

This applies the same `not in self.channels` guard already used by the sibling `CHANNEL_EOF`, `CHANNEL_CLOSE`, and `CHANNEL_WINDOW_ADJUST` handlers: log and ignore the stale message.

Adds tests to `test_ssh_connection.py` for both the unknown-channel case (raised `KeyError: 0` before this change) and normal request delivery to a known channel.