### PR TITLE
Feed a pipeline stage that finishes asynchronously (wget URL | sh)

### DIFF
--- a/src/cowrie/commands/bash.py
+++ b/src/cowrie/commands/bash.py
@@ -87,7 +87,7 @@ class Command_sh(HoneyPotCommand):
             isinstance(self.protocol, HoneyPotExecProtocol)
             and len(self.protocol.cmdstack) == 2
             and self.input_data is None
-            and not getattr(self.protocol.pp, "stdin_from_pipe", False)
+            and not getattr(self.pp, "stdin_from_pipe", False)
         )
 
     def interactive_shell(self) -> None:

--- a/src/cowrie/commands/busybox.py
+++ b/src/cowrie/commands/busybox.py
@@ -93,20 +93,20 @@ class Command_busybox(HoneyPotCommand):
             pp = PipeProtocol(
                 self.protocol,
                 cmdclass,
-                self.protocol.pp.cmdargs[1:],
+                self.pp.cmdargs[1:],
                 self.input_data,
                 None,
-                redirect=self.protocol.pp.redirect,
-                redirections=self.protocol.pp.redirections,
+                redirect=self.pp.redirect,
+                redirections=self.pp.redirections,
                 cwd=self.cwd,
                 user=self.user,
             )
 
             # insert the command as we do when chaining commands with pipes
-            self.protocol.pp.insert_command(pp)
+            self.pp.insert_command(pp)
 
             # invoke inserted command
-            self.protocol.pp.outConnectionLost()
+            self.pp.outConnectionLost()
 
             # Place this here so it doesn't write out only if last statement
             if self.input_data:

--- a/src/cowrie/commands/sudo.py
+++ b/src/cowrie/commands/sudo.py
@@ -128,11 +128,15 @@ class Command_sudo(HoneyPotCommand):
 
             if cmdclass:
                 command = PipeProtocol(
-                    self.protocol, cmdclass, parsed_arguments[1:], None, None,
+                    self.protocol,
+                    cmdclass,
+                    parsed_arguments[1:],
+                    None,
+                    None,
                     cwd=self.cwd,
                     user=self.user,
                 )
-                self.protocol.pp.insert_command(command)
+                self.pp.insert_command(command)
                 # this needs to go here so it doesn't write it out....
                 if self.input_data:
                     self.writeBytes(self.input_data)

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -43,6 +43,10 @@ class HoneyPotCommand:
     # created without __init__ (tests).
     exited: bool = False
 
+    # This command's stdio wiring, set at spawn (see __init__). Class-level so
+    # it holds even for instances created without __init__ (tests).
+    pp: Any = None
+
     def __init__(self, protocol, *args):
         self.protocol = protocol
         self.args = list(args)
@@ -67,17 +71,21 @@ class HoneyPotCommand:
         self.data: bytes = b""  # output data
         # used to store STDIN data passed via PIPE
         self.input_data: bytes | None = None
+        # This command's own stdio: the fd table, its redirections and the
+        # link to the next pipeline stage, handed over at spawn. Held per
+        # command because a command that finishes late (an async download)
+        # must still write to and clean up the fds it was started with, not
+        # whichever pipeline is running by the time it ends.
         pp: Any = getattr(self.protocol, "pp", None)
+        self.pp: Any = pp
         self.writefn: Callable[[bytes], None]
         self.errorWritefn: Callable[[bytes], None]
         if pp and hasattr(pp, "write_stdout") and hasattr(pp, "write_stderr"):
             self.writefn = cast("Callable[[bytes], None]", pp.write_stdout)
             self.errorWritefn = cast("Callable[[bytes], None]", pp.write_stderr)
         else:
