### PR TITLE
fix: report the real size of an SFTP upload

### DIFF
--- a/src/cowrie/shell/filetransfer.py
+++ b/src/cowrie/shell/filetransfer.py
@@ -78,7 +78,13 @@ class CowrieSFTPFile:
     def __init__(self, sftpserver, filename, flags, attrs):
         self.sftpserver = sftpserver
         self.filename = filename
+        # Bytes that arrived, which is what the transfer quota is about.
         self.bytesReceived: int = 0
+        # The file's size, which is not the same number: SFTP writes are
+        # offset-addressed, so a client can resend a chunk it already sent
+        # (making the sum too large) or seek past the end (too small). The
+        # size is the highest offset ever written to.
+        self.size: int = 0
 
         openFlags = 0
         if flags & FXF_READ == FXF_READ and flags & FXF_WRITE == 0:
@@ -110,8 +116,8 @@ class CowrieSFTPFile:
             self.contents = self.sftpserver.fs.file_contents(self.filename)
 
     def close(self):
-        if self.bytesReceived > 0:
-            self.sftpserver.fs.update_size(self.filename, self.bytesReceived)
+        if self.size > 0:
+            self.sftpserver.fs.update_size(self.filename, self.size)
         return self.sftpserver.fs.close(self.fd)
 
     def readChunk(self, offset: int, length: int) -> bytes:
@@ -119,6 +125,7 @@ class CowrieSFTPFile:
 
     def writeChunk(self, offset: int, data: bytes) -> None:
         self.bytesReceived += len(data)
+        self.size = max(self.size, offset + len(data))
         if self.bytesReceivedLimit and self.bytesReceived > self.bytesReceivedLimit:
             raise filetransfer.SFTPError(filetransfer.FX_FAILURE, "Quota exceeded")
         self.sftpserver.fs.lseek(self.fd, offset, os.SEEK_SET)

--- a/src/cowrie/test/test_filetransfer.py
+++ b/src/cowrie/test/test_filetransfer.py
@@ -12,6 +12,7 @@ import os
 import tempfile
 import unittest
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 from twisted.conch.ssh.filetransfer import FXF_CREAT, FXF_WRITE
 
@@ -75,6 +76,49 @@ class SFTPPathJoinTests(unittest.TestCase):
 
     def test_abspath_of_absolute_path_is_unchanged(self) -> None:
         self.assertEqual(self.server._absPath("/etc/passwd"), "/etc/passwd")
+
+
+class UploadSizeTests(unittest.TestCase):
+    """SFTP writes are offset-addressed, so the size reported to the honeyfs
+    is the highest offset written, not the sum of the chunk lengths."""
+
+    def setUp(self) -> None:
+        self.server = SFTPServerForCowrieUser.__new__(SFTPServerForCowrieUser)
+        self.server.fs = fs.HoneyPotFilesystem("linux-x64-lsb", "/root")
+        self.server.avatar = SimpleNamespace(home="/root")
+        self.server.fs.events = MagicMock()
+
+    def _upload(self, chunks: list[tuple[int, bytes]]) -> int:
+        """Write these (offset, data) chunks to an uploaded file; returns the
+        size the honeyfs ends up recording."""
+        handle = self.server.openFile("/tmp/up.bin", FXF_WRITE | FXF_CREAT, {})
+        for offset, data in chunks:
+            handle.writeChunk(offset, data)
+        handle.close()
+        node = self.server.fs.getfile("/tmp/up.bin")
+        assert node is not None
+        return node[fs.A_SIZE]
+
+    def test_sequential_write(self) -> None:
+        self.assertEqual(self._upload([(0, b"0123456789")]), 10)
+
+    def test_sequential_chunks(self) -> None:
+        self.assertEqual(self._upload([(0, b"01234"), (5, b"56789")]), 10)
+
+    def test_retransmitted_chunk_is_not_counted_twice(self) -> None:
+        """A resumed or retried transfer re-sends a chunk it already sent;
+        summing the lengths would report the file as larger than it is."""
+        self.assertEqual(
+            self._upload([(0, b"01234"), (5, b"56789"), (5, b"56789")]), 10
+        )
+
+    def test_write_past_the_end_counts_the_gap(self) -> None:
+        """Seeking past the end makes a sparse file, whose size includes the
+        hole that was never written."""
+        self.assertEqual(self._upload([(0, b"ab"), (100, b"yz")]), 102)
+
+    def test_out_of_order_chunks(self) -> None:
+        self.assertEqual(self._upload([(5, b"56789"), (0, b"01234")]), 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`CowrieSFTPFile.close()` reported the uploaded file's size to the honeyfs as `self.bytesReceived`, a running total of every `writeChunk()` length.

That sum isn't the file's size. SFTP writes are offset-addressed (`writeChunk(offset, data)`) and a client can send overlapping or out-of-order chunks — most commonly a resumed or retried transfer re-sending a chunk it already sent. The sum diverges from the true size in both directions:

- **Overlapping writes** count bytes twice, making it too large.
- **A write past the current end** (a sparse file) never counts the gap, making it too small.

It's not only cosmetic: this value becomes the node's `A_SIZE`, and `update_realfile()` only links the real captured content to the honeyfs node when `f[A_SIZE] < 25000000`. An inflated size can push a node over that ceiling, so the uploaded payload is never linked.

Track the highest offset ever written as the size, and leave `bytesReceived` to the transfer quota — that one *is* about bytes that arrived, so counting a retransmission there is right.

Five tests: a single write, sequential chunks, a retransmitted chunk, a write past the end, and out-of-order chunks. The retransmit case reports 15 instead of 10 before the change, and the sparse case 4 instead of 102.

Fixes #40500
