### PR TITLE
fix: keep exec command usable when it is not valid UTF-8

### DIFF
--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -372,10 +372,10 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
         Before this, execcmd is 'bytes'. Here it converts to 'string' and
         commands work with string rather than bytes.
         """
-        try:
-            self.execcmd = execcmd.decode("utf8")
-        except UnicodeDecodeError:
-            self._log.error("Unusual execcmd: {execcmd!r}", execcmd=execcmd)
+        # The exec command is attacker input and need not be valid UTF-8.
+        # Every caller reads execcmd right after construction, so it must
+        # always be set.
+        self.execcmd = execcmd.decode("utf8", errors="replace")
 
         # When the exec'd command is a shell reading commands from the channel
         # (`ssh host bash`), stdin is delivered to the cmdstack line by line


### PR DESCRIPTION
`HoneyPotExecProtocol.__init__` caught `UnicodeDecodeError` but only logged it — it never assigned `self.execcmd`. `connectionMade()` reads `self.execcmd` unconditionally straight afterwards, so an SSH `exec` request with a non-UTF-8 payload killed the session with `AttributeError: 'HoneyPotExecProtocol' object has no attribute 'execcmd'`.

The exec command is raw attacker input and is not guaranteed to be valid UTF-8.

Decode with `errors="replace"`, which is what the rest of the codebase already does for attacker-supplied bytes (usernames, `TERM`, NEW-ENVIRON values) and what the `cowrie.llm.protocol` twin of this class already does.

Fixes #40460
