### PR TITLE
fix: append to the jsonlog logfile instead of truncating it

### DIFF
--- a/src/cowrie/output/jsonlog.py
+++ b/src/cowrie/output/jsonlog.py
@@ -36,7 +36,7 @@ class Output(cowrie.core.output.Output):
                 base, dirs, defaultMode=0o664
             )
         elif logtype == "plain":
-            self.outfile = open(Path(dirs, base), "w", encoding="utf-8")
+            self.outfile = open(Path(dirs, base), "a", encoding="utf-8")
         else:
             raise ValueError
 


### PR DESCRIPTION
`start()` opened the non-rotating logfile with mode `"w"`, which truncates. `logtype` falls back to `"plain"`, so this is what any install that hasn't explicitly set `logtype = rotating` gets — the default path, not an edge case. Every restart (a crash, an upgrade, a scheduled restart) silently wiped `cowrie.json` and started over.

The sibling `textlog.py` opens its equivalent single logfile with `"a"`, so this looks like an oversight rather than a decision.

Open with `"a"`.

Fixes #40464
