### PR TITLE
fix: nc no longer blocks the reactor with stdlib sockets

### DIFF
--- a/src/cowrie/commands/nc.py
+++ b/src/cowrie/commands/nc.py
@@ -8,14 +8,25 @@ from __future__ import annotations
 import getopt
 import socket
 import struct
+from typing import TYPE_CHECKING
 
+from twisted.internet import error, reactor
 from twisted.internet.defer import inlineCallbacks
+from twisted.internet.protocol import ClientFactory, Protocol, connectionDone
 from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
-from cowrie.core.network import communication_allowed, is_valid_port
+from cowrie.core.network import (
+    is_valid_port,
+    outbound_bind_address,
+    resolve_allowed,
+)
 from cowrie.core.rate_limiter import RateLimiter
 from cowrie.shell.command import HoneyPotCommand
+
+if TYPE_CHECKING:
+    from twisted.internet.interfaces import IAddress, IConnector, ITransport
+    from twisted.python import failure
 
 long = int
 
@@ -61,6 +72,39 @@ def addressInNetwork(ip: int, net: int) -> int:
     return ip & net == net
 
 
+class NcClientProtocol(Protocol):
+    """
+    The outbound TCP connection of an nc session. It runs on the reactor's
+    asynchronous event loop, so a slow, silent, or malicious remote peer only
+    stalls the one session that connected to it, never the whole honeypot.
+    """
+
+    def __init__(self, command: Command_nc) -> None:
+        self.command = command
+
+    def connectionMade(self) -> None:
+        self.command.connectionEstablished(self)
+
+    def dataReceived(self, data: bytes) -> None:
+        self.command.remoteDataReceived(data)
+
+    def connectionLost(self, reason: failure.Failure = connectionDone) -> None:
+        self.command.remoteConnectionLost()
+
+
+class NcClientFactory(ClientFactory):
+    def __init__(self, command: Command_nc) -> None:
+        self.command = command
+
+    def buildProtocol(self, addr: IAddress | None) -> NcClientProtocol:
+        return NcClientProtocol(self.command)
+
+    def clientConnectionFailed(
+        self, connector: IConnector, reason: failure.Failure
+    ) -> None:
+        self.command.connectionFailed(reason)
+
+
 class Command_nc(HoneyPotCommand):
     """
     netcat
@@ -68,8 +112,15 @@ class Command_nc(HoneyPotCommand):
 
     _log = Logger()
 
-    s: socket.socket
     CONNECT_TIMEOUT: float = 10.0  # seconds
+    limit_size: int = CowrieConfig.getint("honeypot", "download_limit_size", fallback=0)
+
+    nc_transport: ITransport | None = None
+    received_size: int = 0
+    verbose: bool = False
+    zero_io: bool = False
+    host: str = ""
+    port: int = 0
 
     def print_usage_error(self, error_msg: str = "") -> None:
         """Print usage error message"""
@@ -243,80 +294,94 @@ class Command_nc(HoneyPotCommand):
             self.exit()
             return
 
-        allowed = yield communication_allowed(host)
-        if not allowed:
+        resolved_ip = yield resolve_allowed(host)
+        if resolved_ip is None:
             self._log.info(
-                "nc: blocked connection attempt to {host} (private/reserved IP range)",
+                "nc: blocked connection attempt to {host} (unresolvable or private/reserved address)",
                 host=host,
             )
             self.exit()
             return
 
-        out_addr = None
-        try:
-            out_addr = (CowrieConfig.get("honeypot", "out_addr"), 0)
-        except Exception:
-            out_addr = ("0.0.0.0", 0)
+        self.host = host
+        self.port = int(port)
+        self.verbose = verbose
+        self.zero_io = zero_io
 
-        self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.s.settimeout(self.CONNECT_TIMEOUT)
-        self.s.bind(out_addr)
-        try:
-            self.s.connect((host, int(port)))
+        # Connect to the IP resolve_allowed() validated, not to the hostname:
+        # re-resolving the hostname here would reopen the DNS-rebinding window
+        # that resolve_allowed() closed.
+        reactor.connectTCP(
+            resolved_ip,
+            self.port,
+            NcClientFactory(self),
+            timeout=self.CONNECT_TIMEOUT,
+            bindAddress=(outbound_bind_address(), 0),
+        )
 
-            if verbose:
-                self.errorWrite(
-                    f"Connection to {host} {port} port [tcp/*] succeeded!\n"
-                )
-
-            # Zero I/O mode: test connection only, no data transfer
-            if zero_io:
-                self.s.close()
-                self.exit()
-                return
-
-            self.recv_data()
-        except TimeoutError:
-            if verbose:
-                self.errorWrite(
-                    f"nc: connect to {host} port {port} (tcp) failed: Operation timed out\n"
-                )
-            self.exit()
-        except OSError:
-            if verbose:
-                self.errorWrite(
-                    f"nc: connect to {host} port {port} (tcp) failed: Connection refused\n"
-                )
-            self.exit()
-        except Exception:
+    def connectionEstablished(self, protocol: NcClientProtocol) -> None:
+        if self.exited:
+            # The connection completed after the command was already
+            # interrupted (^C or EOF while still connecting): tear it down.
+            if protocol.transport is not None:
+                protocol.transport.loseConnection()
+            return
+        self.nc_transport = protocol.transport
+        if self.verbose:
+            self.errorWrite(
+                f"Connection to {self.host} {self.port} port [tcp/*] succeeded!\n"
+            )
+        # Zero I/O mode: test connection only, no data transfer
+        if self.zero_io:
+            if self.nc_transport is not None:
+                self.nc_transport.loseConnection()
             self.exit()
 
-    def recv_data(self) -> None:
-        data = b""
-        while 1:
-            packet = self.s.recv(1024)
-            if packet == b"":
-                break
-            else:
-                data += packet
-
+    def remoteDataReceived(self, data: bytes) -> None:
+        if self.exited:
+            return
+        self.received_size += len(data)
+        if self.limit_size > 0 and self.received_size > self.limit_size:
+            self._log.info(
+                "nc: connection to {host}:{port} closed: exceeded download_limit_size",
+                host=self.host,
+                port=self.port,
+            )
+            if self.nc_transport is not None:
+                self.nc_transport.loseConnection()
+            self.exit()
+            return
         self.writeBytes(data)
-        self.s.close()
+
+    def remoteConnectionLost(self) -> None:
+        self.nc_transport = None
+        self.exit()
+
+    def connectionFailed(self, reason: failure.Failure) -> None:
+        if self.verbose:
+            if reason.check(error.TimeoutError):
+                self.errorWrite(
+                    f"nc: connect to {self.host} port {self.port} (tcp) failed: Operation timed out\n"
+                )
+            else:
+                self.errorWrite(
+                    f"nc: connect to {self.host} port {self.port} (tcp) failed: Connection refused\n"
+                )
         self.exit()
 
     def lineReceived(self, line: str) -> None:
-        if hasattr(self, "s"):
-            self.s.send(line.encode("utf8"))
+        if self.nc_transport is not None:
+            self.nc_transport.write(line.encode("utf8", errors="replace"))
 
     def handle_CTRL_C(self) -> None:
         self.write("^C\n")
-        if hasattr(self, "s"):
-            self.s.close()
+        if self.nc_transport is not None:
+            self.nc_transport.loseConnection()
         self.exit()
 
     def eofReceived(self) -> None:
-        if hasattr(self, "s"):
-            self.s.close()
+        if self.nc_transport is not None:
+            self.nc_transport.loseConnection()
         self.exit()
 
 

--- a/src/cowrie/core/network.py
+++ b/src/cowrie/core/network.py
@@ -183,9 +183,15 @@ def resolve_cname(
 
 
 @inlineCallbacks
-def communication_allowed(address: str) -> Generator[Deferred, None, bool]:
+def resolve_allowed(address: str) -> Generator[Deferred, None, str | None]:
     """
