### PR TITLE
fix: guard IndexError when telnet client sends bare trailing CR

### DIFF
--- a/src/cowrie/telnet_proxy/handler.py
+++ b/src/cowrie/telnet_proxy/handler.py
@@ -248,9 +248,13 @@ class TelnetHandler:
 
         # check if done inputing
         if b"\r" in self.currentData:
-            terminatingChar = chr(
-                self.currentData[self.currentData.index(b"\r") + 1]
-            ).encode()  # usually \n or \x00
+            cr_index = self.currentData.index(b"\r")
+            if cr_index + 1 < len(self.currentData):
+                terminatingChar = chr(
+                    self.currentData[cr_index + 1]
+                ).encode()  # usually \n or \x00
+            else:
+                terminatingChar = b"\n"  # bare CR with no trailing byte
 
             # cleanup
             self.usernameState = process_backspaces(self.usernameState)
@@ -281,9 +285,13 @@ class TelnetHandler:
 
         # check if done inputing
         if b"\r" in self.currentData:
-            terminatingChar = chr(
-                self.currentData[self.currentData.index(b"\r") + 1]
-            ).encode()  # usually \n or \x00
+            cr_index = self.currentData.index(b"\r")
+            if cr_index + 1 < len(self.currentData):
+                terminatingChar = chr(
+                    self.currentData[cr_index + 1]
+                ).encode()  # usually \n or \x00
+            else:
+                terminatingChar = b"\n"  # bare CR with no trailing byte
 
             # cleanup
             self.passwordState = process_backspaces(self.passwordState)


### PR DESCRIPTION
## Summary

`TelnetHandler.processUsernameInput()` and `processPasswordInput()` assume a byte follows `\r` in the current packet. When a client sends a bare CR with no trailing LF/NUL (either as the entire packet or split across TCP reads), `index(\r) + 1` exceeds the data length and raises an unguarded `IndexError` that crashes the login prompt.

## Changes

- **`src/cowrie/telnet_proxy/handler.py`**: In both `processUsernameInput()` and `processPasswordInput()`, check whether a byte exists after `\r` before indexing. Default to `b"\n"` for bare CR (the standard line terminator).

## Test plan

- `b"root\r\n"` → terminatingChar = `b"\n"` ✓
- `b"root\r\x00"` → terminatingChar = `b"\x00"` ✓
- `b"root\r"` → terminatingChar = `b"\n"` ✓ (was IndexError)
- `b"password\r"` → terminatingChar = `b"\n"` ✓ (was IndexError)
- AST verified: no syntax errors

Closes #40503
