### PR TITLE
fix: reassemble proxied SFTP messages by their length prefix

### DIFF
--- a/src/cowrie/ssh_proxy/protocols/base_protocol.py
+++ b/src/cowrie/ssh_proxy/protocols/base_protocol.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 class BaseProtocol:
     data: bytes = b""
     packetSize: int = 0
+    # Bytes received on this stream that do not yet make up a whole message.
+    buffer: bytes = b""
     name: str = ""
     uuid: str = ""
     ttylog_file: str | None = None

--- a/src/cowrie/ssh_proxy/protocols/sftp.py
+++ b/src/cowrie/ssh_proxy/protocols/sftp.py
@@ -87,29 +87,24 @@ class SFTP(base_protocol.BaseProtocol):
         else:
             raise ValueError
 
-        if self.parentPacket.packetSize == 0:
-            self.parentPacket.packetSize = int(data[:4].hex(), 16) - len(data[4:])
-            data = data[4:]
-            self.parentPacket.data = data
-            data = b""
+        # An SFTP message is a 4-byte big-endian length followed by that many
+        # bytes. The channel splits and joins messages wherever it likes, so
+        # accumulate until a whole one is present and then take every whole
+        # message the buffer holds. Anything left over stays for the next call
+        # rather than being read as though it belonged to this message.
+        packet = self.parentPacket
+        packet.buffer += data
 
-        else:
-            if len(data) > self.parentPacket.packetSize:
-                self.parentPacket.data = (
-                    self.parentPacket.data + data[: self.parentPacket.packetSize]
-                )
-                data = data[self.parentPacket.packetSize :]
-                self.parentPacket.packetSize = 0
-            else:
-                self.parentPacket.packetSize -= len(data)
-                self.parentPacket.data = self.parentPacket.data + data
-                data = b""
+        while len(packet.buffer) >= 4:
+            length = int.from_bytes(packet.buffer[:4], byteorder="big")
+            if len(packet.buffer) - 4 < length:
+                # The body has not all arrived yet.
+                return
 
-        if self.parentPacket.packetSize == 0:
+            packet.data = packet.buffer[4 : 4 + length]
+            packet.packetSize = length
+            packet.buffer = packet.buffer[4 + length :]
             self.handle_packet(parent)
-
-        if len(data) != 0:
-            self.parse_packet(parent, data)
 
     def handle_packet(self, parent: str) -> None:
         self.packetSize: int = self.parentPacket.packetSize

