### PR TITLE
fix: report whole days and years from durationHuman

### DIFF
--- a/src/cowrie/core/utils.py
+++ b/src/cowrie/core/utils.py
@@ -78,10 +78,13 @@ def durationHuman(duration: float) -> str:
     minutes, seconds = divmod(seconds, 60)
     hours: int
     hours, minutes = divmod(minutes, 60)
-    days: float
+    days: int
     days, hours = divmod(hours, 24)
-    years: float
-    years, days = divmod(days, 365.242199)
+    # The fractional year length keeps the count leap-accurate. divmod()
+    # promotes both of its results to float against it, but whole years and
+    # days are what gets reported.
+    years: int = int(days // 365.242199)
+    days = int(days % 365.242199)
 
     syears: str = str(years)
     sseconds: str = str(seconds).rjust(2, "0")

--- a/src/cowrie/test/test_utils.py
+++ b/src/cowrie/test/test_utils.py
@@ -36,8 +36,14 @@ class UtilsTestCase(unittest.TestCase):
         hour = durationHuman(3600)
         self.assertEqual(hour, "01:00:00")
 
-        something = durationHuman(364020)
-        self.assertEqual(something, "4.0 days 05:07:00")
+        days = durationHuman(364020)
+        self.assertEqual(days, "4 days 05:07:00")
+
+        one_day = durationHuman(86400)
+        self.assertEqual(one_day, "1 day 00:00")
+
+        years = durationHuman(2 * 365 * 86400)
+        self.assertEqual(years, "1 year ")
 
     def test_get_endpoints_from_section(self) -> None:
         cfg = get_config("[ssh]\nlisten_addr = 1.1.1.1\n")


### PR DESCRIPTION
`durationHuman()` chains `divmod()` on ints all the way down to days, then splits years off with `divmod(days, 365.242199)`. The float divisor promotes both results, so `days` and `years` come out as `4.0` / `1.0` and get formatted straight into the string: `"4.0 days 05:07:00"` instead of `"4 days 05:07:00"`.

The fractional divisor is there for leap-year accuracy, so keep it and convert the two counts back to whole numbers.

**Note on the existing test:** `test_utils.py` asserted `"4.0 days 05:07:00"` as correct. That assertion captured the buggy output rather than the intended format, so this PR updates it to `"4 days 05:07:00"` — flagging it explicitly since it means an existing green test changes. Two cases are added alongside it: a single day (exercises the `day` vs `days` pluralization, which the float also broke — `1.0 != 1` is true, so it said "1.0 days") and a duration over a year (exercises the `years` branch, which had no coverage).

`durationHuman()` has no production call site today — it's only reached from the test — so this is a correctness fix to a utility rather than a user-visible change.

One thing I noticed but did not change, since it's outside this issue: the `years > 0` branch returns only the year count and drops the time entirely, with a trailing space (`"1 year "`). Happy to open a separate issue if that's also unintended.

Fixes #40466
