### PR TITLE
fix: keep the ftpget download running through CTRL-C

### DIFF
--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -185,6 +185,10 @@ Download a file via FTP
         self.artifactFile = Artifact(self.local_file)
         self.ftp_client = None
         self.fakeoutfile = fakeoutfile
+        # True from the moment the data transfer starts until one of the
+        # download callbacks fires. While it is set, the artifact belongs to
+        # the transfer rather than to the command: see exit().
+        self.transfer_running = False
 
         # Start async download
         d = self.ftp_download_async()
@@ -257,6 +261,7 @@ Download a file via FTP
 
         # Retrieve file
         if self.ftp_client:
+            self.transfer_running = True
             d: defer.Deferred[None] = self.ftp_client.retrieveFile(
                 self.remote_file, receiver
             )
@@ -291,26 +296,51 @@ Download a file via FTP
             size=size,
             limit=self.limit_size,
         )
-        self.errorWrite("ftpget: file exceeds download size limit\n")
+        self.lateErrorWrite("ftpget: file exceeds download size limit\n")
+
+    def lateErrorWrite(self, msg: str) -> None:
+        """Report an error to the attacker, unless they already have their
+        prompt back.
+
+        A transfer that outlives its command (CTRL-C) still finishes and is
+        still logged, but writing its outcome to the terminal now would inject
+        text into whatever the attacker is doing instead.
+        """
+        if not self.exited:
+            self.errorWrite(msg)
 
     def handle_CTRL_C(self) -> None:
+        # The transfer is deliberately left running; see exit().
         self.write("^C\n")
         self.exit()
 
     def exit(self, code: int | None = None) -> None:
-        # Close the download artifact on every exit path so an aborted
-        # transfer does not leave its empty temp file behind in the download
-        # directory. close() is idempotent and removes an empty artifact, so
-        # the normal success/error paths are unaffected.
+        # CTRL-C returns the attacker to their prompt but deliberately does not
+        # stop the transfer: the point of the honeypot is the sample, and an
+        # attacker who mistypes or gets bored should not be able to withhold
+        # it. The download runs to completion and _download_success() records
+        # it, so while it is in flight the artifact must stay open -- closing
+        # it here would truncate the capture to whatever had arrived so far.
+        #
+        # With no transfer running there is nothing to wait for, so close the
+        # artifact: that keeps an aborted-before-transfer command from leaving
+        # its empty temp file behind. close() is idempotent and removes an
+        # empty artifact, so the normal completion paths are unaffected.
         artifact = getattr(self, "artifactFile", None)
-        if artifact is not None:
+        if artifact is not None and not getattr(self, "transfer_running", False):
             artifact.close()
         HoneyPotCommand.exit(self, code)
 
     def _download_success(self, result: None) -> None:
         """
         Called when download completes successfully
+
+        This runs whether or not the command has already exited: a transfer
+        interrupted with CTRL-C keeps going, so the sample is still captured
+        and reported. Only output to the attacker's terminal is suppressed
+        once they have their prompt back.
         """
+        self.transfer_running = False
         self.artifactFile.close()
 
         if self.receiver is not None and self.receiver.limit_exceeded:
@@ -348,6 +378,7 @@ Download a file via FTP
         """
         Called when download fails
         """
+        self.transfer_running = False
         self.artifactFile.close()
 
         # Aborting the transfer at the size limit surfaces here as a connection
@@ -374,7 +405,7 @@ Download a file via FTP
             error=error_msg,
         )
 
-        self.errorWrite(f"ftpget: {error_msg}\n")
+        self.lateErrorWrite(f"ftpget: {error_msg}\n")
         self.exit()
 
 

