### PR TITLE
fix: fall back to the default width on a non-numeric COLUMNS

### DIFF
--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -228,6 +228,15 @@ commands["hostname"] = Command_hostname
 
 
 class Command_ps(HoneyPotCommand):
+    def columns(self) -> int:
+        """Width to truncate each line to. COLUMNS is an ordinary shell
+        variable that export sets to anything at all, so fall back to the
+        default width rather than trusting it to be a number."""
+        try:
+            return int(self.environ["COLUMNS"])
+        except (KeyError, ValueError):
+            return 80
+
     def call(self) -> None:
         user = str(self.user["username"])
         args = ""
@@ -795,13 +804,7 @@ class Command_ps(HoneyPotCommand):
                 ]
             s = "".join([output_array[i][x] for x in line])
             if "w" not in args:
-                s = s[
-                    : (
-                        int(self.environ["COLUMNS"])
-                        if "COLUMNS" in self.environ
-                        else 80
-                    )
-                ]
+                s = s[: self.columns()]
             self.write(f"{s}\n")
 
 


### PR DESCRIPTION
`Command_ps.call()` truncated each output line with `int(self.environ["COLUMNS"])` (whenever `-w` isn't given) and no error handling. `COLUMNS` is an ordinary shell variable, and `Command_export` in the same file sets it to anything with no validation — so `export COLUMNS=abc` followed by `ps` raised `ValueError`.

Read the width through a small `columns()` helper that falls back to the default 80 for a missing or non-numeric value. That also replaces the inline conditional that was re-evaluated for every output line.

**On the impact:** the issue says it ends the session; on current main the `ValueError` reaches the shell's Deferred chain and is logged as `shell statement failed`, so the connection survives but the command never exits and no prompt is written again.

Fixes #40477
