### PR TITLE
fix: accept an empty password in userdb.txt

### DIFF
--- a/src/cowrie/core/auth.py
+++ b/src/cowrie/core/auth.py
@@ -127,7 +127,7 @@ class UserDB:
         """
         user = self.re_or_bytes(login)
 
-        if passwd[0] == ord("!"):
+        if passwd.startswith(b"!"):
             policy = False
             passwd = passwd[1:]
         else:

--- a/src/cowrie/test/test_auth.py
+++ b/src/cowrie/test/test_auth.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # ABOUTME: Tests for cowrie/core/auth.py authentication classes.
-# ABOUTME: Covers AuthRandom's returning-attacker fast path.
+# ABOUTME: Covers UserDB rule parsing and AuthRandom's returning-attacker path.
 
 from __future__ import annotations
 
@@ -13,6 +13,33 @@ import unittest
 
 from cowrie.core import auth
 from cowrie.core.config import CowrieConfig
+
+
+class UserDBRuleTests(unittest.TestCase):
+    """UserDB reloads userdb.txt on every login attempt, so one unparseable
+    line breaks authentication for the whole honeypot until it is fixed."""
+
+    def setUp(self) -> None:
+        self.db = auth.UserDB.__new__(auth.UserDB)
+        self.db.userdb = {}
+
+    def test_empty_password_is_a_plain_empty_password(self) -> None:
+        """A userdb.txt line ending in a bare colon ("someuser:x:") parses to
+        an empty password; it must be accepted, not raise IndexError."""
+        self.db.adduser(b"someuser", b"")
+
+        self.assertTrue(self.db.checklogin(b"someuser", b""))
+        self.assertFalse(self.db.checklogin(b"someuser", b"secret"))
+
+    def test_bang_prefix_still_denies(self) -> None:
+        self.db.adduser(b"root", b"!denied")
+
+        self.assertFalse(self.db.checklogin(b"root", b"denied"))
+
+    def test_plain_password_is_accepted(self) -> None:
+        self.db.adduser(b"root", b"secret")
+
+        self.assertTrue(self.db.checklogin(b"root", b"secret"))
 
 
 class AuthRandomReturningLoginTests(unittest.TestCase):


### PR DESCRIPTION
`UserDB.adduser()` tested for the `!` deny prefix with `passwd[0] == ord("!")`. A `userdb.txt` line with nothing after the final colon — e.g. `someuser:x:` — parses to `b""` in `load()`, and `passwd[0]` on empty bytes raises `IndexError`.

The blast radius is larger than one bad entry: `HoneypotPasswordChecker.checkUserPass()` constructs a fresh `UserDB()` (and so re-runs `load()`) on **every** login attempt, so a single such line broke authentication for the whole honeypot until someone noticed and edited the file. `load()`'s own `try/except IndexError` doesn't help — `adduser()` is called from the `else:` clause, outside the handler.

`startswith(b"!")` handles the empty case naturally and reads better than the ordinal comparison.

Tests cover the empty password (accepted as a plain empty password, and not matching a non-empty one), plus the `!` deny prefix and the ordinary case so the change doesn't quietly alter them.

Fixes #40461