--- a/src/cowrie/test/test_proxy_sftp_reassembly.py
+++ b/src/cowrie/test/test_proxy_sftp_reassembly.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: The SSH proxy reassembles SFTP messages from raw channel bytes; the
+# ABOUTME: channel splits and joins them freely, so framing must survive both.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from typing import Any
+from unittest.mock import MagicMock
+
+from twisted.conch.ssh import filetransfer
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+from cowrie.ssh_proxy.protocols import sftp as proxy_sftp
+
+
+def _realpath(path: bytes, request_id: int = 1) -> bytes:
+    """A framed SSH_FXP_REALPATH message for this path."""
+    body = (
+        bytes([filetransfer.FXP_REALPATH])
+        + request_id.to_bytes(4, "big")
+        + len(path).to_bytes(4, "big")
+        + path
+    )
+    return len(body).to_bytes(4, "big") + body
+
+
+class SftpReassemblyTests(unittest.TestCase):
+    """Every scenario must recover the same commands a single unfragmented
+    call does; a desync silently blanks SFTP audit logging for the rest of
+    the connection."""
+
+    def _sftp(self) -> tuple[Any, list[bytes]]:
+        ssh = MagicMock()
+        sftp = proxy_sftp.SFTP("uuid", "chan", ssh)
+        seen: list[bytes] = []
+        original = sftp.handle_packet
+
+        def record(parent: str) -> None:
+            original(parent)
+            seen.append(sftp.command)
+
+        sftp.handle_packet = record  # type: ignore[method-assign]
+        return sftp, seen
+
+    def _feed(
+        self, stream: bytes, chunk: int = 0, parent: str = "[CLIENT]"
+    ) -> list[bytes]:
+        sftp, seen = self._sftp()
+        if chunk:
+            for i in range(0, len(stream), chunk):
+                sftp.parse_packet(parent, stream[i : i + chunk])
+        else:
+            sftp.parse_packet(parent, stream)
+        return seen
+
+    def test_single_message_in_one_call(self) -> None:
+        self.assertEqual(self._feed(_realpath(b"/tmp/one")), [b"cd /tmp/one"])
+
+    def test_single_message_byte_by_byte(self) -> None:
+        self.assertEqual(self._feed(_realpath(b"/tmp/one"), chunk=1), [b"cd /tmp/one"])
+
+    def test_single_message_in_unaligned_chunks(self) -> None:
+        """A client whose channel writes don't line up with message
+        boundaries: the 4-byte header itself arrives split."""
+        self.assertEqual(self._feed(_realpath(b"/tmp/one"), chunk=7), [b"cd /tmp/one"])
+
+    def test_two_coalesced_messages(self) -> None:
+        """Ordinary TCP behaviour: a second message's bytes land on the end of
+        the same read."""
+        stream = _realpath(b"/tmp/one", 1) + _realpath(b"/tmp/two", 2)
+
+        self.assertEqual(self._feed(stream), [b"cd /tmp/one", b"cd /tmp/two"])
+
+    def test_three_coalesced_messages(self) -> None:
+        stream = (
+            _realpath(b"/tmp/one", 1)
+            + _realpath(b"/tmp/two", 2)
+            + _realpath(b"/tmp/three", 3)
+        )
+
+        self.assertEqual(
+            self._feed(stream), [b"cd /tmp/one", b"cd /tmp/two", b"cd /tmp/three"]
+        )
+
+    def test_coalesced_and_fragmented(self) -> None:
+        stream = _realpath(b"/tmp/one", 1) + _realpath(b"/tmp/two", 2)
+
+        self.assertEqual(self._feed(stream, chunk=7), [b"cd /tmp/one", b"cd /tmp/two"])
+
+    def test_client_and_server_streams_are_independent(self) -> None:
+        """The two directions have their own reassembly state; interleaving
+        them must not mix their bytes."""
+        sftp, seen = self._sftp()
+        client = _realpath(b"/tmp/client")
+        server = _realpath(b"/tmp/server")
+
+        # Half of each, then the remainder, alternating directions.
+        sftp.parse_packet("[CLIENT]", client[:6])
+        sftp.parse_packet("[SERVER]", server[:6])
+        sftp.parse_packet("[CLIENT]", client[6:])
+        sftp.parse_packet("[SERVER]", server[6:])
+
+        self.assertEqual(seen, [b"cd /tmp/client", b"cd /tmp/server"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`SFTP.parse_packet()` reassembles length-prefixed SFTP messages out of the raw channel bytes, one `dataReceived()`-driven call at a time. It tracked boundaries with:

```python
self.parentPacket.packetSize = int(data[:4].hex(), 16) - len(data[4:])
```

which is wrong in three related ways, all of which the issue sets out:

1. **Truncated header.** `data[:4]` is read without checking that 4 bytes have arrived, so a client whose channel write is shorter than the header computes a length from a partial prefix.
2. **Coalesced messages miscounted.** `len(data[4:])` is "everything after the header in the buffer", not "how much of *this* message's body is present". A second message's bytes on the same read are subtracted as though they were the first message's body, sending `packetSize` negative.
3. **Leftover bytes prepended to the next header**, corrupting the following message's length even when the first two didn't bite.

Any one desyncs that direction for the rest of the connection, so SFTP audit logging — filenames, `get`/`put`/`ls`/`rm`, captured upload content — silently goes blank or garbled. Coalescing is ordinary TCP behaviour, and small writes need nothing exotic from a client.

This replaces the boundary arithmetic in that one method rather than patching it: the formula is wrong in concept, not by an off-by-one. It now buffers per direction and takes whole messages while the buffer holds one, leaving any remainder for the next call. The `while` loop also replaces the tail-recursive call, which recursed once per coalesced message.

`buffer` is added next to `data` / `packetSize` on `BaseProtocol`, where the other reassembly state lives.

Seven tests: one message in a single call, byte-by-byte, and in 7-byte chunks; two and three coalesced; coalesced *and* fragmented; and interleaved CLIENT/SERVER streams. **Three fail before the change** — byte-by-byte (three spurious empty commands before the real one) and both coalesced cases (nothing recovered at all). The other four happen to survive at these particular message sizes, which is the point: the corruption is data-dependent, so passing on one capture says nothing about the next.

Fixes #40502
