### PR TITLE
fix: guard against IndexError when scp -d given with no target directory

### DIFF
--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -55,7 +55,8 @@ class Command_scp(HoneyPotCommand):
 
         for opt in optlist:
             if opt[0] == "-d":
-                self.out_dir = args[0]
+                if args:
+                    self.out_dir = args[0]
                 break
 
         if self.out_dir:


### PR DESCRIPTION
## Summary

When `scp -d` is executed with no positional arguments, `args` is empty and `args[0]` raises an uncaught `IndexError`, crashing the session instead of producing a graceful error.

The fix adds a simple empty-args guard: `if args:` before reading `args[0]`. When `-d` is given without a target directory, `out_dir` remains empty and the command falls through to the normal error-handling path.

## Changes

- `src/cowrie/commands/scp.py`: Added `if args:` guard before `self.out_dir = args[0]` in the `-d` option handler (line 58)

## Testing

- All 11 existing SCP exec tests pass (`test_scp_exec.py`)
- AST-verified: the guard is syntactically valid and correctly placed

Closes #40473
