### PR TITLE
fix: report a malformed cut field list instead of crashing

### DIFF
--- a/src/cowrie/commands/cut.py
+++ b/src/cowrie/commands/cut.py
@@ -64,7 +64,13 @@ class Command_cut(HoneyPotCommand):
         self.delimiter = delimiter
         self.field_spec = field_spec
         self.suppress = suppress
-        self.field_indices = self._parse_field_spec(field_spec)
+        try:
+            self.field_indices = self._parse_field_spec(field_spec)
+        except ValueError:
+            self.errorWrite(f"cut: invalid field value '{field_spec}'\n")
+            self.errorWrite("Try 'cut --help' for more information.\n")
+            self.exit()
+            return
 
         if self.input_data:
             self._process(self.input_data)


### PR DESCRIPTION
`_parse_field_spec()` calls `int()` on each comma-separated piece of the `-f`/`-b`/`-c` argument with no error handling, and `start()` calls it unconditionally as soon as the option is parsed — before any file or piped input is looked at. `cut -f abc` (or `cut -f 1-x`) let `ValueError` escape `start()` and killed the session.

Real `cut` validates the list and prints `cut: invalid field value 'abc'`.

Catch the `ValueError` in `start()` and write that message, matching the shape of the two error paths already above it in the same method.

One thing I deliberately did **not** change: like the sibling error branches (`invalid option`, `you must specify a list of bytes...`), this exits with status 0 rather than 1 — `self.exit()` leaves `exit_code` at its default. Real `cut` exits 1 for all three. Setting it on only the new path would make the file inconsistent, so I left it and am flagging it here; happy to fix all three together in a follow-up if you want it.

Fixes #40469
