### PR TITLE
fix: guard printf against a malformed escape

### DIFF
--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -175,6 +175,8 @@ commands["echo"] = Command_echo
 
 
 class Command_printf(HoneyPotCommand):
+    _log = Logger()
+
     def call(self) -> None:
         if not self.args:
             self.write("printf: usage: printf [-v var] format [arguments]\n")
@@ -193,7 +195,13 @@ class Command_printf(HoneyPotCommand):
                 if s.endswith("\\c"):
                     s = s[:-2]
 
-                data: bytes = codecs.escape_decode(s)[0]
+                try:
+                    data: bytes = codecs.escape_decode(s)[0]
+                except ValueError:
+                    self._log.info(
+                        "printf command received Python incorrect hex escape"
+                    )
+                    return
                 self.writeBytes(data)
 
 


### PR DESCRIPTION
`Command_printf.call()` decodes escapes in the attacker-supplied format string with `codecs.escape_decode(s)[0]` and no error handling, so a malformed escape — a trailing `\x` with no hex digits, or invalid digits after it — raised `ValueError` out of `call()`.

`Command_echo` in the same file already guards exactly this case: its `-e` escape-decoding path is wrapped in `try/except ValueError` with a log line. `printf` never got the same guard, so this just applies it, keeping the two consistent.

**On the impact:** as with the other command crashes in this batch, the issue says it ends the session; on current main the `ValueError` is caught by the shell's Deferred chain and logged as `shell statement failed`, so the connection survives but the command never exits and no prompt is written again.

Fixes #40476
