### PR TITLE
fix: expand an empty $@ / $* to no words

### DIFF
--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -829,6 +829,12 @@ class BashParser:
             if only.data in ("dollar_var", "dollar_brace"):
                 special = self._special_param(only)
                 if special is not None:
+                    # A function called with no arguments leaves $@ / $* set
+                    # but empty. Unquoted and alone in a word, they expand to
+                    # no words at all -- not to one empty argument -- the same
+                    # as the empty ordinary variable handled just below.
+                    if special == "" and self._var_name(only)[1] in ("@", "*"):
+                        return None
                     return special
                 value = self.context.get_variable(self._var_name(only)[0])
                 if not value:

--- a/src/cowrie/test/test_flow_control.py
+++ b/src/cowrie/test/test_flow_control.py
@@ -126,8 +126,7 @@ class FlowControlTests(unittest.TestCase):
     def test_break_stops_loop(self) -> None:
         self.assertEqual(
             self._run(
-                "for i in 1 2 3 4 5; do echo $i; "
-                "if [ $i -eq 3 ]; then break; fi; done"
+                "for i in 1 2 3 4 5; do echo $i; if [ $i -eq 3 ]; then break; fi; done"
             ),
             b"1\n2\n3\n",
         )
@@ -135,8 +134,7 @@ class FlowControlTests(unittest.TestCase):
     def test_continue_skips_iteration(self) -> None:
         self.assertEqual(
             self._run(
-                "for i in 1 2 3 4; do if [ $i -eq 2 ]; then continue; fi; "
-                "echo $i; done"
+                "for i in 1 2 3 4; do if [ $i -eq 2 ]; then continue; fi; echo $i; done"
             ),
             b"1\n3\n4\n",
         )
@@ -200,6 +198,27 @@ class FlowControlTests(unittest.TestCase):
             b"from_f\n",
         )
 
+    def test_function_forwards_all_arguments(self) -> None:
+        self.assertEqual(
+            self._run("f() { echo before $@ after; }; f one two"),
+            b"before one two after\n",
+        )
+
+    def test_function_with_no_arguments_expands_at_to_nothing(self) -> None:
+        """$@ with no positional parameters contributes no words at all, so
+        the extra separator a phantom empty argument produces must not
+        appear."""
+        self.assertEqual(
+            self._run("f() { echo before $@ after; }; f"),
+            b"before after\n",
+        )
+
+    def test_function_with_no_arguments_expands_star_to_nothing(self) -> None:
+        self.assertEqual(
+            self._run("f() { echo before $* after; }; f"),
+            b"before after\n",
+        )
+
     # -- exit status propagation -------------------------------------------
 
     def test_status_after_if(self) -> None:
@@ -215,8 +234,7 @@ class FlowControlTests(unittest.TestCase):
         # for a downloader; the first success breaks the loop.
         self.assertEqual(
             self._run(
-                "for url in http://a/x http://b/x; do "
-                "echo fetch $url && break; done"
+                "for url in http://a/x http://b/x; do echo fetch $url && break; done"
             ),
             b"fetch http://a/x\n",
         )


### PR DESCRIPTION
`BashParser._eval_word()` drops a word that is exactly an unquoted reference to an unset or empty variable — `echo $unset` contributes no argument at all, matching bash. Special parameters take a separate branch through `_special_param()`, and that branch only checks `special is not None`.

For `$@` / `$*`, `_special_param()` returns `self.context.get_variable("@")`. A function called with zero arguments has that set to `""` — empty but **not** `None`, since `honeypot.py` sets `environ["@"] = " ".join(args)` — so it bypassed the drop and left a phantom empty-string argument in the word list.

The visible effect: `f() { echo before $@ after; }; f` printed `before  after`, with the doubled separator, instead of `before after`.

Drop the word when an unquoted whole-word `$@`/`$*` is empty, the same as the ordinary empty variable handled immediately below it. Only `@` and `*` are affected — `$?` and `$#` always have a real value, and the embedded case (`"x$@y"`) still expands to the empty string, which is correct.

Three tests: `$@` forwarding real arguments (so the change can't break the working case), and `$@` / `$*` with none. The last two fail before the change with the extra separator.

Fixes #40496
