### PR TITLE
fix: guard tab-completion against a missing client window size

### DIFF
--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -1077,7 +1077,13 @@ class HoneyPotShell:
             if newbyt == b"".join(self.protocol.lineBuffer):
                 self.protocol.terminal.write(b"\n")
                 maxlen = max(len(x[fs.A_NAME]) for x in files) + 1
-                perline = int(self.protocol.user.windowSize[1] / (maxlen + 1))
+                # windowSize is only set once the client sent a window-change
+                # request; fall back to 80 columns like __init__ does above.
+                if hasattr(self.protocol.user, "windowSize"):
+                    columns = self.protocol.user.windowSize[1]
+                else:
+                    columns = 80
+                perline = max(1, int(columns / (maxlen + 1)))
                 count = 0
                 for file in files:
                     if count == perline:

--- a/src/cowrie/test/test_shell_tab_completion.py
+++ b/src/cowrie/test/test_shell_tab_completion.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests that tab-completion does not crash for a client that never
+# ABOUTME: sent a window size, falling back to a default column width.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class ShellTabCompletionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        avatar = FakeAvatar(FakeServer())
+        # A client that never sent a window-change request has no windowSize.
+        del avatar.windowSize
+        self.proto = HoneyPotInteractiveProtocol(avatar)
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.proto.terminal = mock.MagicMock()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def test_tab_completion_without_window_size(self) -> None:
+        shell = self.proto.cmdstack[-1]
+        line = b"ls /bin/l"
+        self.proto.lineBuffer = [bytes([c]) for c in line]
+        self.proto.lineBufferIndex = len(self.proto.lineBuffer)
+        # The first TAB expands to the common prefix, the second lists the
+        # ambiguous matches, which is where the window width is read.
+        shell.handle_TAB()
+        shell.handle_TAB()


### PR DESCRIPTION
Closes #40347

`handle_TAB()` read `self.protocol.user.windowSize[1]` unconditionally when listing multiple ambiguous completions, but `windowSize` is only set once the client has sent a window-change request — so a client that never negotiates a pty size raised `AttributeError` and the session died on the first ambiguous Tab. `HoneyPotShell.__init__` already guards the same attribute with `hasattr()` when seeding `$COLUMNS`/`$LINES`; `handle_TAB()` now does the same and falls back to 80 columns, with `perline` clamped to at least 1.

New `src/cowrie/test/test_shell_tab_completion.py` drives `handle_TAB()` with an avatar that has no `windowSize`; it fails with the reported `AttributeError` without the fix and passes with it.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
