### PR TITLE
fix: hold a single sqlite connection in the output pool

### DIFF
--- a/src/cowrie/output/sqlite.py
+++ b/src/cowrie/output/sqlite.py
@@ -29,11 +29,21 @@ class Output(cowrie.core.output.Output):
         Start sqlite3 logging module using Twisted ConnectionPool.
         Need to be started with check_same_thread=False. See
         https://twistedmatrix.com/trac/ticket/3629.
+
+        The pool holds a single connection: SQLite serializes writers at the
+        file level, so concurrent connections to one database file raise
+        "database is locked" instead of gaining throughput, and the
+        LAST_INSERT_ROWID() reads below only mean anything on the same
+        connection as the INSERT they follow.
         """
         sqliteFilename = CowrieConfig.get("output_sqlite", "db_file")
         try:
             self.db = adbapi.ConnectionPool(
-                "sqlite3", database=sqliteFilename, check_same_thread=False
+                "sqlite3",
+                database=sqliteFilename,
+                check_same_thread=False,
+                cp_min=1,
+                cp_max=1,
             )
             self.db.start()
         except sqlite3.OperationalError as e:


### PR DESCRIPTION
`start()` built the `adbapi.ConnectionPool` without a size, so it took Twisted's defaults of `cp_min=3, cp_max=5` — up to five separate `sqlite3` connections to the same database file, used concurrently from different pool threads.

SQLite serializes writers at the file level. `check_same_thread=False` only relaxes Python's own thread-affinity check on a single connection object; it does nothing about SQLite's file locking. Several connections writing to one file is the classic source of `sqlite3.OperationalError: database is locked`, and `sqlerror()` only logs — there's no retry, so a locked-database error silently drops that INSERT/UPDATE.

There's a second problem the issue doesn't mention, and it's a correctness bug rather than a load one: `write()` does

```python
yield self.db.runQuery("INSERT INTO `sensors` (`ip`) VALUES (?)", ...)
r = yield self.db.runQuery("SELECT LAST_INSERT_ROWID()")
```

`LAST_INSERT_ROWID()` is per-connection. With a multi-connection pool those two `runQuery()` calls can land on different connections, so the sensor/client id read back may belong to some other connection's last insert — or to nothing at all. The same shape appears in the `cowrie.client.version` branch.

Pin the pool to a single connection (`cp_min=1, cp_max=1`). Queries serialize through one connection, which is what SQLite does anyway, and it makes the `LAST_INSERT_ROWID()` reads sound.

Fixes #40463
