### PR TITLE
fix: handle a bare trailing CR in telnet proxy auth

### DIFF
--- a/src/cowrie/telnet_proxy/handler.py
+++ b/src/cowrie/telnet_proxy/handler.py
@@ -232,6 +232,16 @@ class TelnetHandler:
             else:
                 self.sendFrontend(self.currentData)
 
+    def terminating_char(self) -> bytes:
+        """The byte the client sent after its CR, usually \\n or NUL.
+
+        There need not be one: a client may send a bare CR for Enter, or the
+        CR and its companion may land in separate reads. An empty result
+        forwards the bare CR to the backend as the client sent it.
+        """
+        after = self.currentData.index(b"\r") + 1
+        return self.currentData[after : after + 1]
+
     def processUsernameInput(self) -> None:
         self.sendData = False  # withold data until input is complete
 
@@ -248,9 +258,7 @@ class TelnetHandler:
 
         # check if done inputing
         if b"\r" in self.currentData:
-            terminatingChar = chr(
-                self.currentData[self.currentData.index(b"\r") + 1]
-            ).encode()  # usually \n or \x00
+            terminatingChar = self.terminating_char()
 
             # cleanup
             self.usernameState = process_backspaces(self.usernameState)
@@ -281,9 +289,7 @@ class TelnetHandler:
 
         # check if done inputing
         if b"\r" in self.currentData:
-            terminatingChar = chr(
-                self.currentData[self.currentData.index(b"\r") + 1]
-            ).encode()  # usually \n or \x00
+            terminatingChar = self.terminating_char()
 
             # cleanup
             self.passwordState = process_backspaces(self.passwordState)

--- a/src/cowrie/test/test_telnet_proxy_handler.py
+++ b/src/cowrie/test/test_telnet_proxy_handler.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: The telnet proxy reads the byte after the client's CR to pick the
+# ABOUTME: line terminator; a client need not send one in the same packet.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+from cowrie.telnet_proxy import handler as telnet_handler
+
+
+def _handler() -> Any:
+    h = telnet_handler.TelnetHandler.__new__(telnet_handler.TelnetHandler)
+    h.currentData = b""
+    h.sendData = True
+    h.server = MagicMock()
+    h.client = MagicMock()
+    h.backendLogin = b"root"
+    h.backendPassword = b"secret"
+    h.usernameState = b""
+    h.passwordState = b""
+    h.inputingLogin = True
+    h.inputingPassword = True
+    h.waitingLoginEcho = False
+    h.prePasswordData = False
+    h.spoofAuthenticationData = False
+    h._log = MagicMock()
+    return h
+
+
+class TerminatingCharTests(unittest.TestCase):
+    """A bare trailing CR must not be indexed past the end of the packet."""
+
+    def _username(self, data: bytes) -> Any:
+        h = _handler()
+        h.currentData = data
+        with patch.object(telnet_handler.TelnetHandler, "sendFrontend"):
+            h.processUsernameInput()
+        return h
+
+    def _password(self, data: bytes) -> Any:
+        h = _handler()
+        h.currentData = data
+        h.processPasswordInput()
+        return h
+
+    def test_username_with_crlf(self) -> None:
+        h = self._username(b"admin\r\n")
+
+        self.assertEqual(h.currentData, b"root\r\n")
+        self.assertFalse(h.inputingLogin)
+
+    def test_username_with_cr_nul(self) -> None:
+        h = self._username(b"admin\r\x00")
+
+        self.assertEqual(h.currentData, b"root\r\x00")
+
+    def test_username_with_bare_trailing_cr(self) -> None:
+        """The CR and its companion can land in separate reads, and some
+        clients only ever send a lone CR for Enter."""
+        h = self._username(b"admin\r")
+
+        self.assertEqual(h.currentData, b"root\r")
+        self.assertFalse(h.inputingLogin)
+
+    def test_password_with_crlf(self) -> None:
+        h = self._password(b"hunter2\r\n")
+
+        self.assertEqual(h.currentData, b"secretfake\r\n")
+        self.assertFalse(h.inputingPassword)
+
+    def test_password_with_bare_trailing_cr(self) -> None:
+        h = self._password(b"hunter2\r")
+
+        self.assertEqual(h.currentData, b"secretfake\r")
+        self.assertFalse(h.inputingPassword)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`TelnetHandler.processUsernameInput()` and `processPasswordInput()` both decide the line terminator to forward to the backend by looking at the byte *immediately after* the client's CR:

```python
terminatingChar = chr(self.currentData[self.currentData.index(b"\r") + 1]).encode()
```

That assumes CR is never the last byte of the packet. A telnet client that only ever sends a lone CR for Enter — or one whose CR and its companion LF/NUL simply land in two separate TCP reads — makes the index equal `len(self.currentData)` and raises `IndexError`. The whole call chain from `FrontendTelnetTransport.dataReceived()` down is unguarded.

Read the byte as a slice instead. It yields `b""` when there's nothing after the CR, so the bare CR is forwarded to the backend exactly as the client sent it.

The same block appeared verbatim in both methods, so it's now one `terminating_char()` helper rather than two copies to keep in step.

The slice also drops the `chr(...).encode()` round-trip, which would have UTF-8-encoded any terminator byte above 0x7f into two bytes. Terminators are `\n` or NUL in practice so this changes nothing real, but it's one less way for the forwarded bytes to differ from what arrived.

New `test_telnet_proxy_handler.py` covers CRLF, CR+NUL and a bare CR for both the username and the password path. The bare-CR cases raise `IndexError` before the change.

Fixes #40503
