### PR TITLE
fix: write the shell prompt as UTF-8

### DIFF
--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -1004,8 +1004,11 @@ class HoneyPotShell:
             else:
                 prompt += "$ "  # "Non-Root" user
 
-        self.protocol.terminal.write(prompt.encode("ascii"))
-        self.protocol.ps = (prompt.encode("ascii"), b"> ")
+        # The username is attacker input from SSH/Telnet auth and is decoded
+        # with errors="replace" rather than restricted to ASCII, so the prompt
+        # goes to the terminal as UTF-8, the way a real shell writes it.
+        self.protocol.terminal.write(prompt.encode("utf-8"))
+        self.protocol.ps = (prompt.encode("utf-8"), b"> ")
 
     def eofReceived(self) -> None:
         """


### PR DESCRIPTION
`HoneyPotShell.showPrompt()` built the prompt from the logged-in username and encoded it as strict ASCII:

```python
self.protocol.terminal.write(prompt.encode("ascii"))
self.protocol.ps = (prompt.encode("ascii"), b"> ")
```

The username is attacker input from SSH/Telnet auth, and the rest of the codebase deliberately does not restrict it to ASCII — `shell/avatar.py`'s `CowrieUser.__init__()` decodes it with `errors="replace"` and says so in a comment, and `telnet/session.py` does the same. Cowrie is normally configured to accept arbitrary credentials, so any login with a non-ASCII username reached `showPrompt()` with that character intact and raised `UnicodeEncodeError`.

It fires on the first prompt after a successful login, before the attacker can run a single command, so the session is lost immediately and nothing about it gets recorded.

Encode as UTF-8, which is what a real shell writes to the terminal.

Fixes #40498
