### PR TITLE
Give each shell its own user identity

### DIFF
--- a/src/cowrie/commands/apt.py
+++ b/src/cowrie/commands/apt.py
@@ -180,8 +180,8 @@ pages for more information and options.
             self.write(f"Setting up {p} ({self.packages[p]['version']}) ...\n")
             self.fs.mkfile(
                 f"/usr/bin/{p}",
-                self.protocol.user.uid,
-                self.protocol.user.gid,
+                self.user["uid"],
+                self.user["gid"],
                 random.randint(10000, 90000),
                 33188,
             )

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -32,7 +32,7 @@ commands: dict[str, Callable] = {}
 
 class Command_whoami(HoneyPotCommand):
     def call(self) -> None:
-        self.write(f"{self.current_user['username']}\n")
+        self.write(f"{self.user['username']}\n")
 
 
 commands["/usr/bin/whoami"] = Command_whoami
@@ -105,7 +105,7 @@ class Command_w(HoneyPotCommand):
             "USER     TTY      FROM              LOGIN@   IDLE   JCPU   PCPU WHAT\n"
         )
         self.write(
-            f"{self.current_user['username']:8s} pts/0    {self.protocol.clientIP[:17].ljust(17)} {time.strftime('%H:%M', time.localtime(self.protocol.logintime))}    0.00s  0.00s  0.00s w\n"
+            f"{self.user['username']:8s} pts/0    {self.protocol.clientIP[:17].ljust(17)} {time.strftime('%H:%M', time.localtime(self.protocol.logintime))}    0.00s  0.00s  0.00s w\n"
         )
 
 
@@ -116,7 +116,7 @@ commands["w"] = Command_w
 class Command_who(HoneyPotCommand):
     def call(self) -> None:
         self.write(
-            f"{self.current_user['username']:8s} pts/0        {time.strftime('%Y-%m-%d', time.localtime(self.protocol.logintime))} {time.strftime('%H:%M', time.localtime(self.protocol.logintime))} ({self.protocol.clientIP})\n"
+            f"{self.user['username']:8s} pts/0        {time.strftime('%Y-%m-%d', time.localtime(self.protocol.logintime))} {time.strftime('%H:%M', time.localtime(self.protocol.logintime))} ({self.protocol.clientIP})\n"
         )
 
 
@@ -215,7 +215,7 @@ commands["reset"] = Command_clear
 class Command_hostname(HoneyPotCommand):
     def call(self) -> None:
         if self.args:
-            if self.current_user["uid"] == 0:
+            if self.user["uid"] == 0:
                 self.protocol.hostname = self.args[0]
             else:
                 self.write("hostname: you must be root to change the host name\n")
@@ -229,7 +229,7 @@ commands["hostname"] = Command_hostname
 
 class Command_ps(HoneyPotCommand):
     def call(self) -> None:
-        user = str(self.current_user["username"])
+        user = str(self.user["username"])
         args = ""
         if self.args:
             args = self.args[0].strip()
@@ -811,7 +811,7 @@ commands["ps"] = Command_ps
 
 class Command_id(HoneyPotCommand):
     def call(self) -> None:
-        u = self.current_user
+        u = self.user
         self.write(
             f"uid={u['uid']}({u['username']}) gid={u.get('gid', u['uid'])}({u['username']}) groups={u.get('gid', u['uid'])}({u['username']})\n"
         )

--- a/src/cowrie/commands/busybox.py
+++ b/src/cowrie/commands/busybox.py
@@ -99,6 +99,7 @@ class Command_busybox(HoneyPotCommand):
                 redirect=self.protocol.pp.redirect,
                 redirections=self.protocol.pp.redirections,
                 cwd=self.cwd,
+                user=self.user,
             )
 
             # insert the command as we do when chaining commands with pipes

--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -467,8 +467,8 @@ class Command_curl(HoneyPotCommand):
         if self.outfile and self.protocol.user:
             self.fs.mkfile(
                 self.outfile,
-                self.current_user["uid"],
-                self.current_user["gid"],
+                self.user["uid"],
+                self.user["gid"],
                 self.currentlength,
                 33188,
             )

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -298,7 +298,7 @@ class Command_cd(HoneyPotCommand):
 
     def call(self) -> None:
         if not self.args or self.args[0] == "~":
