### PR TITLE
fix: apply createfs's -v and -p flags

### DIFF
--- a/src/cowrie/scripts/createfs.py
+++ b/src/cowrie/scripts/createfs.py
@@ -202,11 +202,13 @@ def run():
         printhelp()
         return
 
+    global PROC, VERBOSE
+
     for o, a in optlist:
         if o == "-v":
-            pass
+            VERBOSE = True
         elif o == "-p":
-            pass
+            PROC = True
         elif o == "-l":
             localroot = a
         elif o == "-d":
@@ -238,7 +240,8 @@ def run():
     recurse(localroot, "/", tree[A_CONTENTS], maxdepth)
 
     if output:
-        pickle.dump(tree, open(output, "wb"))
+        with open(output, "wb") as f:
+            pickle.dump(tree, f)
     else:
         print(pickle.dumps(tree))
 


### PR DESCRIPTION
`printhelp()` documents `-v` (verbose) and `-p` (include /proc), and both are gated on module-level globals — `VERBOSE`, read by `logit()`, and `PROC`, read by `recurse()`'s `if (PROC or not localpath.startswith("/proc/")) and maxdepth > 0` condition. But `run()`'s option loop had a bare `pass` for each:

```python
for o, a in optlist:
    if o == "-v":
        pass
    elif o == "-p":
        pass
```

So neither global was ever set. `-v` produced no progress output at all and `-p` still skipped descending into `/proc` subdirectories.

Set them, with a `global` declaration so the assignments land on the module attributes the two readers see.

**One thing beyond the issue:** `run()` ends with `pickle.dump(tree, open(output, "wb"))`, which never closes the file — it relies on the garbage collector to flush the output. The new tests turned that into a `ResourceWarning`, so it's fixed here with a `with` block rather than left as noise in the suite. It's in the same function; happy to split it out if you'd rather.

Fixes #40506
