### PR TITLE
Keep a command's stdio wiring on the command

### DIFF
--- a/src/cowrie/commands/bash.py
+++ b/src/cowrie/commands/bash.py
@@ -87,7 +87,7 @@ class Command_sh(HoneyPotCommand):
             isinstance(self.protocol, HoneyPotExecProtocol)
             and len(self.protocol.cmdstack) == 2
             and self.input_data is None
-            and not getattr(self.protocol.pp, "stdin_from_pipe", False)
+            and not getattr(self.pp, "stdin_from_pipe", False)
         )
 
     def interactive_shell(self) -> None:

--- a/src/cowrie/commands/busybox.py
+++ b/src/cowrie/commands/busybox.py
@@ -93,20 +93,20 @@ class Command_busybox(HoneyPotCommand):
             pp = PipeProtocol(
                 self.protocol,
                 cmdclass,
-                self.protocol.pp.cmdargs[1:],
+                self.pp.cmdargs[1:],
                 self.input_data,
                 None,
-                redirect=self.protocol.pp.redirect,
-                redirections=self.protocol.pp.redirections,
+                redirect=self.pp.redirect,
+                redirections=self.pp.redirections,
                 cwd=self.cwd,
                 user=self.user,
             )
 
             # insert the command as we do when chaining commands with pipes
-            self.protocol.pp.insert_command(pp)
+            self.pp.insert_command(pp)
 
             # invoke inserted command
-            self.protocol.pp.outConnectionLost()
+            self.pp.outConnectionLost()
 
             # Place this here so it doesn't write out only if last statement
             if self.input_data:

--- a/src/cowrie/commands/sudo.py
+++ b/src/cowrie/commands/sudo.py
@@ -128,11 +128,15 @@ class Command_sudo(HoneyPotCommand):
 
             if cmdclass:
                 command = PipeProtocol(
-                    self.protocol, cmdclass, parsed_arguments[1:], None, None,
+                    self.protocol,
+                    cmdclass,
+                    parsed_arguments[1:],
+                    None,
+                    None,
                     cwd=self.cwd,
                     user=self.user,
                 )
-                self.protocol.pp.insert_command(command)
+                self.pp.insert_command(command)
                 # this needs to go here so it doesn't write it out....
                 if self.input_data:
                     self.writeBytes(self.input_data)

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -43,6 +43,10 @@ class HoneyPotCommand:
     # created without __init__ (tests).
     exited: bool = False
 
+    # This command's stdio wiring, set at spawn (see __init__). Class-level so
+    # it holds even for instances created without __init__ (tests).
+    pp: Any = None
+
     def __init__(self, protocol, *args):
         self.protocol = protocol
         self.args = list(args)
@@ -67,17 +71,21 @@ class HoneyPotCommand:
         self.data: bytes = b""  # output data
         # used to store STDIN data passed via PIPE
         self.input_data: bytes | None = None
+        # This command's own stdio: the fd table, its redirections and the
+        # link to the next pipeline stage, handed over at spawn. Held per
+        # command because a command that finishes late (an async download)
+        # must still write to and clean up the fds it was started with, not
+        # whichever pipeline is running by the time it ends.
         pp: Any = getattr(self.protocol, "pp", None)
+        self.pp: Any = pp
         self.writefn: Callable[[bytes], None]
         self.errorWritefn: Callable[[bytes], None]
         if pp and hasattr(pp, "write_stdout") and hasattr(pp, "write_stderr"):
             self.writefn = cast("Callable[[bytes], None]", pp.write_stdout)
             self.errorWritefn = cast("Callable[[bytes], None]", pp.write_stderr)
         else:
