### PR TITLE
fix: let virustotal submit URLs it has never seen before

### DIFF
--- a/src/cowrie/output/virustotal.py
+++ b/src/cowrie/output/virustotal.py
@@ -478,6 +478,7 @@ class Output(cowrie.core.output.Output):
             vtUrl,
             headers,
             process_response=process_response,
+            valid_codes=[200, 404],
             error_prefix="VT scanurl",
         )
         if d:


### PR DESCRIPTION
`scanfile()` and `scanurl()` carry the same "is this new to VT?" logic in their `process_response` callbacks: look for `"error"` with code `"NotFoundError"` in the body and, if found, submit the file/URL for scanning.

But only `scanfile()` passes `valid_codes=[200, 404]` to `_make_request()`. `scanurl()` passes nothing, so it gets the `[200]` default, and `_make_request()` logs-and-drops anything else before `process_response` ever runs. VT returns 404 for an id it has never seen — which is exactly the case `scanfile()` already relies on — so `scanurl()`'s `NotFoundError` branch and the `submiturl()` call behind it were unreachable, and new URLs were never submitted for scanning.

Pass the same `valid_codes` as `scanfile()`.

Worth noting on the 404: the reporter flagged that VT's docs for `GET /api/v3/urls/{id}` only document 200/400 explicitly, so they couldn't confirm the status code live. That's also true of the `files/{id}` docs page, and `scanfile()` demonstrably depends on 404 there. Either way this change is safe — if VT does answer 200 with a `NotFoundError` body, adding 404 to the accepted list changes nothing.

Fixes #40462
