### PR TITLE
fix: handle scp -d with no target directory

### DIFF
--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -54,7 +54,9 @@ class Command_scp(HoneyPotCommand):
         self.out_dir = ""
 
         for opt in optlist:
-            if opt[0] == "-d":
+            # -d takes no getopt argument of its own; the target directory is
+            # the first positional argument, which need not be there.
+            if opt[0] == "-d" and args:
                 self.out_dir = args[0]
                 break
 


### PR DESCRIPTION
`Command_scp.start()` parses `-d` as a flag that takes no `getopt` argument of its own, then reads the target directory from the first positional argument:

```python
for opt in optlist:
    if opt[0] == "-d":
        self.out_dir = args[0]
```

A bare `scp -d` has no positional arguments, so `args[0]` raises `IndexError`.

Only read `args[0]` when there is one; `out_dir` then stays `""`, which the code below already treats as "no target directory given".

**On the impact**, since the issue says it ends the session and that isn't quite what happens on current main: the command runs inside a Deferred callback chain, so the `IndexError` is caught and logged as `shell statement failed`. The connection stays up — but the command never reaches `exit()`, so it sits on the cmdstack forever, the shell never finishes the statement, and no prompt is ever written again. Subsequent input is only echoed. So the session isn't torn down, it's wedged, which for a honeypot amounts to the same loss of interaction.

Fixes #40473
