### PR TITLE
fix: close the upload descriptor before renaming the temp file

### DIFF
--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -506,6 +506,10 @@ class HoneyPotFilesystem:
     def close(self, fd: int) -> None:
         if not fd:
             return
+        # Close the descriptor before renaming or removing the temp file.
+        # POSIX allows both while a handle is still open, but Windows refuses
+        # them with PermissionError, which ends the upload.
+        os.close(fd)
         with open(self.tempfiles[fd], "rb") as f:
             shasum: str = hashlib.sha256(f.read()).hexdigest()
         shasumfile: str = CowrieConfig.get("honeypot", "download_path") + "/" + shasum
@@ -523,7 +527,6 @@ class HoneyPotFilesystem:
         )
         del self.tempfiles[fd]
         del self.filenames[fd]
-        os.close(fd)
 
     def lseek(self, fd: int, offset: int, whence: int) -> int:
         if not fd:

--- a/src/cowrie/test/test_fs.py
+++ b/src/cowrie/test/test_fs.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 import copy
 import hashlib
 import os
-import shutil
-import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
@@ -267,19 +265,31 @@ class UploadCloseTests(unittest.TestCase):
 
     def setUp(self) -> None:
         self.fs = fs.HoneyPotFilesystem("arch", "/root")
-        self.download_path = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, self.download_path, ignore_errors=True)
-        CowrieConfig.set("honeypot", "download_path", self.download_path)
+        # A COWRIE_HONEYPOT_DOWNLOAD_PATH set by another test module wins over
+        # CowrieConfig.set, so read back wherever close() will actually store
+        # the upload rather than pinning it here.
+        self.download_path = CowrieConfig.get("honeypot", "download_path")
         self.fs.events = MagicMock()
 
     def _open_upload(self, contents: bytes) -> int:
+        """Start an upload of these bytes; returns its descriptor.
+
+        The caller passes unique contents so the sha256 name cannot collide
+        with a file another test (or an earlier run) left in download_path,
+        which would silently take close()'s duplicate branch instead.
+        """
+        self.addCleanup(
+            lambda: Path(
+                self.download_path, hashlib.sha256(contents).hexdigest()
+            ).unlink(missing_ok=True)
+        )
         self.fs.mkfile("/tmp/payload", 0, 0, 0, 0o644)
         fd = self.fs.open("/tmp/payload", os.O_CREAT | os.O_WRONLY, 0o644)
         os.write(fd, contents)
         return fd
 
     def test_descriptor_is_closed_before_the_rename(self) -> None:
-        fd = self._open_upload(b"payload")
+        fd = self._open_upload(b"payload for the ordering test")
         calls: list[str] = []
         real_close, real_rename = os.close, os.rename
 
@@ -300,7 +310,7 @@ class UploadCloseTests(unittest.TestCase):
         self.assertEqual(calls, ["close", "rename"])
 
     def test_upload_is_stored_under_its_hash(self) -> None:
-        contents = b"payload"
+        contents = b"payload for the storage test"
         fd = self._open_upload(contents)
 
         self.fs.close(fd)
@@ -312,7 +322,7 @@ class UploadCloseTests(unittest.TestCase):
 
     def test_duplicate_upload_removes_the_temp_file(self) -> None:
         """The remove() branch has the same open-handle problem as rename()."""
-        contents = b"seen before"
+        contents = b"payload for the duplicate test"
         shasum = hashlib.sha256(contents).hexdigest()
         (Path(self.download_path) / shasum).write_bytes(contents)
         fd = self._open_upload(contents)
@@ -323,7 +333,7 @@ class UploadCloseTests(unittest.TestCase):
         self.assertFalse(os.path.exists(tempname))
 
     def test_bookkeeping_is_cleared(self) -> None:
-        fd = self._open_upload(b"payload")
+        fd = self._open_upload(b"payload for the bookkeeping test")
 
         self.fs.close(fd)
 

--- a/src/cowrie/test/test_fs.py
+++ b/src/cowrie/test/test_fs.py
@@ -8,10 +8,16 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import os
+import shutil
+import tempfile
 import unittest
