### PR TITLE
fix: guard empty password in UserDB.adduser()

### DIFF
--- a/src/cowrie/core/auth.py
+++ b/src/cowrie/core/auth.py
@@ -127,7 +127,7 @@ class UserDB:
         """
         user = self.re_or_bytes(login)
 
-        if passwd[0] == ord("!"):
+        if passwd and passwd[0] == ord("!"):
             policy = False
             passwd = passwd[1:]
         else:


### PR DESCRIPTION
## Summary

`UserDB.adduser()` indexes `passwd[0]` without checking that `passwd` is non-empty. A `userdb.txt` line with nothing after the final colon (e.g. `someuser:x:`) parses to an empty `passwd` (`b""`) in `UserDB.load()`, and `passwd[0]` on an empty bytes object raises `IndexError: index out of range`.

Because `HoneypotPasswordChecker.checkUserPass()` constructs a fresh `UserDB()` on *every single login attempt*, a single such line breaks all authentication until the file is fixed.

## Fix

Added an emptiness guard: `if passwd and passwd[0] == ord("!"):` — the `passwd and` check short-circuits before indexing when the password field is empty. When `passwd` is empty, the code falls through to `self.re_or_bytes(passwd)` which handles the empty bytes value correctly.

## Testing

- AST-verified: the `if passwd and passwd[0]` guard is present in the patched code
- Existing test suite passes (authentication tests unaffected for non-empty passwords)

Closes #40461
