### PR TITLE
fix: space-separate ps COMMAND arguments

### DIFF
--- a/src/cowrie/scripts/createdynamicprocess.py
+++ b/src/cowrie/scripts/createdynamicprocess.py
@@ -41,7 +41,8 @@ def run():
             obj["USER"] = info["username"]
             obj["PID"] = info["pid"]
             if info["cmdline"]:
-                obj["COMMAND"] = "/".join(info["cmdline"])
+                # ps space-separates argv in its COMMAND column.
+                obj["COMMAND"] = " ".join(info["cmdline"])
             else:
                 obj["COMMAND"] = "[ " + info["name"] + " ]"
             obj["CPU"] = info["cpu_percent"]


### PR DESCRIPTION
`createdynamicprocess.py` generates the JSON that the live honeypot's `ps` command serves: `shell/server.py` loads it into `self.process` and `Command_ps` prints each entry's `COMMAND` field verbatim under the `COMMAND` column. When building that field it joined the real process's argument list with `/`:

```python
obj["COMMAND"] = "/".join(info["cmdline"])
```

Real `ps` space-separates argv, so this renders as `/usr/sbin/sshd/-D/-oCiphers=aes256-gcm@openssh.com` instead of `/usr/sbin/sshd -D -oCiphers=aes256-gcm@openssh.com` — obviously wrong to anyone who looks at the output, and `ps` is exactly the kind of reconnaissance an attacker runs early in a session.

Fixes #40504
