### PR TITLE
Wait for async commands (wget/curl) in command substitution

### DIFF
--- a/src/cowrie/commands/bash.py
+++ b/src/cowrie/commands/bash.py
@@ -145,9 +145,8 @@ class Command_exit(HoneyPotCommand):
                 code = 2
         # The code is the dying shell's final status: whoever launched the
         # shell (sh -c, su -c, a substitution) reads it from last_exit_code.
-        shell.last_exit_code = code
         self.exit_code = code
-        self.protocol.cmdstack.remove(shell)
+        shell.exit_shell(code)
         # start() follows with exit(); with the shell gone that either resumes
         # the command that launched it (nested shell) or, on an empty cmdstack
         # (top-level shell), ends the session with this exit_code.

--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -256,7 +256,8 @@ class Command_curl(HoneyPotCommand):
 
         for opt in optlist:
             if opt[0] == "-o":
-                self.outfile = opt[1]
+                # `-o -` writes the body to stdout, same as no -o at all.
+                self.outfile = opt[1] if opt[1] != "-" else None
             if opt[0] == "-O":
                 self.outfile = urldata.path.split("/")[-1]
                 if not len(self.outfile.strip()) or not urldata.path.count("/"):

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -590,7 +590,7 @@ class Command_wget(HoneyPotCommand):
         self.proglen = len(s)
         self.lastupdate = time.time()
 
-        if not self.outfile:
+        if not self.outfile or self.outfile == "-":
             self.writeBytes(data)
 
     def collectioncomplete(self, data: None) -> None:
@@ -631,7 +631,7 @@ class Command_wget(HoneyPotCommand):
             )
 
         # Update the honeyfs to point to artifact file if output is to file
