### PR TITLE
Fix IndexError in scp when -d is given without a target directory

### DIFF
--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -55,7 +55,10 @@ class Command_scp(HoneyPotCommand):
 
         for opt in optlist:
             if opt[0] == "-d":
-                self.out_dir = args[0]
+                # `scp -d` may be given with no positional target directory;
+                # guard against indexing an empty args list (IndexError).
+                if args:
+                    self.out_dir = args[0]
                 break
 
         if self.out_dir:

--- a/src/cowrie/test/test_scp_options.py
+++ b/src/cowrie/test/test_scp_options.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for scp command option parsing.
+# ABOUTME: Verifies `scp -d` with no target directory does not crash.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+class ScpOptionTests(unittest.TestCase):
+    """Tests for cowrie/commands/scp.py option handling."""
+
+    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+    tr = FakeTransport("", "31337")
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.proto.makeConnection(cls.tr)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proto.connectionLost()
+
+    def setUp(self) -> None:
+        self.tr.clear()
+
+    def test_scp_dash_d_without_target_does_not_crash(self) -> None:
+        """`scp -d` with no positional target directory used to read args[0]
+        on an empty list, raising IndexError and killing the session before it
+        wrote anything. It should now start cleanly and emit its null-byte
+        handshake."""
+        self.proto.lineReceived(b"scp -d\n")
+        value = self.tr.value()
+        # A crash left the transport empty; a clean start writes the scp
+        # acknowledgement bytes.
+        self.assertTrue(value, "scp -d produced no output (command crashed)")
+        self.assertEqual(value, b"\x00" * len(value))


### PR DESCRIPTION
Fixes #40473

### Problem

`Command_scp.start()` in `src/cowrie/commands/scp.py` treats `-d` as a flag and then reads the target directory from the first positional argument:

```python
for opt in optlist:
    if opt[0] == "-d":
        self.out_dir = args[0]
        break
```

A bare `scp -d` with no positional arguments leaves `args` empty, so `args[0]` raises an uncaught `IndexError` that ends the session instead of producing a clean result.

### Fix

Only read `args[0]` when a positional argument is actually present; otherwise fall through with `out_dir` unset (the later `if self.out_dir:` block is simply skipped).

### Test

Added `src/cowrie/test/test_scp_options.py`, which drives `scp -d` through the interactive protocol and asserts it starts cleanly (emitting its null-byte handshake) rather than crashing. Before the fix the command produces no output and logs `IndexError`; the test fails without the change and passes with it. Existing `test_scp_exec.py` still passes (11 tests).