### PR TITLE
fix: strip pip, setuptools and wheel from the runtime venv

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,7 +55,8 @@ RUN python3 -m venv cowrie-env && \
     pip install -q --no-cache-dir --upgrade pip setuptools wheel && \
     pip install -q --no-cache-dir --upgrade cffi && \
     pip install -q --no-cache-dir --upgrade -r ${COWRIE_HOME}/cowrie-git/requirements.txt && \
-    pip install -q --no-cache-dir --upgrade -r ${COWRIE_HOME}/cowrie-git/requirements-output.txt
+    pip install -q --no-cache-dir --upgrade -r ${COWRIE_HOME}/cowrie-git/requirements-output.txt && \
+    pip uninstall -q -y pip setuptools wheel
 
 COPY --chown=${COWRIE_USER}:${COWRIE_GROUP} . ${COWRIE_HOME}/cowrie-git
 


### PR DESCRIPTION
The build tooling in `cowrie-env` is only needed while installing requirements, but it was shipped into the distroless runtime image. Since pip 26.2, pip ships an SBOM at `pip/_vendor/bom.cdx.json` that declares its vendored `pkg_resources` copy as `setuptools@70.3.0`, which vulnerability scanners report as an outdated setuptools in the image — even though the actually installed setuptools is current.

This uninstalls pip, setuptools and wheel at the end of the builder venv setup, so the tooling is still available for any sdist builds during `pip install` but never reaches the runtime image.

Verified that nothing needs `pkg_resources` at runtime: cowrie's source has no references, and the only hit in site-packages is pytz's `open_resource` fallback, which only runs when `importlib.resources` is unavailable (never on Python 3.13).

Tested by building the full image: site-packages contains no pip/setuptools/wheel/pkg_resources, the container starts both SSH and Telnet listeners, and a real SSH login session (password auth, `uname -a`, exit) works with no errors in the logs. Also slightly shrinks the image.