### PR TITLE
fix: declare ILogObserver on the log observer factory

### DIFF
--- a/src/cowrie/python/logfile.py
+++ b/src/cowrie/python/logfile.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from twisted.logger import (
     FilteringLogObserver,
+    ILogObserver,
     InvalidLogLevelError,
     Logger,
     LogLevel,
@@ -20,6 +21,7 @@ from twisted.logger import (
 )
 from twisted.python import context, logfile
 from twisted.python.log import ILogContext
+from zope.interface import directlyProvides
 
 from cowrie.core.config import CowrieConfig
 
@@ -140,6 +142,10 @@ def _observer(outFile: Any) -> Callable[[dict], None]:
                 event = {**event, "log_system": system}
         filtered(event)
 
+    # twistd's AppLogger only accepts the observer natively when it
+    # declares ILogObserver; otherwise it warns and wraps it in a
+    # legacy adapter.
+    directlyProvides(annotated, ILogObserver)
     return annotated
 
 

--- a/src/cowrie/test/test_logfile.py
+++ b/src/cowrie/test/test_logfile.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for the cowrie.log observer factory: the observers it
+# ABOUTME: produces must declare ILogObserver so twistd accepts them natively.
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from twisted.logger import ILogObserver
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class LogObserverInterfaceTests(unittest.TestCase):
+    """
+    twistd's AppLogger only recognizes observers that declare
+    twisted.logger.ILogObserver; anything else is wrapped in a legacy
+    adapter with a deprecation warning.
+    """
+
+    def setUp(self) -> None:
+        self.dir = tempfile.mkdtemp()
+        os.environ["COWRIE_HONEYPOT_LOG_PATH"] = self.dir
+
+    def tearDown(self) -> None:
+        del os.environ["COWRIE_HONEYPOT_LOG_PATH"]
+        shutil.rmtree(self.dir)
+
+    def test_logger_provides_ilogobserver(self) -> None:
+        from cowrie.python.logfile import logger
+
+        observer = logger()
+        self.assertTrue(ILogObserver.providedBy(observer))
+
+    def test_stdout_logger_provides_ilogobserver(self) -> None:
+        from cowrie.python.logfile import stdoutLogger
+
+        observer = stdoutLogger()
+        self.assertTrue(ILogObserver.providedBy(observer))


### PR DESCRIPTION
## Summary

Starting cowrie prints this on every launch:

```
twisted/application/app.py:372: DeprecationWarning: Passing a logger factory which makes log observers which do not implement twisted.logger.ILogObserver or twisted.python.log.ILogObserver to twisted.application.app.AppLogger was deprecated in Twisted 16.2. ...
```

The observer built in `cowrie/python/logfile.py` is new-style `twisted.logger` machinery throughout (`textFileLogObserver` behind a `FilteringLogObserver`), but the factory returns a bare closure that never *declares* `ILogObserver`. `AppLogger.start` checks the zope.interface declaration, not the call signature, so it assumes a legacy `twisted.python.log` observer, emits the warning, and wraps the observer in a `LegacyLogObserverWrapper` that converts every event to legacy shape before delivery.

Fix: mark the returned observer with `directlyProvides(annotated, ILogObserver)`. twistd now accepts it natively — no warning, no legacy translation layer. Covers both `logger()` (cowrie.log) and `stdoutLogger()` (`COWRIE_STDOUT`/Docker), which share `_observer()`.

## Testing

- New `test_logfile.py` asserts both factories produce `ILogObserver`-providing observers (fails without the fix).
- Started cowrie from source and drove a real SSH session: warning gone, session-prefixed log lines (`[HoneyPotSSHTransport,0,...]`) render unchanged, no tracebacks.
- Full unittest suite, ruff, and mypy pass.