-        if self.outfile and self.protocol.user:
+        if self.outfile and self.outfile != "-" and self.protocol.user:
             self.fs.mkfile(
                 self.outfile,
                 self.current_user["uid"],

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -64,7 +64,10 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
 
 from lark import Lark, Token, Tree
 from lark.exceptions import LarkError
@@ -187,8 +190,9 @@ class ShellContext(Protocol):
         """Return ``$?`` -- the last command's exit status, as a string."""
         ...
 
-    def command_substitution(self, source: str) -> str:
-        """Execute ``source`` and return its captured stdout (newlines stripped)."""
+    def command_substitution(self, source: str) -> Awaitable[str]:
+        """Execute ``source``; the awaitable completes with its captured stdout
+        (trailing newlines stripped) once every command in it has finished."""
         ...
 
 
@@ -777,24 +781,27 @@ class BashParser:
 
     # -- word evaluation ----------------------------------------------------
 
-    def evaluate(self, command: Command) -> list[str]:
+    async def evaluate(self, command: Command) -> list[str]:
         """Expand a command's words against the live context, now.
 
         Operator strings pass through; each word tree is evaluated against the
         current shell (variables, command substitution), and a word that
-        resolves to nothing (an unquoted unset reference) is dropped.
+        resolves to nothing (an unquoted unset reference) is dropped. A
+        command substitution suspends the expansion until its subshell
+        finishes, as bash blocks on the substitution pipe; substitutions
+        therefore run left to right, each to completion before the next.
         """
         tokens: list[str] = []
         for item in command.items:
             if isinstance(item, str):
                 tokens.append(item)
                 continue
-            value = self._eval_word(command.line, item)
+            value = await self._eval_word(command.line, item)
             if value is not None:
                 tokens.append(value)
         return tokens
 
-    def _eval_word(self, line: str, word: Tree) -> str | None:
+    async def _eval_word(self, line: str, word: Tree) -> str | None:
         """Evaluate a word to its final string, or None if it should be dropped.
 
         A word is dropped when it is exactly an unquoted reference to an unset
@@ -819,10 +826,10 @@ class BashParser:
 
         parts: list[str] = []
         for atom in atoms:
-            parts.append(self._eval_atom(line, atom))
+            parts.append(await self._eval_atom(line, atom))
         return "".join(parts)
 
-    def _eval_atom(self, line: str, atom: Tree | Token) -> str:
+    async def _eval_atom(self, line: str, atom: Tree | Token) -> str:
         if isinstance(atom, Token):
             if atom.type == "ESC":
                 # Unquoted backslash escape: the backslash is removed.
@@ -832,16 +839,20 @@ class BashParser:
         if atom.data == "sq":
             return self._leaf_value(atom)[1:-1]  # strip surrounding quotes
         if atom.data == "dq":
-            return self._eval_dquoted(line, atom)
+            return await self._eval_dquoted(line, atom)
         if atom.data == "dollar_var" or atom.data == "dollar_brace":
             return self._expand_embedded(atom)
         if atom.data == "cmdsub":
-            return self.context.command_substitution(self._group_source(line, atom))
+            return await self.context.command_substitution(
+                self._group_source(line, atom)
+            )
         if atom.data == "backtick":
-            return self.context.command_substitution(self._backtick_source(line, atom))
+            return await self.context.command_substitution(
+                self._backtick_source(line, atom)
+            )
         return ""
 
-    def _eval_dquoted(self, line: str, dq: Tree) -> str:
+    async def _eval_dquoted(self, line: str, dq: Tree) -> str:
         parts: list[str] = []
         for part in dq.children:
             if isinstance(part, Token):
@@ -854,11 +865,15 @@ class BashParser:
                 parts.append(self._expand_embedded(part))
             elif part.data == "cmdsub":
                 parts.append(
-                    self.context.command_substitution(self._group_source(line, part))
+                    await self.context.command_substitution(
+                        self._group_source(line, part)
+                    )
                 )
             elif part.data == "backtick":
                 parts.append(
-                    self.context.command_substitution(self._backtick_source(line, part))
+                    await self.context.command_substitution(
+                        self._backtick_source(line, part)
+                    )
                 )
         return "".join(parts)
 

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -182,8 +182,11 @@ class HoneyPotCommand:
         # Queue on the innermost shell, the next stdin reader once this
         # command exits: an outer shell only resumes after the shells above
         # it unwind, so a line queued there would wait on the whole stack.
+        # A capture subshell ($(...)) is skipped: its program is fixed source
+        # text, and typed input is stdin data for the next real reader, never
+        # a command to run -- and capture -- inside the substitution.
         for item in reversed(self.protocol.cmdstack):
-            if hasattr(item, "queue_line"):
+            if hasattr(item, "queue_line") and not getattr(item, "redirect", False):
                 item.queue_line(line)
                 return
 

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -121,10 +121,15 @@ class HoneyPotShell:
         # Capture-subshell state (redirect=True): every statement's captured
         # stdout accumulates here -- one pipe buffer for the whole subshell,
         # like the pipe bash wires a $(...) child to. capture_done fires with
-        # the buffer when this shell leaves the cmdstack (its queue drained,
-        # or an inner `exit` ended it): the subshell's pipe seeing EOF.
+        # the finished subshell (buffer and final status) when it leaves the
+        # cmdstack -- its queue drained, or an inner `exit` ended it: the
+        # subshell's pipe seeing EOF.
         self.captured: bytes = b""
-        self.capture_done: Deferred[bytes] | None = None
+        self.capture_done: Deferred[HoneyPotShell] | None = None
+        # Final status of the most recent command substitution expanded for
+        # the current statement: bash makes it the statement's own status
+        # when the statement is only assignments.
+        self._subst_status: int | None = None
         # Exit status of the most recent command in this shell, for $? and the
         # && / || short-circuit logic.
         self.last_exit_code: int = 0
@@ -164,15 +169,21 @@ class HoneyPotShell:
         short-circuit. Output is captured instead of reaching the terminal.
         """
 
-        def decode(data: bytes) -> str:
+        def finished(subshell: HoneyPotShell) -> str:
+            # The subshell's status becomes $? for the rest of the expansion
+            # and, via _subst_status, for a statement of only assignments
+            # (`x=$(false)` leaves $? = 1).
+            self.last_exit_code = subshell.last_exit_code
+            self._subst_status = subshell.last_exit_code
             # The captured output is attacker bytes and need not be valid UTF-8.
-            return data.decode(errors="replace").rstrip("\n")
+            return subshell.captured.decode(errors="replace").rstrip("\n")
 
-        return self.capture(source).addCallback(decode)
+        return self.capture(source).addCallback(finished)
 
-    def capture(self, source: str) -> Deferred[bytes]:
+    def capture(self, source: str) -> Deferred[HoneyPotShell]:
         """Run ``source`` in a capture subshell and return a Deferred that
-        fires with its accumulated stdout once the subshell finishes.
+        fires with the finished subshell -- its accumulated stdout in
+        ``captured`` and its final status in ``last_exit_code``.
 
         The subshell runs its statements through the normal cmdpending /
         _advance machinery, so a command that pauses on a Deferred (wget)
@@ -182,7 +193,7 @@ class HoneyPotShell:
         the time this returns.
         """
         shell = HoneyPotShell(self.protocol, interactive=False, redirect=True)
-        done: Deferred[bytes] = Deferred()
+        done: Deferred[HoneyPotShell] = Deferred()
         shell.capture_done = done
         self.protocol.cmdstack.append(shell)
         shell._queue_statements(self.bashparser.parse(source))
@@ -202,13 +213,13 @@ class HoneyPotShell:
             self.protocol.pp = None
 
     def _complete_capture(self) -> None:
-        """Fire ``capture_done`` with the accumulated output: the subshell is
-        gone and the parent's read on the substitution pipe sees EOF."""
+        """Fire ``capture_done`` with this finished subshell: it is gone and
+        the parent's read on the substitution pipe sees EOF."""
         if self.capture_done is None:
             return
         self._harvest_capture()
         done, self.capture_done = self.capture_done, None
-        done.callback(self.captured)
+        done.callback(self)
 
     def exit_shell(self, code: int) -> None:
         """End this shell from the ``exit`` builtin: record the final status
@@ -676,6 +687,7 @@ class HoneyPotShell:
         # subshell finishes; the statement then runs from the callback. With
         # only synchronous substitutions the Deferred has already fired and
         # the statement runs before this returns.
+        self._subst_status = None
         d = Deferred.fromCoroutine(self.bashparser.evaluate(command))
         d.addCallback(self._run_expanded)
         d.addErrback(self._statement_failed)
@@ -704,10 +716,14 @@ class HoneyPotShell:
         if not cmd_tokens:
             # A statement of only assignments (no command) persists those
             # variables for the rest of the session. They are shell variables,
-            # not exported, so self.exported is left untouched. A bare
-            # assignment succeeds, so $? is 0.
+            # not exported, so self.exported is left untouched. Its status is
+            # that of the last command substitution its words ran, as in bash
+            # (`x=$(false)` leaves $? = 1); with no substitution a bare
+            # assignment succeeds.
             self.environ = environ
-            self.last_exit_code = 0
+            self.last_exit_code = (
+                self._subst_status if self._subst_status is not None else 0
+            )
             self._advance()
             return
 

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+from twisted.internet.defer import Deferred
 from twisted.logger import Logger
 from twisted.python.compat import iterbytes
 
@@ -26,7 +27,6 @@ from cowrie.shell.bashparse import (
     BashParser,
     BraceGroup,
     CaseClause,
-    Command,
     ForClause,
     FunctionDef,
     IfClause,
@@ -116,6 +116,13 @@ class HoneyPotShell:
             self.environ["LINES"] = str(protocol.user.windowSize[0])
         self.parser = CommandParser()
         self.bashparser = BashParser(self)
+        # Capture-subshell state (redirect=True): every statement's captured
+        # stdout accumulates here -- one pipe buffer for the whole subshell,
+        # like the pipe bash wires a $(...) child to. capture_done fires with
+        # the buffer when this shell leaves the cmdstack (its queue drained,
+        # or an inner `exit` ended it): the subshell's pipe seeing EOF.
+        self.captured: bytes = b""
+        self.capture_done: Deferred[bytes] | None = None
         # Exit status of the most recent command in this shell, for $? and the
         # && / || short-circuit logic.
         self.last_exit_code: int = 0
@@ -147,43 +154,71 @@ class HoneyPotShell:
         """Run ``source`` as a command substitution and return its captured
         stdout with trailing newlines stripped.
 
-        The inner source runs in a single capture subshell with the same
-        sequencing as a top-level line: a same-line assignment is visible to
-        later statements, ``$?`` carries across them, and ``&&`` / ``||``
-        short-circuit. A nested ``(...)`` group recurses. Output is captured
-        instead of reaching the terminal.
+        The inner source runs in a capture subshell with the same sequencing
+        as a top-level line: a same-line assignment is visible to later
+        statements, ``$?`` carries across them, and ``&&`` / ``||``
+        short-circuit. Output is captured instead of reaching the terminal.
+        A substitution whose commands have not all finished when this returns
+        (an async command such as wget) yields the empty string.
+        """
+        captured: bytes = b""
+
+        def grab(data: bytes) -> None:
+            nonlocal captured
+            captured = data
+
+        self.capture(source).addCallback(grab)
+        # The captured output is attacker bytes and need not be valid UTF-8.
+        return captured.decode(errors="replace").rstrip("\n")
+
+    def capture(self, source: str) -> Deferred[bytes]:
+        """Run ``source`` in a capture subshell and return a Deferred that
+        fires with its accumulated stdout once the subshell finishes.
+
+        The subshell runs its statements through the normal cmdpending /
+        _advance machinery, so a command that pauses on a Deferred (wget)
+        keeps the subshell alive until it completes -- the returned Deferred
+        is the parent's blocking read on the substitution pipe. When every
+        statement completes synchronously the Deferred has already fired by
+        the time this returns.
         """
         shell = HoneyPotShell(self.protocol, interactive=False, redirect=True)
+        done: Deferred[bytes] = Deferred()
+        shell.capture_done = done
         self.protocol.cmdstack.append(shell)
-        try:
-            return shell._capture_statements(self.bashparser.parse(source)).rstrip("\n")
-        finally:
-            # Remove the capture shell by identity: an `exit` inside the
-            # substitution already removed it (ending the subshell), and a
-            # blind pop() would remove the real shell instead, leaving the
-            # cmdstack empty and crashing the next command's instantiation.
-            if shell in self.protocol.cmdstack:
-                self.protocol.cmdstack.remove(shell)
+        shell._queue_statements(self.bashparser.parse(source))
+        shell._advance()
+        return done
 
-    def _capture_statements(self, statements: list[Statement]) -> str:
-        """Run statements in this capture shell, concatenating their stdout and
-        honoring &&/|| short-circuit between them (a subshell's gate covers the
-        whole group)."""
-        output = ""
-        for statement in statements:
-            if self not in self.protocol.cmdstack:
-                # An `exit` in the substitution ended this subshell; the
-                # remaining statements never run, as in bash.
-                break
-            if not isinstance(statement, (Command, Subshell)):
-                continue  # ignore a syntax error inside a substitution
-            if self._short_circuit(statement.op):
-                continue
-            if isinstance(statement, Subshell):
-                output += self._capture_statements(statement.statements)
-            else:
-                output += self._capture_command(statement)
-        return output
+    def _harvest_capture(self) -> None:
+        """Fold the finished statement's captured stdout into this capture
+        subshell's buffer and clear ``protocol.pp`` so a statement that builds
+        no pipe (a bare assignment, or a command-not-found) reads as empty
+        output rather than re-reading the previous statement's capture."""
+        if not self.redirect:
+            return
+        pp = self.protocol.pp
+        if pp is not None:
+            self.captured += pp.redirected_data
+            self.protocol.pp = None
+
+    def _complete_capture(self) -> None:
+        """Fire ``capture_done`` with the accumulated output: the subshell is
+        gone and the parent's read on the substitution pipe sees EOF."""
+        if self.capture_done is None:
+            return
+        self._harvest_capture()
+        done, self.capture_done = self.capture_done, None
+        done.callback(self.captured)
+
+    def exit_shell(self, code: int) -> None:
+        """End this shell from the ``exit`` builtin: record the final status
+        for whoever launched it, leave the cmdstack, and complete a capture
+        subshell's substitution."""
+        self.last_exit_code = code
+        if self in self.protocol.cmdstack:
+            self.protocol.cmdstack.remove(self)
+        self._complete_capture()
 
     def lineReceived(self, line: str) -> None:
         """Parse a command line with the Lark grammar and run the result."""
@@ -253,22 +288,6 @@ class HoneyPotShell:
             )
         self.last_exit_code = 2  # bash uses 2 for a syntax error
 