-            self.writefn = cast("Callable[[bytes], None]", self.protocol.pp.outReceived)
-            self.errorWritefn = cast(
-                "Callable[[bytes], None]", self.protocol.pp.errReceived
-            )
+            self.writefn = cast("Callable[[bytes], None]", pp.outReceived)
+            self.errorWritefn = cast("Callable[[bytes], None]", pp.errReceived)
 
     def write(self, data: str) -> None:
         """
@@ -136,13 +144,16 @@ class HoneyPotCommand:
         self.exited = True
         if code is not None:
             self.exit_code = code
+        # Register this command's own redirection backing files for hashing at
+        # session close. Read from self.pp, not the protocol's current pipe: a
+        # command that finishes after a later one started would otherwise
+        # register that command's files and orphan its own.
         if (
             self.protocol
             and self.protocol.terminal
-            and hasattr(self.protocol, "pp")
-            and getattr(self.protocol.pp, "redirect_real_files", None)
+            and getattr(self.pp, "redirect_real_files", None)
         ):
-            for real_path, virtual_path in self.protocol.pp.redirect_real_files:
+            for real_path, virtual_path in self.pp.redirect_real_files:
                 self.protocol.terminal.redirFiles.add((real_path, virtual_path))
 
         if len(self.protocol.cmdstack):

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -47,6 +47,10 @@ class HoneyPotCommand:
     # it holds even for instances created without __init__ (tests).
     pp: Any = None
 
+    # True when this command was still running once start() returned, so it
+    # owes the next pipeline stage the EOF on its stdout when it exits.
+    advance_pipe_on_exit: bool = False
+
     def __init__(self, protocol, *args):
         self.protocol = protocol
         self.args = list(args)
@@ -158,6 +162,20 @@ class HoneyPotCommand:
 
         if len(self.protocol.cmdstack):
             self.protocol.cmdstack.remove(self)
+
+        if (
+            self.advance_pipe_on_exit
+            and self.pp is not None
+            and self.pp.next_command is not None
+        ):
+            # An upstream pipeline stage that outlived its own start() (an
+            # async download, or a command parked on stdin). Its stdout only
+            # closes now, so hand control to the next stage rather than back
+            # to the shell: the stage that ends the pipeline resumes the
+            # shell, and its status is the pipeline's, as in bash.
+            self.advance_pipe_on_exit = False
+            self.pp.outConnectionLost()
+            return
 
         if len(self.protocol.cmdstack):
             # Hand the exit status to the shell that ran us, for $? and the

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -391,11 +391,23 @@ class HoneyPotShell:
                 self._advance_pending = False
                 if self.cmdpending:
                     self.runCommand()
+                elif self._busy():
+                    # The queue is drained but something this shell started is
+                    # still running (an async download, or a pipeline stage
+                    # waiting on one). The statement is not over: whatever is
+                    # above resumes this shell when it finishes.
+                    return
                 else:
                     self._finish()
                 running = self._advance_pending
         finally:
             self._advancing = False
+
+    def _busy(self) -> bool:
+        """Whether something this shell started is still on the cmdstack above
+        it -- a command that has not exited, or a shell it launched."""
+        stack = self.protocol.cmdstack
+        return bool(stack) and self in stack and stack[-1] is not self
 
     # -- flow control -------------------------------------------------------
     #

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -51,6 +51,12 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         self.environ = avatar.environ
         self.hostname: str = self.user.server.hostname
         self.fs = self.user.server.fs
+        # The pipeline being handed to the command now starting, which the
+        # command keeps as its own (HoneyPotCommand.pp). It stays set to the
+        # most recently started command's pipeline afterwards, which is what
+        # the running shell reads to tell mid-pipeline from statement end and
+        # to collect a substitution's captured output. Only ever one at a time:
+        # commands run strictly in sequence.
         self.pp = None
         self.logintime: float
         self.realClientIP: str

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -291,14 +291,25 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         self.cmdstack.append(obj)
         obj.start()
 
-        if self.pp:
-            # Advancing to the next pipeline stage: flatten the callback so a
-            # long pipeline does not recurse (see call_command).
-            self._advancing_pipe = True
-            try:
-                self.pp.outConnectionLost()
-            finally:
-                self._advancing_pipe = False
+        if obj.exited:
+            # The command finished as it started, so its stdout is closed and
+            # the next pipeline stage can run. Flatten the callback so a long
+            # pipeline does not recurse (see call_command). This uses the
+            # protocol's current pipe rather than the command's own: a wrapper
+            # like busybox dispatches an applet during start(), and it is that
+            # applet's stdout which just closed.
+            if self.pp:
+                self._advancing_pipe = True
+                try:
+                    self.pp.outConnectionLost()
+                finally:
+                    self._advancing_pipe = False
+        else:
+            # Still running -- an async download, or parked reading stdin. The
+            # next stage must wait for this one's output rather than start on
+            # an empty pipe, so the command advances the pipeline itself when
+            # it finally exits.
+            obj.advance_pipe_on_exit = True
 
         # Mirror ProcessProtocol.transport.closeStdin(): if the command parked
         # waiting for stdin but nothing will ever write to it, signal EOF so it

--- a/src/cowrie/test/test_pipeline_async.py
+++ b/src/cowrie/test/test_pipeline_async.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests that a pipeline stage which finishes asynchronously still
+# ABOUTME: feeds the next stage, as `wget URL | sh` does on a real shell.
+
+from __future__ import annotations
+
+import os
+import unittest
+from typing import ClassVar
+
+from cowrie.shell.command import HoneyPotCommand
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+
+class FakeAsyncCommand(HoneyPotCommand):
+    """Like wget/curl: start() returns and the command only writes its output
+    and exits when an external event (here: finish()) fires."""
+
+    pending: ClassVar[list[FakeAsyncCommand]] = []
+
+    def start(self) -> None:
+        FakeAsyncCommand.pending.append(self)
+
+    def finish(self, text: str = "payload") -> None:
+        FakeAsyncCommand.pending.remove(self)
+        self.write(f"{text}\n")
+        self.exit(0)
+
+
+class AsyncPipelineStageTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.proto.commands["fakeasync"] = FakeAsyncCommand
+        FakeAsyncCommand.pending = []
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def finish_one(self, text: str = "payload") -> None:
+        self.assertTrue(FakeAsyncCommand.pending, "no async command is running")
+        FakeAsyncCommand.pending[0].finish(text)
+
+    def test_async_stage_output_reaches_next_stage(self) -> None:
+        self.proto.lineReceived(b"fakeasync | cat\n")
+        self.assertEqual(self.tr.value(), b"")
+        self.finish_one()
+        self.assertEqual(self.tr.value(), b"payload\n" + PROMPT)
+
+    def test_async_stage_feeds_grep(self) -> None:
+        self.proto.lineReceived(b"fakeasync | grep payload\n")
+        self.finish_one()
+        self.assertEqual(self.tr.value(), b"payload\n" + PROMPT)
+
+    def test_async_stage_output_can_be_redirected_downstream(self) -> None:
+        self.proto.lineReceived(b"fakeasync | cat > /tmp/pipeline_async.txt\n")
+        self.finish_one()
+        self.tr.clear()
+        self.proto.lineReceived(b"cat /tmp/pipeline_async.txt\n")
+        self.assertEqual(self.tr.value(), b"payload\n" + PROMPT)
+
+    def test_statement_after_async_pipeline_runs_once(self) -> None:
+        self.proto.lineReceived(b"fakeasync | cat; echo after\n")
+        self.finish_one()
+        self.assertEqual(self.tr.value(), b"payload\nafter\n" + PROMPT)
+
+    def test_downloaded_script_reaches_the_shell(self) -> None:
+        # The staging idiom: `wget -qO- URL | sh` must run what was fetched.
+        self.proto.lineReceived(b"fakeasync | sh\n")
+        self.finish_one("echo staged")
+        self.assertEqual(self.tr.value(), b"staged\n" + PROMPT)
+
+    def test_sync_pipeline_unchanged(self) -> None:
+        self.proto.lineReceived(b"echo hello | cat\n")
+        self.assertEqual(self.tr.value(), b"hello\n" + PROMPT)
+
+    def test_async_last_stage_writes_to_terminal(self) -> None:
+        self.proto.lineReceived(b"echo seed | fakeasync\n")
+        self.finish_one()
+        self.assertEqual(self.tr.value(), b"payload\n" + PROMPT)

--- a/src/cowrie/test/test_pp_ownership.py
+++ b/src/cowrie/test/test_pp_ownership.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests that a command keeps its own stdio wiring: a pipeline stage
+# ABOUTME: that finishes late must still see its own fds, not a later command's.
+
+from __future__ import annotations
+
+import os
+import unittest
+from typing import ClassVar
+
+from cowrie.shell.command import HoneyPotCommand
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+
+class FakeAsyncCommand(HoneyPotCommand):
+    """Like wget/curl: start() returns and the command only writes its output
+    and exits when an external event (here: finish()) fires."""
+
+    pending: ClassVar[list[FakeAsyncCommand]] = []
+
+    def start(self) -> None:
+        FakeAsyncCommand.pending.append(self)
+
+    def finish(self) -> None:
+        FakeAsyncCommand.pending.remove(self)
+        self.errorWrite("stderr-payload\n")
+        self.exit(0)
+
+
+class CommandOwnsItsPipeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.proto.commands["fakeasync"] = FakeAsyncCommand
+        FakeAsyncCommand.pending = []
+        self.created: list[str] = []
+        self.before = set(self.proto.terminal.redirFiles)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+        for real in self.created:
+            if os.path.exists(real):
+                os.remove(real)
+
+    def new_redir_files(self) -> set[tuple[str, str]]:
+        new: set[tuple[str, str]] = set(self.proto.terminal.redirFiles) - self.before
+        self.created.extend(real for real, _virtual in new)
+        return new
+
+    def test_async_stage_registers_its_own_redirect(self) -> None:
+        # The async stage's stderr redirect must be registered for hashing when
+        # it finishes, even though a downstream stage started meanwhile. Losing
+        # it orphans the attacker's captured bytes in the download directory
+        # with no file_download event.
+        self.proto.lineReceived(b"fakeasync 2> /tmp/pp_async_err.log | cat\n")
+        FakeAsyncCommand.pending[0].finish()
+        self.assertIn(
+            "/tmp/pp_async_err.log",
+            {virtual for _real, virtual in self.new_redir_files()},
+        )
+
+    def test_sync_redirect_still_registers(self) -> None:
+        self.proto.lineReceived(b"echo hi > /tmp/pp_sync.log\n")
+        self.assertIn(
+            "/tmp/pp_sync.log",
+            {virtual for _real, virtual in self.new_redir_files()},
+        )
+
+    def test_command_pipe_is_its_own(self) -> None:
+        self.proto.lineReceived(b"fakeasync | cat\n")
+        stage = FakeAsyncCommand.pending[0]
+        self.assertIsNotNone(stage.pp)
+        self.assertIs(stage.pp.cmd, FakeAsyncCommand)


### PR DESCRIPTION
Stacked on #40430 — please merge that first; the diff here is the last commit only.

`wget URL | sh` — the standard malware staging idiom — ran `sh` on an empty pipe and dropped the payload entirely.

A pipeline stage's stdout was closed as soon as `start()` returned, which is right for a command that completes synchronously but wrong for one that finishes on a Deferred (wget, curl) or parks reading stdin. The downstream stage was started immediately, got EOF on an empty pipe, and by the time the upstream stage actually produced output there was nobody left to read it.

The pipeline now advances when the writer really exits:

- A stage still running when `start()` returned advances the pipeline from `exit()` instead of resuming the shell. The stage that *ends* the pipeline resumes the shell and supplies its exit status, which is bash's rule for a pipeline's status.
- A stage that finished during `start()` advances exactly as before, through `call_command`'s flattened drive — so long pipelines still don't recurse (#40352) and busybox's applet dispatch, which closes its own pipe inside `call()`, is untouched.

Also fixed, found while testing this and confirmed pre-existing: the shell treated a drained queue as the end of a statement even when a command it started was still on the cmdstack, so for `echo x | wget URL` the prompt appeared before the async stage had produced anything.

Testing: new `test_pipeline_async.py`, written failing first — including `fakeasync | sh` carrying `echo staged`, the staging idiom itself, which produced nothing before this change. Also covers feeding grep, redirecting the downstream stage's output, a following statement running exactly once, an async last stage, and a synchronous pipeline staying byte-identical. Full suite (1059 tests), `ruff check` and mypy green. Live SSH check: `wget -qO- http://example.com/ | grep -o Example` now delivers the fetched document to grep, where it previously printed nothing.

Note this changes only *when* the next stage starts, not the pipe semantics: stages still run one after another rather than concurrently, so a stage cannot consume a partial stream from a still-running upstream. That is the same simplification cowrie has always made.