-            pname = self.protocol.user.avatar.home
+            pname = self.user["home"]
         else:
             pname = self.args[0]
         newpath = ""
@@ -583,7 +583,7 @@ class Command_mkdir(HoneyPotCommand):
                 return
             try:
                 self.fs.mkdir(
-                    pname, self.protocol.user.uid, self.protocol.user.gid, 4096, 16877
+                    pname, self.user["uid"], self.user["gid"], 4096, 16877
                 )
             except fs.FileNotFound:
                 self.errorWrite(
@@ -673,7 +673,7 @@ class Command_touch(HoneyPotCommand):
                 return
 
             self.fs.mkfile(
-                pname, self.protocol.user.uid, self.protocol.user.gid, 0, 33188
+                pname, self.user["uid"], self.user["gid"], 0, 33188
             )
 
 

--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -332,7 +332,7 @@ Download a file via FTP
         self.fs.update_realfile(
             self.fs.getfile(self.fakeoutfile), self.artifactFile.shasumFilename
         )
-        self.fs.chown(self.fakeoutfile, self.protocol.user.uid, self.protocol.user.gid)
+        self.fs.chown(self.fakeoutfile, self.user["uid"], self.user["gid"])
 
         self.exit()
 

--- a/src/cowrie/commands/gcc.py
+++ b/src/cowrie/commands/gcc.py
@@ -206,7 +206,7 @@ gcc version {version} (Debian {version}-5)"""
 
         # Create file for the protocol
         self.fs.mkfile(
-            outfile, self.protocol.user.uid, self.protocol.user.gid, len(data), 33188
+            outfile, self.user["uid"], self.user["gid"], len(data), 33188
         )
         self.fs.update_realfile(self.fs.getfile(outfile), safeoutfile)
 

--- a/src/cowrie/commands/git.py
+++ b/src/cowrie/commands/git.py
@@ -42,8 +42,8 @@ class Command_git(HoneyPotCommand):
                 else:
                     self.fs.mkdir(
                         pname,
-                        self.current_user["uid"],
-                        self.current_user["gid"],
+                        self.user["uid"],
+                        self.user["gid"],
                         4096,
                         16877,
                     )
@@ -51,8 +51,8 @@ class Command_git(HoneyPotCommand):
                     initialize_git = self.fs.resolve_path(".git", path + "/" + repo)
                     self.fs.mkdir(
                         initialize_git,
-                        self.current_user["uid"],
-                        self.current_user["gid"],
+                        self.user["uid"],
+                        self.user["gid"],
                         4096,
                         16877,
                     )
@@ -77,7 +77,7 @@ class Command_git(HoneyPotCommand):
                 )
             else:
                 self.fs.mkdir(
-                    pname, self.current_user["uid"], self.current_user["gid"], 4096, 16877
+                    pname, self.user["uid"], self.user["gid"], 4096, 16877
                 )
                 self.write(f"Initialized empty Git repository in {path}/.git/\n")
 

--- a/src/cowrie/commands/groups.py
+++ b/src/cowrie/commands/groups.py
@@ -63,7 +63,7 @@ class Command_groups(HoneyPotCommand):
     def output(self, file_content, username):
         groups_string = bytes("", encoding="utf-8")
         if not username:
-            username = str(self.current_user["username"])
+            username = str(self.user["username"])
         else:
             if not self.check_valid_user(username):
                 self.write(f"groups: '{username}': no such user\n")

--- a/src/cowrie/commands/iptables.py
+++ b/src/cowrie/commands/iptables.py
@@ -54,7 +54,7 @@ class Command_iptables(HoneyPotCommand):
     current_table: dict[str, list[Any]]
 
     def user_is_root(self) -> bool:
-        return self.current_user["uid"] == 0
+        return bool(self.user["uid"] == 0)
 
     def start(self) -> None:
         """

--- a/src/cowrie/commands/last.py
+++ b/src/cowrie/commands/last.py
@@ -25,7 +25,7 @@ class Command_last(HoneyPotCommand):
 
         self.write(
             "{:8s} {:12s} {:16s} {}   still logged in\n".format(
-                self.current_user["username"],
+                self.user["username"],
                 "pts/0",
                 self.protocol.clientIP,
                 time.strftime(

--- a/src/cowrie/commands/nohup.py
+++ b/src/cowrie/commands/nohup.py
@@ -20,7 +20,7 @@ class Command_nohup(HoneyPotCommand):
         path = self.fs.resolve_path("nohup.out", self.cwd)
         if self.fs.exists(path):
             return
-        self.fs.mkfile(path, self.current_user["uid"], self.current_user["gid"], 0, 33188)
+        self.fs.mkfile(path, self.user["uid"], self.user["gid"], 0, 33188)
         self.write("nohup: ignoring input and appending output to 'nohup.out'\n")
 
 

--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -123,7 +123,7 @@ class Command_scp(HoneyPotCommand):
             f = self.fs.getfile(fname)
             if f:
                 self.fs.update_realfile(f, hash_path)
-                self.fs.chown(fname, self.current_user["uid"], self.current_user["gid"])
+                self.fs.chown(fname, self.user["uid"], self.user["gid"])
 
     def parse_scp_data(self, data: bytes) -> bytes:
         # scp data format:
@@ -174,8 +174,8 @@ class Command_scp(HoneyPotCommand):
                     try:
                         self.fs.mkfile(
                             outfile,
-                            self.current_user["uid"],
-                            self.current_user["gid"],
+                            self.user["uid"],
+                            self.user["gid"],
                             filesize,
                             fileperm,
                         )

--- a/src/cowrie/commands/ssh.py
+++ b/src/cowrie/commands/ssh.py
@@ -103,7 +103,7 @@ class Command_ssh(HoneyPotCommand):
             )
 
         self.host = host
-        self.user = user
+        self.remote_user = user
 
         self.write(
             f"The authenticity of host '{self.host} ({self.ip})' \
@@ -121,7 +121,7 @@ class Command_ssh(HoneyPotCommand):
             f"Warning: Permanently added '{self.host}' (RSA) to the \
             list of known hosts.\n"
         )
-        self.write(f"{self.user}@{self.host}'s password: ")
+        self.write(f"{self.remote_user}@{self.host}'s password: ")
         self.protocol.password_input = True
 
     def wait(self, line: str) -> None:

--- a/src/cowrie/commands/su.py
+++ b/src/cowrie/commands/su.py
@@ -114,7 +114,7 @@ class Command_su(HoneyPotCommand):
         }
 
         # Root doesn't need to enter a password (check effective uid, not session uid)
-        if self.current_user["uid"] == 0:
+        if self.user["uid"] == 0:
             self.switch_user()
         else:
             # Prompt for password (hidden input)
@@ -152,10 +152,11 @@ class Command_su(HoneyPotCommand):
         self, command: str, effective_user: dict[str, Any], preserve_env: bool
     ) -> None:
         """Execute a single command as the target user."""
-        # Create a non-interactive shell to run the command
-        shell = HoneyPotShell(
-            self.protocol, interactive=False, effective_user=effective_user
-        )
+        # Create a non-interactive shell running as the target user. The
+        # identity must be set before the command line runs so the commands
+        # it spawns snapshot the switched credentials.
+        shell = HoneyPotShell(self.protocol, interactive=False)
+        shell.user = dict(effective_user)
 
         # Update environment for the target user
         if not preserve_env:
@@ -177,9 +178,8 @@ class Command_su(HoneyPotCommand):
         self, effective_user: dict[str, Any], login_shell: bool, preserve_env: bool
     ) -> None:
         """Start an interactive shell as the target user."""
