### PR TITLE
feat: add a nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ _trial_temp
 .idea/
 .tox
 .coverage
+
+# nix build output
+/result

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -64,6 +64,12 @@ SPDX-FileCopyrightText = "2021-2026 Michel Oosterhof <michel@oosterhof.net>"
 SPDX-License-Identifier = "BSD-3-Clause"
 
 [[annotations]]
+path = "flake.lock"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Michel Oosterhof <michel@oosterhof.net>"
+SPDX-License-Identifier = "BSD-3-Clause"
+
+[[annotations]]
 path = ".pyre_configuration"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2021-2026 Michel Oosterhof <michel@oosterhof.net>"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785301185,
+        "narHash": "sha256-eoS3KQTO0aPWXZvIaRbRAzSSHW3l5wdMFXtT1ISfoKA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+{
+  description = "Cowrie SSH/Telnet honeypot";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+          python = pkgs.python3;
+        in
+        {
+          default = self.packages.${system}.cowrie;
+
+          cowrie = python.pkgs.buildPythonApplication {
+            pname = "cowrie";
+            version = "3.0.5-${self.shortRev or "dirty"}";
+            pyproject = true;
+            src = self;
+
+            # setuptools-scm needs git metadata the nix source tree lacks.
+            env.SETUPTOOLS_SCM_PRETEND_VERSION = "3.0.5";
+
+            build-system = with python.pkgs; [
+              setuptools
+              setuptools-scm
+            ];
+
+            # pyproject.toml pins exact versions; build against what nixpkgs has.
+            pythonRelaxDeps = true;
+
+            dependencies = with python.pkgs; [
+              attrs
+              bcrypt
+              cryptography
+              hyperlink
+              idna
+              lark
+              packaging
+              pyasn1
+              pyasn1-modules
+              service-identity
+              treq
+              twisted
+            ];
+
+            checkPhase = ''
+              runHook preCheck
+              PYTHONPATH=src:$PYTHONPATH ${python.interpreter} -m unittest discover -s src/cowrie/test -t src
+              runHook postCheck
+            '';
+
+            meta = {
+              description = "SSH/Telnet honeypot";
+              homepage = "https://www.cowrie.org/";
+              license = nixpkgs.lib.licenses.bsd3;
+              mainProgram = "cowrie";
+            };
+          };
+        }
+      );
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          # The venv itself is managed by direnv (`layout python`) and
+          # `pip install -e '.[dev]'`; the shell only supplies the interpreter.
+          default = pkgs.mkShell {
+            packages = [ pkgs.python3 ];
+            env.PYTHONUNBUFFERED = "1";
+            env.PYTHONDEVMODE = "1";
+          };
+        }
+      );
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = nixpkgs.lib.getExe self.packages.${system}.cowrie;
+        };
+      });
+    };
+}

--- a/src/cowrie/test/test_async_substitution.py
+++ b/src/cowrie/test/test_async_substitution.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 from typing import ClassVar
 
@@ -17,7 +18,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_attacker_bytes.py
+++ b/src/cowrie/test/test_attacker_bytes.py
@@ -19,7 +19,7 @@ from twisted.conch.ssh.transport import SSHServerTransport
 from twisted.web.http_headers import Headers
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 from cowrie.commands.curl import Command_curl

--- a/src/cowrie/test/test_awk.py
+++ b/src/cowrie/test/test_awk.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -11,7 +12,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_base64.py
+++ b/src/cowrie/test/test_base64.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -12,7 +13,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 TRY_CHMOD_HELP_MSG = b"Try 'base64 --help' for more information.\n"

--- a/src/cowrie/test/test_cat.py
+++ b/src/cowrie/test/test_cat.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -12,7 +13,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_chmod.py
+++ b/src/cowrie/test/test_chmod.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -13,7 +14,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 TRY_CHMOD_HELP_MSG = b"Try 'chmod --help' for more information.\n"

--- a/src/cowrie/test/test_command_input_events.py
+++ b/src/cowrie/test/test_command_input_events.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 from typing import TypeVar
 
@@ -17,7 +18,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 T = TypeVar("T", bound=HoneyPotCommand)

