### PR TITLE
fix: catch ValueError for non-numeric uid/gid in fsctl chown/chgrp

### DIFF
--- a/src/cowrie/scripts/fsctl.py
+++ b/src/cowrie/scripts/fsctl.py
@@ -729,7 +729,11 @@ class fseditCmd(cmd.Cmd):
 
         target_object = getpath(self.fs, target_path)
         olduid = target_object[A_UID]
-        target_object[A_UID] = int(uid)
+        try:
+            target_object[A_UID] = int(uid)
+        except ValueError:
+            print("Incorrect uid: " + uid)
+            return
         print("former UID: " + str(olduid) + ". New UID: " + str(uid))
         self.save_pickle()
 
@@ -752,7 +756,11 @@ class fseditCmd(cmd.Cmd):
 
         target_object = getpath(self.fs, target_path)
         oldgid = target_object[A_GID]
-        target_object[A_GID] = int(gid)
+        try:
+            target_object[A_GID] = int(gid)
+        except ValueError:
+            print("Incorrect gid: " + gid)
+            return
         print("former GID: " + str(oldgid) + ". New GID: " + str(gid))
         self.save_pickle()
 


### PR DESCRIPTION
## Summary

`do_chown()` and `do_chgrp()` in `fsctl.py` convert the user-supplied uid/gid with a bare `int()` call. If the argument is not a valid integer (e.g. a typo like `chown roo /etc/passwd`), this raises an uncaught `ValueError` that terminates the entire interactive `fsctl` session.

The adjacent `do_chmod()` already handles the equivalent case correctly with a `try/except Exception` guard. This fix applies the same pattern to `do_chown()` and `do_chgrp()`, printing an error message and returning cleanly on invalid input.

## Changes

- `src/cowrie/scripts/fsctl.py`: Wrapped `int(uid)` in `do_chown()` and `int(gid)` in `do_chgrp()` with `try/except ValueError` guards, matching the existing pattern in `do_chmod()`

## Testing

- AST-verified: both `try/except ValueError` blocks correctly placed
- Existing test suite unaffected (fsctl is an offline utility, not tested in CI)

Closes #40507
