### PR TITLE
Give each shell its own working directory

### DIFF
--- a/src/cowrie/commands/awk.py
+++ b/src/cowrie/commands/awk.py
@@ -66,7 +66,7 @@ class Command_awk(HoneyPotCommand):
                     self.output(self.input_data)
                     continue
 
-                pname = self.fs.resolve_path(arg, self.protocol.cwd)
+                pname = self.fs.resolve_path(arg, self.cwd)
 
                 if self.fs.isdir(pname):
                     self.errorWrite(f"awk: {arg}: Is a directory\n")

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -1348,7 +1348,7 @@ class Command_test(HoneyPotCommand):
             # An empty path is not any kind of file: bash reports every file
             # test on "" as false. Short-circuit before resolving it.
             return False
-        path = self.fs.resolve_path(operand, self.protocol.cwd)
+        path = self.fs.resolve_path(operand, self.cwd)
         if op in ("-L", "-h"):
             try:
                 return bool(self.fs.islink(path))

--- a/src/cowrie/commands/base64.py
+++ b/src/cowrie/commands/base64.py
@@ -108,7 +108,7 @@ Try 'base64 --help' for more information.
                 self.exit()
                 return
 
-            pname = self.fs.resolve_path(args[0], self.protocol.cwd)
+            pname = self.fs.resolve_path(args[0], self.cwd)
             if not self.fs.isdir(pname):
                 try:
                     self.dojob(self.fs.file_contents(pname))

--- a/src/cowrie/commands/bash.py
+++ b/src/cowrie/commands/bash.py
@@ -48,7 +48,7 @@ class Command_sh(HoneyPotCommand):
     def execute_script_file(self, filename: str) -> None:
         # bash refuses to run a binary file and reports it the same way for a
         # missing one; the script contents otherwise go straight to the parser.
-        path = self.fs.resolve_path(filename, self.protocol.cwd)
+        path = self.fs.resolve_path(filename, self.cwd)
         run_script_file(
             self,
             path,

--- a/src/cowrie/commands/busybox.py
+++ b/src/cowrie/commands/busybox.py
@@ -77,7 +77,7 @@ class Command_busybox(HoneyPotCommand):
         line = " ".join(self.args)
         cmd = self.args[0]
         cmdclass = self.protocol.getCommand(
-            cmd, self.environ.get("PATH", "").split(":")
+            cmd, self.environ.get("PATH", "").split(":"), self.cwd
         )
         if cmdclass:
             # log found command
@@ -98,6 +98,7 @@ class Command_busybox(HoneyPotCommand):
                 None,
                 redirect=self.protocol.pp.redirect,
                 redirections=self.protocol.pp.redirections,
+                cwd=self.cwd,
             )
 
             # insert the command as we do when chaining commands with pipes

--- a/src/cowrie/commands/cat.py
+++ b/src/cowrie/commands/cat.py
@@ -53,7 +53,7 @@ class Command_cat(HoneyPotCommand):
                     self.output(self.input_data)
                     continue
 
-                pname = self.fs.resolve_path(arg, self.protocol.cwd)
+                pname = self.fs.resolve_path(arg, self.cwd)
 
                 if self.fs.isdir(pname):
                     self.errorWrite(f"cat: {arg}: Is a directory\n")

--- a/src/cowrie/commands/chmod.py
+++ b/src/cowrie/commands/chmod.py
@@ -85,11 +85,11 @@ class Command_chmod(HoneyPotCommand):
         for file in files:
             if file == "*":
                 # if the current directory is empty, return 'No such file or directory'
-                files = self.fs.get_path(self.protocol.cwd)[:]
+                files = self.fs.get_path(self.cwd)[:]
                 if not files:
                     self.errorWrite("chmod: cannot access '*': No such file or directory\n")
             else:
