### PR TITLE
fix: catch ValueError for malformed \x escape in printf

### DIFF
--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -193,7 +193,11 @@ class Command_printf(HoneyPotCommand):
                 if s.endswith("\\c"):
                     s = s[:-2]
 
-                data: bytes = codecs.escape_decode(s)[0]
+                try:
+                    data: bytes = codecs.escape_decode(s)[0]
+                except ValueError:
+                    self._log.info("printf command received Python incorrect hex escape")
+                    return
                 self.writeBytes(data)
 
 


### PR DESCRIPTION
## Summary

`Command_printf.call()` decodes escape sequences in the attacker-supplied format string with `codecs.escape_decode(s)[0]` and no error handling. A malformed escape — for example a trailing `\x` with no hex digits following it — makes `escape_decode()` raise `ValueError` uncaught, ending the session.

The sibling `Command_echo` in the same file already guards against exactly this case (its `-e` escape-decoding path is wrapped in `try/except ValueError`); `printf` never got the same guard.

## Fix

Wrapped the `codecs.escape_decode(s)` call in `try/except ValueError`, matching the existing pattern in `Command_echo`. On a malformed escape, the error is logged and the command returns cleanly instead of crashing.

## Testing

- **1017 tests pass** (clean venv, no plugin conflicts)
- AST-verified: `try/except ValueError` guard present in `Command_printf`
- Runtime-confirmed: `codecs.escape_decode('\\x')` raises `ValueError` — the fix catches it

Closes #40476
