### PR TITLE
fix: name temp backing files with a prefix and uuid

### DIFF
--- a/src/cowrie/commands/gcc.py
+++ b/src/cowrie/commands/gcc.py
@@ -6,15 +6,12 @@
 from __future__ import annotations
 
 import getopt
-import os
 import random
-import re
-import time
 from typing import TYPE_CHECKING
 
 from twisted.internet import reactor
 
-from cowrie.core.config import CowrieConfig
+from cowrie.core.artifact import temp_download_path
 from cowrie.shell.command import HoneyPotCommand
 
 if TYPE_CHECKING:
@@ -190,15 +187,7 @@ gcc version {version} (Debian {version}-5)"""
     def generate_file(self, outfile: str) -> None:
         data = b""
         # TODO: make sure it is written to temp file, not downloads
-        tmp_fname = "{}_{}_{}_{}".format(
-            time.strftime("%Y%m%d%H%M%S"),
-            self.protocol.getProtoTransport().transportId,
-            self.protocol.terminal.transport.session.id,
-            re.sub("[^A-Za-z0-9]", "_", outfile),
-        )
-        safeoutfile = os.path.join(
-            CowrieConfig.get("honeypot", "download_path", fallback="."), tmp_fname
-        )
+        safeoutfile = temp_download_path("gcc")
 
         # Data contains random garbage from an actual file, so when
         # catting the file, you'll see some 'real' compiled data

--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -9,8 +9,8 @@ import hashlib
 import os
 import posixpath
 import re
-import time
 
+from cowrie.core.artifact import temp_download_path
 from cowrie.core.config import CowrieConfig
 from cowrie.shell import fs
 from cowrie.shell.command import HoneyPotCommand
@@ -85,21 +85,14 @@ class Command_scp(HoneyPotCommand):
         )
         self.protocol.terminal.write("\x00")
 
-    def drop_tmp_file(self, data: bytes, name: str) -> None:
-        tmp_fname = "{}-{}-{}-scp_{}".format(
-            time.strftime("%Y%m%d-%H%M%S"),
-            self.protocol.getProtoTransport().transportId,
-            self.protocol.terminal.transport.session.id,
-            re.sub("[^A-Za-z0-9]", "_", name),
-        )
-
-        self.safeoutfile = os.path.join(self.download_path, tmp_fname)
+    def drop_tmp_file(self, data: bytes) -> None:
+        self.safeoutfile = temp_download_path("scp")
 
         with open(self.safeoutfile, "wb+") as f:
             f.write(data)
 
     def save_file(self, data: bytes, fname: str) -> None:
-        self.drop_tmp_file(data, fname)
+        self.drop_tmp_file(data)
 
         if os.path.exists(self.safeoutfile):
             shasum = hashlib.sha256(data).hexdigest()

--- a/src/cowrie/core/artifact.py
+++ b/src/cowrie/core/artifact.py
@@ -27,12 +27,23 @@ from __future__ import annotations
 import hashlib
 import os
 import tempfile
+import uuid
 from typing import TYPE_CHECKING, Any
 
 from cowrie.core.config import CowrieConfig
 
 if TYPE_CHECKING:
     from types import TracebackType
+
+
+def temp_download_path(prefix: str) -> str:
+    """A unique download-dir path for a temp file that is renamed to its
+    sha256 or serves as honeyfs realfile backing once written. The name
+    carries no session or attacker-controlled text, only the prefix."""
+    return os.path.join(
+        CowrieConfig.get("honeypot", "download_path", fallback="."),
+        f"{prefix}_{uuid.uuid4().hex}",
+    )
 
 
 class Artifact:

--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -16,6 +16,7 @@ from twisted.logger import Logger
 from twisted.python.compat import iterbytes
 
 from cowrie.core import ttylog
+from cowrie.core.artifact import temp_download_path
 from cowrie.core.config import CowrieConfig
 from cowrie.shell import protocol
 
@@ -83,7 +84,7 @@ class LoggingServerProtocol(insults.ServerProtocol):
             self.ttylogOpen = True
             self.ttylogSize = 0
 
-        self.stdinlogFile = f"{self.downloadPath}/{time.strftime('%Y%m%d-%H%M%S')}-{transportId}-{channelId}-stdin.log"
+        self.stdinlogFile = temp_download_path("stdin")
 
         if self.type == "e":
             self.stdinlogOpen = True

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -12,7 +12,6 @@ import errno
 import hashlib
 import os
 import posixpath
-import re
 import stat
 import sys
 import time
@@ -21,6 +20,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 
 from twisted.logger import Logger
 
+from cowrie.core.artifact import temp_download_path
 from cowrie.core.config import CowrieConfig
 from cowrie.core.resources import read_data_bytes
 from cowrie.shell import honeyfs
@@ -481,11 +481,7 @@ class HoneyPotFilesystem:
         if openFlags & os.O_WRONLY == os.O_WRONLY or openFlags & os.O_RDWR == os.O_RDWR:
             # strip executable bit
             hostmode: int = mode & ~(111)
-            hostfile: str = "{}/{}_sftp_{}".format(
-                CowrieConfig.get("honeypot", "download_path"),
-                time.strftime("%Y%m%d-%H%M%S"),
-                re.sub("[^A-Za-z0-9]", "_", filename),
-            )
+            hostfile: str = temp_download_path("sftp")
             self.mkfile(filename, 0, 0, 0, stat.S_IFREG | mode)
             fd = os.open(hostfile, openFlags, hostmode)
             self.update_realfile(self.getfile(filename), hostfile)

--- a/src/cowrie/shell/pipe.py
+++ b/src/cowrie/shell/pipe.py
@@ -7,14 +7,12 @@
 
 from __future__ import annotations
 
-import os
-import re
 import stat
-import time
 from typing import TYPE_CHECKING, Any
 
 from twisted.logger import Logger
 
+from cowrie.core.artifact import temp_download_path
 from cowrie.core.config import CowrieConfig
 from cowrie.shell import fs
 
@@ -221,15 +219,10 @@ class PipeProtocol:
 
     def _create_redirect_target(self, outfile: str) -> str | None:
         """Create a new backing file for a redirected output target."""
-        tmp_fname = "{}-{}-{}-redir_{}".format(
-            time.strftime("%Y%m%d-%H%M%S"),
-            self.protocol.getProtoTransport().transportId,
-            self.protocol.terminal.transport.session.id,
-            re.sub("[^A-Za-z0-9]", "_", outfile),
-        )
-        safeoutfile = os.path.join(
-            CowrieConfig.get("honeypot", "download_path"), tmp_fname
-        )
+        # The backing file is renamed to its sha256 once the session ends
+        # and session attribution travels with the event, so the name only
+        # needs to be unique (#40351).
+        safeoutfile = temp_download_path("redir")
         perm = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
         try:
             self.protocol.fs.mkfile(

--- a/src/cowrie/test/test_scp_exec.py
+++ b/src/cowrie/test/test_scp_exec.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 from twisted.internet.protocol import connectionDone
 
@@ -22,6 +23,8 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 _DOWNLOAD_DIR = tempfile.mkdtemp(prefix="cowrie_scp_exec_")
+# Temp backing files land wherever config points when they are created.
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = _DOWNLOAD_DIR
 
 # Class-level download paths are read from config at import time, so another
 # test module importing these classes first can pin them elsewhere. Force them
@@ -214,13 +217,14 @@ class ScpExecHardeningTests(unittest.TestCase):
     def test_unwritable_download_path_does_not_crash(self) -> None:
         """A real filesystem error while saving the upload (download_path
         missing) must be handled, not raise OSError out of the EOF handler."""
-        orig = scp.Command_scp.download_path
-        scp.Command_scp.download_path = os.path.join(_DOWNLOAD_DIR, "missing", "dir")
-        self.addCleanup(setattr, scp.Command_scp, "download_path", orig)
+        missing = os.path.join(_DOWNLOAD_DIR, "missing", "dir")
 
         framed = b"C0644 1 f\n" + b"x\x00"
 
-        saved, events = run_exec_scp_push(framed)
+        with mock.patch.object(
+            scp, "temp_download_path", lambda prefix: os.path.join(missing, prefix)
+        ):
+            saved, events = run_exec_scp_push(framed)
 
         self.assertEqual(saved, [])
         self.assertNotIn(

--- a/src/cowrie/test/test_temp_file_naming.py
+++ b/src/cowrie/test/test_temp_file_naming.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests that shell temp backing files (redirects, gcc, scp) are named
+# ABOUTME: prefix + uuid, independent of transport chains and attacker input.
+
+from __future__ import annotations
+
+import os
+import unittest
+from types import SimpleNamespace
+
+from cowrie.commands.gcc import Command_gcc
+from cowrie.commands.scp import Command_scp
+from cowrie.core.artifact import temp_download_path
+from cowrie.shell import fs
+from cowrie.shell.pipe import PipeProtocol
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class _StubFilesystem:
+    """Accepts the honeyfs calls the temp-file writers make."""
+
+    def __init__(self) -> None:
+        self.realfiles: list[str] = []
+
+    def resolve_path(self, path: str, cwd: str) -> str:
+        return path
+
+    def mkfile(self, path: str, uid: int, gid: int, size: int, mode: int) -> bool:
+        return True
+
+    def getfile(self, path: str) -> list:
+        return []
+
+    def update_realfile(self, f: list, realfile: str) -> None:
+        self.realfiles.append(realfile)
+
+
+class TempFileNamingTests(unittest.TestCase):
+    """Temp backing files are named <prefix>_<uuid4 hex>: unique, free of
+    attacker-controlled text, and independent of any transport chain
+    (issue #40351)."""
+
+    def setUp(self) -> None:
+        self.safeoutfiles: list[str] = []
+
+    def tearDown(self) -> None:
+        for safeoutfile in self.safeoutfiles:
+            if os.path.exists(safeoutfile):
+                os.unlink(safeoutfile)
+
+    def assertPrefixUuidName(self, safeoutfile: str, prefix: str) -> None:
+        self.safeoutfiles.append(safeoutfile)
+        self.assertRegex(os.path.basename(safeoutfile), rf"^{prefix}_[0-9a-f]{{32}}$")
+        self.assertTrue(os.path.exists(safeoutfile))
+
+    def _redirect_target(self) -> str:
+        protocol = SimpleNamespace(
+            user=SimpleNamespace(uid=0, gid=0),
+            fs=_StubFilesystem(),
+        )
+        pipe = PipeProtocol(
+            protocol, cmd=None, cmdargs=[], input_data=None, next_command=None
+        )
+        safeoutfile = pipe._create_redirect_target("out.txt")
+        assert safeoutfile is not None
+        return safeoutfile
+
+    def test_redirect_target(self) -> None:
+        self.assertPrefixUuidName(self._redirect_target(), "redir")
+
+    def test_redirect_targets_are_unique(self) -> None:
+        first = self._redirect_target()
+        second = self._redirect_target()
+        self.assertNotEqual(first, second)
+        self.assertPrefixUuidName(first, "redir")
+        self.assertPrefixUuidName(second, "redir")
+
+    def test_gcc_output_file(self) -> None:
+        cmd = Command_gcc.__new__(Command_gcc)
+        cmd.fs = _StubFilesystem()
+        cmd.protocol = SimpleNamespace(
+            cwd="/root",
+            user=SimpleNamespace(uid=0, gid=0),
+            commands={},
+        )
+        cmd.generate_file("a.out")
+        self.assertEqual(len(cmd.fs.realfiles), 1)
+        self.assertPrefixUuidName(cmd.fs.realfiles[0], "gcc")
+
+    def test_scp_dropped_file(self) -> None:
+        cmd = Command_scp.__new__(Command_scp)
+        cmd.download_path = "/tmp"
+        cmd.drop_tmp_file(b"contents")
+        self.assertPrefixUuidName(cmd.safeoutfile, "scp")
+        with open(cmd.safeoutfile, "rb") as f:
+            self.assertEqual(f.read(), b"contents")
+
+    def test_helper_builds_download_dir_paths(self) -> None:
+        path = temp_download_path("stdin")
+        self.assertEqual(os.path.dirname(path), "/tmp")
+        self.assertRegex(os.path.basename(path), r"^stdin_[0-9a-f]{32}$")
+        self.assertNotEqual(path, temp_download_path("stdin"))
+
+    def test_sftp_upload_backing_file(self) -> None:
+        honeyfs = fs.HoneyPotFilesystem("arch", "/root")
+        fd = honeyfs.open("/root/upload.bin", os.O_WRONLY | os.O_CREAT, 33188)
+        assert fd is not None
+        try:
+            self.assertPrefixUuidName(honeyfs.tempfiles[fd], "sftp")
+        finally:
+            os.close(fd)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #40351.

Cowrie's temp backing files were named from timestamps, `getProtoTransport().transportId`, and `terminal.transport.session.id` — attributes only the SSH and interactive-Telnet transport chains provide (the pipe.py copy is what #40351 flagged) — plus a sanitized copy of the attacker-chosen filename.

None of that carries any load. The names only need to be unique: redirect/scp/sftp/stdin files are renamed to their sha256 in `download_path` when consumed, gcc's file is an anonymous realfile backing, and session attribution travels with the dispatched event. curl/wget/tftp/ftpget already worked this way via `Artifact`'s `NamedTemporaryFile`.

All five hand-rolled sites now use a shared `temp_download_path(prefix)` helper next to `Artifact`, producing `<prefix>_<uuid4 hex>`:

- `redir_` — shell output redirection (`pipe.py`, the #40351 site)
- `gcc_` — fake compiler output (`commands/gcc.py`)
- `scp_` — scp uploads (`commands/scp.py`)
- `sftp_` — SFTP uploads (`shell/fs.py open()`)
- `stdin_` — piped-stdin capture (`insults/insults.py`)

This also drops attacker-controlled text from local filenames and removes the same-second collisions the timestamp scheme allowed. Ttylog names are untouched — those are permanent forensic logs, not temp files; proxy-mode SFTP already writes directly to the sha256 path.

`test_temp_file_naming.py` covers the helper and the pipe/gcc/scp/sftp writers (format, uniqueness, no transport chain needed — the pipe.py case raised `AttributeError` with a bare protocol before this change). `test_scp_exec.py`'s unwritable-download-path test now injects the failure through the helper, since the instance attribute it used to patch no longer feeds the temp path.