--- a/src/cowrie/test/test_ftpget.py
+++ b/src/cowrie/test/test_ftpget.py
@@ -19,7 +19,9 @@ from twisted.cred.checkers import (
 from twisted.cred.portal import Portal
 from twisted.internet import defer
 from twisted.internet import reactor as _reactor
+from twisted.internet.error import ConnectionDone
 from twisted.protocols.ftp import FTPFactory, FTPRealm
+from twisted.python.failure import Failure
 
 from cowrie.commands import ftpget as ftpget_module
 from cowrie.commands.ftpget import (
@@ -179,6 +181,89 @@ class FtpGetArtifactCleanupTests(unittest.TestCase):
         self.assertFalse(
             os.path.exists(temp_name), "aborted transfer left its temp file behind"
         )
+
+
+class FtpGetCtrlCKeepsDownloadingTests(unittest.TestCase):
+    """CTRL-C returns the attacker to their prompt but must not cost us the
+    sample: the transfer keeps running and is still captured and logged."""
+
+    def _mid_transfer(self) -> Command_ftpget:
+        """A command whose data transfer is under way."""
+        cmd = Command_ftpget.__new__(Command_ftpget)
+        cmd.exited = False
+        cmd.exit_code = 0
+        cmd.protocol = mock.Mock()
+        cmd.fs = mock.Mock()
+        cmd.user = {"uid": 0, "gid": 0}
+        cmd.write = mock.Mock()  # type: ignore[method-assign]
+        cmd.errorWrite = mock.Mock()  # type: ignore[method-assign]
+        cmd.url_log = "ftp://evil.example/payload"
+        cmd.local_file = "payload"
+        cmd.fakeoutfile = "/root/payload"
+        cmd.artifactFile = Artifact("ftpget-test")
+        self.addCleanup(cmd.artifactFile.close)
+        cmd.receiver = FTPFileReceiver(cmd.artifactFile)
+        cmd.receiver.makeConnection(mock.Mock())
+        cmd.transfer_running = True
+        return cmd
+
+    def _ctrl_c(self, cmd: Command_ftpget) -> None:
+        with mock.patch.object(HoneyPotCommand, "exit"):
+            cmd.handle_CTRL_C()
+        cmd.exited = True
+
+    def test_data_connection_is_left_open(self) -> None:
+        cmd = self._mid_transfer()
+
+        self._ctrl_c(cmd)
+
+        cast("mock.Mock", cmd.receiver.transport).loseConnection.assert_not_called()
+
+    def test_the_rest_of_the_sample_is_still_written(self) -> None:
+        """exit() must not close the artifact out from under the transfer, or
+        the capture is truncated to whatever had arrived by then."""
+        cmd = self._mid_transfer()
+        cmd.receiver.dataReceived(b"first half ")
+
+        self._ctrl_c(cmd)
+        cmd.receiver.dataReceived(b"second half")
+
+        cmd.artifactFile.fp.flush()
+        with open(cmd.artifactFile.fp.name, "rb") as f:
+            self.assertEqual(f.read(), b"first half second half")
+
+    def test_completion_after_ctrl_c_still_reports_the_download(self) -> None:
+        cmd = self._mid_transfer()
+        cmd.receiver.dataReceived(b"malware")
+        self._ctrl_c(cmd)
+
+        with mock.patch.object(HoneyPotCommand, "exit"):
+            cmd._download_success(None)
+
+        eventids = [
+            call.args[0] for call in cmd.protocol.events.dispatch.call_args_list
+        ]
+        self.assertIn("cowrie.session.file_download", eventids)
+        cmd.fs.mkfile.assert_called_once()
+
+    def test_no_terminal_output_after_ctrl_c(self) -> None:
+        """The attacker has their prompt back; a late error must not inject
+        text into whatever they are doing now."""
+        cmd = self._mid_transfer()
+        self._ctrl_c(cmd)
+
+        with mock.patch.object(HoneyPotCommand, "exit"):
+            cmd._download_error(Failure(ConnectionDone()))
+
+        cmd.errorWrite.assert_not_called()
+
+    def test_error_is_reported_while_the_command_is_still_running(self) -> None:
+        cmd = self._mid_transfer()
+
+        with mock.patch.object(HoneyPotCommand, "exit"):
+            cmd._download_error(Failure(ConnectionDone()))
+
+        cmd.errorWrite.assert_called_once()
 
 
 class FTPFileReceiverSizeLimitTests(unittest.TestCase):


### PR DESCRIPTION
**Rewritten after Michel's review.** The first version made CTRL-C abort the transfer. That's wrong for a honeypot: we want the full malware sample even when the attacker changes their mind. CTRL-C now only cancels in the UI — the download runs to completion and is captured as normal.

**First, a correction to the issue.** It says `Command_ftpget` "has no `handle_CTRL_C()` override and no `exit()` override". On current `main` it has both. That part looks to have been written against an older tree.

**The real problem is the opposite of the one reported.** `exit()` closes `artifactFile` on every path, including CTRL-C mid-transfer. The transfer keeps running (nothing cancels it), so its remaining chunks hit a closed artifact — the new test raises `ValueError: write to closed file` against current `main`. So today an attacker can withhold the payload just by hitting CTRL-C, deliberately or by accident, and we keep only the fragment that had already arrived.

Changes:

- **`exit()` leaves the artifact open while a transfer is in flight** (`transfer_running`), so the capture isn't truncated. With no transfer running it still closes, which keeps the existing behaviour that an aborted-before-transfer command doesn't leave an empty temp file behind.
- **The download callbacks no longer care whether the command exited.** `_download_success()` still closes and stores the artifact, updates the honeyfs and dispatches `cowrie.session.file_download`. This is safe for a late callback: `self.fs` is snapshotted at construction, and the event log is deliberately kept across `connectionLost` so a download finishing after disconnect can still emit an attributed event.
- **Terminal output is the one thing suppressed** once the attacker has their prompt back, via `lateErrorWrite()` — writing a transfer's outcome to the terminal now would inject text into whatever they're doing.
- The data connection is never dropped. The size-limit abort in `FTPFileReceiver` is untouched; that one protects us from a rogue server, which is a different thing.

Five tests: the connection stays open, the rest of the sample is still written after CTRL-C, completion still reports the download, no terminal output after CTRL-C, and errors *are* still reported while the command is running.

**Worth deciding separately:** `wget.py` and `curl.py` go the other way — they guard their late callbacks with `if self.exited: return` and drop the sample (`test_late_download_callbacks_after_exit_are_inert`). If this is the policy we want, they should match, but that's a change to an existing deliberate decision so I've left them alone. Happy to do it in a follow-up.

Fixes #40499