-            self.writefn = cast("Callable[[bytes], None]", self.protocol.pp.outReceived)
-            self.errorWritefn = cast(
-                "Callable[[bytes], None]", self.protocol.pp.errReceived
-            )
+            self.writefn = cast("Callable[[bytes], None]", pp.outReceived)
+            self.errorWritefn = cast("Callable[[bytes], None]", pp.errReceived)
 
     def write(self, data: str) -> None:
         """
@@ -136,13 +144,16 @@ class HoneyPotCommand:
         self.exited = True
         if code is not None:
             self.exit_code = code
+        # Register this command's own redirection backing files for hashing at
+        # session close. Read from self.pp, not the protocol's current pipe: a
+        # command that finishes after a later one started would otherwise
+        # register that command's files and orphan its own.
         if (
             self.protocol
             and self.protocol.terminal
-            and hasattr(self.protocol, "pp")
-            and getattr(self.protocol.pp, "redirect_real_files", None)
+            and getattr(self.pp, "redirect_real_files", None)
         ):
-            for real_path, virtual_path in self.protocol.pp.redirect_real_files:
+            for real_path, virtual_path in self.pp.redirect_real_files:
                 self.protocol.terminal.redirFiles.add((real_path, virtual_path))
 
         if len(self.protocol.cmdstack):

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -51,6 +51,12 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         self.environ = avatar.environ
         self.hostname: str = self.user.server.hostname
         self.fs = self.user.server.fs
+        # The pipeline being handed to the command now starting, which the
+        # command keeps as its own (HoneyPotCommand.pp). It stays set to the
+        # most recently started command's pipeline afterwards, which is what
+        # the running shell reads to tell mid-pipeline from statement end and
+        # to collect a substitution's captured output. Only ever one at a time:
+        # commands run strictly in sequence.
         self.pp = None
         self.logintime: float
         self.realClientIP: str

--- a/src/cowrie/test/test_pp_ownership.py
+++ b/src/cowrie/test/test_pp_ownership.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests that a command keeps its own stdio wiring: a pipeline stage
+# ABOUTME: that finishes late must still see its own fds, not a later command's.
+
+from __future__ import annotations
+
+import os
+import unittest
+from typing import ClassVar
+
+from cowrie.shell.command import HoneyPotCommand
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+
+class FakeAsyncCommand(HoneyPotCommand):
+    """Like wget/curl: start() returns and the command only writes its output
+    and exits when an external event (here: finish()) fires."""
+
+    pending: ClassVar[list[FakeAsyncCommand]] = []
+
+    def start(self) -> None:
+        FakeAsyncCommand.pending.append(self)
+
+    def finish(self) -> None:
+        FakeAsyncCommand.pending.remove(self)
+        self.errorWrite("stderr-payload\n")
+        self.exit(0)
+
+
+class CommandOwnsItsPipeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.proto.commands["fakeasync"] = FakeAsyncCommand
+        FakeAsyncCommand.pending = []
+        self.created: list[str] = []
+        self.before = set(self.proto.terminal.redirFiles)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+        for real in self.created:
+            if os.path.exists(real):
+                os.remove(real)
+
+    def new_redir_files(self) -> set[tuple[str, str]]:
+        new: set[tuple[str, str]] = set(self.proto.terminal.redirFiles) - self.before
+        self.created.extend(real for real, _virtual in new)
+        return new
+
+    def test_async_stage_registers_its_own_redirect(self) -> None:
+        # The async stage's stderr redirect must be registered for hashing when
+        # it finishes, even though a downstream stage started meanwhile. Losing
+        # it orphans the attacker's captured bytes in the download directory
+        # with no file_download event.
+        self.proto.lineReceived(b"fakeasync 2> /tmp/pp_async_err.log | cat\n")
+        FakeAsyncCommand.pending[0].finish()
+        self.assertIn(
+            "/tmp/pp_async_err.log",
+            {virtual for _real, virtual in self.new_redir_files()},
+        )
+
+    def test_sync_redirect_still_registers(self) -> None:
+        self.proto.lineReceived(b"echo hi > /tmp/pp_sync.log\n")
+        self.assertIn(
+            "/tmp/pp_sync.log",
+            {virtual for _real, virtual in self.new_redir_files()},
+        )
+
+    def test_command_pipe_is_its_own(self) -> None:
+        self.proto.lineReceived(b"fakeasync | cat\n")
+        stage = FakeAsyncCommand.pending[0]
+        self.assertIsNotNone(stage.pp)
+        self.assertIs(stage.pp.cmd, FakeAsyncCommand)


### PR DESCRIPTION
Follow-up to #40428 and #40429, continuing to put per-process state where the process can see it.

`protocol.pp` is a single slot holding whichever pipeline started most recently, and commands reached through it whenever they needed their own file descriptors. For a command that finishes late, that slot has already moved on: with an async first stage, the pipe machinery starts the downstream stage while the first is still running, so `HoneyPotCommand.exit()` read the *next* command's pipeline.

The visible consequence is lost attacker data. For `wget URL 2> err.log | sh`, the wget stage's own redirection backing file was never registered in `redirFiles`, so at session close it was neither hashed nor reported — the redirected bytes were left as an orphaned `redir_*` file in the download directory with no `cowrie.session.file_download` event.

A command now keeps the pipeline it was handed at spawn (`HoneyPotCommand.pp`, alongside the `cwd`/`user` snapshots from the previous two PRs) and uses it for its output wiring and for registering its redirection files on exit. `busybox`, `sudo` and `bash` read their own pipeline directly instead of going through the protocol.

**Scope note.** I deliberately stopped short of also moving the shell-side notion ("the pipeline currently in flight for this statement", read by `runCommand`'s mid-pipeline guard and by `_harvest_capture`) onto the shell. I probed for a misfire there — nested substitutions, adjacent substitutions in one word, assignment-only and command-not-found statements inside a substitution, and an async command inside a nested substitution — and found none: commands run strictly in sequence, so the slot is always the right one by the time either reads it. Moving it would be machinery for no current behavior change. It becomes necessary with background jobs (`&`), where a background pipeline genuinely cannot share one slot with the foreground, and it belongs with that work. The remaining role of `protocol.pp` is documented at its definition.

This does not fix `wget URL | sh` losing the payload; that needs the downstream stage to wait for the upstream writer to close, which is a change to the pipe sequencing. This makes that change expressible.

Testing: new `test_pp_ownership.py`, written failing first — an async first stage with its own stderr redirect registered nothing. Full suite (1052 tests), `ruff check`, and mypy green. Live SSH check of `wget http://example.com/ -O /dev/null 2> /tmp/wgeterr.log | cat`: the stderr redirect is now hashed and reported, with no orphaned `redir_*` files left behind.

Also includes a one-line `ruff format` fix for a call I hand-wrote in #40428.