-        shell = HoneyPotShell(
-            self.protocol, interactive=True, effective_user=effective_user
-        )
+        shell = HoneyPotShell(self.protocol, interactive=True)
+        shell.user = dict(effective_user)
 
         # A login shell (`su -`) starts in the target user's home; a plain su
         # keeps the inherited working directory.

--- a/src/cowrie/commands/sudo.py
+++ b/src/cowrie/commands/sudo.py
@@ -130,6 +130,7 @@ class Command_sudo(HoneyPotCommand):
                 command = PipeProtocol(
                     self.protocol, cmdclass, parsed_arguments[1:], None, None,
                     cwd=self.cwd,
+                    user=self.user,
                 )
                 self.protocol.pp.insert_command(command)
                 # this needs to go here so it doesn't write it out....

--- a/src/cowrie/commands/tar.py
+++ b/src/cowrie/commands/tar.py
@@ -27,8 +27,8 @@ class Command_tar(HoneyPotCommand):
             if p and not self.fs.exists(p):
                 self.fs.mkdir(
                     p,
-                    self.current_user["uid"],
-                    self.current_user["gid"],
+                    self.user["uid"],
+                    self.user["gid"],
                     4096,
                     f.mode,
                     f.mtime,
@@ -83,8 +83,8 @@ class Command_tar(HoneyPotCommand):
             if f.isdir():
                 self.fs.mkdir(
                     dest,
-                    self.current_user["uid"],
-                    self.current_user["gid"],
+                    self.user["uid"],
+                    self.user["gid"],
                     4096,
                     f.mode,
                     f.mtime,
@@ -93,8 +93,8 @@ class Command_tar(HoneyPotCommand):
                 self.mkfullpath(posixpath.dirname(dest), f)
                 self.fs.mkfile(
                     dest,
-                    self.current_user["uid"],
-                    self.current_user["gid"],
+                    self.user["uid"],
+                    self.user["gid"],
                     f.size,
                     f.mode,
                     f.mtime,

--- a/src/cowrie/commands/tee.py
+++ b/src/cowrie/commands/tee.py
@@ -70,7 +70,7 @@ class Command_tee(HoneyPotCommand):
 
             try:
                 self.fs.mkfile(
-                    pname, self.current_user["uid"], self.current_user["gid"], 0, 0o644
+                    pname, self.user["uid"], self.user["gid"], 0, 0o644
                 )
             except FileNotFound:
                 self.errorWrite(f"tee: {arg}: No such file or directory\n")

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -487,8 +487,8 @@ class Command_tftp(HoneyPotCommand):
             size = self.tftp_client.bytes_received if self.tftp_client else 0
             self.fs.mkfile(
                 self.fakeoutfile,
-                self.current_user["uid"],
-                self.current_user["gid"],
+                self.user["uid"],
+                self.user["gid"],
                 size,
                 33188,
             )
@@ -496,7 +496,7 @@ class Command_tftp(HoneyPotCommand):
                 self.fs.getfile(self.fakeoutfile), self.artifactFile.shasumFilename
             )
             self.fs.chown(
-                self.fakeoutfile, self.current_user["uid"], self.current_user["gid"]
+                self.fakeoutfile, self.user["uid"], self.user["gid"]
             )
 
         self._safe_exit()

--- a/src/cowrie/commands/unzip.py
+++ b/src/cowrie/commands/unzip.py
@@ -27,8 +27,8 @@ class Command_unzip(HoneyPotCommand):
             if not self.fs.exists(directory):
                 self.fs.mkdir(
                     directory,
-                    self.current_user["uid"],
-                    self.current_user["gid"],
+                    self.user["uid"],
+                    self.user["gid"],
                     4096,
                     33188,
                 )
@@ -117,8 +117,8 @@ class Command_unzip(HoneyPotCommand):
             if f.is_dir():
                 self.fs.mkdir(
                     dest,
-                    self.current_user["uid"],
-                    self.current_user["gid"],
+                    self.user["uid"],
+                    self.user["gid"],
                     4096,
                     33188,
                 )
@@ -126,8 +126,8 @@ class Command_unzip(HoneyPotCommand):
                 self.mkfullpath(posixpath.dirname(dest))
                 self.fs.mkfile(
                     dest,
-                    self.current_user["uid"],
-                    self.current_user["gid"],
+                    self.user["uid"],
+                    self.user["gid"],
                     f.file_size,
                     33188,
                 )

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -634,8 +634,8 @@ class Command_wget(HoneyPotCommand):
         if self.outfile and self.outfile != "-" and self.protocol.user:
             self.fs.mkfile(
                 self.outfile,
-                self.current_user["uid"],
-                self.current_user["gid"],
+                self.user["uid"],
+                self.user["gid"],
                 self.currentlength,
                 33188,
             )

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -43,26 +43,6 @@ class HoneyPotCommand:
     # created without __init__ (tests).
     exited: bool = False
 
-    @property
-    def current_user(self) -> dict[str, str | int]:
-        """
-        Get the current effective user info.
-        Returns effective_user from the nearest shell in cmdstack (set by su)
-        if present, otherwise returns the session user's info.
-        """
-        # Search cmdstack for a shell with effective_user (from su)
-        # Walk from top to bottom of stack
-        for item in reversed(self.protocol.cmdstack):
-            if hasattr(item, "effective_user") and item.effective_user:
-                return dict(item.effective_user)
-        # Fall back to session user
-        return {
-            "uid": self.protocol.user.uid,
-            "gid": self.protocol.user.gid,
-            "username": self.protocol.user.username,
-            "home": self.protocol.user.avatar.home,
-        }
-
     def __init__(self, protocol, *args):
         self.protocol = protocol
         self.args = list(args)
@@ -72,15 +52,17 @@ class HoneyPotCommand:
         self.environ = self.protocol.cmdstack[-1].environ
         self.exported = self.protocol.cmdstack[-1].exported
         # The shell this command runs in (the nearest shell on the cmdstack at
-        # spawn -- wrapper commands like busybox may sit in between). cwd is
-        # snapshot at spawn, as a spawned process inherits its parent's; the
-        # cd builtin mutates the shell's, not its own.
+        # spawn -- wrapper commands like busybox may sit in between). cwd and
+        # user identity are snapshot at spawn, as a spawned process inherits
+        # its parent's; the cd and su builtins mutate shell state, not their
+        # own.
         self.shell = next(
             item
             for item in reversed(self.protocol.cmdstack)
             if hasattr(item, "queue_line")
         )
         self.cwd: str = self.shell.cwd
+        self.user: dict[str, Any] = dict(self.shell.user)
         self.fs = self.protocol.fs
         self.data: bytes = b""  # output data
         # used to store STDIN data passed via PIPE

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -87,7 +87,6 @@ class HoneyPotShell:
         protocol: Any,
         interactive: bool = True,
         redirect: bool = False,
-        effective_user: dict[str, Any] | None = None,
         reads_stdin: bool = False,
     ) -> None:
         self.protocol = protocol
@@ -96,27 +95,34 @@ class HoneyPotShell:
         # The shell's commands arrive over a live stdin (an SSH exec channel
         # running `bash`): a drained queue means idle, not done, until EOF.
         self.reads_stdin: bool = reads_stdin
-        self.effective_user = effective_user  # For su: {uid, gid, username, home}
         # Parsed-but-not-yet-evaluated statements; each is expanded against the
         # live environment only when it is about to run (see runCommand). A
         # subshell stays a single unit here so its &&/|| gate covers the whole
         # group; runCommand splices its statements in only when it runs.
         self.cmdpending: list[Statement | _Continuation] = []
         # A nested shell (e.g. a command substitution) inherits the live
-        # environment and working directory of whichever shell or command is
-        # currently running, as a forked shell process inherits its parent's;
-        # the very first shell of a session falls back to the login
-        # environment (all of which is exported) and the user's home. cwd is
-        # this shell's own from here on: a cd inside a substitution or nested
-        # script shell never changes the parent's.
+        # environment, working directory and user identity of whichever shell
+        # or command is currently running, as a forked shell process inherits
+        # its parent's; the very first shell of a session falls back to the
+        # login environment (all of which is exported), the login user, and
+        # that user's home. cwd and user are this shell's own from here on: a
+        # cd or su inside a substitution or nested script shell never changes
+        # the parent's.
         if protocol.cmdstack:
             parent = protocol.cmdstack[-1]
             self.environ: dict[str, str] = copy.copy(parent.environ)
             self.exported: set[str] = copy.copy(parent.exported)
             self.cwd: str = parent.cwd
+            self.user: dict[str, Any] = dict(parent.user)
         else:
             self.environ = copy.copy(protocol.environ)
             self.exported = set(protocol.environ.keys())
+            self.user = {
+                "uid": protocol.user.uid,
+                "gid": protocol.user.gid,
+                "username": protocol.user.username,
+                "home": protocol.user.avatar.home,
+            }
             if protocol.fs.exists(protocol.user.avatar.home):
                 self.cwd = protocol.user.avatar.home
             else:
@@ -773,6 +779,7 @@ class HoneyPotShell:
                     self.redirect,
                     first_ops,
                     cwd=self.cwd,
+                    user=self.user,
                 )
                 for real_path, virtual_path in pp.redirect_real_files:
                     self.protocol.terminal.redirFiles.add((real_path, virtual_path))
