### PR TITLE
fix: tftp IPv6 crash, missing rate limiter, unenforced size limit, and resolution TOCTOU (#40394)

### DIFF
--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -16,6 +16,7 @@ from twisted.logger import Logger
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
 from cowrie.core.network import (
+    DownloadLimitExceeded,
     communication_allowed,
     is_valid_port,
     outbound_bind_address,
@@ -96,11 +97,20 @@ class TFTPClient(DatagramProtocol):
 
     _log = Logger()
 
-    def __init__(self, host: str, port: int, filename: str, artifact: Artifact):
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        filename: str,
+        artifact: Artifact,
+        limit_size: int = 0,
+    ):
         self.host = host
         self.port = port
         self.filename = filename
         self.artifact = artifact
+        # Bytes after which to abort the transfer; 0 means unlimited.
+        self.limit_size = limit_size
         self.deferred: defer.Deferred[None] = defer.Deferred()
         self.current_block = 0
         self.last_packet = b""
@@ -187,6 +197,26 @@ class TFTPClient(DatagramProtocol):
 
         # Check if this is the expected block
         if block_num == self.current_block + 1:
+            # An attacker chooses the file, so the server can stream without
+            # end. Stop once the configured limit is exceeded rather than
+            # writing an unbounded artifact to disk.
+            if (
+                self.limit_size > 0
+                and self.bytes_received + len(data) > self.limit_size
+            ):
+                self._log.info(
+                    "TFTP: transfer exceeded download limit of {limit} bytes, aborting",
+                    limit=self.limit_size,
+                )
+                if self.timeout_call is not None and self.timeout_call.active():
+                    self.timeout_call.cancel()
+                self.deferred.errback(
+                    DownloadLimitExceeded(
+                        f"Transfer exceeded download limit of {self.limit_size} bytes"
+                    )
+                )
+                return
+
             self.current_block = block_num
             self.bytes_received += len(data)
 
@@ -361,7 +391,11 @@ class Command_tftp(HoneyPotCommand):
         # Create TFTP client. host_ip is the numeric address resolved in
         # start(); the UDP transport requires it (a hostname would be rejected).
         self.tftp_client = TFTPClient(
-            self.host_ip, self.port, self.file_to_get, self.artifactFile
+            self.host_ip,
+            self.port,
+            self.file_to_get,
+            self.artifactFile,
+            limit_size=self.limit_size,
         )
 
         # Listen on a random UDP port, bound to the configured outbound source

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -15,7 +15,11 @@ from twisted.logger import Logger
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
-from cowrie.core.network import communication_allowed, outbound_bind_address
+from cowrie.core.network import (
+    communication_allowed,
+    is_valid_port,
+    outbound_bind_address,
+)
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.customparser import CustomParser, ExitException, OptionNotFound
 
@@ -50,6 +54,38 @@ MODE_NETASCII = b"netascii"
 TFTP_BLOCK_SIZE = 512
 TFTP_TIMEOUT = 5  # seconds
 TFTP_MAX_RETRIES = 3
+
+
+def parse_host_port(target: str, default_port: int) -> tuple[str, int] | None:
+    """Split a tftp target into (host, port).
+
+    Accepts host, host:port, bare IPv6 (two or more colons), [IPv6], and
+    [IPv6]:port. Returns None when the host is empty or the port invalid.
+    """
+    host = target
+    port_str: str | None = None
+
+    if target.startswith("["):
+        bracket_end = target.find("]")
+        if bracket_end == -1:
+            return None
+        host = target[1:bracket_end]
+        rest = target[bracket_end + 1 :]
+        if rest:
+            if not rest.startswith(":"):
+                return None
+            port_str = rest[1:]
+    elif target.count(":") == 1:
+        host, port_str = target.split(":")
+    # Two or more colons without brackets: a bare IPv6 address, no port.
+
+    if not host:
+        return None
+    if port_str is None:
+        return (host, default_port)
+    if not is_valid_port(port_str):
+        return None
+    return (host, int(port_str))
 
 
 class TFTPClient(DatagramProtocol):
@@ -272,11 +308,13 @@ class Command_tftp(HoneyPotCommand):
             self.exit(1)
             return
 
-        # Parse port from hostname if provided
-        if self.hostname.find(":") != -1:
-            host, port_str = self.hostname.split(":")
-            self.hostname = host
-            self.port = int(port_str)
+        # Parse port from the target, handling IPv6 literals
+        parsed = parse_host_port(self.hostname, self.port)
+        if parsed is None:
+            self.write(f"tftp: bad port spec '{self.hostname}'\n")
+            self.exit(1)
+            return
+        self.hostname, self.port = parsed
 
         # Check if communication is allowed
         allowed = yield communication_allowed(self.hostname)

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -21,6 +21,7 @@ from cowrie.core.network import (
     is_valid_port,
     outbound_bind_address,
 )
+from cowrie.core.rate_limiter import RateLimiter
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.customparser import CustomParser, ExitException, OptionNotFound
 
@@ -29,6 +30,15 @@ if TYPE_CHECKING:
     from twisted.python.failure import Failure
 
 commands = {}
+
+# Bound how many outbound TFTP transfers per destination a session can trigger,
+# so the honeypot cannot be used to flood a victim host.
+tftp_rate_limiter = RateLimiter(
+    enabled=CowrieConfig.getboolean("shell", "tftp_rate_limit_enabled", fallback=True),
+    max_requests=CowrieConfig.getint("shell", "tftp_rate_limit_requests", fallback=5),
+    window_seconds=CowrieConfig.getint("shell", "tftp_rate_limit_window", fallback=60),
+    max_keys=CowrieConfig.getint("shell", "tftp_rate_limit_max_hosts", fallback=1000),
+)
 
 # TFTP Opcodes (RFC 1350)
 OPCODE_RRQ = 1  # Read request
@@ -345,6 +355,16 @@ class Command_tftp(HoneyPotCommand):
             self.exit(1)
             return
         self.hostname, self.port = parsed
+
+        # Check rate limit before any outbound traffic
+        if not tftp_rate_limiter.check(self.hostname):
+            self._log.info(
+                "tftp: rate limit exceeded for host: {host}. Simulating transfer timeout",
+                host=self.hostname,
+            )
+            self.write("tftp: Transfer timed out\n")
+            self.exit(1)
+            return
 
         # Check if communication is allowed
         allowed = yield communication_allowed(self.hostname)

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -18,6 +18,7 @@ from cowrie.core.config import CowrieConfig
 from cowrie.core.network import (
     DownloadLimitExceeded,
     communication_allowed,
+    is_ip_address,
     is_valid_port,
     outbound_bind_address,
 )
@@ -366,20 +367,34 @@ class Command_tftp(HoneyPotCommand):
             self.exit(1)
             return
 
-        # Check if communication is allowed
-        allowed = yield communication_allowed(self.hostname)
-        if not allowed:
-            self.exit(1)
-            return
-
-        # Resolve the hostname to a numeric IP before any UDP I/O: Twisted's UDP
+        # Resolve the target to a numeric IP before any UDP I/O: Twisted's UDP
         # transport rejects hostnames and raises InvalidAddressError. Done before
         # the artifact is created so a resolution failure leaves nothing behind.
-        try:
-            self.host_ip = yield reactor.resolve(self.hostname)
-        except Exception:
-            self._log.info("TFTP: could not resolve host {host}", host=self.hostname)
-            self.write(f"tftp: {self.hostname}: Name or service not known\n")
+        # A target that is already numeric (including an IPv6 literal, which the
+        # IPv4-only default resolver cannot look up) is used as given.
+        if is_ip_address(self.hostname) is not None:
+            self.host_ip = self.hostname
+        else:
+            try:
+                self.host_ip = yield reactor.resolve(self.hostname)
+            except Exception:
+                self._log.info(
+                    "TFTP: could not resolve host {host}", host=self.hostname
+                )
+                self.write(f"tftp: {self.hostname}: Name or service not known\n")
+                self.exit(1)
+                return
+
+        # Validate the address that will actually be contacted. Resolving the
+        # hostname a second time here would let a DNS answer that changes
+        # between lookups (rebinding) point the transfer at a private or
+        # metadata address after a public one passed the check.
+        allowed = yield communication_allowed(self.host_ip)
+        if not allowed:
+            self._log.info(
+                "TFTP: attempt to access blocked network address {ip}",
+                ip=self.host_ip,
+            )
             self.exit(1)
             return
 

--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -594,8 +594,8 @@ operating_system = GNU/Linux
 # SSH Version as printed by "ssh -V" in shell emulation
 ssh_version = OpenSSH_7.9p1, OpenSSL 1.1.1a  20 Nov 2018
 
-# Rate limiting for outbound connections made by the wget, curl, nc and
-# ftpget commands. Limits the number of connections per unique host within a
+# Rate limiting for outbound connections made by the wget, curl, nc, ftpget
+# and tftp commands. Limits the number of connections per unique host within a
 # time window.
 # *_rate_limit_enabled: enable/disable the rate limiter (default: true)
 # *_rate_limit_requests: max connections per host per window (default: 5)
@@ -617,6 +617,10 @@ ssh_version = OpenSSH_7.9p1, OpenSSL 1.1.1a  20 Nov 2018
 #ftpget_rate_limit_requests = 5
 #ftpget_rate_limit_window = 60
 #ftpget_rate_limit_max_hosts = 1000
+#tftp_rate_limit_enabled = true
+#tftp_rate_limit_requests = 5
+#tftp_rate_limit_window = 60
+#tftp_rate_limit_max_hosts = 1000
 
 # Maximum number of files one scp upload session will save. Every uploaded
 # file costs a real temp-file write, a sha256 hash and a rename on the host

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -8,6 +8,7 @@ import os
 import struct
 import tempfile
 import unittest
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import patch
 
@@ -446,7 +447,9 @@ class TFTPHostPortParseTests(unittest.TestCase):
         self.assertEqual(self.parse("host.example.com"), ("host.example.com", 69))
 
     def test_host_with_port(self) -> None:
-        self.assertEqual(self.parse("host.example.com:1069"), ("host.example.com", 1069))
+        self.assertEqual(
+            self.parse("host.example.com:1069"), ("host.example.com", 1069)
+        )
 
     def test_ipv4_with_port(self) -> None:
         self.assertEqual(self.parse("192.0.2.1:1069"), ("192.0.2.1", 1069))
@@ -510,6 +513,103 @@ class TFTPTargetHandlingTests(unittest.TestCase):
         output = self.tr.value()
         self.assertIn(b"bad port", output)
         self.assertIn(PROMPT, output)
+
+
+class TFTPResolutionPinningTests(unittest.TestCase):
+    """The address validated must be the address contacted.
+
+    The command used to validate one resolution of the target and then resolve
+    it again independently for the UDP transport, so a DNS answer that changed
+    between the two lookups let a private address through (issue #40394).
+    """
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+        capture_events(self.proto)
+        tftp_rate_limiter.reset()
+        self.addCleanup(tftp_rate_limiter.reset)
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def _reactor_resolving_to(self, address: str) -> Any:
+        """The tftp module's reactor, with resolution pinned to one answer."""
+        return SimpleNamespace(
+            resolve=lambda _host: defer.succeed(address),
+            listenUDP=reactor.listenUDP,
+            callLater=reactor.callLater,
+        )
+
+    def test_validates_the_address_it_will_contact(self) -> None:
+        validated: list[str] = []
+
+        def fake_allowed(address: str) -> defer.Deferred[bool]:
+            validated.append(address)
+            return defer.succeed(False)  # stop before any transfer
+
+        with (
+            patch.object(
+                tftp_module, "reactor", self._reactor_resolving_to("192.0.2.7")
+            ),
+            patch.object(tftp_module, "communication_allowed", fake_allowed),
+        ):
+            self.proto.lineReceived(b"tftp -c get /tmp/pin.txt host.example.com\n")
+
+        self.assertEqual(
+            validated,
+            ["192.0.2.7"],
+            "the resolved address must be what gets validated, not the hostname",
+        )
+
+    def test_address_resolving_to_private_is_refused(self) -> None:
+        # The rebinding case: the hostname would pass validation, but it
+        # resolves to loopback. The transfer must never start.
+        started: list[bool] = []
+
+        def fake_download(_self: Any) -> defer.Deferred[None]:
+            started.append(True)
+            return defer.succeed(None)
+
+        def only_blocks_the_private_ip(address: str) -> defer.Deferred[bool]:
+            """Stands in for a DNS answer that differs between lookups: the
+            hostname validates, the address it resolves to does not."""
+            return defer.succeed(address != "127.0.0.1")
+
+        with (
+            patch.object(
+                tftp_module, "reactor", self._reactor_resolving_to("127.0.0.1")
+            ),
+            patch.object(
+                tftp_module, "communication_allowed", only_blocks_the_private_ip
+            ),
+            patch.object(
+                tftp_module.Command_tftp, "tftp_download_async", fake_download
+            ),
+        ):
+            self.proto.lineReceived(b"tftp -c get /tmp/pin.txt rebind.example.com\n")
+
+        self.assertEqual(started, [], "contacted an address that resolves to loopback")
+
+    def test_public_address_still_downloads(self) -> None:
+        started: list[bool] = []
+
+        def fake_download(_self: Any) -> defer.Deferred[None]:
+            started.append(True)
+            return defer.succeed(None)
+
+        # 8.8.8.8 is globally routable, so the real blocklist permits it.
+        with (
+            patch.object(tftp_module, "reactor", self._reactor_resolving_to("8.8.8.8")),
+            patch.object(
+                tftp_module.Command_tftp, "tftp_download_async", fake_download
+            ),
+        ):
+            self.proto.lineReceived(b"tftp -c get /tmp/pin.txt host.example.com\n")
+
+        self.assertEqual(started, [True])
 
 
 class TFTPRateLimitTests(unittest.TestCase):

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -9,12 +9,14 @@ import struct
 import tempfile
 import unittest
 from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import patch
 
 from twisted.internet import defer
 from twisted.internet import reactor as _reactor
 from twisted.internet.protocol import DatagramProtocol
 from twisted.python.failure import Failure
 
+from cowrie.commands import tftp as tftp_module
 from cowrie.commands.tftp import (
     OPCODE_ACK,
     OPCODE_DATA,
@@ -22,9 +24,11 @@ from cowrie.commands.tftp import (
     OPCODE_RRQ,
     TFTP_BLOCK_SIZE,
     Command_tftp,
+    tftp_rate_limiter,
 )
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
+from cowrie.core.rate_limiter import RateLimiter
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.eventcapture import capture_events
 from cowrie.test.fake_server import FakeAvatar, FakeServer
@@ -111,6 +115,8 @@ class ShellTftpCommandTests(unittest.TestCase):
         self.proto.makeConnection(self.tr)
         self.tr.clear()
         capture_events(self.proto)
+        # The limiter is a module-level singleton; keep tests isolated.
+        tftp_rate_limiter.reset()
 
     def tearDown(self) -> None:
         self.proto.connectionLost()
@@ -189,6 +195,8 @@ class ShellTftpAsyncTests(unittest.TestCase):
 
     def setUp(self) -> None:
         self.tr.clear()
+        # The limiter is a module-level singleton; keep tests isolated.
+        tftp_rate_limiter.reset()
 
     def test_successful_download(self) -> defer.Deferred[None]:
         """Test successful TFTP download"""
@@ -480,6 +488,8 @@ class TFTPTargetHandlingTests(unittest.TestCase):
         self.proto.makeConnection(self.tr)
         self.tr.clear()
         capture_events(self.proto)
+        # The limiter is a module-level singleton; keep tests isolated.
+        tftp_rate_limiter.reset()
 
     def tearDown(self) -> None:
         self.proto.connectionLost()
@@ -500,6 +510,46 @@ class TFTPTargetHandlingTests(unittest.TestCase):
         output = self.tr.value()
         self.assertIn(b"bad port", output)
         self.assertIn(PROMPT, output)
+
+
+class TFTPRateLimitTests(unittest.TestCase):
+    """tftp must bound how many outbound transfers a session can trigger,
+    the way wget, curl and ftpget do (issue #40394)."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+        capture_events(self.proto)
+        tftp_rate_limiter.reset()
+        self.addCleanup(tftp_rate_limiter.reset)
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def test_transfers_over_limit_are_refused(self) -> None:
+        limiter = RateLimiter(max_requests=2, window_seconds=60)
+        with patch.object(tftp_module, "tftp_rate_limiter", limiter):
+            # 192.0.2.0/24 is TEST-NET-1: globally routable per the blocklist,
+            # so the limiter is what stops the third attempt, and no packet
+            # reaches a real host.
+            for _ in range(3):
+                self.proto.lineReceived(b"tftp -c get /tmp/rl.txt 192.0.2.1\n")
+
+        self.assertEqual(limiter.check("192.0.2.1"), False)
+        self.assertIn(b"timed out", self.tr.value())
+
+    def test_limit_is_per_host(self) -> None:
+        limiter = RateLimiter(max_requests=1, window_seconds=60)
+        with patch.object(tftp_module, "tftp_rate_limiter", limiter):
+            self.proto.lineReceived(b"tftp -c get /tmp/rl1.txt 192.0.2.1\n")
+            self.proto.lineReceived(b"tftp -c get /tmp/rl2.txt 192.0.2.2\n")
+
+        # Each host consumed its own single allowance.
+        self.assertFalse(limiter.check("192.0.2.1"))
+        self.assertFalse(limiter.check("192.0.2.2"))
+        self.assertNotIn(b"timed out", self.tr.value())
 
 
 class TFTPDownloadLimitTests(unittest.TestCase):

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 import struct
 import tempfile
+import time
 import unittest
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
@@ -38,7 +39,6 @@ from cowrie.test.fake_transport import FakeTransport
 if TYPE_CHECKING:
     from twisted.internet.address import IPv4Address
     from twisted.internet.interfaces import (
-        IListeningPort,
         IReactorTime,
         IReactorUDP,
     )
@@ -54,6 +54,23 @@ os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "
+
+
+def pump(predicate: Any, timeout: float = 5.0) -> bool:
+    """Run the reactor until ``predicate()`` is true, or ``timeout`` elapses.
+
+    These tests do real UDP I/O, so they need the reactor to turn. The suite
+    runs under plain unittest (see CLAUDE.md), which ignores a returned
+    Deferred: a test that schedules its assertions with callLater and returns
+    a Deferred never runs them at all. Driving the reactor here keeps the
+    assertions in the test body where they execute.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        _reactor.iterate(0.01)
+    return bool(predicate())
 
 
 class MockTFTPServer(DatagramProtocol):
@@ -131,172 +148,173 @@ class ShellTftpCommandTests(unittest.TestCase):
             + PROMPT,
         )
 
-    def test_tftp_insufficient_args(self) -> defer.Deferred[None]:
+    def test_tftp_insufficient_args(self) -> None:
         """Test tftp with only hostname shows usage"""
-        d: defer.Deferred[None] = defer.Deferred()
+        self.proto.lineReceived(b"tftp hostname.com\n")
+        pump(lambda: b"usage: tftp" in self.tr.value())
+        self.assertIn(b"usage: tftp", self.tr.value())
 
-        def do_test():
-            self.proto.lineReceived(b"tftp hostname.com\n")
-
-            def check():
-                output = self.tr.value()
-                self.assertIn(b"usage: tftp", output)
-                d.callback(None)
-
-            reactor.callLater(0.1, check)
-
-        reactor.callLater(0, do_test)
-        return d
-
-    def test_tftp_invalid_directory(self) -> defer.Deferred[None]:
+    def test_tftp_invalid_directory(self) -> None:
         """Test tftp with invalid local directory"""
-        d: defer.Deferred[None] = defer.Deferred()
-
-        def do_test():
-            self.proto.lineReceived(b"tftp -c get /nonexistent/file.txt host.com\n")
-
-            def check():
-                output = self.tr.value()
-                self.assertIn(b"No such file or directory", output)
-                d.callback(None)
-
-            reactor.callLater(0.1, check)
-
-        reactor.callLater(0, do_test)
-        return d
+        with patch.object(
+            tftp_module, "communication_allowed", lambda _address: defer.succeed(True)
+        ):
+            self.proto.lineReceived(b"tftp -c get /nonexistent/file.txt 8.8.8.8\n")
+            pump(lambda: b"No such file or directory" in self.tr.value())
+        self.assertIn(b"No such file or directory", self.tr.value())
 
 
 class ShellTftpAsyncTests(unittest.TestCase):
-    """Async tests for TFTP with mock server"""
+    """Async tests for TFTP with mock server.
 
-    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
-    tr = FakeTransport("", "31337")
-    tftp_port: int
-    tftp_server: IListeningPort | None = None
+    The mock server listens on loopback, which the outbound blocklist refuses,
+    so these tests permit loopback for the duration. Without that the command
+    exits at the address check and every assertion below passes without a
+    single byte being transferred.
+    """
+
     test_content = b"Test file from TFTP server\n"
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.proto.makeConnection(cls.tr)
-        capture_events(cls.proto)
-
-        # Setup mock TFTP server
-        server_protocol = MockTFTPServer(cls.test_content)
-        server = reactor.listenUDP(
-            0, server_protocol, interface="127.0.0.1", maxPacketSize=8192
-        )
-        cls.tftp_server = server
-        cls.tftp_port = cast("IPv4Address", server.getHost()).port
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        cls.proto.connectionLost()
-        if cls.tftp_server:
-            cls.tftp_server.stopListening()
-
     def setUp(self) -> None:
+        # Per-test protocol and server: these tests turn the reactor, so a
+        # shared protocol would let one test's in-flight transfer land in
+        # another test's output and events.
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
         self.tr.clear()
+        self.events = capture_events(self.proto)
+
+        self.tftp_port = self.serve(self.test_content)
+
         # The limiter is a module-level singleton; keep tests isolated.
         tftp_rate_limiter.reset()
+        allow_loopback = patch.object(
+            tftp_module, "communication_allowed", lambda _address: defer.succeed(True)
+        )
+        allow_loopback.start()
+        self.addCleanup(allow_loopback.stop)
 
-    def test_successful_download(self) -> defer.Deferred[None]:
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def serve(self, content: bytes) -> int:
+        """Start a mock TFTP server on loopback and return its port."""
+        server = reactor.listenUDP(
+            0, MockTFTPServer(content), interface="127.0.0.1", maxPacketSize=8192
+        )
+        self.addCleanup(server.stopListening)
+        return cast("IPv4Address", server.getHost()).port
+
+    def downloaded(self) -> list[dict[str, Any]]:
+        return [
+            e for e in self.events if e["eventid"] == "cowrie.session.file_download"
+        ]
+
+    def failed(self) -> list[dict[str, Any]]:
+        return [
+            e
+            for e in self.events
+            if e["eventid"] == "cowrie.session.file_download.failed"
+        ]
+
+    def test_successful_download(self) -> None:
         """Test successful TFTP download"""
         cmd = f"tftp -c get /tmp/tftp_test.txt 127.0.0.1:{self.tftp_port}\n"
         self.proto.lineReceived(cmd.encode())
 
-        d: defer.Deferred[None] = defer.Deferred()
+        self.assertTrue(
+            pump(lambda: self.downloaded()), "no file_download event dispatched"
+        )
+        output = self.tr.value()
+        self.assertIn(PROMPT, output)
+        self.assertNotIn(b"tftp: TFTP Error", output)
+        # The file really arrived, with the content the server served.
+        with open(self.downloaded()[0]["outfile"], "rb") as f:
+            self.assertEqual(f.read(), self.test_content)
 
-        def check():
-            output = self.tr.value()
-            # Should complete and show prompt
-            self.assertIn(PROMPT, output)
-            # Should not show error
-            self.assertNotIn(b"tftp: TFTP Error", output)
-            d.callback(None)
-
-        reactor.callLater(1.0, check)
-        return d
-
-    def test_download_with_r_flag(self) -> defer.Deferred[None]:
+    def test_download_with_r_flag(self) -> None:
         """Test TFTP download with -r flag"""
         cmd = f"tftp -r /tmp/tftp_test2.txt -g 127.0.0.1:{self.tftp_port}\n"
         self.proto.lineReceived(cmd.encode())
 
-        d: defer.Deferred[None] = defer.Deferred()
+        self.assertTrue(
+            pump(lambda: self.downloaded()), "no file_download event dispatched"
+        )
+        self.assertNotIn(b"tftp: TFTP Error", self.tr.value())
 
-        def check():
-            output = self.tr.value()
-            self.assertIn(PROMPT, output)
-            self.assertNotIn(b"tftp: TFTP Error", output)
-            d.callback(None)
+    def test_unreachable_host_reports_timeout(self) -> None:
+        """An unreachable target fails the transfer instead of hanging."""
+        # Shorten the retransmission schedule so the failure lands promptly.
+        with (
+            patch.object(tftp_module, "TFTP_TIMEOUT", 0.05),
+            patch.object(tftp_module, "TFTP_MAX_RETRIES", 2),
+        ):
+            # 192.0.2.1 is TEST-NET-1: routers drop it, nothing answers.
+            self.proto.lineReceived(b"tftp -c get /tmp/test.txt 192.0.2.1\n")
+            self.assertTrue(
+                pump(lambda: self.failed()), "unreachable transfer never failed"
+            )
 
-        reactor.callLater(1.0, check)
-        return d
+        self.assertIn("timed out", self.failed()[0]["error"].lower())
+        self.assertEqual(self.downloaded(), [])
+        self.assertIn(PROMPT, self.tr.value())
 
-    def test_connection_refused(self) -> defer.Deferred[None]:
-        """Test TFTP with unreachable host"""
-        # Use non-routable IP
-        cmd = b"tftp -c get /tmp/test.txt 192.0.2.1\n"
-        self.proto.lineReceived(cmd)
+    def test_non_blocking_behavior(self) -> None:
+        """A transfer must not wedge the reactor or the shell.
 
-        d: defer.Deferred[None] = defer.Deferred()
+        The download runs on the reactor rather than blocking it, so other
+        scheduled work still fires while it is in flight, and input queued
+        behind the command runs once it finishes.
+        """
+        ticked: list[bool] = []
+        reactor.callLater(0, lambda: ticked.append(True))
 
-        def check():
-            output = self.tr.value()
-            # Should show error or timeout
-            self.assertIn(PROMPT, output)
-            d.callback(None)
-
-        # Give it time to timeout
-        reactor.callLater(6.0, check)
-        return d
-
-    def test_non_blocking_behavior(self) -> defer.Deferred[None]:
-        """Test that TFTP download doesn't block the reactor"""
-        # Start TFTP download
         cmd = f"tftp -c get /tmp/nonblock.txt 127.0.0.1:{self.tftp_port}\n"
         self.proto.lineReceived(cmd.encode())
-
-        # Immediately try another command
+        # Queued behind the running command.
         self.proto.lineReceived(b"echo test\n")
 
-        d: defer.Deferred[None] = defer.Deferred()
-
-        def check():
-            output = self.tr.value()
-            # Should see echo output, proving shell wasn't blocked
-            self.assertIn(b"test", output)
-            d.callback(None)
-
-        reactor.callLater(1.0, check)
-        return d
-
-    def test_large_file_download(self) -> defer.Deferred[None]:
-        """Test TFTP download of file larger than one block"""
-        # Create a larger test file (2 blocks)
-        large_content = b"X" * (TFTP_BLOCK_SIZE * 2 + 100)
-
-        # Create new server with large content
-        server_protocol = MockTFTPServer(large_content)
-        large_server = reactor.listenUDP(
-            0, server_protocol, interface="127.0.0.1", maxPacketSize=8192
+        self.assertTrue(pump(lambda: self.downloaded()), "transfer never completed")
+        self.assertEqual(ticked, [True], "reactor did not run during the transfer")
+        self.assertTrue(
+            pump(lambda: b"test" in self.tr.value()),
+            "queued command never ran after the transfer",
         )
-        large_port = cast("IPv4Address", large_server.getHost()).port
+
+    def test_large_file_download(self) -> None:
+        """Test TFTP download of file larger than one block"""
+        # Two full blocks plus a short final one
+        large_content = b"X" * (TFTP_BLOCK_SIZE * 2 + 100)
+        large_port = self.serve(large_content)
 
         cmd = f"tftp -c get /tmp/large.txt 127.0.0.1:{large_port}\n"
         self.proto.lineReceived(cmd.encode())
 
-        d: defer.Deferred[None] = defer.Deferred()
+        self.assertTrue(
+            pump(lambda: self.downloaded()), "no file_download event dispatched"
+        )
+        self.assertNotIn(b"tftp: TFTP Error", self.tr.value())
+        # All three blocks were reassembled, not just the first.
+        with open(self.downloaded()[0]["outfile"], "rb") as f:
+            self.assertEqual(f.read(), large_content)
 
-        def check():
-            output = self.tr.value()
-            self.assertIn(PROMPT, output)
-            self.assertNotIn(b"tftp: TFTP Error", output)
-            large_server.stopListening()
-            d.callback(None)
+    def test_download_over_limit_is_refused(self) -> None:
+        """A transfer past download_limit_size must abort, end to end."""
+        limited_port = self.serve(b"Y" * (TFTP_BLOCK_SIZE * 3))
 
-        reactor.callLater(1.5, check)
-        return d
+        orig_limit = Command_tftp.limit_size
+        Command_tftp.limit_size = TFTP_BLOCK_SIZE  # one block
+        self.addCleanup(setattr, Command_tftp, "limit_size", orig_limit)
+
+        cmd = f"tftp -c get /tmp/limited.txt 127.0.0.1:{limited_port}\n"
+        self.proto.lineReceived(cmd.encode())
+
+        self.assertTrue(
+            pump(lambda: self.failed()), "transfer over the limit was not refused"
+        )
+        self.assertIn("limit", self.failed()[0]["error"].lower())
+        self.assertEqual(self.downloaded(), [])
 
 
 class TFTPArtifactCloseTests(unittest.TestCase):

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -502,6 +502,119 @@ class TFTPTargetHandlingTests(unittest.TestCase):
         self.assertIn(PROMPT, output)
 
 
+class TFTPDownloadLimitTests(unittest.TestCase):
+    """download_limit_size must actually stop a transfer.
+
+    The limit was declared on the command but never reached the client that
+    receives the data, so transfers were unbounded in practice (issue #40394).
+    """
+
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.mkdtemp()
+        self._orig_artifact_dir = Artifact.artifactDir
+        Artifact.artifactDir = self.tmpdir
+        self._artifacts: list[Artifact] = []
+
+    def tearDown(self) -> None:
+        # Close artifacts while artifactDir still points at the scratch dir,
+        # so close() renames into it rather than the configured download path.
+        for artifact in self._artifacts:
+            artifact.close()
+        Artifact.artifactDir = self._orig_artifact_dir
+        for name in os.listdir(self.tmpdir):
+            os.remove(os.path.join(self.tmpdir, name))
+        os.rmdir(self.tmpdir)
+
+    def _client(self, limit_size: int) -> Any:
+        from cowrie.commands.tftp import TFTPClient
+
+        artifact = Artifact("tftp-limit")
+        self._artifacts.append(artifact)
+        client = TFTPClient("127.0.0.1", 69, "f", artifact, limit_size=limit_size)
+        # A real transport is only needed for ACKs; record writes instead.
+        client.transport = cast("Any", _FakeUDPTransport())
+        return client
+
+    def _data_packet(self, block: int, payload: bytes) -> bytes:
+        return struct.pack("!HH", OPCODE_DATA, block) + payload
+
+    def test_transfer_over_limit_fails(self) -> None:
+        client = self._client(limit_size=600)
+        results: list[Any] = []
+        client.deferred.addBoth(results.append)
+
+        # Two full blocks: 1024 bytes received against a 600-byte limit.
+        client.datagramReceived(
+            self._data_packet(1, b"A" * TFTP_BLOCK_SIZE), ("127.0.0.1", 69)
+        )
+        client.datagramReceived(
+            self._data_packet(2, b"B" * TFTP_BLOCK_SIZE), ("127.0.0.1", 69)
+        )
+
+        self.assertEqual(len(results), 1, "transfer over the limit did not stop")
+        self.assertIsInstance(results[0], Failure)
+        self.assertIn("limit", results[0].getErrorMessage().lower())
+
+    def test_transfer_under_limit_completes(self) -> None:
+        client = self._client(limit_size=10000)
+        results: list[Any] = []
+        client.deferred.addBoth(results.append)
+
+        # A short final block completes the transfer.
+        client.datagramReceived(self._data_packet(1, b"A" * 10), ("127.0.0.1", 69))
+
+        self.assertEqual(results, [None])
+
+    def test_zero_limit_means_unlimited(self) -> None:
+        client = self._client(limit_size=0)
+        results: list[Any] = []
+        client.deferred.addBoth(results.append)
+
+        client.datagramReceived(
+            self._data_packet(1, b"A" * TFTP_BLOCK_SIZE), ("127.0.0.1", 69)
+        )
+        # Still running: no result yet, and the block was kept.
+        self.assertEqual(results, [])
+        self.assertEqual(client.bytes_received, TFTP_BLOCK_SIZE)
+        if client.timeout_call and client.timeout_call.active():
+            client.timeout_call.cancel()
+
+    def test_command_threads_limit_to_client(self) -> None:
+        # The command must hand its configured limit to the client, otherwise
+        # the enforcement above never runs in production.
+        cmd = Command_tftp.__new__(Command_tftp)
+        cmd.hostname = "127.0.0.1"
+        cmd.host_ip = "127.0.0.1"
+        cmd.port = 69
+        cmd.file_to_get = "test.sh"
+        cmd.limit_size = 1234
+        cmd.artifactFile = Artifact("tftp-download")
+
+        d = cmd.tftp_download_async()
+        client = cmd.tftp_client
+        try:
+            assert client is not None
+            self.assertEqual(client.limit_size, 1234)
+        finally:
+            if client and client.timeout_call and client.timeout_call.active():
+                client.timeout_call.cancel()
+            if cmd.udp_port:
+                cmd.udp_port.stopListening()
+            d.addErrback(lambda _f: None)
+            d.cancel()
+            cmd.artifactFile.close()
+
+
+class _FakeUDPTransport:
+    """Records datagrams instead of sending them."""
+
+    def __init__(self) -> None:
+        self.written: list[tuple[bytes, Any]] = []
+
+    def write(self, data: bytes, addr: Any = None) -> None:
+        self.written.append((data, addr))
+
+
 class TFTPProtocolTests(unittest.TestCase):
     """Tests for TFTP protocol implementation"""
 

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -425,6 +425,83 @@ class TFTPHostnameResolutionTests(unittest.TestCase):
         self.assertEqual(self._bound_host(cmd), "0.0.0.0")
 
 
+class TFTPHostPortParseTests(unittest.TestCase):
+    """The target argument accepts host, host:port, bare IPv6, and
+    [IPv6]:port forms; any IPv6 literal used to crash the two-way split."""
+
+    def parse(self, target: str) -> tuple[str, int] | None:
+        from cowrie.commands.tftp import parse_host_port
+
+        return parse_host_port(target, 69)
+
+    def test_plain_host(self) -> None:
+        self.assertEqual(self.parse("host.example.com"), ("host.example.com", 69))
+
+    def test_host_with_port(self) -> None:
+        self.assertEqual(self.parse("host.example.com:1069"), ("host.example.com", 1069))
+
+    def test_ipv4_with_port(self) -> None:
+        self.assertEqual(self.parse("192.0.2.1:1069"), ("192.0.2.1", 1069))
+
+    def test_bare_ipv6_loopback(self) -> None:
+        self.assertEqual(self.parse("::1"), ("::1", 69))
+
+    def test_bare_ipv6(self) -> None:
+        self.assertEqual(self.parse("2001:db8::1"), ("2001:db8::1", 69))
+
+    def test_bracketed_ipv6_with_port(self) -> None:
+        self.assertEqual(self.parse("[2001:db8::1]:1069"), ("2001:db8::1", 1069))
+
+    def test_bracketed_ipv6_without_port(self) -> None:
+        self.assertEqual(self.parse("[2001:db8::1]"), ("2001:db8::1", 69))
+
+    def test_non_numeric_port_rejected(self) -> None:
+        self.assertIsNone(self.parse("host.example.com:abc"))
+
+    def test_out_of_range_port_rejected(self) -> None:
+        self.assertIsNone(self.parse("host.example.com:99999"))
+
+    def test_zero_port_rejected(self) -> None:
+        self.assertIsNone(self.parse("host.example.com:0"))
+
+    def test_bracketed_bad_port_rejected(self) -> None:
+        self.assertIsNone(self.parse("[2001:db8::1]:abc"))
+
+    def test_empty_host_rejected(self) -> None:
+        self.assertIsNone(self.parse(":69"))
+
+
+class TFTPTargetHandlingTests(unittest.TestCase):
+    """Shell-level target handling: IPv6 must not crash the command."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+        capture_events(self.proto)
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def test_ipv6_target_does_not_crash(self) -> None:
+        # ::1 is an IP literal: no DNS is involved, the blocklist check runs
+        # synchronously, and the command must come back to a prompt instead of
+        # dying in host:port parsing with ValueError.
+        self.proto.lineReceived(b"tftp -c get /tmp/tftp_v6.txt ::1\n")
+        self.assertIn(PROMPT, self.tr.value())
+
+    def test_bracketed_ipv6_target_does_not_crash(self) -> None:
+        self.proto.lineReceived(b"tftp -c get /tmp/tftp_v6.txt [::1]:1069\n")
+        self.assertIn(PROMPT, self.tr.value())
+
+    def test_invalid_port_reports_error(self) -> None:
+        self.proto.lineReceived(b"tftp -c get /tmp/tftp_bad.txt host.example.com:abc\n")
+        output = self.tr.value()
+        self.assertIn(b"bad port", output)
+        self.assertIn(PROMPT, output)
+
+
 class TFTPProtocolTests(unittest.TestCase):
     """Tests for TFTP protocol implementation"""
 


### PR DESCRIPTION
Fixes all four issues in #40394, one commit each, each with a regression test written first.

### 1. Crash on any IPv6 target
Port parsing did a two-way `split(":")`, so any IPv6 literal — even `::1` — raised `ValueError: too many values to unpack` before any I/O. A non-numeric or out-of-range port raised from `int()` too. `parse_host_port()` now handles host, `host:port`, bare IPv6, `[IPv6]`, and `[IPv6]:port`, validates the port range with the existing `is_valid_port()`, and the command reports a bad port spec instead of crashing.

### 2. No rate limiter
Added a `tftp_rate_limit_*`-configured `RateLimiter`, checked before any outbound traffic, matching wget/curl/nc/ftpget. New keys documented in `cowrie.cfg.dist`.

### 3. download_limit_size never enforced
The limit was declared on the command but never reached `TFTPClient`, and `handleDATA()` never checked it. It is now threaded through and the transfer aborts with `DownloadLimitExceeded` once the next block would exceed the limit — the same exception wget and curl use.

### 4. DNS-rebinding TOCTOU
The command validated one resolution and then resolved the same name again for the UDP transport. It now resolves once, validates *that* address, and hands the same pinned address to the transport. A target that is already numeric skips resolution entirely, which also lets IPv6 literals past the IPv4-only default resolver.

### Also: the tftp transfer tests were not running
While adding end-to-end coverage for the size limit I found the existing async tftp tests scheduled their assertions with `callLater` and returned a Deferred. The suite runs under plain `unittest`, which ignores a returned Deferred, so **those assertions never executed** — I confirmed by making one assert `99999` and watching it pass. They were also pointed at loopback, which `communication_allowed()` refuses, so no transfer had ever occurred in any of them.

The last commit drives the reactor from the test body instead, permits loopback for the duration, and asserts on dispatched events and stored file content. Mutation-checked: disabling the limit enforcement now fails two tests. Note the same pattern still affects 9 tests in `test_ftpget.py` and `test_telnet_new_environ.py` — worth a follow-up.

Full suite passes (961 tests), ruff and mypy clean.