### PR TITLE
fix: reconcile event id consumers with the ids Cowrie emits

### DIFF
--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -78,12 +78,12 @@ class Command_scp(HoneyPotCommand):
 
     def lineReceived(self, line: str) -> None:
         self.protocol.events.dispatch(
-            "cowrie.session.file_download",
+            "cowrie.session.input",
             "INPUT (%(realm)s): %(input)s",
             realm="scp",
             input=line,
         )
-        self.protocol.terminal.write("\x00")
+        self.write("\x00")
 
     def drop_tmp_file(self, data: bytes, name: str) -> None:
         tmp_fname = "{}-{}-{}-scp_{}".format(

--- a/src/cowrie/core/cef.py
+++ b/src/cowrie/core/cef.py
@@ -3,21 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
-#  cowrie.client.fingerprint
-#  cowrie.client.size
-#  cowrie.client.var
-#  cowrie.client.version
-#  cowrie.command.failed
-#  cowrie.command.success
-#  cowrie.direct-tcpip.data
-#  cowrie.direct-tcpip.request
-#  cowrie.log.closed
-#  cowrie.login.failed
-#  cowrie.login.success
-#  cowrie.session.closed
-#  cowrie.session.connect
-#  cowrie.session.file_download
-#  cowrie.session.file_upload
+# ABOUTME: Formats Cowrie events as CEF (Common Event Format) strings for
+# ABOUTME: the localsyslog and textlog output plugins.
+# The event ids and their attributes are documented in docs/OUTPUT.rst.
 
 from __future__ import annotations
 

--- a/src/cowrie/core/cef.py
+++ b/src/cowrie/core/cef.py
@@ -56,10 +56,9 @@ def formatCef(logentry: dict[str, str]) -> str:
         case "cowrie.login.failed":
             cefExtensions["duser"] = logentry["username"]
             cefExtensions["outcome"] = "failed"
-        case "cowrie.file.file_download" | "cowrie.file.file_upload":
-            cefExtensions["filehash"] = logentry["filehash"]
-            cefExtensions["filePath"] = logentry["filename"]
-            cefExtensions["fsize"] = logentry["size"]
+        case "cowrie.session.file_download" | "cowrie.session.file_upload":
+            cefExtensions["filehash"] = logentry["shasum"]
+            cefExtensions["filePath"] = logentry["outfile"]
         case _:
             pass
 

--- a/src/cowrie/core/output.py
+++ b/src/cowrie/core/output.py
@@ -16,24 +16,9 @@ from cowrie.core.config import CowrieConfig
 if TYPE_CHECKING:
     from cowrie.core.events import EventDispatcher
 
-# Events:
-#  cowrie.client.fingerprint
-#  cowrie.client.size
-#  cowrie.client.var
-#  cowrie.client.version
-#  cowrie.command.input
-#  cowrie.command.failed
-#  cowrie.command.success (deprecated)
-#  cowrie.direct-tcpip.data
-#  cowrie.direct-tcpip.request
-#  cowrie.log.closed
-#  cowrie.login.failed
-#  cowrie.login.success
-#  cowrie.session.closed
-#  cowrie.session.connect
-#  cowrie.session.file_download
-#  cowrie.session.file_upload
-
+# ABOUTME: Base class for output plugins: config wiring, sensor naming, and
+# ABOUTME: the write()/dispatch() contract every plugin implements.
+# The event ids and their attributes are documented in docs/OUTPUT.rst.
 
 # The time is available in two formats in each event, as key 'time'
 # in epoch format and in key 'timestamp' as a ISO compliant string

--- a/src/cowrie/output/slack.py
+++ b/src/cowrie/output/slack.py
@@ -88,10 +88,6 @@ class Output(cowrie.core.output.Output):
 
         # Dictionary of event handlers
         event_handlers = {
-            "cowrie.client.connect": lambda: (
-                f":large_green_circle: *CONNECT* :large_green_circle: New {event.get('protocol', '').upper()} "
-                + f"connection `{event.get('src_ip', 'unknown')}`, port: `{event.get('src_port', 'unknown')}`"
-            ),
             "cowrie.session.connect": lambda: (
                 f":large_green_circle: *CONNECT* :large_green_circle: New {event.get('protocol', '').upper()} "
                 + f"connection `{event.get('src_ip', 'unknown')}`, port: `{event.get('src_port', 'unknown')}`"
@@ -137,11 +133,8 @@ class Output(cowrie.core.output.Output):
                 f"*CMD* : :arrow_right_hook: *Failed* `{event.get('input', 'unknown')}` > "
                 + f"`{event.get('message', 'unknown')}`"
             ),
-            "cowrie.session.file_download_failed": lambda: (
+            "cowrie.session.file_download.failed": lambda: (
                 f"*FILE* : :x: *Download Failed* `{event.get('message', 'unknown')}`"
-            ),
-            "cowrie.session.file_upload_failed": lambda: (
-                f"*FILE* : :x: *Upload Failed* `{event.get('message', 'unknown')}`"
             ),
         }
 
@@ -188,11 +181,10 @@ class Output(cowrie.core.output.Output):
         # Check for verbose events to skip in case of not verbose mode
         verbose_events = (
             "cowrie.client.kex",
-            "cowrie.client.connect",
             "cowrie.client.size",
             "cowrie.client.var",
             "cowrie.log.closed",
-            "cowrie.log.opened",
+            "cowrie.log.open",
             "cowrie.session.params",
         )
         eventid = event.get("eventid", "")

--- a/src/cowrie/test/test_cef.py
+++ b/src/cowrie/test/test_cef.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for the CEF formatter used by the localsyslog and textlog
+# ABOUTME: output plugins; file events must carry their hash and path.
+
+from __future__ import annotations
+
+import unittest
+
+from cowrie.core.cef import formatCef
+
+
+def _entry(**extra: str) -> dict[str, str]:
+    entry = {
+        "sensor": "testsensor",
+        "message": "a message",
+        "src_ip": "1.2.3.4",
+    }
+    entry.update(extra)
+    return entry
+
+
+class CefFormatTests(unittest.TestCase):
+    def test_session_connect(self) -> None:
+        cef = formatCef(
+            _entry(
+                eventid="cowrie.session.connect",
+                src_port="55555",
+                dst_ip="10.0.0.1",
+                dst_port="2222",
+            )
+        )
+        self.assertIn("spt=55555", cef)
+        self.assertIn("dpt=2222", cef)
+        self.assertIn("dst=10.0.0.1", cef)
+
+    def test_file_download_carries_hash_and_path(self) -> None:
+        cef = formatCef(
+            _entry(
+                eventid="cowrie.session.file_download",
+                url="http://example.invalid/payload",
+                outfile="var/lib/cowrie/downloads/abc123",
+                shasum="abc123",
+            )
+        )
+        self.assertIn("filehash=abc123", cef)
+        self.assertIn("filePath=var/lib/cowrie/downloads/abc123", cef)
+
+    def test_file_upload_carries_hash_and_path(self) -> None:
+        cef = formatCef(
+            _entry(
+                eventid="cowrie.session.file_upload",
+                filename="payload.bin",
+                outfile="var/lib/cowrie/downloads/def456",
+                shasum="def456",
+            )
+        )
+        self.assertIn("filehash=def456", cef)
+        self.assertIn("filePath=var/lib/cowrie/downloads/def456", cef)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_command_input_events.py
+++ b/src/cowrie/test/test_command_input_events.py
@@ -136,6 +136,17 @@ class CommandInputEventTests(unittest.TestCase):
         cmd = self.make_command(Command_grep, "grep", "stdin")
         self.assert_direct_input_event(cmd, "cowrie.command.input", "grep")
 
+    def test_scp_input_event(self) -> None:
+        from cowrie.commands.scp import Command_scp
+
+        cmd = self.make_command(Command_scp, "scp", "-t", "/tmp")
+        self.assert_direct_input_event(cmd, "cowrie.session.input", "scp")
+        # The stdin line is input, not a captured file transfer.
+        self.assertNotIn(
+            "cowrie.session.file_download",
+            [e["eventid"] for e in self.tr.dispatchedEvents],
+        )
+
     def test_tail_input_event(self) -> None:
         self.assert_input_event(b"tail", "cowrie.command.input", "tail")
 

--- a/src/cowrie/test/test_output_slack.py
+++ b/src/cowrie/test/test_output_slack.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: The slack output plugin must react to the event ids Cowrie really
+# ABOUTME: emits: dotted file_download.failed and cowrie.log.open.
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from typing import Any
+from unittest.mock import Mock, patch
+
+try:
+    import slack  # noqa: F401
+except ImportError:
+    # The slack sdk is an optional dependency; stub it so the plugin imports.
+    _slack = types.ModuleType("slack")
+    _slack.WebClient = Mock  # type: ignore[attr-defined]
+    sys.modules["slack"] = _slack
+
+from cowrie.output import slack as slack_output
+
+
+def _make(simplified: bool = True, verbose: bool = True) -> Any:
+    """Construct the plugin without running its config-reading start()."""
+    with patch.object(slack_output.Output, "start", lambda self: None):
+        out = slack_output.Output()
+    out.slack_channel = "#honeypot"
+    out.slack_token = "token"
+    out.simplified = simplified
+    out.show_timestamp = False
+    out.verbose = verbose
+    return out
+
+
+def _post(out: Any, event: dict[str, Any]) -> list[str]:
+    """Run one event through write() and return the texts posted to Slack."""
+    client = Mock()
+    with patch.object(slack_output, "WebClient", return_value=client):
+        out.write(event)
+    return [c.kwargs["text"] for c in client.chat_postMessage.call_args_list]
+
+
+class SlackEventIdTests(unittest.TestCase):
+    def test_download_failed_uses_dotted_eventid(self) -> None:
+        texts = _post(
+            _make(),
+            {
+                "eventid": "cowrie.session.file_download.failed",
+                "session": "abc123",
+                "src_ip": "1.2.3.4",
+                "url": "http://example.invalid/payload",
+                "message": "Attempt to download file(s) failed",
+                "system": "cowrie.ssh",
+            },
+        )
+        self.assertEqual(len(texts), 1)
+        self.assertIn("Download Failed", texts[0])
+
+    def test_log_open_suppressed_when_not_verbose(self) -> None:
+        texts = _post(
+            _make(verbose=False),
+            {
+                "eventid": "cowrie.log.open",
+                "session": "abc123",
+                "src_ip": "1.2.3.4",
+                "ttylog": "var/lib/cowrie/tty/abc",
+                "message": "Opening TTY Log",
+                "system": "cowrie.ssh",
+            },
+        )
+        self.assertEqual(texts, [])
+
+    def test_session_connect_posts(self) -> None:
+        texts = _post(
+            _make(),
+            {
+                "eventid": "cowrie.session.connect",
+                "session": "abc123",
+                "src_ip": "1.2.3.4",
+                "src_port": 55555,
+                "protocol": "ssh",
+                "message": "New connection",
+                "system": "cowrie.ssh",
+            },
+        )
+        self.assertEqual(len(texts), 1)
+        self.assertIn("CONNECT", texts[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
An audit of every dispatched event id (done while completing docs/OUTPUT.rst in #40418) found consumers keyed on ids that are never emitted, and one emitter using the wrong id. Each fix is TDD'd with a regression test.

- **slack**: the simplified formatter handled `cowrie.session.file_download_failed` (underscore) while the emitted id is `cowrie.session.file_download.failed` (dot), so download failures rendered as the generic fallback; non-verbose mode suppressed `cowrie.log.opened`, which does not exist, letting every `cowrie.log.open` event through. Handlers for `cowrie.client.connect` and `cowrie.session.file_upload_failed` are removed — neither id is emitted anywhere, and `cowrie.session.connect` already covers connections.
- **scp**: `Command_scp.lineReceived` dispatched attacker stdin under `cowrie.session.file_download` with the INPUT format string, polluting the download stream; it now uses `cowrie.session.input` like the other stdin-consuming commands. It also wrote its SCP ACK byte as `str` to the terminal (which requires bytes), raising TypeError on interactive lines.
- **CEF**: the file branch matched `cowrie.file.file_download`/`file_upload` — ids nothing emits — and read `filehash`/`filename`/`size` keys the real events don't carry. It now matches `cowrie.session.file_download`/`file_upload` and maps `shasum`/`outfile`.
- The stale 15-entry event id inventories in `core/output.py` and `core/cef.py` now point at the documented schema instead of duplicating it.

Not changed (design questions, flagging for discussion): `cowrie.command.success` is marked deprecated but still emitted by busybox/passwd/php; interactive-stdin lines are split inconsistently between `cowrie.command.input` and `cowrie.session.input` depending on the command.

Full suite passes (943 tests), ruff and mypy clean on the changed files.