@@ -820,6 +827,7 @@ class HoneyPotShell:
                         self.redirect,
                         cmd.get("redirects", []),
                         cwd=self.cwd,
+                        user=self.user,
                     )
                     pp = lastpp
                 else:
@@ -832,6 +840,7 @@ class HoneyPotShell:
                         self.redirect,
                         cmd.get("redirects", []),
                         cwd=self.cwd,
+                        user=self.user,
                     )
                     lastpp = pp
             else:
@@ -859,6 +868,7 @@ class HoneyPotShell:
                         self.redirect,
                         redirects,
                         cwd=self.cwd,
+                        user=self.user,
                     )
                     temp_pp.errReceived(message)
                     for real_path, virtual_path in temp_pp.redirect_real_files:
@@ -947,15 +957,9 @@ class HoneyPotShell:
             prompt = CowrieConfig.get("honeypot", "prompt")
             prompt += " "
         else:
-            # Use effective_user if set (from su), otherwise use session user
-            if self.effective_user:
-                username = self.effective_user["username"]
-                uid = self.effective_user["uid"]
-                home = self.effective_user["home"]
-            else:
-                username = self.protocol.user.username
-                uid = self.protocol.user.uid
-                home = self.protocol.user.avatar.home
+            username = self.user["username"]
+            uid = self.user["uid"]
+            home = self.user["home"]
 
             cwd = self.cwd
             homelen = len(home)

