### PR TITLE
fix: read rethinkdblog event timestamps as UTC

### DIFF
--- a/src/cowrie/output/rethinkdblog.py
+++ b/src/cowrie/output/rethinkdblog.py
@@ -5,8 +5,7 @@
 
 from __future__ import annotations
 
-import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import rethinkdb as r
 
@@ -15,7 +14,13 @@ from cowrie.core.config import CowrieConfig
 
 
 def iso8601_to_timestamp(value):
-    return time.mktime(datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ").timetuple())
+    """Unix timestamp for an event timestamp.
+
+    The trailing Z marks the value as UTC, so it is read as UTC: the instant
+    stored must not shift with the honeypot host's own timezone.
+    """
+    parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+    return parsed.replace(tzinfo=timezone.utc).timestamp()
 
 
 RETHINK_DB_SEGMENT = "output_rethinkdblog"


### PR DESCRIPTION
`iso8601_to_timestamp()` parsed the event timestamp with `%Y-%m-%dT%H:%M:%S.%fZ` — the trailing `Z` says the value is UTC — and then converted it with `time.mktime(...timetuple())`. `mktime()` interprets the tuple as **local** time, so on any host not running in UTC every event stored in RethinkDB carried a `timestamp` off by the host's UTC offset.

Attach `timezone.utc` and use `datetime.timestamp()` instead, which drops the `time` import.

Fixes #40486
