### PR TITLE
fix: parse /etc/passwd by line in finger

### DIFF
--- a/src/cowrie/commands/finger.py
+++ b/src/cowrie/commands/finger.py
@@ -23,18 +23,13 @@ class Command_finger(HoneyPotCommand):
         all_users_byte = self.fs.file_contents("/etc/passwd")
         # An attacker can overwrite /etc/passwd with arbitrary bytes.
         all_users = all_users_byte.decode("utf-8", errors="replace")
-        # Convert all new lines to : character
-        all_users = all_users.replace("\n", ":")
-        # Convert into list by splitting string
-        all_users_list = all_users.split(":")
-        # Loop over the data in sets of 7
-        for i in range(0, len(all_users_list), 7):
-            x = i
-            # Ensure any added list contains data and is not a blank space by >
-            if len(all_users_list[x : x + 7]) != 1:
-                # Take the next 7 elements and put them a list, then add to 2d>
-                user_data.append(all_users_list[x : x + 7])
-        # THIS CODE IS FOR DEBUGGING self.write(str(user_data))
+        # A record is one line of seven colon-separated fields. Lines that do
+        # not have all seven are not records: skip them, the way getpwent()
+        # does, so the rest of the file still parses.
+        for line in all_users.splitlines():
+            fields = line.split(":")
+            if len(fields) == 7:
+                user_data.append(fields)
 
         # If finger called without args
         if len(self.args) == 0:

--- a/src/cowrie/test/test_finger.py
+++ b/src/cowrie/test/test_finger.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: finger reads /etc/passwd, which an attacker can overwrite over
+# ABOUTME: SFTP, so a malformed record must not crash the session.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+WELL_FORMED = (
+    b"root:x:0:0:root:/root:/bin/bash\nphil:x:1000:1000:Phil:/home/phil:/bin/sh\n"
+)
+
+
+class ShellFingerCommandTests(unittest.TestCase):
+    """Test for cowrie/commands/finger.py."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def _passwd(self, contents: bytes):
+        return patch.object(self.proto.fs, "file_contents", return_value=contents)
+
+    def test_lists_users(self) -> None:
+        with self._passwd(WELL_FORMED):
+            self.proto.lineReceived(b"finger\n")
+
+        out = self.tr.value()
+        self.assertIn(b"root", out)
+        self.assertIn(b"phil", out)
+        self.assertTrue(out.endswith(PROMPT))
+
+    def test_shows_one_user(self) -> None:
+        with self._passwd(WELL_FORMED):
+            self.proto.lineReceived(b"finger phil\n")
+
+        out = self.tr.value()
+        self.assertIn(b"Login: phil", out)
+        self.assertIn(b"/home/phil", out)
+        self.assertIn(b"/bin/sh", out)
+
+    def test_truncated_record_does_not_crash(self) -> None:
+        """A line without all seven fields must be skipped, not throw off the
+        parse of every following line."""
+        with self._passwd(b"truncated:x:0\n" + WELL_FORMED):
+            self.proto.lineReceived(b"finger\n")
+
+        out = self.tr.value()
+        self.assertTrue(out.endswith(PROMPT))
+        self.assertIn(b"root", out)
+        self.assertIn(b"phil", out)
+
+    def test_named_user_after_truncated_record(self) -> None:
+        with self._passwd(b"truncated:x:0\n" + WELL_FORMED):
+            self.proto.lineReceived(b"finger phil\n")
+
+        self.assertIn(b"Login: phil", self.tr.value())
+
+    def test_garbage_passwd_does_not_crash(self) -> None:
+        with self._passwd(b"not a passwd file at all\n\n:::\n"):
+            self.proto.lineReceived(b"finger\n")
+
+        self.assertTrue(self.tr.value().endswith(PROMPT))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`finger` parsed `/etc/passwd` by replacing every newline with `:`, splitting the whole file on `:`, and then walking the flat list in strides of 7 to reconstruct records. That only works if every line has exactly 7 fields — the newline-to-colon step throws away the record boundaries the parse then has to guess back.

The `len(...) != 1` guard only drops the single empty string left after the file's trailing newline. It doesn't check that a chunk has 7 fields, so any line that isn't 7 fields shifts every following record out of alignment and produces short "records" of 2–6 elements. The no-args branch then indexes up to element 4 of each one, raising `IndexError` and killing the session.

`/etc/passwd` is attacker-controllable via SFTP upload — the code's own comment says so (`# An attacker can overwrite /etc/passwd with arbitrary bytes.`).

Fix the parse rather than guarding the indexes: keep line boundaries, split each line on `:`, and keep only records with all 7 fields, which is what `getpwent()` does with a malformed line. Short of that, the misalignment would still silently corrupt the records that *do* parse — the second test below covers that: before the change, a truncated first line makes `finger phil` report "no such user" even though the entry is there and well-formed.

New `test_finger.py` covers listing, a named user, a truncated record (both branches), and unparseable content. The two malformed-record tests fail before the change — one with the `IndexError`, one with the silent misparse.

Fixes #40465