-                path = self.fs.resolve_path(file, self.protocol.cwd)
+                path = self.fs.resolve_path(file, self.cwd)
                 if not self.fs.exists(path):
                     self.errorWrite(
                         f"chmod: cannot access '{file}': No such file or directory\n"

--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -266,7 +266,7 @@ class Command_curl(HoneyPotCommand):
                     return
 
         if self.outfile:
-            self.outfile = self.fs.resolve_path(self.outfile, self.protocol.cwd)
+            self.outfile = self.fs.resolve_path(self.outfile, self.cwd)
             path = posixpath.dirname(self.outfile) if self.outfile else ""
             if not path or not self.fs.exists(path) or not self.fs.isdir(path):
                 self.errorWrite(

--- a/src/cowrie/commands/cut.py
+++ b/src/cowrie/commands/cut.py
@@ -71,7 +71,7 @@ class Command_cut(HoneyPotCommand):
             self.exit()
         elif args:
             for arg in args:
-                pname = self.fs.resolve_path(arg, self.protocol.cwd)
+                pname = self.fs.resolve_path(arg, self.cwd)
                 try:
                     contents = self.fs.file_contents(pname)
                     self._process(contents)

--- a/src/cowrie/commands/dd.py
+++ b/src/cowrie/commands/dd.py
@@ -47,7 +47,7 @@ class Command_dd(HoneyPotCommand):
             block = 512
             if "if" in self.ddargs:
                 iname = self.ddargs["if"]
-                pname = self.fs.resolve_path(iname, self.protocol.cwd)
+                pname = self.fs.resolve_path(iname, self.cwd)
                 if self.fs.isdir(pname):
                     self.errorWrite(f"dd: {iname}: Is a directory\n")
                     bSuccess = False

--- a/src/cowrie/commands/du.py
+++ b/src/cowrie/commands/du.py
@@ -81,7 +81,7 @@ or available locally via: info '(coreutils) du invocation'\n"""
     def call(self) -> None:
         self.showHidden = False
         self.showDirectories = False
-        path = self.protocol.cwd
+        path = self.cwd
         args = self.args
         if args:
             if "-sh" == args[0]:

--- a/src/cowrie/commands/find.py
+++ b/src/cowrie/commands/find.py
@@ -27,7 +27,7 @@ class Command_find(HoneyPotCommand):
         self.name_pattern = None
         self.type_filter = None
 
-        self.start_path = self.protocol.cwd
+        self.start_path = self.cwd
 
         idx = 0
         while idx < len(self.args):
@@ -68,8 +68,8 @@ class Command_find(HoneyPotCommand):
                     self.exit()
                     return
 
-            elif not arg.startswith("-") and self.start_path == self.protocol.cwd:
-                self.start_path = self.fs.resolve_path(arg, self.protocol.cwd)
+            elif not arg.startswith("-") and self.start_path == self.cwd:
+                self.start_path = self.fs.resolve_path(arg, self.cwd)
 
             else:
                 self.errorWrite(f"find: unknown argument '{arg}'\n")

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -303,7 +303,7 @@ class Command_cd(HoneyPotCommand):
             pname = self.args[0]
         newpath = ""
         try:
-            newpath = self.fs.resolve_path(pname, self.protocol.cwd)
+            newpath = self.fs.resolve_path(pname, self.cwd)
             inode = self.fs.getfile(newpath)
         except Exception:
             inode = None
@@ -316,7 +316,9 @@ class Command_cd(HoneyPotCommand):
         if inode[fs.A_TYPE] != fs.T_DIR:
             self.errorWrite(f"bash: cd: {pname}: Not a directory\n")
             return
-        self.protocol.cwd = newpath
+        # cd is a builtin: it changes the running shell's directory, not this
+        # command process's own.
+        self.shell.cwd = newpath
 
 
 commands["cd"] = Command_cd
@@ -402,7 +404,7 @@ or available locally via: info '(coreutils) rm invocation'\n"""
                 return
 
         for f in args:
-            pname = self.fs.resolve_path(f, self.protocol.cwd)
+            pname = self.fs.resolve_path(f, self.cwd)
             node = self.fs.getfile(pname, follow_symlinks=False)
             if node is None:
                 if not force:
@@ -448,7 +450,7 @@ class Command_cp(HoneyPotCommand):
                 recursive = True
 
         def resolv(pname: str) -> str:
-            rsv: str = self.fs.resolve_path(pname, self.protocol.cwd)
+            rsv: str = self.fs.resolve_path(pname, self.cwd)
             return rsv
 
         if len(args) < 2:
@@ -520,7 +522,7 @@ class Command_mv(HoneyPotCommand):
             return
 
         def resolv(pname: str) -> str:
-            rsv: str = self.fs.resolve_path(pname, self.protocol.cwd)
+            rsv: str = self.fs.resolve_path(pname, self.cwd)
             return rsv
 
         if len(args) < 2:
@@ -575,7 +577,7 @@ class Command_mkdir(HoneyPotCommand):
 
     def call(self) -> None:
         for f in self.args:
-            pname = self.fs.resolve_path(f, self.protocol.cwd)
+            pname = self.fs.resolve_path(f, self.cwd)
             if self.fs.exists(pname):
                 self.errorWrite(f"mkdir: cannot create directory `{f}': File exists\n")
                 return
@@ -601,7 +603,7 @@ class Command_rmdir(HoneyPotCommand):
 
     def call(self) -> None:
         for f in self.args:
-            pname = self.fs.resolve_path(f, self.protocol.cwd)
+            pname = self.fs.resolve_path(f, self.cwd)
             try:
                 if len(self.fs.get_path(pname)):
                     self.errorWrite(
@@ -638,7 +640,7 @@ class Command_pwd(HoneyPotCommand):
     """
 
     def call(self) -> None:
-        self.write(self.protocol.cwd + "\n")
+        self.write(self.cwd + "\n")
 
 
 commands["/bin/pwd"] = Command_pwd
@@ -656,7 +658,7 @@ class Command_touch(HoneyPotCommand):
             self.errorWrite("Try `touch --help' for more information.\n")
             return
         for f in self.args:
-            pname = self.fs.resolve_path(f, self.protocol.cwd)
+            pname = self.fs.resolve_path(f, self.cwd)
             if not self.fs.exists(posixpath.dirname(pname)):
                 self.errorWrite(
                     f"touch: cannot touch `{pname}`: No such file or directory\n"

--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -163,7 +163,7 @@ Download a file via FTP
             self.exit(1)
             return
 
-        fakeoutfile = self.fs.resolve_path(self.local_file, self.protocol.cwd)
+        fakeoutfile = self.fs.resolve_path(self.local_file, self.cwd)
         path = posixpath.dirname(fakeoutfile)
         if not path or not self.fs.exists(path) or not self.fs.isdir(path):
             self.errorWrite(

--- a/src/cowrie/commands/gcc.py
+++ b/src/cowrie/commands/gcc.py
@@ -120,7 +120,7 @@ class Command_gcc(HoneyPotCommand):
         # Check for *.c or *.cpp files
         for value in args:
             if ".c" in value.lower():
-                sourcefile = self.fs.resolve_path(value, self.protocol.cwd)
+                sourcefile = self.fs.resolve_path(value, self.cwd)
 
                 if self.fs.exists(sourcefile):
                     input_files = input_files + 1
@@ -202,7 +202,7 @@ gcc version {version} (Debian {version}-5)"""
             f.write(data)
 
         # Output file
-        outfile = self.fs.resolve_path(outfile, self.protocol.cwd)
+        outfile = self.fs.resolve_path(outfile, self.cwd)
 
         # Create file for the protocol
         self.fs.mkfile(

--- a/src/cowrie/commands/git.py
+++ b/src/cowrie/commands/git.py
@@ -22,7 +22,7 @@ class Command_git(HoneyPotCommand):
             self.display_usage()
             return
 
-        path = self.protocol.cwd
+        path = self.cwd
         subcommand = self.args[0]
 
         if subcommand == "--version":

--- a/src/cowrie/commands/ls.py
+++ b/src/cowrie/commands/ls.py
@@ -35,7 +35,7 @@ class Command_ls(HoneyPotCommand):
             return group
 
     def call(self) -> None:
-        path = self.protocol.cwd
+        path = self.cwd
         paths = []
         self.showHidden = False
         self.showDirectories = False
@@ -65,7 +65,7 @@ class Command_ls(HoneyPotCommand):
                 self.showDirectories = True
 
         for arg in args:
-            paths.append(self.protocol.fs.resolve_path(arg, self.protocol.cwd))
+            paths.append(self.protocol.fs.resolve_path(arg, self.cwd))
 
         if not paths:
             func(path)

--- a/src/cowrie/commands/nohup.py
+++ b/src/cowrie/commands/nohup.py
@@ -17,7 +17,7 @@ class Command_nohup(HoneyPotCommand):
             self.write("nohup: missing operand\n")
             self.write("Try `nohup --help' for more information.\n")
             return
-        path = self.fs.resolve_path("nohup.out", self.protocol.cwd)
+        path = self.fs.resolve_path("nohup.out", self.cwd)
         if self.fs.exists(path):
             return
         self.fs.mkfile(path, self.current_user["uid"], self.current_user["gid"], 0, 33188)

--- a/src/cowrie/commands/perl.py
+++ b/src/cowrie/commands/perl.py
@@ -96,7 +96,7 @@ class Command_perl(HoneyPotCommand):
                 return
 
         for value in args:
-            sourcefile = self.fs.resolve_path(value, self.protocol.cwd)
+            sourcefile = self.fs.resolve_path(value, self.cwd)
 
             if self.fs.exists(sourcefile):
                 self.exit()

--- a/src/cowrie/commands/python.py
+++ b/src/cowrie/commands/python.py
@@ -105,7 +105,7 @@ class Command_python(HoneyPotCommand):
                 return
 
         for value in args:
-            sourcefile = self.fs.resolve_path(value, self.protocol.cwd)
+            sourcefile = self.fs.resolve_path(value, self.cwd)
 
             if self.fs.exists(sourcefile) or value == "-":
                 self.exit()

--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -59,7 +59,7 @@ class Command_scp(HoneyPotCommand):
                 break
 
         if self.out_dir:
-            outdir = self.fs.resolve_path(self.out_dir, self.protocol.cwd)
+            outdir = self.fs.resolve_path(self.out_dir, self.cwd)
 
             if not self.fs.exists(outdir):
                 self.errorWrite(f"-scp: {self.out_dir}: No such file or directory\n")
@@ -169,7 +169,7 @@ class Command_scp(HoneyPotCommand):
                     else:
                         fname = scpname
 
-                    outfile = self.fs.resolve_path(fname, self.protocol.cwd)
+                    outfile = self.fs.resolve_path(fname, self.cwd)
 
                     try:
                         self.fs.mkfile(

--- a/src/cowrie/commands/ssh.py
+++ b/src/cowrie/commands/ssh.py
@@ -135,9 +135,8 @@ class Command_ssh(HoneyPotCommand):
         else:
             host = "localhost"
         self.protocol.hostname = host
-        self.protocol.cwd = "/root"
-        if not self.fs.exists(self.protocol.cwd):
-            self.protocol.cwd = "/"
+        # The fake remote login lands the running shell in root's home there.
+        self.shell.cwd = "/root" if self.fs.exists("/root") else "/"
         self.protocol.password_input = False
         self.write(
             f"Linux {self.protocol.hostname} 2.6.26-2-686 #1 SMP Wed Nov 4 20:45:37 \

--- a/src/cowrie/commands/su.py
+++ b/src/cowrie/commands/su.py
@@ -177,16 +177,17 @@ class Command_su(HoneyPotCommand):
         self, effective_user: dict[str, Any], login_shell: bool, preserve_env: bool
     ) -> None:
         """Start an interactive shell as the target user."""
-        # For login shell, change cwd BEFORE creating shell (since shell shows prompt)
-        if login_shell:
-            if self.protocol.fs.exists(effective_user["home"]):
-                self.protocol.cwd = effective_user["home"]
-            else:
-                self.protocol.cwd = "/"
-
         shell = HoneyPotShell(
             self.protocol, interactive=True, effective_user=effective_user
         )
+
+        # A login shell (`su -`) starts in the target user's home; a plain su
+        # keeps the inherited working directory.
+        if login_shell:
+            if self.protocol.fs.exists(effective_user["home"]):
+                shell.cwd = effective_user["home"]
+            else:
+                shell.cwd = "/"
 
         if login_shell:
             # Login shell: reset environment to target user's defaults

--- a/src/cowrie/commands/sudo.py
+++ b/src/cowrie/commands/sudo.py
@@ -94,7 +94,7 @@ class Command_sudo(HoneyPotCommand):
         parsed_arguments = []
         for count in range(0, len(self.args)):
             class_found = self.protocol.getCommand(
-                self.args[count], self.environ.get("PATH", "").split(":")
+                self.args[count], self.environ.get("PATH", "").split(":"), self.cwd
             )
             if class_found:
                 start_value = count
@@ -123,12 +123,13 @@ class Command_sudo(HoneyPotCommand):
         if len(parsed_arguments) > 0:
             cmd = parsed_arguments[0]
             cmdclass = self.protocol.getCommand(
-                cmd, self.environ.get("PATH", "").split(":")
+                cmd, self.environ.get("PATH", "").split(":"), self.cwd
             )
 
             if cmdclass:
                 command = PipeProtocol(
-                    self.protocol, cmdclass, parsed_arguments[1:], None, None
+                    self.protocol, cmdclass, parsed_arguments[1:], None, None,
+                    cwd=self.cwd,
                 )
                 self.protocol.pp.insert_command(command)
                 # this needs to go here so it doesn't write it out....

--- a/src/cowrie/commands/tar.py
+++ b/src/cowrie/commands/tar.py
@@ -49,7 +49,7 @@ class Command_tar(HoneyPotCommand):
         if "v" in self.args[0]:
             verbose = True
 
-        path = self.fs.resolve_path(filename, self.protocol.cwd)
+        path = self.fs.resolve_path(filename, self.cwd)
         if not path or not self.protocol.fs.exists(path):
             self.errorWrite(
                 f"tar: {filename}: Cannot open: No such file or directory\n"
@@ -75,7 +75,7 @@ class Command_tar(HoneyPotCommand):
             return
 
         for f in t:
-            dest = self.fs.resolve_path(f.name.strip("/"), self.protocol.cwd)
+            dest = self.fs.resolve_path(f.name.strip("/"), self.cwd)
             if verbose:
                 self.write(f"{f.name}\n")
             if not extract or not len(dest):

--- a/src/cowrie/commands/tee.py
+++ b/src/cowrie/commands/tee.py
@@ -57,13 +57,13 @@ class Command_tee(HoneyPotCommand):
                 self.ignoreInterupts = True
 
         for arg in args:
-            pname = self.fs.resolve_path(arg, self.protocol.cwd)
+            pname = self.fs.resolve_path(arg, self.cwd)
             if self.fs.isdir(pname):
                 self.errorWrite(f"tee: {arg}: Is a directory\n")
                 continue
 
             folder_path = posixpath.dirname(pname)
-            fname = self.fs.resolve_path(folder_path, self.protocol.cwd)
+            fname = self.fs.resolve_path(folder_path, self.cwd)
             if not self.fs.isdir(fname):
                 self.errorWrite(f"tee: {arg}: No such file or directory\n")
                 continue

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -399,7 +399,7 @@ class Command_tftp(HoneyPotCommand):
             return
 
         # Resolve local file path
-        self.fakeoutfile = self.fs.resolve_path(self.file_to_get, self.protocol.cwd)
+        self.fakeoutfile = self.fs.resolve_path(self.file_to_get, self.cwd)
         path = self.fakeoutfile.rsplit("/", 1)[0] if "/" in self.fakeoutfile else "/"
 
         if not self.fs.exists(path) or not self.fs.isdir(path):

--- a/src/cowrie/commands/unzip.py
+++ b/src/cowrie/commands/unzip.py
@@ -65,7 +65,7 @@ class Command_unzip(HoneyPotCommand):
 
         filename = self.args[0]
 
-        path = self.fs.resolve_path(filename, self.protocol.cwd)
+        path = self.fs.resolve_path(filename, self.cwd)
         if not path:
             self.write(
                 f"unzip:  cannot find or open {filename}, {filename}.zip or {filename}.ZIP.\n"
@@ -110,7 +110,7 @@ class Command_unzip(HoneyPotCommand):
             return
         self.write(f"Archive:  {filename}\n")
         for f in t:
-            dest = self.fs.resolve_path(f.filename.strip("/"), self.protocol.cwd)
+            dest = self.fs.resolve_path(f.filename.strip("/"), self.cwd)
             self.write(f"  inflating: {f.filename}\n")
             if not len(dest):
                 continue

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -276,10 +276,10 @@ class Command_wget(HoneyPotCommand):
             self.outfile = urldata.path.split("/")[-1]
             if not len(self.outfile.strip()) or not urldata.path.count("/"):
                 self.outfile = "index.html"
-            self.outfile = self.fs.resolve_path(self.outfile, self.protocol.cwd)
+            self.outfile = self.fs.resolve_path(self.outfile, self.cwd)
 
         elif self.outfile != "-":
-            self.outfile = self.fs.resolve_path(self.outfile, self.protocol.cwd)
+            self.outfile = self.fs.resolve_path(self.outfile, self.cwd)
             path = posixpath.dirname(self.outfile)
             if not path or not self.fs.exists(path) or not self.fs.isdir(path):
                 self.errorWrite(

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -71,6 +71,16 @@ class HoneyPotCommand:
         self.exit_code: int = 0
         self.environ = self.protocol.cmdstack[-1].environ
         self.exported = self.protocol.cmdstack[-1].exported
+        # The shell this command runs in (the nearest shell on the cmdstack at
+        # spawn -- wrapper commands like busybox may sit in between). cwd is
+        # snapshot at spawn, as a spawned process inherits its parent's; the
+        # cd builtin mutates the shell's, not its own.
+        self.shell = next(
+            item
+            for item in reversed(self.protocol.cmdstack)
+            if hasattr(item, "queue_line")
+        )
+        self.cwd: str = self.shell.cwd
         self.fs = self.protocol.fs
         self.data: bytes = b""  # output data
         # used to store STDIN data passed via PIPE
@@ -108,7 +118,7 @@ class HoneyPotCommand:
     def check_arguments(self, application, args):
         files = []
         for arg in args:
-            path = self.fs.resolve_path(arg, self.protocol.cwd)
+            path = self.fs.resolve_path(arg, self.cwd)
             if self.fs.isdir(path):
                 self.errorWrite(
                     f"{application}: error reading `{arg}': Is a directory\n"

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -103,16 +103,24 @@ class HoneyPotShell:
         # group; runCommand splices its statements in only when it runs.
         self.cmdpending: list[Statement | _Continuation] = []
         # A nested shell (e.g. a command substitution) inherits the live
-        # environment of whichever shell is currently running; the very first
-        # shell of a session falls back to the login environment, all of which
-        # is exported.
+        # environment and working directory of whichever shell or command is
+        # currently running, as a forked shell process inherits its parent's;
+        # the very first shell of a session falls back to the login
+        # environment (all of which is exported) and the user's home. cwd is
+        # this shell's own from here on: a cd inside a substitution or nested
+        # script shell never changes the parent's.
         if protocol.cmdstack:
             parent = protocol.cmdstack[-1]
             self.environ: dict[str, str] = copy.copy(parent.environ)
             self.exported: set[str] = copy.copy(parent.exported)
+            self.cwd: str = parent.cwd
         else:
             self.environ = copy.copy(protocol.environ)
             self.exported = set(protocol.environ.keys())
+            if protocol.fs.exists(protocol.user.avatar.home):
+                self.cwd = protocol.user.avatar.home
+            else:
+                self.cwd = "/"
         if hasattr(protocol.user, "windowSize"):
             self.environ["COLUMNS"] = str(protocol.user.windowSize[1])
             self.environ["LINES"] = str(protocol.user.windowSize[0])
@@ -254,10 +262,9 @@ class HoneyPotShell:
 
         A subshell is queued as one unit so its join operator (e.g. the || in
         `x || (a; b)`) gates the whole group; runCommand splices the inner
-        statements in only when the group actually runs. Cowrie does not
-        emulate a subshell's isolated environment (``cwd`` and friends live on
-        the protocol, not the shell), so the inner statements then run in the
-        parent shell.
+        statements in only when the group actually runs. Cowrie does not give
+        a ``(...)`` group its own isolated shell, so the inner statements run
+        in the parent shell and their ``cd`` / variable effects persist.
 
         Returns False to stop queueing after a syntax error: commands already
         queued before the error still run, as in bash.
@@ -765,6 +772,7 @@ class HoneyPotShell:
                     None,
                     self.redirect,
                     first_ops,
+                    cwd=self.cwd,
                 )
                 for real_path, virtual_path in pp.redirect_real_files:
                     self.protocol.terminal.redirFiles.add((real_path, virtual_path))
@@ -795,7 +803,7 @@ class HoneyPotShell:
         cmdclass = None
         for index, cmd in reversed(list(enumerate(cmd_array))):
             cmdclass = self.protocol.getCommand(
-                cmd["command"], environ.get("PATH", "").split(":")
+                cmd["command"], environ.get("PATH", "").split(":"), self.cwd
             )
             if cmdclass:
                 self._log.info(
@@ -811,6 +819,7 @@ class HoneyPotShell:
                         None,
                         self.redirect,
                         cmd.get("redirects", []),
+                        cwd=self.cwd,
                     )
                     pp = lastpp
                 else:
@@ -822,6 +831,7 @@ class HoneyPotShell:
                         lastpp,
                         self.redirect,
                         cmd.get("redirects", []),
+                        cwd=self.cwd,
                     )
                     lastpp = pp
             else:
@@ -848,6 +858,7 @@ class HoneyPotShell:
                         None,
                         self.redirect,
                         redirects,
+                        cwd=self.cwd,
                     )
                     temp_pp.errReceived(message)
                     for real_path, virtual_path in temp_pp.redirect_real_files:
@@ -881,7 +892,7 @@ class HoneyPotShell:
         directory" (ENOENT). Anything else yields "command not found".
         """
         if cmd[:1] in (".", "/"):
-            path = self.protocol.fs.resolve_path(cmd, self.protocol.cwd)
+            path = self.protocol.fs.resolve_path(cmd, self.cwd)
             if self.protocol.fs.isdir(path):
                 return f"-bash: {cmd}: Is a directory\n"
             if not self.protocol.fs.exists(path):
@@ -946,7 +957,7 @@ class HoneyPotShell:
                 uid = self.protocol.user.uid
                 home = self.protocol.user.avatar.home
 
-            cwd = self.protocol.cwd
+            cwd = self.cwd
             homelen = len(home)
             if cwd == home:
                 cwd = "~"
@@ -1000,12 +1011,12 @@ class HoneyPotShell:
             basedir += "/"
 
         if not basedir:
-            tmppath = self.protocol.cwd
+            tmppath = self.cwd
         else:
             tmppath = basedir
 
         try:
-            r = self.protocol.fs.resolve_path(tmppath, self.protocol.cwd)
+            r = self.protocol.fs.resolve_path(tmppath, self.cwd)
         except Exception:
             return
 

--- a/src/cowrie/shell/pipe.py
+++ b/src/cowrie/shell/pipe.py
@@ -46,11 +46,16 @@ class PipeProtocol:
         next_command: Any,
         redirect: bool = False,
         redirections: list[dict[str, Any]] | None = None,
+        *,
+        cwd: str,
     ) -> None:
         self.cmd = cmd
         self.cmdargs = cmdargs
         self.input_data: bytes | None = input_data
         self.next_command = next_command
+        # Working directory redirection targets resolve against: the cwd of
+        # the shell that built this pipeline, at the moment it was built.
+        self.cwd = cwd
         # True once an upstream command has been wired to write to this
         # command's stdin via a pipe; used to decide whether stdin should be
         # closed (EOF) when no terminal will ever feed it.
@@ -162,7 +167,7 @@ class PipeProtocol:
     def _prepare_stdin(self, target: str) -> None:
         """Load stdin from a redirected file path into input_data."""
         try:
-            path = self.protocol.fs.resolve_path(target, self.protocol.cwd)
+            path = self.protocol.fs.resolve_path(target, self.cwd)
             data = self.protocol.fs.file_contents(path)
         except fs.FileNotFound:
             self._emit_redirection_error(
@@ -177,7 +182,7 @@ class PipeProtocol:
 
     def _prepare_output_file(self, target: str, append: bool) -> dict[str, Any] | None:
         """Resolve and ready an output file, returning metadata for writing."""
-        outfile = self.protocol.fs.resolve_path(target, self.protocol.cwd)
+        outfile = self.protocol.fs.resolve_path(target, self.cwd)
         p = self.protocol.fs.getfile(outfile)
         if outfile == "/dev/null":
             return {

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -61,10 +61,6 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         self.sessionno: int
         self.factory = None
 
-        if self.fs.exists(self.user.avatar.home):
-            self.cwd = self.user.avatar.home
-        else:
-            self.cwd = "/"
         self.data = None
         self.password_input = False
         self.cmdstack = []
@@ -189,18 +185,18 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         """
         return True if cmd in self.commands else False
 
-    def getCommand(self, cmd, paths):
+    def getCommand(self, cmd, paths, cwd):
         if not cmd.strip():
             return None
         path = None
         if cmd in self.commands:
             return self.commands[cmd]
         if cmd[0] in (".", "/"):
-            path = self.fs.resolve_path(cmd, self.cwd)
+            path = self.fs.resolve_path(cmd, cwd)
             if not self.fs.exists(path):
                 return None
         else:
-            for i in [f"{self.fs.resolve_path(x, self.cwd)}/{cmd}" for x in paths if x]:
+            for i in [f"{self.fs.resolve_path(x, cwd)}/{cmd}" for x in paths if x]:
                 if self.fs.exists(i):
                     path = i
                     break

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -220,7 +220,7 @@ class ShellBaseCommandsTests(unittest.TestCase):  # TODO: ps, history
 
         self.proto.lineReceived(f"cd {path:s}".encode())
         self.assertEqual(self.tr.value(), PROMPT.replace(b"~", path.encode()))
-        self.assertEqual(self.proto.cwd, path)
+        self.assertEqual(self.proto.cmdstack[0].cwd, path)
 
     def test_cd_error_output(self) -> None:
         self.proto.lineReceived(f"cd {NONEXISTEN_FILE:s}".encode())
@@ -342,7 +342,9 @@ class ShellFileCommandsTests(unittest.TestCase):
 
     def test_pwd_output(self) -> None:
         self.proto.lineReceived(b"pwd\n")
-        self.assertEqual(self.tr.value(), self.proto.cwd.encode() + b"\n" + PROMPT)
+        self.assertEqual(
+            self.tr.value(), self.proto.cmdstack[0].cwd.encode() + b"\n" + PROMPT
+        )
 
     def test_touch_output(self) -> None:
         path = "/tmp/test.txt"

--- a/src/cowrie/test/test_shell_cwd.py
+++ b/src/cowrie/test/test_shell_cwd.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests that cwd is per-shell, like a process: cd in a substitution
+# ABOUTME: or nested shell must not change the parent shell's directory.
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+PROMPT_TMP = b"root@unitTest:/tmp# "
+
+
+class ShellCwdTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def test_top_level_cd_persists(self) -> None:
+        self.proto.lineReceived(b"cd /tmp; pwd\n")
+        self.assertEqual(self.tr.value(), b"/tmp\n" + PROMPT_TMP)
+
+    def test_substitution_sees_its_own_cd(self) -> None:
+        self.proto.lineReceived(b"echo $(cd /tmp; pwd)\n")
+        self.assertEqual(self.tr.value(), b"/tmp\n" + PROMPT)
+
+    def test_substitution_cd_does_not_leak(self) -> None:
+        self.proto.lineReceived(b"echo $(cd /tmp; pwd); pwd\n")
+        self.assertEqual(self.tr.value(), b"/tmp\n/root\n" + PROMPT)
+
+    def test_substitution_inherits_parent_cwd(self) -> None:
+        self.proto.lineReceived(b"cd /etc\n")
+        self.tr.clear()
+        self.proto.lineReceived(b"echo $(pwd)\n")
+        self.assertEqual(self.tr.value(), b"/etc\nroot@unitTest:/etc# ")
+
+    def test_nested_sh_cd_does_not_leak(self) -> None:
+        self.proto.lineReceived(b"sh -c 'cd /tmp; pwd'; pwd\n")
+        self.assertEqual(self.tr.value(), b"/tmp\n/root\n" + PROMPT)
+
+    def test_relative_path_resolves_against_shell_cwd(self) -> None:
+        self.proto.lineReceived(b"cd /etc; cat passwd\n")
+        out = self.tr.value()
+        self.assertIn(b"root:", out)

--- a/src/cowrie/test/test_temp_file_naming.py
+++ b/src/cowrie/test/test_temp_file_naming.py
@@ -65,7 +65,12 @@ class TempFileNamingTests(unittest.TestCase):
             fs=_StubFilesystem(),
         )
         pipe = PipeProtocol(
-            protocol, cmd=None, cmdargs=[], input_data=None, next_command=None
+            protocol,
+            cmd=None,
+            cmdargs=[],
+            input_data=None,
+            next_command=None,
+            cwd="/root",
         )
         safeoutfile = pipe._create_redirect_target("out.txt")
         assert safeoutfile is not None
@@ -84,8 +89,8 @@ class TempFileNamingTests(unittest.TestCase):
     def test_gcc_output_file(self) -> None:
         cmd = Command_gcc.__new__(Command_gcc)
         cmd.fs = _StubFilesystem()
+        cmd.cwd = "/root"
         cmd.protocol = SimpleNamespace(
-            cwd="/root",
             user=SimpleNamespace(uid=0, gid=0),
             commands={},
         )


### PR DESCRIPTION
Follow-up to #40425.

cwd was a single protocol-wide value, so `cd` anywhere changed the whole session: `echo $(cd /tmp; pwd); pwd` left the session in `/tmp`, and a `cd` inside `sh -c '...'` or an `su` shell leaked into the login shell. Real cwd is per-process state, so it now lives on `HoneyPotShell`:

- A nested shell (substitution subshell, `sh -c`, `su`) copies its parent's cwd at creation, like a forked shell process — `$(cd /tmp; pwd)` sees `/tmp` inside and leaves the caller untouched.
- Commands snapshot the launching shell's cwd at spawn (process inheritance) and resolve all paths against that snapshot; `HoneyPotCommand` gains `self.shell` (the nearest shell on the cmdstack at construction) and `self.cwd`.
- The writers keep their semantics through the new owner: the `cd` builtin mutates its shell's cwd; `su -` starts the new shell in the target user's home (a plain `su` keeps the inherited directory); the fake `ssh` moves the running shell to the remote root's home.
- `PipeProtocol` takes the building shell's cwd for redirection targets; `getCommand()` takes the caller's cwd for path-like command names. `protocol.cwd` is gone — no compatibility alias, so nothing can silently fall back to session-global behavior.

Known limitation, unchanged and now documented: a `(...)` group runs spliced into the current shell, so its `cd` still persists; giving groups their own shell instance is a separate change.

Testing: new `test_shell_cwd.py` covers top-level `cd` persistence (including the prompt), substitution inheritance and isolation, `sh -c` isolation, and relative-path resolution. Full suite (1039 tests), `ruff check`, and mypy are green, plus a live SSH session check of `cd /tmp; pwd; echo sub:$(cd /etc; pwd); pwd`.
