### PR TITLE
fix: release misp session tracking when the session closes

### DIFF
--- a/src/cowrie/output/misp.py
+++ b/src/cowrie/output/misp.py
@@ -261,6 +261,12 @@ class Output(cowrie.core.output.Output):
                         )
                         self.session_tracking[session_id]["event_created"] = True
 
+                # The session is over and anything reportable about it has
+                # been submitted, so drop it rather than carrying one entry
+                # per session ever seen for the life of the process. What
+                # stop() still walks is the sessions that never closed.
+                del self.session_tracking[session_id]
+
     def find_attribute(self, attribute_type, searchterm):
         """
         Returns a matching attribute or None if nothing was found.


### PR DESCRIPTION
`Output.write()` accumulates login, command, download and upload activity per session in `self.session_tracking`. On `cowrie.session.closed` it builds and submits the MISP event — and then leaves the entry in the dict forever, whether or not an event was created for it.

Every session that ever connects adds one entry that lives for the whole process, so on a long-running, actively-scanned honeypot this grows without bound. Sessions with nothing worth reporting are the worse case: they never even reach `create_session_event()`, so nothing ever looks at them again.

Same class of bug as #40492 in `dshield.py`, different plugin.

Delete the entry at the end of the close branch. That's after everything that reads it, and it doesn't disturb `stop()` — `stop()` walks `session_tracking` to flush sessions that *never* closed, which is exactly what's left once closed ones are removed.

Fixes #40493
