### PR TITLE
fix: reject a non-numeric uid/gid in fsctl chown/chgrp

### DIFF
--- a/src/cowrie/scripts/fsctl.py
+++ b/src/cowrie/scripts/fsctl.py
@@ -723,13 +723,19 @@ class fseditCmd(cmd.Cmd):
         uid = arg_list[0]
         target_path = resolve_reference(self.pwd, arg_list[1])
 
+        try:
+            newuid = int(uid)
+        except ValueError:
+            print("Incorrect uid: " + uid)
+            return
+
         if not exists(self.fs, target_path):
             print(f"File '{target_path}' doesn't exist.")
             return
 
         target_object = getpath(self.fs, target_path)
         olduid = target_object[A_UID]
-        target_object[A_UID] = int(uid)
+        target_object[A_UID] = newuid
         print("former UID: " + str(olduid) + ". New UID: " + str(uid))
         self.save_pickle()
 
@@ -746,13 +752,19 @@ class fseditCmd(cmd.Cmd):
         gid = arg_list[0]
         target_path = resolve_reference(self.pwd, arg_list[1])
 
+        try:
+            newgid = int(gid)
+        except ValueError:
+            print("Incorrect gid: " + gid)
+            return
+
         if not exists(self.fs, target_path):
             print(f"File '{target_path}' doesn't exist.")
             return
 
         target_object = getpath(self.fs, target_path)
         oldgid = target_object[A_GID]
-        target_object[A_GID] = int(gid)
+        target_object[A_GID] = newgid
         print("former GID: " + str(oldgid) + ". New GID: " + str(gid))
         self.save_pickle()
 


### PR DESCRIPTION
`fseditCmd.do_chown()` and `do_chgrp()` convert the user-supplied uid/gid with a bare `int()`. `cmd.Cmd.onecmd()` — the base class driving this tool's REPL — calls the `do_*` method with no exception handling around it, so an ordinary typo like `chown roo /etc/passwd` raised `ValueError` and terminated the whole interactive `fsctl` session, losing any unsaved edits, not just that one command.

`do_chmod()` immediately below them already guards the same class of input and prints `Incorrect mode: ...`.

Both now validate before touching the tree, so a bad argument can't leave a half-applied change either.

Fixes #40507
