### PR TITLE
fix: create missing tty log directory in ttylog_open()

### DIFF
--- a/src/cowrie/core/ttylog.py
+++ b/src/cowrie/core/ttylog.py
@@ -11,6 +11,7 @@ Should be compatible with user mode linux
 from __future__ import annotations
 
 import hashlib
+import os
 import struct
 
 OP_OPEN, OP_CLOSE, OP_WRITE, OP_EXEC = 1, 2, 3, 4
@@ -25,6 +26,9 @@ def ttylog_open(logfile: str, stamp: float) -> None:
     @param logfile: logfile name
     @param stamp: timestamp
     """
+    directory = os.path.dirname(logfile)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
     with open(logfile, "ab") as f:
         sec, usec = int(stamp), int(1000000 * (stamp - int(stamp)))
         f.write(struct.pack(TTYSTRUCT, OP_OPEN, 0, 0, 0, sec, usec))

--- a/src/cowrie/test/test_ttylog.py
+++ b/src/cowrie/test/test_ttylog.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Asserts the tty log writer creates its log file even when the
+# ABOUTME: configured tty log directory was removed after startup.
+
+from __future__ import annotations
+
+import os
+import struct
+import tempfile
+import unittest
+
+from cowrie.core import ttylog
+
+
+class TtylogOpenTests(unittest.TestCase):
+    def test_open_creates_missing_directory(self) -> None:
+        """ttylog_open() recreates a tty log directory removed after startup."""
+        base = tempfile.mkdtemp(prefix="cowrie_ttylog_")
+        logfile = os.path.join(base, "tty", "20260728", "abcdef")
+
+        ttylog.ttylog_open(logfile, 1234.5)
+
+        self.assertTrue(os.path.exists(logfile))
+        with open(logfile, "rb") as f:
+            op = struct.unpack(
+                ttylog.TTYSTRUCT, f.read(struct.calcsize(ttylog.TTYSTRUCT))
+            )[0]
+        self.assertEqual(op, ttylog.OP_OPEN)


### PR DESCRIPTION
Closes #40381

`ttylog_open()` opened the tty log file directly and assumed its parent directory still existed, so if `var/lib/cowrie/tty/` is removed after startup (log rotation, a remounted container volume, tmpwatch) the next session died with an unhandled `FileNotFoundError` and its tty log was never written. It now creates the parent directory with `os.makedirs(exist_ok=True)` first.

New `src/cowrie/test/test_ttylog.py` fails with that exact `FileNotFoundError` without the fix and passes with it.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