--- a/src/cowrie/shell/pipe.py
+++ b/src/cowrie/shell/pipe.py
@@ -48,14 +48,17 @@ class PipeProtocol:
         redirections: list[dict[str, Any]] | None = None,
         *,
         cwd: str,
+        user: dict[str, Any],
     ) -> None:
         self.cmd = cmd
         self.cmdargs = cmdargs
         self.input_data: bytes | None = input_data
         self.next_command = next_command
-        # Working directory redirection targets resolve against: the cwd of
-        # the shell that built this pipeline, at the moment it was built.
+        # Working directory and user identity of the shell that built this
+        # pipeline, at the moment it was built: redirection targets resolve
+        # against the cwd, and the files they create are owned by the user.
         self.cwd = cwd
+        self.user = user
         # True once an upstream command has been wired to write to this
         # command's stdin via a pipe; used to decide whether stdin should be
         # closed (EOF) when no terminal will ever feed it.
@@ -232,8 +235,8 @@ class PipeProtocol:
         try:
             self.protocol.fs.mkfile(
                 outfile,
-                self.protocol.user.uid,
-                self.protocol.user.gid,
+                self.user["uid"],
+                self.user["gid"],
                 0,
                 stat.S_IFREG | perm,
             )

--- a/src/cowrie/test/test_su.py
+++ b/src/cowrie/test/test_su.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import unittest
 