+from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock, patch
 
+from cowrie.core.config import CowrieConfig
 from cowrie.shell import fs, honeyfs
 
 os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
@@ -252,6 +258,77 @@ class CopyOnWriteTests(unittest.TestCase):
         a.chmod("/etc/passwd", 0o600)
         a.remove("/tmp/x")
         self.assertEqual(base, snapshot)
+
+
+class UploadCloseTests(unittest.TestCase):
+    """close() finishes an SFTP upload by hashing the temp file and renaming
+    it to its sha256 name. Windows refuses to rename or remove a file that
+    still has an open handle, so the descriptor has to go first."""
+
+    def setUp(self) -> None:
+        self.fs = fs.HoneyPotFilesystem("arch", "/root")
+        self.download_path = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.download_path, ignore_errors=True)
+        CowrieConfig.set("honeypot", "download_path", self.download_path)
+        self.fs.events = MagicMock()
+
+    def _open_upload(self, contents: bytes) -> int:
+        self.fs.mkfile("/tmp/payload", 0, 0, 0, 0o644)
+        fd = self.fs.open("/tmp/payload", os.O_CREAT | os.O_WRONLY, 0o644)
+        os.write(fd, contents)
+        return fd
+
+    def test_descriptor_is_closed_before_the_rename(self) -> None:
+        fd = self._open_upload(b"payload")
+        calls: list[str] = []
+        real_close, real_rename = os.close, os.rename
+
+        def record_close(handle: int) -> None:
+            calls.append("close")
+            real_close(handle)
+
+        def record_rename(src: str, dst: str) -> None:
+            calls.append("rename")
+            real_rename(src, dst)
+
+        with (
+            patch.object(os, "close", record_close),
+            patch.object(os, "rename", record_rename),
+        ):
+            self.fs.close(fd)
+
+        self.assertEqual(calls, ["close", "rename"])
+
+    def test_upload_is_stored_under_its_hash(self) -> None:
+        contents = b"payload"
+        fd = self._open_upload(contents)
+
+        self.fs.close(fd)
+
+        shasum = hashlib.sha256(contents).hexdigest()
+        stored = Path(self.download_path) / shasum
+        self.assertTrue(stored.is_file())
+        self.assertEqual(stored.read_bytes(), contents)
+
+    def test_duplicate_upload_removes_the_temp_file(self) -> None:
+        """The remove() branch has the same open-handle problem as rename()."""
+        contents = b"seen before"
+        shasum = hashlib.sha256(contents).hexdigest()
+        (Path(self.download_path) / shasum).write_bytes(contents)
+        fd = self._open_upload(contents)
+        tempname = self.fs.tempfiles[fd]
+
+        self.fs.close(fd)
+
+        self.assertFalse(os.path.exists(tempname))
+
+    def test_bookkeeping_is_cleared(self) -> None:
+        fd = self._open_upload(b"payload")
+
+        self.fs.close(fd)
+
+        self.assertNotIn(fd, self.fs.tempfiles)
+        self.assertNotIn(fd, self.fs.filenames)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`HoneyPotFilesystem.close()` finishes an SFTP upload by hashing the temp file, renaming it to its sha256 name (or removing it if that name already exists), and only *then* calling `os.close(fd)` on the descriptor that was writing to it.

POSIX treats the directory entry and the open handle as independent, so renaming or unlinking a file that still has an open fd is fine — which is why this works on Linux and macOS. Windows does not allow it: both `os.rename()` and `os.remove()` raise `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process`.

The reporter hit this on a real production instance running on Windows, when an SSH client's connection was lost to an idle timeout while an SFTP upload was mid-flight.

Move `os.close(fd)` to the top. Closing first is also the safer order on POSIX — it means the bytes are flushed before the file is hashed rather than relying on the write having already reached the file.

Tests: one pins the `close`-before-`rename` ordering directly (it's the whole point, and it isn't observable in the result on this platform), plus coverage of the rename path, the duplicate-upload `remove()` path — which has the same open-handle problem — and the bookkeeping cleanup.

Fixes #40497