-    def _capture_command(self, command: Command) -> str:
-        """Run one command in this capture shell and return its captured stdout.
-
-        The command's words are expanded against the capture shell's live
-        environment, so it sees inherited and same-substitution variables.
-        ``protocol.pp`` is cleared first so a statement that builds no pipe
-        (a bare assignment, or a command-not-found) reads as empty output
-        rather than re-reading the previous statement's capture.
-        """
-        self.protocol.pp = None
-        self.cmdpending.append(command)
-        self.runCommand()
-        pp = self.protocol.pp
-        # The captured output is attacker bytes and need not be valid UTF-8.
-        return pp.redirected_data.decode(errors="replace") if pp is not None else ""
-
     def _finish(self) -> None:
         """The command queue is drained: do the shell's idle action.
 
@@ -278,15 +297,22 @@ class HoneyPotShell:
         nested non-interactive shell that runs a script or ``-c`` commands
         (sh/bash/su) removes itself from the cmdstack and resumes the command
         that launched it -- this is what hands control back once the script's
-        async commands (wget/curl) have all finished. A command-substitution /
-        redirect capture shell is left alone: its creator pops it in a finally
-        when capture returns.
+        async commands (wget/curl) have all finished. A command-substitution
+        capture subshell removes itself and completes its substitution.
         """
         if self.interactive:
             self.showPrompt()
         elif self.reads_stdin:
             # Idle, not done: the channel will deliver more lines or EOF.
             pass
