### PR TITLE
fix: encode base64 interactive input as UTF-8

### DIFF
--- a/src/cowrie/commands/base64.py
+++ b/src/cowrie/commands/base64.py
@@ -148,7 +148,7 @@ Try 'base64 --help' for more information.
             input=line,
         )
 
-        self.dojob(line.encode("ascii"))
+        self.dojob(line.encode("utf-8"))
 
     def eofReceived(self) -> None:
         self.exit()


### PR DESCRIPTION
`Command_base64.lineReceived()` encoded each typed line with `line.encode("ascii")`. By the time a line gets there, `shell/protocol.py` has already decoded the raw client bytes to `str` with `errors="replace"` — deliberately, so that bad input "must not raise out of the protocol and kill the session". Re-encoding strictly as ASCII undoes that: any non-ASCII character, including the U+FFFD that the protocol's own replace step produces, raised `UnicodeEncodeError` and ended the session.

Encode as UTF-8, which is what the sibling stdin-reading commands already do — `cat`, `tee` and `cut` all use `line.encode("utf-8")` in the same place.

UTF-8 rather than `ascii` with `errors="replace"` because it keeps the output correct as well as non-crashing: typing `café` now encodes the UTF-8 bytes real `base64` would have read from the tty, instead of turning the character into `?`.

Fixes #40468