-    Return True if communication to this address is allowed, False if blocked (for both IPs and DNS names).
+    Resolve an IP or DNS name once, validate the resolved IP against the
+    blocklist, and return that exact IP (or None if unresolvable or blocked).
+
+    Callers making outbound connections must connect to the returned IP, not
+    the original hostname: re-resolving the hostname at connect time lets a
+    malicious DNS server answer the validation lookup with a public IP and
+    the connection lookup with a private/internal one (DNS rebinding).
     """
     # First, check if it's already a valid IP address (either IPv4 or IPv6)
     ip = is_ip_address(address)
@@ -199,7 +205,7 @@ def communication_allowed(address: str) -> Generator[Deferred, None, bool]:
 
         # If no IP was resolved, it's not allowed
         if result is None:
-            return False
+            return None
         else:
             resolved_ip = result  # type: ignore
 
@@ -207,12 +213,21 @@ def communication_allowed(address: str) -> Generator[Deferred, None, bool]:
     try:
         ip = ipaddress.ip_address(resolved_ip)
     except ValueError:
-        return False  # If the resolved IP is not a valid IP address, return False
+        return None  # If the resolved IP is not a valid IP address
 
     if _is_blocked(ip):
-        return False  # Blocked IP found
+        return None  # Blocked IP found
 
-    return True  # Communication is allowed
+    return resolved_ip
+
+
+@inlineCallbacks
+def communication_allowed(address: str) -> Generator[Deferred, None, bool]:
+    """
+    Return True if communication to this address is allowed, False if blocked (for both IPs and DNS names).
+    """
+    resolved = yield resolve_allowed(address)
+    return resolved is not None
 
 
 class DownloadLimitExceeded(Exception):

--- a/src/cowrie/test/test_nc.py
+++ b/src/cowrie/test/test_nc.py
@@ -1,0 +1,268 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for cowrie/commands/nc.py.
+
+The connection tests patch nc's reactor and the DNS resolver, so no real
+network traffic is generated and every assertion runs synchronously.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+from unittest import mock
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+from twisted.internet import error
+from twisted.internet.defer import Deferred, fail, succeed
+from twisted.names import dns
+from twisted.names import error as names_error
+from twisted.python.failure import Failure
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+from cowrie.commands.nc import Command_nc, NcClientFactory, nc_rate_limiter
+
+PROMPT = b"root@unitTest:~# "
+
+
+def _fake_lookup(
+    records: dict[str, list[dns.RRHeader]],
+) -> Callable[[Any], Deferred]:
+    """A lookupAddress double serving canned answers."""
+
+    def lookup(name: Any) -> Deferred:
+        if name in records:
+            return succeed((records[name], [], []))
+        return fail(names_error.DNSNameError(name))
+
+    return lookup
+
+
+def _a(address: str) -> dns.RRHeader:
+    return dns.RRHeader(type=dns.A, payload=dns.Record_A(address))
+
+
+class ShellNcCommandTests(unittest.TestCase):
+    """Argument handling: these paths finish before any network I/O."""
+
+    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+    tr = FakeTransport("", "31337")
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.proto.makeConnection(cls.tr)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proto.connectionLost()
+
+    def setUp(self) -> None:
+        self.tr.clear()
+        # The limiter is a module-level singleton; keep tests isolated.
+        nc_rate_limiter.reset()
+
+    def test_help(self) -> None:
+        self.proto.lineReceived(b"nc -h\n")
+        output = self.tr.value()
+        self.assertIn(b"OpenBSD netcat", output)
+        self.assertIn(b"usage: nc", output)
+        self.assertTrue(output.endswith(PROMPT))
+
+    def test_no_args_shows_usage(self) -> None:
+        self.proto.lineReceived(b"nc\n")
+        self.assertIn(b"usage: nc", self.tr.value())
+
+    def test_missing_port(self) -> None:
+        self.proto.lineReceived(b"nc example.com\n")
+        self.assertIn(b"nc: missing port number", self.tr.value())
+
+    def test_invalid_port(self) -> None:
+        self.proto.lineReceived(b"nc example.com 99999\n")
+        self.assertIn(b"nc: port number invalid: 99999", self.tr.value())
+
+    def test_listen_without_port(self) -> None:
+        self.proto.lineReceived(b"nc -l\n")
+        self.assertIn(b"nc: missing port number", self.tr.value())
+
+    def test_listen_with_port_denied(self) -> None:
+        self.proto.lineReceived(b"nc -l -p 4444\n")
+        self.assertIn(b"nc: Permission denied", self.tr.value())
+
+    def test_udp_denied(self) -> None:
+        self.proto.lineReceived(b"nc -u 8.8.8.8 53\n")
+        self.assertIn(b"nc: Permission denied", self.tr.value())
+
+    def test_ipv6_unreachable(self) -> None:
+        self.proto.lineReceived(b"nc -6 example.com 80\n")
+        self.assertIn(b"nc: Network is unreachable", self.tr.value())
+
+
+class NcConnectionTests(unittest.TestCase):
+    """The outbound connection must go through the async reactor API — to the
+    validated IP, bound to the configured source address, with a connect
+    timeout and the download size limit enforced."""
+
+    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+    tr = FakeTransport("", "31337")
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.proto.makeConnection(cls.tr)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proto.connectionLost()
+
+    def setUp(self) -> None:
+        self.tr.clear()
+        nc_rate_limiter.reset()
+        patcher = mock.patch("cowrie.commands.nc.reactor")
+        self.reactor = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def tearDown(self) -> None:
+        # A test that failed mid-connection leaves its command on the stack;
+        # pop it so the shared shell is usable for the next test.
+        while len(self.proto.cmdstack) > 1:
+            self.proto.cmdstack[-1].exit()
+
+    def _connect(self, cmdline: bytes) -> SimpleNamespace:
+        """Run an nc command line and capture the resulting connectTCP call."""
+        self.proto.lineReceived(cmdline)
+        self.assertEqual(self.reactor.connectTCP.call_count, 1)
+        args, kwargs = self.reactor.connectTCP.call_args
+        command = self.proto.cmdstack[-1]
+        self.assertIsInstance(command, Command_nc)
+        return SimpleNamespace(
+            command=command, ip=args[0], port=args[1], factory=args[2], kwargs=kwargs
+        )
+
+    def _establish(self, factory: NcClientFactory) -> SimpleNamespace:
+        """Build the client protocol and connect it to a mock transport."""
+        protocol = factory.buildProtocol(None)
+        transport = mock.Mock()
+        protocol.makeConnection(transport)
+        return SimpleNamespace(protocol=protocol, transport=transport)
+
+    def test_connects_async_to_validated_ip(self) -> None:
+        conn = self._connect(b"nc 8.8.8.8 4444\n")
+        self.assertEqual(conn.ip, "8.8.8.8")
+        self.assertEqual(conn.port, 4444)
+        self.assertEqual(conn.kwargs["timeout"], Command_nc.CONNECT_TIMEOUT)
+        self.assertEqual(conn.kwargs["bindAddress"], ("0.0.0.0", 0))
+
+    def test_hostname_connects_to_pinned_ip(self) -> None:
+        records = {"dl.example.com": [_a("8.8.4.4")]}
+        with mock.patch(
+            "cowrie.core.network.client.lookupAddress",
+            side_effect=_fake_lookup(records),
+        ):
+            conn = self._connect(b"nc dl.example.com 4444\n")
+        self.assertEqual(conn.ip, "8.8.4.4")
+
+    def test_blocked_target_never_connects(self) -> None:
+        self.proto.lineReceived(b"nc 10.1.1.1 4444\n")
+        self.reactor.connectTCP.assert_not_called()
+        self.assertEqual(self.tr.value(), PROMPT)
+
+    def test_rate_limit_never_connects(self) -> None:
+        for _ in range(5):
+            self.assertTrue(nc_rate_limiter.check("8.8.8.8"))
+        self.proto.lineReceived(b"nc -v 8.8.8.8 4444\n")
+        self.reactor.connectTCP.assert_not_called()
+        self.assertIn(b"Operation timed out", self.tr.value())
+
+    def test_remote_data_written_to_terminal(self) -> None:
+        conn = self._connect(b"nc 8.8.8.8 4444\n")
+        link = self._establish(conn.factory)
+        link.protocol.dataReceived(b"hello from remote\n")
+        self.assertIn(b"hello from remote", self.tr.value())
+        link.protocol.connectionLost(Failure(error.ConnectionDone()))
+        self.assertTrue(self.tr.value().endswith(PROMPT))
+
+    def test_verbose_success_message(self) -> None:
+        conn = self._connect(b"nc -v 8.8.8.8 4444\n")
+        self._establish(conn.factory)
+        self.assertIn(
+            b"Connection to 8.8.8.8 4444 port [tcp/*] succeeded!", self.tr.value()
+        )
+
+    def test_zero_io_closes_after_connect(self) -> None:
+        conn = self._connect(b"nc -z 8.8.8.8 4444\n")
+        link = self._establish(conn.factory)
+        link.transport.loseConnection.assert_called_once()
+        self.assertTrue(conn.command.exited)
+        self.assertTrue(self.tr.value().endswith(PROMPT))
+
+    def test_stdin_forwarded_to_remote(self) -> None:
+        conn = self._connect(b"nc 8.8.8.8 4444\n")
+        link = self._establish(conn.factory)
+        # recvline delivers lines without their terminator, so none is added.
+        self.proto.lineReceived(b"hello remote")
+        link.transport.write.assert_called_once_with(b"hello remote")
+
+    def test_download_limit_closes_connection(self) -> None:
+        conn = self._connect(b"nc 8.8.8.8 4444\n")
+        link = self._establish(conn.factory)
+        with mock.patch.object(Command_nc, "limit_size", 10):
+            link.protocol.dataReceived(b"12345")
+            self.assertIn(b"12345", self.tr.value())
+            link.protocol.dataReceived(b"67890ABCDEF")  # total 16 > 10
+        link.transport.loseConnection.assert_called_once()
+        self.assertTrue(conn.command.exited)
+        self.assertNotIn(b"ABCDEF", self.tr.value())
+
+    def test_connection_refused_verbose(self) -> None:
+        conn = self._connect(b"nc -v 8.8.8.8 4444\n")
+        conn.factory.clientConnectionFailed(
+            None, Failure(error.ConnectionRefusedError())
+        )
+        self.assertIn(b"Connection refused", self.tr.value())
+        self.assertTrue(conn.command.exited)
+
+    def test_connection_timeout_verbose(self) -> None:
+        conn = self._connect(b"nc -v 8.8.8.8 4444\n")
+        conn.factory.clientConnectionFailed(None, Failure(error.TimeoutError()))
+        self.assertIn(b"Operation timed out", self.tr.value())
+        self.assertTrue(conn.command.exited)
+
+    def test_connection_failed_silent_without_verbose(self) -> None:
+        conn = self._connect(b"nc 8.8.8.8 4444\n")
+        conn.factory.clientConnectionFailed(
+            None, Failure(error.ConnectionRefusedError())
+        )
+        self.assertEqual(self.tr.value(), PROMPT)
+        self.assertTrue(conn.command.exited)
+
+    def test_ctrl_c_closes_connection(self) -> None:
+        conn = self._connect(b"nc 8.8.8.8 4444\n")
+        link = self._establish(conn.factory)
+        conn.command.handle_CTRL_C()
+        link.transport.loseConnection.assert_called_once()
+        self.assertTrue(conn.command.exited)
+
+    def test_ctrl_c_before_connect_closes_late_connection(self) -> None:
+        conn = self._connect(b"nc 8.8.8.8 4444\n")
+        conn.command.handle_CTRL_C()
+        self.assertTrue(conn.command.exited)
+        # The TCP connection completes after the command was interrupted:
+        # it must be torn down, not left open.
+        link = self._establish(conn.factory)
+        link.transport.loseConnection.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_network.py
+++ b/src/cowrie/test/test_network.py
@@ -12,7 +12,11 @@ from twisted.names import dns
 from twisted.names import error as names_error
 from twisted.python import log
 
-from cowrie.core.network import communication_allowed, resolve_cname
+from cowrie.core.network import (
+    communication_allowed,
+    resolve_allowed,
+    resolve_cname,
+)
 
 # The communication_allowed function and other dependencies would already be imported here
 
@@ -217,6 +221,49 @@ class TestResolveCnameChain(unittest.TestCase):
             "b.example.com": [_cname("a.example.com")],
         }
         self.assertIsNone(self._resolve(records, "a.example.com"))
+
+
+class TestResolveAllowed(unittest.TestCase):
+    """resolve_allowed must resolve a target once, validate that exact IP,
+    and hand the pinned IP back to the caller, so the address that was
+    validated is the same one the caller connects to (no DNS-rebinding
+    window between validation and connect)."""
+
+    def _resolve(
+        self, records: dict[str, list[dns.RRHeader]], name: str
+    ) -> str | None:
+        with mock.patch(
+            "cowrie.core.network.client.lookupAddress",
+            side_effect=_fake_lookup(records),
+        ):
+            results: list[str | None] = []
+            resolve_allowed(name).addBoth(results.append)
+        self.assertEqual(len(results), 1)
+        return results[0]
+
+    def test_public_ip_passes_through(self) -> None:
+        self.assertEqual(self._resolve({}, "8.8.8.8"), "8.8.8.8")
+
+    def test_blocked_ip_returns_none(self) -> None:
+        self.assertIsNone(self._resolve({}, "10.1.1.1"))
+
+    def test_hostname_resolves_to_pinned_ip(self) -> None:
+        records = {"dl.example.com": [_a("8.8.4.4")]}
+        self.assertEqual(self._resolve(records, "dl.example.com"), "8.8.4.4")
+
+    def test_hostname_resolving_to_blocked_ip_returns_none(self) -> None:
+        records = {"rebind.example.com": [_a("127.0.0.1")]}
+        self.assertIsNone(self._resolve(records, "rebind.example.com"))
+
+    def test_unresolvable_hostname_returns_none(self) -> None:
+        self.assertIsNone(self._resolve({}, "nonexistent.example.com"))
+
+    def test_cname_chain_resolves_to_pinned_ip(self) -> None:
+        records = {
+            "cdn.example.com": [_cname("origin.example.org")],
+            "origin.example.org": [_a("8.8.8.8")],
+        }
+        self.assertEqual(self._resolve(records, "cdn.example.com"), "8.8.8.8")
 
 
 class TestResolveCnameLogging(unittest.TestCase):


### PR DESCRIPTION
Fixes #40397.

`nc` was the last network command on blocking stdlib sockets: `Command_nc.start()` called `socket.connect()` and then looped on `socket.recv(1024)` on the reactor thread. One attacker session running `nc` against a peer that accepts and then stays silent or trickles data stalled every session on the honeypot — up to 10 seconds for the connect phase, indefinitely for the receive loop (each byte received reset the per-call socket timeout). The receive loop also accumulated everything into an unbounded in-memory buffer.

Changes:

- The outbound connection now runs through `reactor.connectTCP` with a client protocol and a 10s connect timeout, so a slow or malicious peer only affects the session that ran `nc`.
- Received data streams to the attacker's terminal and is bounded by `download_limit_size`, matching wget/curl/ftpget; exceeding the bound closes the connection.
- The source address comes from the centralized `outbound_bind_address()` helper (`[honeypot] out_addr`), matching the other network commands.
- New `cowrie.core.network.resolve_allowed()` resolves the target once, validates that exact IP, and returns it pinned; `nc` connects to that IP instead of re-resolving the hostname at connect time. This closes the DNS-rebinding TOCTOU gap of #40390 for `nc`; `communication_allowed()` is now a thin wrapper around the helper, so wget/curl/ftpget/tftp can adopt it in a follow-up to close #40390 completely.
- A connection that completes after the command was interrupted (^C or EOF while still connecting) is torn down instead of being leaked, and the socket file-descriptor leaks on the old error paths are gone with the blocking socket.
- New `test_nc.py`: argument handling plus connection-path tests against a mocked reactor and canned DNS — no real network traffic. `resolve_allowed` is covered in `test_network.py`.

Credit to @vbontchev for the report and analysis in #40397.