### PR TITLE
fix: decode the line buffer leniently for tab completion

### DIFF
--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -1026,6 +1026,12 @@ class HoneyPotShell:
     def handle_TAB(self) -> None:
         """
         lineBuffer is an array of bytes
+
+        These are the raw keystrokes typed so far, so they need not be valid
+        UTF-8: an ordinary multi-byte character is an incomplete sequence
+        until its last byte arrives. Decoding is lossy for the same reason
+        lineReceived's is -- completing on a line must not raise out of the
+        protocol and kill the session.
         """
         if not self.protocol.lineBuffer:
             return
@@ -1034,7 +1040,7 @@ class HoneyPotShell:
         if line[-1:] == b" ":
             clue = ""
         else:
-            clue = line.split()[-1].decode("utf8")
+            clue = line.split()[-1].decode("utf8", errors="replace")
 
         # clue now contains the string to complete or is empty.
         # line contains the buffer as bytes
@@ -1075,7 +1081,10 @@ class HoneyPotShell:
         newbuf = ""
         if len(files) == 1:
             newbuf = " ".join(
-                [*line.decode("utf8").split()[:-1], f"{basedir}{files[0][fs.A_NAME]}"]
+                [
+                    *line.decode("utf8", errors="replace").split()[:-1],
+                    f"{basedir}{files[0][fs.A_NAME]}",
+                ]
             )
             if files[0][fs.A_TYPE] == fs.T_DIR:
                 newbuf += "/"
@@ -1087,7 +1096,7 @@ class HoneyPotShell:
                 prefix = posixpath.commonprefix([x[fs.A_NAME] for x in files])
             else:
                 prefix = ""
-            first = line.decode("utf8").split(" ")[:-1]
+            first = line.decode("utf8", errors="replace").split(" ")[:-1]
             newbuf = " ".join([*first, f"{basedir}{prefix}"])
             newbyt = newbuf.encode("utf8")
             if newbyt == b"".join(self.protocol.lineBuffer):


### PR DESCRIPTION
`HoneyPotShell.handle_TAB()` works on `self.protocol.lineBuffer` — the raw keystroke bytes typed so far. This runs *before* Enter, so it isn't the already-decoded, already-`errors="replace"`-protected `str` that reaches a command's `lineReceived()`.

Three calls in that method decoded the buffer with a plain `.decode("utf8")`:

- the "word to complete" lookup,
- the single-match branch that rebuilds the line buffer,
- the multi-match branch that does the same.

None of them had an `errors=` fallback, so any invalid or incomplete UTF-8 in the typed line raised `UnicodeDecodeError`. This isn't only about deliberately malformed input — an ordinary multi-byte character is an incomplete sequence until its last byte arrives, so pressing TAB partway through typing one hits it.

That contradicts the stated intent in `shell/protocol.py`, whose `lineReceived()` decodes with `errors="replace"` precisely so that "the line must not raise out of the protocol and kill the session". These three were the one spot in the line-editing path that never got the same treatment.

Fixes #40478
