### PR TITLE
fix: report an invalid grep pattern instead of raising re.error

### DIFF
--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -41,9 +41,12 @@ class Command_grep(HoneyPotCommand):
         except Exception:
             self.errorWrite(f"grep: {filename}: No such file or directory\n")
 
-    def grep_application(self, contents: bytes, match: str) -> None:
+    def compile_match(self, match: str) -> re.Pattern[bytes]:
         bmatch = os.path.basename(match).replace('"', "").encode("utf8")
-        matcher = re.compile(bmatch)
+        return re.compile(bmatch)
+
+    def grep_application(self, contents: bytes, match: str) -> None:
+        matcher = self.compile_match(match)
         for line in contents.split(b"\n"):
             if matcher.search(line):
                 self.matched = True
@@ -97,6 +100,16 @@ class Command_grep(HoneyPotCommand):
             return
 
         self.match = args[0]
+
+        # grep validates the pattern before it reads any input, so a malformed
+        # one is reported once rather than per file or per line of stdin.
+        try:
+            self.compile_match(self.match)
+        except re.error:
+            self.errorWrite("grep: Invalid regular expression\n")
+            self.exit(2)
+            return
+
         files = args[1:]
 
         if self.input_data is not None:
@@ -582,9 +595,7 @@ class Command_mkdir(HoneyPotCommand):
                 self.errorWrite(f"mkdir: cannot create directory `{f}': File exists\n")
                 return
             try:
-                self.fs.mkdir(
-                    pname, self.user["uid"], self.user["gid"], 4096, 16877
-                )
+                self.fs.mkdir(pname, self.user["uid"], self.user["gid"], 4096, 16877)
             except fs.FileNotFound:
                 self.errorWrite(
                     f"mkdir: cannot create directory `{f}': No such file or directory\n"
@@ -672,9 +683,7 @@ class Command_touch(HoneyPotCommand):
                 self.errorWrite(f"touch: cannot touch `{pname}`: Permission denied\n")
                 return
 
-            self.fs.mkfile(
-                pname, self.user["uid"], self.user["gid"], 0, 33188
-            )
+            self.fs.mkfile(pname, self.user["uid"], self.user["gid"], 0, 33188)
 
 
 commands["/bin/touch"] = Command_touch

--- a/src/cowrie/test/test_grep.py
+++ b/src/cowrie/test/test_grep.py
@@ -74,6 +74,28 @@ class ShellGrepCommandTests(unittest.TestCase):
         self.proto.lineReceived(b"echo $?\n")
         self.assertEqual(self.tr.value(), PROMPT + b"1\n" + PROMPT)
 
+    def test_grep_invalid_pattern_piped(self) -> None:
+        """A pattern that is not a valid regex is an error, not a wedged
+        shell: the pattern is attacker input on every grep path."""
+        self.proto.lineReceived(b"echo hello | grep '['; echo $?\n")
+        self.assertEqual(
+            self.tr.value(), b"grep: Invalid regular expression\n2\n" + PROMPT
+        )
+
+    def test_grep_invalid_pattern_file(self) -> None:
+        self.proto.lineReceived(b"grep 'a(' /etc/passwd\n")
+        value = self.tr.value()
+        self.assertIn(b"grep: Invalid regular expression", value)
+        self.assertTrue(value.endswith(PROMPT))
+
+    def test_grep_invalid_pattern_stdin(self) -> None:
+        """The stdin path must reject the pattern up front rather than
+        waiting for a line to fail on."""
+        self.proto.lineReceived(b"grep '['\n")
+        self.assertEqual(
+            self.tr.value(), b"grep: Invalid regular expression\n" + PROMPT
+        )
+
     def test_grep_no_args_shows_usage(self) -> None:
         self.proto.lineReceived(b"grep\n")
         value = self.tr.value()


### PR DESCRIPTION
`Command_grep.grep_application()` compiled the attacker-supplied pattern with `re.compile(bmatch)` and no error handling, so any pattern that isn't a valid Python regex — an unterminated character class, an unbalanced parenthesis — raised `re.error`. It's reachable on every path that runs grep: a file argument, a pipe, or interactive stdin.

Validate the pattern once in `start()`, before any input is read, which is also what real grep does, and report `grep: Invalid regular expression` with exit status 2.

Pulled the compile into `compile_match()` so `start()` and `grep_application()` can't disagree about what counts as a valid pattern.

Two things worth noting beyond the issue:

- The file path didn't actually crash — `grep_get_contents()` wraps the call in a bare `except Exception`, so `grep 'a(' /etc/passwd` reported **`grep: /etc/passwd: No such file or directory`**. The regex error was being silently mis-reported as a missing file, on a file that exists.
- On the piped and stdin paths, the `re.error` propagates into the shell's Deferred chain, where it's logged as `shell statement failed`. The connection survives, but the command never exits, so the shell never returns to a prompt. (The issue says this ends the session; on current main it wedges it instead.)

Three tests, one per path; all three fail before the change.

Fixes #40474
