### PR TITLE
fix: decode bytes IP in ssh_proxy connect_to_backend for clean logging

### DIFF
--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -186,7 +186,7 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
 
     def connect_to_backend(self, ip, port):
         # remember target so we can log consistently on success/failure
-        self.backend_ip = ip
+        self.backend_ip = ip.decode() if isinstance(ip, bytes) else ip
         self.backend_port = port
 
         # connection to the backend starts here


### PR DESCRIPTION
## Summary

The telnet_proxy version of `connect_to_backend()` already normalizes the IP with:
```python
self.backend_ip = ip.decode() if isinstance(ip, bytes) else ip
```
but the ssh_proxy version stores the raw bytes directly, causing log lines to show `b'10.0.0.5'` instead of `10.0.0.5` when a pool-assigned backend connection fails.

This aligns ssh_proxy with telnet_proxy's existing normalization (same comment, same purpose, the implementations clearly diverged).

## Changes

- **`src/cowrie/ssh_proxy/server_transport.py`**: Decode bytes IP in `connect_to_backend()` to match telnet_proxy behavior

## Test plan

- `b'10.0.0.5'.decode() if isinstance(b'10.0.0.5', bytes) else b'10.0.0.5'` → `'10.0.0.5'` ✓
- `'10.0.0.5'.decode() if isinstance('10.0.0.5', bytes) else '10.0.0.5'` → `'10.0.0.5'` ✓
- AST verified: no syntax errors

Closes #40508