+from cowrie.shell import fs
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
@@ -243,3 +244,35 @@ class SuEnvironmentTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SuFileOwnershipTests(unittest.TestCase):
+    """Files created while su'd must be owned by the effective user, the way
+    a forked process carries the switched credentials."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def test_touch_under_su_owned_by_target_user(self) -> None:
+        self.proto.lineReceived(b"su -c 'touch /tmp/philfile' phil\n")
+        entry = self.proto.fs.getfile("/tmp/philfile")
+        self.assertEqual(entry[fs.A_UID], 1000)
+        self.assertEqual(entry[fs.A_GID], 1000)
+
+    def test_mkdir_under_su_owned_by_target_user(self) -> None:
+        self.proto.lineReceived(b"su -c 'mkdir /tmp/phildir' phil\n")
+        entry = self.proto.fs.getfile("/tmp/phildir")
+        self.assertEqual(entry[fs.A_UID], 1000)
+        self.assertEqual(entry[fs.A_GID], 1000)
+
+    def test_touch_as_root_owned_by_root(self) -> None:
+        self.proto.lineReceived(b"touch /tmp/rootfile\n")
+        entry = self.proto.fs.getfile("/tmp/rootfile")
+        self.assertEqual(entry[fs.A_UID], 0)
+        self.assertEqual(entry[fs.A_GID], 0)

--- a/src/cowrie/test/test_temp_file_naming.py
+++ b/src/cowrie/test/test_temp_file_naming.py
@@ -71,6 +71,7 @@ class TempFileNamingTests(unittest.TestCase):
             input_data=None,
             next_command=None,
             cwd="/root",
+            user={"uid": 0, "gid": 0, "username": "root", "home": "/root"},
         )
         safeoutfile = pipe._create_redirect_target("out.txt")
         assert safeoutfile is not None
@@ -90,6 +91,7 @@ class TempFileNamingTests(unittest.TestCase):
         cmd = Command_gcc.__new__(Command_gcc)
         cmd.fs = _StubFilesystem()
         cmd.cwd = "/root"
+        cmd.user = {"uid": 0, "gid": 0, "username": "root", "home": "/root"}
         cmd.protocol = SimpleNamespace(
             user=SimpleNamespace(uid=0, gid=0),
             commands={},


### PR DESCRIPTION
Follow-up to #40428, applying the same process model to user identity.

Identity was split three ways: the login avatar on the protocol, the `effective_user` dict `su` hung on its shell, and commands reading through *either* the `current_user` cmdstack search *or* `protocol.user` directly. The two read paths disagreed, visibly: under `su phil`, `touch`, `mkdir`, `gcc`, `apt-get`, `ftpget`, and shell redirections (`echo x > f`) created files owned by **root**, while `wget`/`curl` downloads in the same shell were owned by **phil** — `ls -l` showed the inconsistency to anyone who looked.

Identity now lives where a process's credentials live: on `HoneyPotShell`.

- A nested shell (substitution, `sh -c`, `su`) copies its parent's identity at creation, like a forked process; the first shell of a session takes the login avatar's.
- `su` sets the target identity on the shell it spawns — before the `-c` command line runs, so spawned commands see the switched credentials.
- Commands snapshot the launching shell's identity at spawn (`self.user` next to `self.cwd` from #40428) and use it for file ownership, `whoami`/`id`/`w`/`groups`, and root checks (`iptables`, `su`'s password prompt).
- `PipeProtocol` carries the building shell's identity so redirection-created files are owned correctly.
- The `effective_user` constructor parameter and the `current_user` stack-walking property are removed.
- `Command_ssh`'s remote login name is renamed to `remote_user`; it collided with the identity attribute.

Testing: new `SuFileOwnershipTests` in `test_su.py` (written failing first: touch and mkdir under `su phil` produced uid 0). Existing su/prompt/id tests unchanged and green. Full suite (1049 tests), `ruff check`, mypy clean. Live SSH check: `su -c 'touch /tmp/sufile; echo out > /tmp/suredir' phil; touch /tmp/rootfile; ls -l /tmp` shows phil-owned `sufile`/`suredir` and root-owned `rootfile`, with `whoami` back to root afterwards.