+        elif self.redirect:
+            # Capture subshell: its program has run to completion, so the
+            # substitution's pipe sees EOF. The suspended evaluation that
+            # created it carries on from the capture_done callback, so no
+            # resume() of the shell below is needed here.
+            if self in self.protocol.cmdstack:
+                self.protocol.cmdstack.remove(self)
+            self._complete_capture()
         elif len(self.protocol.cmdstack) == 1:
             # Top-level non-interactive shell (an exec session): end the process
             # with the last command's status so the SSH channel reports a real
@@ -294,13 +320,12 @@ class HoneyPotShell:
             self.protocol.terminal.transport.processEnded(
                 process_status(self.last_exit_code)
             )
-        elif not self.redirect and self.protocol.cmdstack[-1] is self:
+        elif self.protocol.cmdstack[-1] is self:
             # Nested script / `-c` shell whose queue is drained: unwind it and
             # let the launching command carry on. Done here rather than with an
             # unconditional pop() at the call site because an async command
             # (wget/curl) leaves this shell mid-stack until it later resumes and
-            # drains us. A redirect/command-substitution capture shell is
-            # excluded -- it is popped by its own creator in a finally.
+            # drains us.
             self.protocol.cmdstack.remove(self)
             if self.protocol.cmdstack:
                 self.protocol.cmdstack[-1].resume()
@@ -543,6 +568,11 @@ class HoneyPotShell:
         # drop b's output.
         if self.protocol.pp is not None and self.protocol.pp.next_command is not None:
             return
+
+        # A capture subshell folds the statement that just finished into its
+        # output buffer before touching the next one; loop bodies and spliced
+        # groups pass through here too, so every statement is collected.
+        self._harvest_capture()
 
         # A pending break / continue: drop the rest of the current loop body up
         # to the innermost loop continuation, which consumes the signal.
@@ -832,6 +862,12 @@ class HoneyPotShell:
         self.last_exit_code = code
         if self in self.protocol.cmdstack:
             self.protocol.cmdstack.remove(self)
+        if self.capture_done is not None:
+            # A capture subshell's substitution carries on from the
+            # capture_done callback; resuming the shell below as well would
+            # drive it twice.
+            self._complete_capture()
+            return
         if self.protocol.cmdstack:
             self.protocol.cmdstack[-1].resume()
         else:

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -17,7 +17,9 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-from twisted.internet.defer import Deferred
+    from twisted.python.failure import Failure
+
+from twisted.internet.defer import Deferred, succeed
 from twisted.logger import Logger
 from twisted.python.compat import iterbytes
 
@@ -150,26 +152,23 @@ class HoneyPotShell:
         """Return $? -- the last command's exit status as a string."""
         return str(self.last_exit_code)
 
-    def command_substitution(self, source: str) -> str:
-        """Run ``source`` as a command substitution and return its captured
-        stdout with trailing newlines stripped.
+    def command_substitution(self, source: str) -> Deferred[str]:
+        """Run ``source`` as a command substitution: the returned Deferred
+        fires with its captured stdout, trailing newlines stripped, once the
+        subshell finishes -- the evaluator awaits it, as bash blocks on the
+        substitution pipe.
 
         The inner source runs in a capture subshell with the same sequencing
         as a top-level line: a same-line assignment is visible to later
         statements, ``$?`` carries across them, and ``&&`` / ``||``
         short-circuit. Output is captured instead of reaching the terminal.
-        A substitution whose commands have not all finished when this returns
-        (an async command such as wget) yields the empty string.
         """
-        captured: bytes = b""
 
-        def grab(data: bytes) -> None:
-            nonlocal captured
-            captured = data
+        def decode(data: bytes) -> str:
+            # The captured output is attacker bytes and need not be valid UTF-8.
+            return data.decode(errors="replace").rstrip("\n")
 
-        self.capture(source).addCallback(grab)
-        # The captured output is attacker bytes and need not be valid UTF-8.
-        return captured.decode(errors="replace").rstrip("\n")
+        return self.capture(source).addCallback(decode)
 
     def capture(self, source: str) -> Deferred[bytes]:
         """Run ``source`` in a capture subshell and return a Deferred that
@@ -330,6 +329,14 @@ class HoneyPotShell:
             if self.protocol.cmdstack:
                 self.protocol.cmdstack[-1].resume()
 
