### PR TITLE
fix: drop empty $@/$* instead of emitting a phantom empty argument

### DIFF
--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -829,6 +829,14 @@ class BashParser:
             if only.data in ("dollar_var", "dollar_brace"):
                 special = self._special_param(only)
                 if special is not None:
+                    _, special_name = self._var_name(only)
+                    if special_name in ("@", "*") and special == "":
+                        # $@ / $* represent the positional-parameter list; with
+                        # none set, they contribute zero words, like an unset
+                        # ordinary variable -- not a phantom empty-string
+                        # argument. $? and $# are scalars where "0" is a real
+                        # value, so they are not touched here.
+                        return None
                     return special
                 value = self.context.get_variable(self._var_name(only)[0])
                 if not value:

--- a/src/cowrie/test/test_bashparse.py
+++ b/src/cowrie/test/test_bashparse.py
@@ -144,6 +144,36 @@ class BashParseVariableTests(unittest.TestCase):
     def test_question_mark_status(self) -> None:
         self.assertEqual(self._tokens("echo $?"), ["echo", "0"])
 
+    def test_empty_positional_params_drop_word(self) -> None:
+        # $@ / $* with no positional parameters (e.g. a function called with
+        # zero arguments) contribute nothing at all, exactly like an unset
+        # ordinary variable -- not a phantom empty-string argument.
+        ctx = FakeContext({"@": "", "*": "", "#": "0"})
+        parser = BashParser(ctx)
+
+        statement = parser.parse("echo before $@ after")[0]
+        assert isinstance(statement, Command)
+        self.assertEqual(
+            evaluate_now(parser, statement), ["echo", "before", "after"]
+        )
+
+        statement = parser.parse("echo before $* after")[0]
+        assert isinstance(statement, Command)
+        self.assertEqual(
+            evaluate_now(parser, statement), ["echo", "before", "after"]
+        )
+
+    def test_positional_param_count_not_dropped(self) -> None:
+        # $# is a scalar count where "0" is a real, meaningful value, unlike
+        # $@/$* which represent a list that can legitimately be empty. It
+        # must not be dropped the way an empty $@/$* is.
+        ctx = FakeContext({"@": "", "#": "0"})
+        parser = BashParser(ctx)
+
+        statement = parser.parse("echo count $#")[0]
+        assert isinstance(statement, Command)
+        self.assertEqual(evaluate_now(parser, statement), ["echo", "count", "0"])
+
 
 class BashParseRedirectionTests(unittest.TestCase):
     """Redirection operators are emitted as discrete tokens for runCommand."""


### PR DESCRIPTION
## Summary

`BashParser._eval_word()` treats a whole, unquoted `$@`/`$*` word as a
special parameter and returns `_special_param()`'s result directly as
soon as it is not `None`. When there are no positional parameters
(e.g. a shell function called with zero arguments),
`context.get_variable("@"/"*")` returns `""` rather than `None`, so
that empty string was returned as a literal token instead of going
through the same "drop the word" path an empty/unset ordinary `$var`
already gets.

```
$ f() { echo before $@ after; }; f
```

produced `['echo', 'before', '', 'after']` (a phantom empty-string
argument) instead of the correct `['echo', 'before', 'after']` that
real bash produces, since `$@`/`$*` with nothing to expand to should
contribute zero words.

The fix only touches the `@`/`*` case: `$?` and `$#` are scalars where
`"0"` is a real, meaningful value and must still be returned as-is.

Fixes #40496

## Test plan

- Added `test_empty_positional_params_drop_word` to
  `src/cowrie/test/test_bashparse.py`, which fails on `main`
  (`['echo', 'before', '', 'after']` vs. expected
  `['echo', 'before', 'after']`) and passes with this fix.
- Added `test_positional_param_count_not_dropped` to guard that `$#`
  (a real `"0"` count) is not affected by the fix.
- `python -m twisted.trial cowrie.test.test_bashparse` — 58/58 pass.
- Ran the full suite (`python -m twisted.trial cowrie.test`) before
  and after the change to confirm no regressions; the pre-existing
  failures in that run are identical on unmodified `main` and are
  unrelated to this change (a shell/terminal integration-harness
  issue: `HoneyPotInteractiveProtocol` has no attribute `terminal`
  outside a full session fixture).