### PR TITLE
fix: log the proxy backend address as a string

### DIFF
--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -185,6 +185,12 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         )
 
     def connect_to_backend(self, ip, port):
+        # The pool hands the address back as the bytes it read off the wire; a
+        # directly configured backend is already a str. Normalise it here so
+        # the failure log below reports an address rather than a bytes repr.
+        if isinstance(ip, bytes):
+            ip = ip.decode("utf-8", errors="replace")
+
         # remember target so we can log consistently on success/failure
         self.backend_ip = ip
         self.backend_port = port


### PR DESCRIPTION
`connect_to_backend()` stored the target address verbatim in `self.backend_ip`. That value is `bytes` when it comes from the backend pool (`received_pool_data()`'s `honey_ip`, unpacked straight off the wire in `pool_interface/client.py`) and `str` when it comes from a directly configured backend (`CowrieConfig.get("proxy", "backend_ssh_host")`).

`backend_connection_error()` then formats it with `%(backend_ip)s`, so a failed connection to a pool-assigned backend logged:

```
Connection to honeypot backend b'10.0.0.5':2222 refused: ...
```

Normalise to `str` in `connect_to_backend()`, at the one point both callers go through, rather than at the log site — that also keeps the address consistent for the `TCP4ClientEndpoint` below it and for the disconnect log, which reads the same attribute.

The success path was already unaffected: `backend_connection_success()` overwrites `backend_ip` with a `str` from the peer.

Fixes #40508