+    def _statement_failed(self, failure: Failure) -> None:
+        """An error escaped a statement's expansion or setup: log it, give the
+        statement bash's generic failure status, and carry on with the queue --
+        a shell that stops responding would fingerprint the honeypot."""
+        self._log.failure("shell statement failed", failure=failure)
+        self.last_exit_code = 1
+        self._advance()
+
     def _short_circuit(self, op: str | None) -> bool:
         """Whether a statement joined by ``op`` should be skipped given the last
         command's exit status: ``&&`` after a failure, ``||`` after a success.
@@ -396,7 +403,15 @@ class HoneyPotShell:
 
     def _run_for(self, node: ForClause) -> None:
         """``for VAR in WORDS; do BODY; done`` over the expanded word list."""
-        values = self.bashparser.evaluate(node.items) if node.items else []
+        if node.items:
+            d = Deferred.fromCoroutine(self.bashparser.evaluate(node.items))
+        else:
+            d = succeed([])
+        d.addCallback(self._run_for_expanded, node)
+        d.addErrback(self._statement_failed)
+
+    def _run_for_expanded(self, values: list[str], node: ForClause) -> None:
+        """Loop over the expanded ``in`` list, one body pass per word."""
         values = values[:MAX_FOR_ITEMS]
         if not values:
             # A loop over an empty list runs the body zero times and succeeds.
@@ -482,7 +497,16 @@ class HoneyPotShell:
 
     def _run_case(self, node: CaseClause) -> None:
         """``case WORD in PATTERN) BODY ;; ... esac`` -- first match wins."""
-        word = " ".join(self.bashparser.evaluate(node.word)) if node.word else ""
+        if node.word:
+            d = Deferred.fromCoroutine(self.bashparser.evaluate(node.word))
+        else:
+            d = succeed([])
+        d.addCallback(self._run_case_expanded, node)
+        d.addErrback(self._statement_failed)
+
+    def _run_case_expanded(self, tokens: list[str], node: CaseClause) -> None:
+        """Match the expanded case word against each pattern arm."""
+        word = " ".join(tokens)
         for patterns, body in node.items:
             for pattern in patterns:
                 if fnmatch.fnmatchcase(word, self._strip_quotes(pattern)):
@@ -560,8 +584,6 @@ class HoneyPotShell:
         return True, replaces
 
     def runCommand(self):
-        pp = None
-
         # Mid-pipeline: an earlier stage just finished but a downstream command
         # has not run yet. Let the pipe machinery drive the rest before touching
         # the next statement -- otherwise `a | b; c` would run c before b and
@@ -649,8 +671,20 @@ class HoneyPotShell:
             return
 
         # Expand the statement's words against the *current* environment, just
-        # before it runs, so a same-line `x=hi; echo $x` sees the value.
-        cmdAndArgs = self.bashparser.evaluate(command)
+        # before it runs, so a same-line `x=hi; echo $x` sees the value. A
+        # command substitution in a word suspends the expansion until its
+        # subshell finishes; the statement then runs from the callback. With
+        # only synchronous substitutions the Deferred has already fired and
+        # the statement runs before this returns.
+        d = Deferred.fromCoroutine(self.bashparser.evaluate(command))
+        d.addCallback(self._run_expanded)
+        d.addErrback(self._statement_failed)
+
+    def _run_expanded(self, cmdAndArgs: list[str]) -> None:
+        """Run one expanded simple command / pipeline: split off leading
+        assignments, resolve each stage to a command class, wire the pipe and
+        redirections, and start it."""
+        pp = None
 
         # Probably no reason to be this comprehensive for just PATH...
         environ = copy.copy(self.environ)

--- a/src/cowrie/test/test_async_substitution.py
+++ b/src/cowrie/test/test_async_substitution.py
@@ -83,3 +83,60 @@ class AsyncSubstitutionTests(unittest.TestCase):
     def test_sync_substitution_still_inline(self) -> None:
         self.proto.lineReceived(b"echo $(echo inner)\n")
         self.assertEqual(self.tr.value(), b"inner\n" + PROMPT)
+
+    def test_exit_inside_substitution(self) -> None:
+        self.proto.lineReceived(b"echo a$(exit)b\n")
+        self.assertEqual(self.tr.value(), b"ab\n" + PROMPT)
+
+    def test_exit_stops_substitution_statements(self) -> None:
+        self.proto.lineReceived(b"echo $(echo x; exit; echo y)\n")
+        self.assertEqual(self.tr.value(), b"x\n" + PROMPT)
+
+    def test_nested_async_substitution(self) -> None:
+        self.proto.lineReceived(b"echo $(echo $(fakeasync))\n")
+        self.assertEqual(self.tr.value(), b"")
+        self.finish_one()
+        self.assertEqual(self.tr.value(), b"async-output\n" + PROMPT)
+
+    def test_conditional_after_async_inside_substitution(self) -> None:
+        self.proto.lineReceived(b"echo $(fakeasync && echo ok)\n")
+        self.finish_one()
+        self.assertEqual(self.tr.value(), b"async-output\nok\n" + PROMPT)
+
+    def test_failed_async_skips_and_arm(self) -> None:
+        self.proto.lineReceived(b"echo $(fakeasync && echo ok)\n")
+        self.finish_one(code=1)
+        self.assertEqual(self.tr.value(), b"async-output\n" + PROMPT)
+
+    def test_loop_inside_substitution(self) -> None:
+        self.proto.lineReceived(b"echo $(for i in a b; do echo $i; done)\n")
+        self.assertEqual(self.tr.value(), b"a\nb\n" + PROMPT)
+
+    def test_line_typed_during_substitution_runs_after(self) -> None:
+        # The typed line is stdin data buffered for the next reader, never a
+        # command inside the subshell: "later" must reach the terminal, not
+        # the capture buffer (x would swallow it).
+        self.proto.lineReceived(b"x=$(fakeasync)\n")
+        self.proto.lineReceived(b"echo later\n")
+        self.assertEqual(self.tr.value(), b"")
+        self.finish_one()
+        self.assertEqual(self.tr.value(), b"later\n" + PROMPT)
+
+    def test_async_substitution_status_reaches_assignment(self) -> None:
+        self.proto.lineReceived(b"x=$(fakeasync)\n")
+        self.finish_one(code=3)
+        self.tr.clear()
+        self.proto.lineReceived(b"echo $?\n")
+        self.assertEqual(self.tr.value(), b"3\n" + PROMPT)
+
+    def test_sync_substitution_status_reaches_assignment(self) -> None:
+        self.proto.lineReceived(b"x=$(exit 5)\n")
+        self.tr.clear()
+        self.proto.lineReceived(b"echo $?\n")
+        self.assertEqual(self.tr.value(), b"5\n" + PROMPT)
+
+    def test_command_status_wins_over_substitution(self) -> None:
+        self.proto.lineReceived(b"echo $(exit 5)\n")
+        self.tr.clear()
+        self.proto.lineReceived(b"echo $?\n")
+        self.assertEqual(self.tr.value(), b"0\n" + PROMPT)

--- a/src/cowrie/test/test_async_substitution.py
+++ b/src/cowrie/test/test_async_substitution.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests command substitution around commands that finish via a
+# ABOUTME: Deferred (wget/curl): the shell must block and capture their output.
+
+from __future__ import annotations
+
+import os
+import unittest
+from typing import ClassVar
+
+from cowrie.shell.command import HoneyPotCommand
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+
+class FakeAsyncCommand(HoneyPotCommand):
+    """A command that, like wget/curl, returns from start() and only writes
+    its output and exits when an external event (here: finish()) fires."""
+
+    pending: ClassVar[list[FakeAsyncCommand]] = []
+
+    def start(self) -> None:
+        FakeAsyncCommand.pending.append(self)
+
+    def finish(self, output: str = "async-output", code: int = 0) -> None:
+        FakeAsyncCommand.pending.remove(self)
+        self.write(f"{output}\n")
+        self.exit(code)
+
+
+class AsyncSubstitutionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.proto.commands["fakeasync"] = FakeAsyncCommand
+        FakeAsyncCommand.pending = []
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def finish_one(self, output: str = "async-output", code: int = 0) -> None:
+        self.assertTrue(FakeAsyncCommand.pending, "no async command is running")
+        FakeAsyncCommand.pending[0].finish(output, code)
+
+    def test_substitution_blocks_until_command_finishes(self) -> None:
+        self.proto.lineReceived(b"echo A $(fakeasync) B\n")
+        self.assertEqual(self.tr.value(), b"")
+
+    def test_substitution_captures_async_output(self) -> None:
+        self.proto.lineReceived(b"echo A $(fakeasync) B\n")
+        self.finish_one()
+        self.assertEqual(self.tr.value(), b"A async-output B\n" + PROMPT)
+
+    def test_backtick_captures_async_output(self) -> None:
+        self.proto.lineReceived(b"echo `fakeasync`\n")
+        self.finish_one()
+        self.assertEqual(self.tr.value(), b"async-output\n" + PROMPT)
+
+    def test_assignment_captures_async_output(self) -> None:
+        self.proto.lineReceived(b"x=$(fakeasync); echo $x\n")
+        self.finish_one()
+        self.assertEqual(self.tr.value(), b"async-output\n" + PROMPT)
+
+    def test_shell_usable_after_async_substitution(self) -> None:
+        self.proto.lineReceived(b"echo $(fakeasync)\n")
+        self.finish_one()
+        self.tr.clear()
+        self.proto.lineReceived(b"echo done\n")
+        self.assertEqual(self.tr.value(), b"done\n" + PROMPT)
+
+    def test_sync_substitution_still_inline(self) -> None:
+        self.proto.lineReceived(b"echo $(echo inner)\n")
+        self.assertEqual(self.tr.value(), b"inner\n" + PROMPT)

--- a/src/cowrie/test/test_bashparse.py
+++ b/src/cowrie/test/test_bashparse.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import unittest
 
+from twisted.internet.defer import Deferred, ensureDeferred, succeed
+
 from cowrie.shell.bashparse import (
     BashParser,
     BraceGroup,
@@ -37,10 +39,19 @@ class FakeContext:
     def get_status(self) -> str:
         return self.status
 
-    def command_substitution(self, source: str) -> str:
+    def command_substitution(self, source: str) -> Deferred[str]:
         self.substitutions.append(source)
         # Echo back a marker so tests can assert the captured source text.
-        return f"<{source.strip()}>"
+        return succeed(f"<{source.strip()}>")
+
+
+def evaluate_now(parser: BashParser, statement: Command) -> list[str]:
+    """Drive the evaluator coroutine; every await here resolves synchronously,
+    so the result is available before this returns."""
+    results: list[list[str]] = []
+    ensureDeferred(parser.evaluate(statement)).addCallback(results.append)
+    assert results, "evaluation suspended unexpectedly"
+    return results[0]
 
 
 class BashParseTokenTests(unittest.TestCase):
@@ -53,7 +64,7 @@ class BashParseTokenTests(unittest.TestCase):
     def _tokens(self, line: str) -> list[str]:
         statement = self.parser.parse(line)[0]
         assert isinstance(statement, Command)
-        return self.parser.evaluate(statement)
+        return evaluate_now(self.parser, statement)
 
     def test_simple_words(self) -> None:
         self.assertEqual(self._tokens("echo hello world"), ["echo", "hello", "world"])
@@ -93,7 +104,7 @@ class BashParseVariableTests(unittest.TestCase):
     def _tokens(self, line: str) -> list[str]:
         statement = self.parser.parse(line)[0]
         assert isinstance(statement, Command)
-        return self.parser.evaluate(statement)
+        return evaluate_now(self.parser, statement)
 
     def test_bare_variable_expands(self) -> None:
         self.assertEqual(self._tokens("echo $LOGNAME"), ["echo", "root"])
@@ -143,7 +154,7 @@ class BashParseRedirectionTests(unittest.TestCase):
     def _tokens(self, line: str) -> list[str]:
         statement = self.parser.parse(line)[0]
         assert isinstance(statement, Command)
-        return self.parser.evaluate(statement)
+        return evaluate_now(self.parser, statement)
 
     def test_stdout_redirect(self) -> None:
         self.assertEqual(self._tokens("echo a > f"), ["echo", "a", ">", "f"])
@@ -189,7 +200,7 @@ class BashParseStatementTests(unittest.TestCase):
 
     def _eval(self, statement: object) -> list[str]:
         assert isinstance(statement, Command)
-        return self.parser.evaluate(statement)
+        return evaluate_now(self.parser, statement)
 
     def test_semicolon_splits(self) -> None:
         statements = self.parser.parse("echo a; echo b")
@@ -289,7 +300,7 @@ class BashParseCommentTests(unittest.TestCase):
     def _tokens(self, line: str) -> list[str]:
         statement = self.parser.parse(line)[0]
         assert isinstance(statement, Command)
-        return self.parser.evaluate(statement)
+        return evaluate_now(self.parser, statement)
 
     def test_trailing_comment_dropped(self) -> None:
         self.assertEqual(self._tokens("echo foo #comment"), ["echo", "foo"])
@@ -318,7 +329,7 @@ class BashParseCompoundTests(unittest.TestCase):
 
     def _eval(self, command: object) -> list[str]:
         assert isinstance(command, Command)
-        return self.parser.evaluate(command)
+        return evaluate_now(self.parser, command)
 
     def test_for_clause(self) -> None:
         node = self._one("for i in a b c; do echo $i; done")

--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -15,6 +15,7 @@ from unittest import mock
 
 from twisted.internet import defer, error
 from twisted.python.failure import Failure
+from twisted.web.http_headers import Headers
 
 from cowrie.commands.curl import Command_curl
 from cowrie.core.artifact import Artifact
@@ -207,3 +208,59 @@ class CurlOutboundBindTests(unittest.TestCase):
     def test_default_bind_is_wildcard(self) -> None:
         agent = self._capture_agent(head_request=False, verb="get")
         self.assertEqual(agent._endpointFactory._bindAddress, ("0.0.0.0", 0))
+
+
+class CurlStdoutOutputTests(unittest.TestCase):
+    """curl -o - must stream the fetched body to stdout, like real curl."""
+
+    PROMPT = b"root@unitTest:~# "
+    BODY = b"fetched-body-bytes\n"
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+        self.events = capture_events(self.proto)
+
+        self.tmpdir = tempfile.mkdtemp()
+        self._orig_artifact_dir = Artifact.artifactDir
+        Artifact.artifactDir = self.tmpdir
+
+    def tearDown(self) -> None:
+        Artifact.artifactDir = self._orig_artifact_dir
+        self.proto.connectionLost()
+        for name in os.listdir(self.tmpdir):
+            os.remove(os.path.join(self.tmpdir, name))
+        os.rmdir(self.tmpdir)
+
+    def _serve(self, line: bytes) -> None:
+        """Run a curl line with treq stubbed to deliver BODY for any URL."""
+        headers = Headers({b"content-type": [b"text/html"]})
+        response = mock.Mock(length=len(self.BODY), code=200, phrase=b"OK")
+        response.headers = headers
+
+        def fake_get(url: str, agent: Any = None, **kwargs: Any) -> Any:
+            return defer.succeed(response)
+
+        def fake_collect(resp: Any, collector: Any) -> Any:
+            collector(self.BODY)
+            return defer.succeed(None)
+
+        with (
+            mock.patch("cowrie.commands.curl.treq.get", fake_get),
+            mock.patch("cowrie.commands.curl.treq.collect", fake_collect),
+        ):
+            self.proto.lineReceived(line)
+
+    def test_dash_output_streams_body_to_stdout(self) -> None:
+        self._serve(b"curl -s -o - http://8.8.8.8/page\n")
+        self.assertEqual(self.tr.value(), self.BODY + self.PROMPT)
+
+    def test_dash_output_creates_no_honeyfs_file(self) -> None:
+        self._serve(b"curl -s -o - http://8.8.8.8/page\n")
+        self.assertFalse(self.proto.fs.exists("/root/-"))
+
+    def test_substitution_captures_dash_output_body(self) -> None:
+        self._serve(b"echo got:$(curl -s -o - http://8.8.8.8/page)\n")
+        self.assertEqual(self.tr.value(), b"got:fetched-body-bytes\n" + self.PROMPT)

--- a/src/cowrie/test/test_wget.py
+++ b/src/cowrie/test/test_wget.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 
 from twisted.internet import defer, error
 from twisted.python.failure import Failure
+from twisted.web.http_headers import Headers
 
 from cowrie.commands.wget import Command_wget
 from cowrie.core.artifact import Artifact
@@ -238,3 +239,60 @@ class WgetOutboundBindTests(unittest.TestCase):
             cmd.ftpDownload(urldata)
 
         self.assertEqual(captured["bindAddress"], ("127.0.0.1", 0))
+
+
+class WgetStdoutOutputTests(unittest.TestCase):
+    """wget -O- must stream the fetched body to stdout, like real wget."""
+
+    PROMPT = b"root@unitTest:~# "
+    BODY = b"fetched-body-bytes\n"
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+        self.events = capture_events(self.proto)
+
+        self.tmpdir = tempfile.mkdtemp()
+        self._orig_artifact_dir = Artifact.artifactDir
+        Artifact.artifactDir = self.tmpdir
+
+    def tearDown(self) -> None:
+        Artifact.artifactDir = self._orig_artifact_dir
+        self.proto.connectionLost()
+        for name in os.listdir(self.tmpdir):
+            os.remove(os.path.join(self.tmpdir, name))
+        os.rmdir(self.tmpdir)
+
+    def _serve(self, line: bytes) -> None:
+        """Run a wget line with treq stubbed to deliver BODY for any URL."""
+        headers = Headers({b"content-type": [b"text/html"]})
+        response = mock.Mock(length=len(self.BODY), code=200, phrase=b"OK")
+        response.headers = headers
+
+        def fake_get(url: str, agent: Any = None, **kwargs: Any) -> Any:
+            return defer.succeed(response)
+
+        def fake_collect(resp: Any, collector: Any) -> Any:
+            collector(self.BODY)
+            return defer.succeed(None)
+
+        with (
+            mock.patch("cowrie.commands.wget.treq.get", fake_get),
+            mock.patch("cowrie.commands.wget.treq.collect", fake_collect),
+        ):
+            self.proto.lineReceived(line)
+
+    def test_dash_outfile_streams_body_to_stdout(self) -> None:
+        self._serve(b"wget -qO- http://8.8.8.8/page\n")
+        self.assertEqual(self.tr.value(), self.BODY + self.PROMPT)
+
+    def test_dash_outfile_creates_no_honeyfs_file(self) -> None:
+        self._serve(b"wget -qO- http://8.8.8.8/page\n")
+        self.assertFalse(self.proto.fs.exists("/root/-"))
+        self.assertFalse(self.proto.fs.exists("-"))
+
+    def test_substitution_captures_dash_outfile_body(self) -> None:
+        self._serve(b"echo got:$(wget -qO- http://8.8.8.8/page)\n")
+        self.assertEqual(self.tr.value(), b"got:fetched-body-bytes\n" + self.PROMPT)


### PR DESCRIPTION
Fixes #40346.

`echo $(wget -qO- URL)` always substituted the empty string: `_capture_command()` read the capture buffer as soon as `runCommand()` returned, but wget/curl only produce output when their Deferred fires. The still-running command object was also stranded on the cmdstack, and its eventual `exit()` called `resume()` on whatever happened to top the stack at that later point.

This takes the blocking-semantics route discussed in the issue: word evaluation now waits for the substitution's subshell to finish, the way bash blocks on the substitution pipe.

**How it works**

- A capture subshell runs its statements through the normal `cmdpending`/`_advance` machinery and accumulates every statement's captured stdout in one shell-owned buffer (all commands in a `$(...)` child share one pipe). Completion is a Deferred that fires when the subshell leaves the cmdstack — queue drained, an inner `exit`, or an `exec` replacement — the analog of the parent's read seeing EOF. An async command now sits above the capture subshell until it finishes, so its `exit()` resumes the subshell that ran it: the stranded-command hazard is gone structurally.
- Word evaluation (`evaluate`/`_eval_word`/`_eval_atom`/`_eval_dquoted`) is a coroutine driven by `Deferred.fromCoroutine`; a `$(...)`/backtick atom awaits the capture Deferred. These are Twisted-native coroutines, not asyncio: awaiting an already-fired Deferred resumes in the same stack, so a line with only synchronous substitutions completes inline exactly as before. `bashparse` stays Twisted-free — it awaits whatever awaitable the `ShellContext` returns. Substitutions run left to right, each to completion.
- The substitution's exit status becomes `$?` for the rest of the expansion and for an assignments-only statement (`x=$(false); echo $?` prints 1).
- A line typed while a substitution is pending is stdin data buffered for the next real reader; it no longer executes inside the subshell with its output swallowed into the captured text.
- Compound statements inside substitutions (`$(for i in a b; do echo $i; done)`) now run; the old capture loop skipped everything but simple commands and subshell groups.

**Related fixes found while verifying end-to-end**

- `wget -O-` never wrote the fetched body to stdout (the stdout branch checked `not self.outfile`, and `"-"` is truthy) and created a honeyfs file literally named `-`. The issue's exact repro needs this.
- `curl -o -` had the same defect; it is normalized to the stdout path at option parse time.

**Testing**

- New `test_async_substitution.py` (16 tests) driving a fake Deferred-completing command through the real shell: blocking, capture, backticks, assignment, nesting, `$(exit)`, `&&`/`||` around the async command, loops inside substitutions, typed input during a pending substitution, `$?` propagation.
- New treq-stubbed `-O-`/`-o -` stdout tests in `test_wget.py`/`test_curl.py`.
- Verified live against a running cowrie over real SSH: `echo $(wget -qO- http://example.com/)` blocks, then substitutes the fetched page body; the download artifact and `file_download` event are unchanged.
- Full suite (999 tests), `ruff check`, and mypy are green.

**Known limitations (pre-existing, unchanged)**: substitution results are not word-split; `$(cd /tmp)` leaks cwd (protocol-owned); an async command in a mid-pipeline stage (`$(wget URL | grep x)`) still races the downstream stage — that is pipeline machinery, independent of substitution.
