### PR TITLE
fix: escape attacker text in telegram messages

### DIFF
--- a/src/cowrie/output/telegram.py
+++ b/src/cowrie/output/telegram.py
@@ -5,11 +5,23 @@
 
 # Simple Telegram Bot logger
 
+from html import escape
+
 import treq
 from twisted.logger import Logger
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
+
+
+def esc(value: str) -> str:
+    """Escape a value for a Telegram message sent with parse_mode=HTML.
+
+    Telegram's HTML mode wants "<", ">" and "&" escaped in text. Quotes are
+    left alone: nothing here is interpolated into an attribute, and Telegram
+    does not define the numeric entity html.escape would produce for "'".
+    """
+    return escape(str(value), quote=False)
 
 
 class Output(cowrie.core.output.Output):
@@ -40,22 +52,26 @@ class Output(cowrie.core.output.Output):
         # else:
         #     logon_type = ""
 
+        # The message is sent with parse_mode=HTML, so every value put into it
+        # is escaped: the command, credentials and URL are attacker-controlled,
+        # and a literal "<", ">" or "&" would otherwise be read as markup --
+        # breaking the message, or rendering markup the attacker chose.
         # Prepare base message
-        msgtxt = "<strong>[Cowrie " + event["sensor"] + "]</strong>"
-        msgtxt += "\nEvent: " + event["eventid"]
+        msgtxt = "<strong>[Cowrie " + esc(event["sensor"]) + "]</strong>"
+        msgtxt += "\nEvent: " + esc(event["eventid"])
         # msgtxt += "\nLogon type: " + logon_type
-        msgtxt += "\nSource: <code>" + event["src_ip"] + "</code>"
-        msgtxt += "\nSession: <code>" + event["session"] + "</code>"
+        msgtxt += "\nSource: <code>" + esc(event["src_ip"]) + "</code>"
+        msgtxt += "\nSession: <code>" + esc(event["session"]) + "</code>"
 
         if event["eventid"] == "cowrie.login.success":
-            msgtxt += "\nUsername: <code>" + event["username"] + "</code>"
-            msgtxt += "\nPassword: <code>" + event["password"] + "</code>"
+            msgtxt += "\nUsername: <code>" + esc(event["username"]) + "</code>"
+            msgtxt += "\nPassword: <code>" + esc(event["password"]) + "</code>"
             self.send_message(msgtxt)
         elif event["eventid"] in ["cowrie.command.failed", "cowrie.command.input"]:
-            msgtxt += "\nCommand: <pre>" + event["input"] + "</pre>"
+            msgtxt += "\nCommand: <pre>" + esc(event["input"]) + "</pre>"
             self.send_message(msgtxt)
         elif event["eventid"] == "cowrie.session.file_download":
-            msgtxt += "\nUrl: " + event.get("url", "")
+            msgtxt += "\nUrl: " + esc(event.get("url", ""))
             self.send_message(msgtxt)
 
     def send_message(self, message):

--- a/src/cowrie/test/test_telegram.py
+++ b/src/cowrie/test/test_telegram.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: The telegram plugin sends HTML-parsed messages, so attacker text
+# ABOUTME: interpolated into them has to be escaped rather than sent as markup.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+from cowrie.output import telegram
+
+
+def _make() -> tuple[Any, list[str]]:
+    """The plugin with its config-reading start() and its HTTP call stubbed."""
+    with patch.object(telegram.Output, "start", lambda self: None):
+        out = telegram.Output()
+    sent: list[str] = []
+    out.send_message = sent.append  # type: ignore[method-assign]
+    return out, sent
+
+
+def _event(**extra: str) -> dict[str, str]:
+    event = {
+        "sensor": "testsensor",
+        "src_ip": "1.2.3.4",
+        "session": "s1",
+    }
+    event.update(extra)
+    return event
+
+
+class TelegramHtmlEscapingTests(unittest.TestCase):
+    def test_redirect_in_command_is_escaped(self) -> None:
+        """A shell redirect is an ordinary command; unescaped it produces
+        malformed HTML that the Telegram API rejects, dropping the alert."""
+        out, sent = _make()
+
+        out.write(_event(eventid="cowrie.command.input", input="ls -la > /tmp/x"))
+
+        self.assertIn("ls -la &gt; /tmp/x", sent[0])
+        self.assertNotIn("> /tmp/x", sent[0])
+
+    def test_markup_in_command_is_not_rendered(self) -> None:
+        """A crafted command must not become live markup in the operator's
+        chat -- Telegram's HTML mode supports <a href>."""
+        out, sent = _make()
+
+        out.write(
+            _event(
+                eventid="cowrie.command.input",
+                input='<a href="http://evil.example">click</a>',
+            )
+        )
+
+        self.assertNotIn("<a href", sent[0])
+        self.assertIn("&lt;a href=", sent[0])
+
+    def test_ampersand_in_command_is_escaped(self) -> None:
+        out, sent = _make()
+
+        out.write(_event(eventid="cowrie.command.input", input="wget a?x=1&y=2"))
+
+        self.assertIn("wget a?x=1&amp;y=2", sent[0])
+
+    def test_credentials_are_escaped(self) -> None:
+        out, sent = _make()
+
+        out.write(
+            _event(
+                eventid="cowrie.login.success",
+                username="<b>root</b>",
+                password="p&w<d",
+            )
+        )
+
+        self.assertIn("&lt;b&gt;root&lt;/b&gt;", sent[0])
+        self.assertIn("p&amp;w&lt;d", sent[0])
+
+    def test_download_url_is_escaped(self) -> None:
+        out, sent = _make()
+
+        out.write(
+            _event(
+                eventid="cowrie.session.file_download",
+                url="http://evil.example/x?a=1&b=<2",
+            )
+        )
+
+        self.assertIn("a=1&amp;b=&lt;2", sent[0])
+
+    def test_wrapping_tags_survive(self) -> None:
+        """The plugin's own markup must still be markup."""
+        out, sent = _make()
+
+        out.write(_event(eventid="cowrie.command.input", input="ls"))
+
+        self.assertIn("<strong>[Cowrie testsensor]</strong>", sent[0])
+        self.assertIn("<pre>ls</pre>", sent[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`Output.write()` concatenates event fields straight into a message wrapped in `<code>`/`<pre>` tags and sends it with `parse_mode: "HTML"`. `event["username"]`, `event["password"]`, `event["input"]` (the typed command) and `event.get("url", "")` are all attacker-controlled and none of them were escaped, so Telegram's Bot API parses any `<`, `>` or `&` in them as markup:

- An entirely ordinary command with a redirect or a URL query string — `ls -la > /tmp/x`, `wget 'http://x/?a=1&b=2'` — produces malformed HTML that the API rejects, silently dropping that security notification. This is the common case, not the crafted one.
- A crafted command, username, password or URL containing Telegram-supported HTML (it supports `<a href="...">`) renders as live markup in the operator's chat — e.g. a clickable attacker-chosen link styled to look like part of the notification.

Added `esc()` and applied it to every interpolated value, including `sensor`, `eventid`, `src_ip` and `session`, so there's no per-field judgement about what's attacker-reachable to get wrong later.

`quote=False`: nothing here goes into an attribute, and `html.escape`'s default would emit `&#x27;` for an apostrophe — a numeric entity Telegram's HTML mode doesn't define, which would show up literally in the chat. Apostrophes in commands are common.

Six tests: a redirect, an `<a href>` injection, an ampersand, credentials, a download URL, and one pinning that the plugin's *own* tags still render as markup.

Fixes #40495
