### PR TITLE
fix: survive an empty -c argument and non-UTF-8 stdin in sh

### DIFF
--- a/src/cowrie/commands/bash.py
+++ b/src/cowrie/commands/bash.py
@@ -26,8 +26,11 @@ class Command_sh(HoneyPotCommand):
             line = " ".join(self.args[1:])
 
             # it might be sh -c 'echo "sometext"', so don't use line.strip('\'\"')
-            if (line[0] == "'" and line[-1] == "'") or (
-                line[0] == '"' and line[-1] == '"'
+            # "-c" with nothing after it leaves line empty, which bash runs as
+            # an empty command.
+            if line and (
+                (line[0] == "'" and line[-1] == "'")
+                or (line[0] == '"' and line[-1] == '"')
             ):
                 line = line[1:-1]
 
@@ -35,7 +38,8 @@ class Command_sh(HoneyPotCommand):
             self.exit()
 
         elif self.input_data:
-            self.execute_commands(self.input_data.decode("utf8"))
+            # Piped stdin is attacker bytes and need not be valid UTF-8.
+            self.execute_commands(self.input_data.decode("utf8", errors="replace"))
             self.exit()
 
         elif self.args and not self.args[0].startswith("-"):


### PR DESCRIPTION
Two crashes in `Command_sh.start()`, both reachable from ordinary attacker input. They're in the same method so they're fixed together here.

**`bash -c` with no command string (#40471)** — `-c` handling joins everything after it into `line = " ".join(self.args[1:])` and then checks `line[0]` / `line[-1]` to strip a matching pair of surrounding quotes. With nothing after `-c`, `line` is `""` and `line[0]` raises `IndexError`. Real bash treats this as running an empty command, a harmless no-op. Guard the quote-stripping on `line` being non-empty.

**Non-UTF-8 piped stdin (#40472)** — `self.input_data.decode("utf8")` had no `errors=` fallback. `input_data` is whatever was piped in (`cat somefile | bash`), i.e. attacker bytes with no encoding guarantee, so invalid UTF-8 raised `UnicodeDecodeError` and killed the session. Every sibling command that decodes piped bytes — `cat`, `tee`, `awk`, `cut` — already uses `errors="replace"`.

Fixes #40471
Fixes #40472