--- a/src/cowrie/test/test_cut.py
+++ b/src/cowrie/test/test_cut.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -11,7 +12,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -11,7 +12,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_exec_builtin.py
+++ b/src/cowrie/test/test_exec_builtin.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.insults import insults
@@ -18,7 +19,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_exit_status.py
+++ b/src/cowrie/test/test_exit_status.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.insults import insults
@@ -18,7 +19,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_fd_redirection.py
+++ b/src/cowrie/test/test_fd_redirection.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -15,7 +16,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_filetransfer.py
+++ b/src/cowrie/test/test_filetransfer.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import errno
 import os
+import tempfile
 import unittest
 from types import SimpleNamespace
 
@@ -18,7 +19,7 @@ from cowrie.shell import fs
 from cowrie.shell.filetransfer import SFTPServerForCowrieUser
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 

--- a/src/cowrie/test/test_flow_control.py
+++ b/src/cowrie/test/test_flow_control.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -15,7 +16,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_ftpget.py
+++ b/src/cowrie/test/test_ftpget.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 reactor = cast("_Reactor", _reactor)
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_grep.py
+++ b/src/cowrie/test/test_grep.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -11,7 +12,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_greynoise.py
+++ b/src/cowrie/test/test_greynoise.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -18,7 +19,7 @@ from twisted.web.client import ResponseNeverReceived
 from cowrie.output.greynoise import Output
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 CONNECT_EVENT = {

--- a/src/cowrie/test/test_jsonlog.py
+++ b/src/cowrie/test/test_jsonlog.py
@@ -15,7 +15,7 @@ import unittest
 from pathlib import Path
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 

--- a/src/cowrie/test/test_kafka.py
+++ b/src/cowrie/test/test_kafka.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 
 import asyncio
 import os
+import tempfile
 import unittest
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 

--- a/src/cowrie/test/test_logfile.py
+++ b/src/cowrie/test/test_logfile.py
@@ -15,7 +15,7 @@ import unittest
 from twisted.logger import ILogObserver
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 

--- a/src/cowrie/test/test_ls.py
+++ b/src/cowrie/test/test_ls.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -12,7 +13,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_nc.py
+++ b/src/cowrie/test/test_nc.py
@@ -11,6 +11,7 @@ network traffic is generated and every assertion runs synchronously.
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
@@ -30,7 +31,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 from cowrie.commands.nc import Command_nc, NcClientFactory, nc_rate_limiter

--- a/src/cowrie/test/test_output_mongodb.py
+++ b/src/cowrie/test/test_output_mongodb.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 import os
 import sys
+import tempfile
 import types
 import unittest
 from typing import Any
 from unittest.mock import patch
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 try:

--- a/src/cowrie/test/test_output_mysql.py
+++ b/src/cowrie/test/test_output_mysql.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import sys
+import tempfile
 import types
 import unittest
 from typing import Any
@@ -18,7 +19,7 @@ from twisted.internet import defer
 from twisted.python.failure import Failure
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 try:

--- a/src/cowrie/test/test_output_network_errors.py
+++ b/src/cowrie/test/test_output_network_errors.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 from typing import Any
 from unittest.mock import Mock, patch
@@ -19,7 +20,7 @@ from twisted.web.client import ResponseNeverReceived
 from cowrie.output import axiom, datadog, graylog, telegram
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 

--- a/src/cowrie/test/test_output_postgresql.py
+++ b/src/cowrie/test/test_output_postgresql.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 import os
 import sys
+import tempfile
 import types
 import unittest
 from typing import Any
 from unittest.mock import Mock, patch
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 try:

--- a/src/cowrie/test/test_output_rethinkdblog.py
+++ b/src/cowrie/test/test_output_rethinkdblog.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 import os
 import sys
+import tempfile
 import types
 import unittest
 from typing import Any
 from unittest.mock import patch
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 try:

--- a/src/cowrie/test/test_output_sqlite.py
+++ b/src/cowrie/test/test_output_sqlite.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+import tempfile
 import unittest
 from typing import Any
 from unittest.mock import Mock, patch
@@ -17,7 +18,7 @@ from twisted.enterprise import adbapi
 from twisted.internet import defer
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 from cowrie.output import sqlite as sqlite_output

--- a/src/cowrie/test/test_pipe_eof.py
+++ b/src/cowrie/test/test_pipe_eof.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -15,7 +16,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_pipe_recursion.py
+++ b/src/cowrie/test/test_pipe_recursion.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -15,7 +16,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_pipeline_async.py
+++ b/src/cowrie/test/test_pipeline_async.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 from typing import ClassVar
 
@@ -17,7 +18,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_pp_ownership.py
+++ b/src/cowrie/test/test_pp_ownership.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 from typing import ClassVar
 
@@ -17,7 +18,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_queued_input.py
+++ b/src/cowrie/test/test_queued_input.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -15,7 +16,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_script_execution.py
+++ b/src/cowrie/test/test_script_execution.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 from typing import ClassVar
 
@@ -18,7 +19,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_shell_cwd.py
+++ b/src/cowrie/test/test_shell_cwd.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -15,7 +16,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_shell_variables.py
+++ b/src/cowrie/test/test_shell_variables.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -15,7 +16,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_tee.py
+++ b/src/cowrie/test/test_tee.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -12,7 +13,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_temp_file_naming.py
+++ b/src/cowrie/test/test_temp_file_naming.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 from types import SimpleNamespace
 
@@ -18,7 +19,7 @@ from cowrie.shell import fs
 from cowrie.shell.pipe import PipeProtocol
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 
@@ -102,7 +103,7 @@ class TempFileNamingTests(unittest.TestCase):
 
     def test_scp_dropped_file(self) -> None:
         cmd = Command_scp.__new__(Command_scp)
-        cmd.download_path = "/tmp"
+        cmd.download_path = tempfile.gettempdir()
         cmd.drop_tmp_file(b"contents")
         self.assertPrefixUuidName(cmd.safeoutfile, "scp")
         with open(cmd.safeoutfile, "rb") as f:
@@ -110,7 +111,7 @@ class TempFileNamingTests(unittest.TestCase):
 
     def test_helper_builds_download_dir_paths(self) -> None:
         path = temp_download_path("stdin")
-        self.assertEqual(os.path.dirname(path), "/tmp")
+        self.assertEqual(os.path.dirname(path), tempfile.gettempdir())
         self.assertRegex(os.path.basename(path), r"^stdin_[0-9a-f]{32}$")
         self.assertNotEqual(path, temp_download_path("stdin"))
 

--- a/src/cowrie/test/test_test_builtin.py
+++ b/src/cowrie/test/test_test_builtin.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -15,7 +16,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_tftp.py
+++ b/src/cowrie/test/test_tftp.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 reactor = cast("_Reactor", _reactor)
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "

--- a/src/cowrie/test/test_txtcmds_path.py
+++ b/src/cowrie/test/test_txtcmds_path.py
@@ -17,7 +17,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 ENV_TXTCMDS = "COWRIE_HONEYPOT_TXTCMDS_PATH"

--- a/src/cowrie/test/test_uniq.py
+++ b/src/cowrie/test/test_uniq.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
@@ -13,7 +14,7 @@ from cowrie.test.fake_server import FakeAvatar, FakeServer
 from cowrie.test.fake_transport import FakeTransport
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
-os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
 os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
 
 PROMPT = b"root@unitTest:~# "


### PR DESCRIPTION
Adds a nix flake so cowrie can be built, run, and developed with nix:

- **`packages.cowrie`** (also `default`): `buildPythonApplication` from the local tree. setuptools-scm gets `SETUPTOOLS_SCM_PRETEND_VERSION` since the nix source tree has no git metadata, and `pythonRelaxDeps` bridges pyproject's exact pins to whatever nixpkgs carries. The full unittest suite runs as the check phase, so `nix build` doubles as a test gate — 1059 tests pass in the sandbox.
- **`devShells.default`**: supplies only the interpreter (plus `PYTHONUNBUFFERED`/`PYTHONDEVMODE`); the venv itself stays with the existing direnv `layout python` + pip workflow.
- **`apps.default`**: `nix run` starts cowrie.
- `flake.lock` is committed and REUSE-annotated; `/result` is gitignored.

## Test fix the sandbox flushed out

Eight scp/stdin-capture tests failed inside the nix sandbox with "saved no file". The cause was not permissions: on macOS the nix build TMPDIR lives on the Nix Store APFS volume while `/tmp` is on the system volume, so the artifact save's `os.rename` from the config-pinned literal `/tmp` to a `mkdtemp`'d directory crosses filesystems, raises EXDEV, and the upload-hardening guards swallow the error. Production always renames within a single directory and is unaffected; the coupling was purely in the tests, where 42 modules pinned `COWRIE_HONEYPOT_DOWNLOAD_PATH = "/tmp"`. They now use `tempfile.gettempdir()`, which keeps the temp file and its rename target on one filesystem and stops the suite writing to the real `/tmp`.

Note: the test sweep touches files that #40432 also edits; whichever merges second may need a trivial rebase.