### PR TITLE
fix: report a malformed URL port in curl and wget

### DIFF
--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -250,7 +250,18 @@ class Command_curl(HoneyPotCommand):
 
         if "://" not in url:
             url = "http://" + url
-        urldata = parse.urlparse(url)
+
+        # urlparse() raises on malformed IPv6 brackets, and .port and .hostname
+        # are parsed lazily and raise rather than returning None for a port
+        # that is not a decimal 0-65535. The URL is attacker input.
+        try:
+            urldata = parse.urlparse(url)
+            hostname = urldata.hostname
+            port = urldata.port
+        except ValueError:
+            self.errorWrite("curl: (3) URL using bad/illegal format or missing URL\n")
+            self.exit(3)
+            return
 
         for opt in optlist:
             if opt[0] == "-o":
@@ -277,21 +288,20 @@ class Command_curl(HoneyPotCommand):
         # encoding it as ASCII raised UnicodeEncodeError.
         self.url = url.encode("utf8")
 
-        parsed = parse.urlparse(url)
-        scheme = parsed.scheme
+        scheme = urldata.scheme
         if scheme != "http" and scheme != "https":
             self.errorWrite(
                 f'curl: (1) Protocol "{scheme}" not supported or disabled in libcurl\n'
             )
             self.exit(1)
             return
-        if parsed.hostname:
-            self.host = parsed.hostname
+        if hostname:
+            self.host = hostname
         else:
             self.errorWrite("curl: (3) URL using bad/illegal format or missing URL\n")
             self.exit(3)
             return
-        self.port = parsed.port or (443 if scheme == "https" else 80)
+        self.port = port or (443 if scheme == "https" else 80)
 
         # Check rate limit before proceeding
         if not curl_rate_limiter.check(self.host):

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -220,20 +220,31 @@ class Command_wget(HoneyPotCommand):
         if "://" not in url:
             url = f"http://{url}"
 
-        urldata = parse.urlparse(url)
+        # urlparse() raises on malformed IPv6 brackets, and .port and .hostname
+        # are parsed lazily and raise rather than returning None for a port
+        # that is not a decimal 0-65535. The URL is attacker input.
+        try:
+            urldata = parse.urlparse(url)
+            hostname = urldata.hostname
+            port = urldata.port
+        except ValueError:
+            self.print_usage_error("invalid URL")
+            self.exit()
+            return
+
         self.scheme = (urldata.scheme or "http").lower()
 
         # self.host is required as it will be used as key in rate limiter from this point forward
-        if urldata.hostname:
-            self.host = urldata.hostname
+        if hostname:
+            self.host = hostname
         else:
             self.print_usage_error("invalid URL")
             self.exit()
             return
 
         # Determine self.port: use explicit port from URL, otherwise use scheme default
-        if urldata.port is not None:
-            self.port = urldata.port
+        if port is not None:
+            self.port = port
         elif self.scheme == "https":
             self.port = 443
         elif self.scheme == "ftp":

--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -52,6 +52,26 @@ class CurlArtifactCleanupTests(unittest.TestCase):
             os.remove(os.path.join(self.tmpdir, name))
         os.rmdir(self.tmpdir)
 
+    def test_malformed_port_does_not_hang(self) -> None:
+        # Seen in production: a dropper built HOST=1.2.3.4:3001 and PORT=80
+        # separately, producing a host part with a non-numeric port. urlparse's
+        # .port raises ValueError rather than returning None.
+        self.proto.lineReceived(b"curl -s 'http://1.2.3.4:3001:80/x'; echo rc=$?")
+        self.assertIn(
+            b"rc=",
+            self.tr.value(),
+            "shell never resumed: the command hung instead of exiting",
+        )
+
+    def test_out_of_range_port_does_not_hang(self) -> None:
+        self.proto.lineReceived(b"curl -s 'http://1.2.3.4:99999/x'; echo rc=$?")
+        self.assertIn(b"rc=", self.tr.value())
+
+    def test_invalid_ipv6_brackets_do_not_hang(self) -> None:
+        # urlparse() itself raises ValueError here, before .port is reached.
+        self.proto.lineReceived(b"curl -s 'http://[::1/x'; echo rc=$?")
+        self.assertIn(b"rc=", self.tr.value())
+
     def test_failed_download_removes_temp_artifact(self) -> None:
         # Bypass HoneyPotCommand.__init__: its stdout/stderr wiring needs a
         # running process protocol (self.protocol.pp), which is irrelevant to

--- a/src/cowrie/test/test_wget.py
+++ b/src/cowrie/test/test_wget.py
@@ -68,6 +68,26 @@ class WgetArtifactCleanupTests(unittest.TestCase):
             "shell never resumed: the command hung instead of exiting",
         )
 
+    def test_malformed_port_does_not_hang(self) -> None:
+        # Seen in production: a dropper built HOST=1.2.3.4:3001 and PORT=80
+        # separately, producing a host part with a non-numeric port. urlparse's
+        # .port raises ValueError rather than returning None.
+        self.proto.lineReceived(b"wget -q 'http://1.2.3.4:3001:80/x'; echo rc=$?")
+        self.assertIn(
+            b"rc=",
+            self.tr.value(),
+            "shell never resumed: the command hung instead of exiting",
+        )
+
+    def test_out_of_range_port_does_not_hang(self) -> None:
+        self.proto.lineReceived(b"wget -q 'http://1.2.3.4:99999/x'; echo rc=$?")
+        self.assertIn(b"rc=", self.tr.value())
+
+    def test_invalid_ipv6_brackets_do_not_hang(self) -> None:
+        # urlparse() itself raises ValueError here, before .port is reached.
+        self.proto.lineReceived(b"wget -q 'http://[::1/x'; echo rc=$?")
+        self.assertIn(b"rc=", self.tr.value())
+
     def test_tcp_timeout_reports_connection_timed_out(self) -> None:
         # A TCP connect that times out yields TCPTimedOutError, built by the
         # reactor (so its Failure has no traceback frames). error() must report


### PR DESCRIPTION
Both commands call `urllib.parse.urlparse()` and read `.port` / `.hostname` on the result. Those properties are evaluated lazily and **raise** `ValueError` rather than returning `None` when the port substring isn't a decimal 0–65535, and `urlparse()` itself raises at parse time for malformed IPv6 bracket syntax.

Neither command caught it, so the `@inlineCallbacks` generator raised before its first `yield` — an unhandled error in the returned Deferred. The command never exits, so the shell never gets its exit status or prompt back and the session is stuck.

The reporter found this in production traffic: a dropper script built `HOST=94.154.43.231:3001` and `PORT=80` as separate shell variables and then combined them, producing a host part with two colons.

Both now parse inside a `try`, reporting the URL as invalid the way each command already does for a missing hostname — `curl: (3) URL using bad/illegal format or missing URL` (exit 3) and wget's `invalid URL` usage error.

`curl.py` also parsed the same URL twice, into `urldata` and then `parsed`; the second parse is dropped so there's one place that can raise and one result to guard.

Three tests per command: a non-numeric port, an out-of-range port, and unbalanced IPv6 brackets. Each asserts the shell resumes (`echo rc=$?` runs); all six hang before the change.

Fixes #40509
