### PR TITLE
fix: handle unknown curl content length

### DIFF
--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -16,6 +16,7 @@ from twisted.internet.defer import inlineCallbacks
 from twisted.logger import Logger
 from twisted.python import failure
 from twisted.web.client import Agent
+from twisted.web.iweb import UNKNOWN_LENGTH
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
@@ -369,8 +370,8 @@ class Command_curl(HoneyPotCommand):
         """
         successful treq get
         """
-        self.totallength = response.length
-        # TODO possible this is UNKNOWN_LENGTH
+        total_length = None if response.length == UNKNOWN_LENGTH else response.length
+        self.totallength = total_length or 0
 
         if self.head_request:
             reason = responses.get(response.code, "")
@@ -391,7 +392,11 @@ class Command_curl(HoneyPotCommand):
             self.exit()
             return
 
-        if self.limit_size > 0 and self.totallength > self.limit_size:
+        if (
+            total_length is not None
+            and self.limit_size > 0
+            and self.totallength > self.limit_size
+        ):
             self._log.info(
                 "Not saving URL ({url}) (size: {size}) exceeds file size limit ({limit})",
                 url=self.url.decode(),

--- a/src/cowrie/test/test_download_limit.py
+++ b/src/cowrie/test/test_download_limit.py
@@ -14,6 +14,7 @@ import unittest
 from typing import Any
 
 from twisted.web.http_headers import Headers
+from twisted.web.iweb import UNKNOWN_LENGTH
 
 from cowrie.commands.curl import Command_curl
 from cowrie.commands.wget import Command_wget
@@ -40,7 +41,7 @@ class FakeBodyTransport:
 class FakeResponse:
     """Minimal treq response: headers, length, and a recordable body."""
 
-    def __init__(self, length: int) -> None:
+    def __init__(self, length: Any) -> None:
         self.length = length
         self.code = 200
         self.phrase = b"OK"
@@ -118,6 +119,22 @@ class DownloadSizeLimitTests(unittest.TestCase):
                 self.assertTrue(cmd.exited)
                 self.assertIsNotNone(response.delivered_to)
                 self.assertTrue(response.transport.stopped)
+
+    def test_curl_unknown_content_length_does_not_crash(self) -> None:
+        cmd = self._make_cmd(
+            Command_curl,
+            silent=True,
+            outfile=None,
+            head_request=False,
+        )
+        response = FakeResponse(length=UNKNOWN_LENGTH)
+
+        cmd.success(response)
+
+        self.assertFalse(cmd.exited)
+        self.assertEqual(cmd.totallength, 0)
+        self.assertIsNotNone(response.delivered_to)
+        self.assertFalse(response.transport.stopped)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- Treat Twisted's `UNKNOWN_LENGTH` sentinel as an unknown curl response size.
- Skip the header-time size comparison for unknown lengths and continue enforcing the limit while bytes are collected.
- Add regression coverage for chunked/no-Content-Length responses.

Tests:
- `python -m pytest -q src/cowrie/test/test_download_limit.py src/cowrie/test/test_curl.py`

Fixes #40391
