### PR TITLE
fix: release dshield session state when the session closes

### DIFF
--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -109,6 +109,11 @@ class Output(cowrie.core.output.Output):
                     "banner": state["banner"],
                 }
             )
+            # The state has been consumed into the batch entry above and the
+            # session is over, so drop it rather than carrying one entry per
+            # session ever seen for the life of the process.
+            self.session_state.pop(session, None)
+
             if self.debug:
                 self._log.info(
                     "dshield: log appended, batch size {batch_len} max size {batch_size}",


### PR DESCRIPTION
`Output.write()` keeps `self.session_state` keyed by session id, created on the first event for a session and updated as login and command events arrive. On `cowrie.session.closed` the accumulated state is read to build the batch entry — and then left in the dict forever.

Every session that ever connects adds one entry that lives for the whole process. On the deployment this plugin is for — a long-running, actively-scanned honeypot — that grows without bound with total connection count.

Drop the entry once it has been consumed into the batch entry.

Fixes #40492
