### PR TITLE
output/mongodb: dedicated single-worker thread pool for non-blocking, ordered writes

### DIFF
--- a/src/cowrie/output/mongodb.py
+++ b/src/cowrie/output/mongodb.py
@@ -6,7 +6,9 @@
 from __future__ import annotations
 
 import pymongo
+from twisted.internet import reactor, threads
 from twisted.logger import Logger
+from twisted.python.threadpool import ThreadPool
 
 import cowrie.core.output
 from cowrie.core.config import CowrieConfig
@@ -18,6 +20,7 @@ class Output(cowrie.core.output.Output):
     """
 
     _log = Logger()
+    pool: ThreadPool | None = None
 
     def insert_one(self, collection, event):
         try:
@@ -40,7 +43,14 @@ class Output(cowrie.core.output.Output):
         db_name = CowrieConfig.get("output_mongodb", "database")
 
         try:
-            self.mongo_client = pymongo.MongoClient(db_addr)
+            # Bound worst-case blocking time per call so an unreachable host
+            # can't hang the worker thread (or reactor shutdown) forever.
+            self.mongo_client = pymongo.MongoClient(
+                db_addr,
+                serverSelectionTimeoutMS=5000,
+                connectTimeoutMS=5000,
+                socketTimeoutMS=5000,
+            )
             self.mongo_db = self.mongo_client[db_name]
             # Define Collections.
             self.col_sensors = self.mongo_db["sensors"]
@@ -54,14 +64,29 @@ class Output(cowrie.core.output.Output):
             self.col_event = self.mongo_db["event"]
             self.col_ipforwards = self.mongo_db["ipforwards"]
             self.col_ipforwardsdata = self.mongo_db["ipforwardsdata"]
+
+            # Dedicated single-worker pool: keeps writes off the reactor
+            # thread while guaranteeing they execute in the order they were
+            # logged, so the find/update pairs below can't race each other.
+            self.pool = ThreadPool(
+                minthreads=1, maxthreads=1, name="MongoDBOutputPool"
+            )
+            self.pool.start()
         except Exception as e:
             self._log.info("output_mongodb: Error: {error}", error=e)
 
     def stop(self):
+        if self.pool:
+            self.pool.stop()
         if hasattr(self, "mongo_client"):
             self.mongo_client.close()
 
     def write(self, event):
+        d = threads.deferToThreadPool(reactor, self.pool, self._write_sync, event)
+        d.addErrback(lambda f: self._log.failure("mongodb output error", f))
+        return d
+
+    def _write_sync(self, event):
         for i in list(event):
             # Remove twisted 15 legacy keys
             if i.startswith("log_"):
@@ -92,22 +117,25 @@ class Output(cowrie.core.output.Output):
                 self.insert_one(self.col_downloads, event)
 
             case "cowrie.client.version":
-                doc = self.col_sessions.find_one({"session": event["session"]})
-                if doc:
-                    doc["sshversion"] = event["version"]
-                    self.update_one(self.col_sessions, event["session"], doc)
+                self.update_one(
+                    self.col_sessions,
+                    event["session"],
+                    {"sshversion": event["version"]},
+                )
 
             case "cowrie.client.size":
-                doc = self.col_sessions.find_one({"session": event["session"]})
-                if doc:
-                    doc["termsize"] = f"{event['width']}x{event['height']}"
-                    self.update_one(self.col_sessions, event["session"], doc)
+                self.update_one(
+                    self.col_sessions,
+                    event["session"],
+                    {"termsize": f"{event['width']}x{event['height']}"},
+                )
 
             case "cowrie.session.closed":
-                doc = self.col_sessions.find_one({"session": event["session"]})
-                if doc:
-                    doc["endtime"] = event["timestamp"]
-                    self.update_one(self.col_sessions, event["session"], doc)
+                self.update_one(
+                    self.col_sessions,
+                    event["session"],
+                    {"endtime": event["timestamp"]},
+                )
 
             case "cowrie.log.closed":
                 # ToDo Compress to opimise the space and if your sending to remote db

--- a/src/cowrie/test/test_asciinema.py
+++ b/src/cowrie/test/test_asciinema.py
@@ -14,6 +14,7 @@ import struct
 import tempfile
 import unittest
 from pathlib import Path
+from typing import cast
 
 from cowrie.scripts import asciinema
 
@@ -45,7 +46,7 @@ class PlaylogDecodeTests(unittest.TestCase):
     def _convert(self, *chunks: bytes) -> dict:
         asciinema.playlog(_ttylog(*chunks), {"colorify": False, "output": self.outfile})
         with open(self.outfile) as f:
-            return json.load(f)
+            return cast(dict, json.load(f))
 
     def test_plain_output_is_converted(self) -> None:
         log = self._convert(b"hello\n")

--- a/src/cowrie/test/test_asciinema.py
+++ b/src/cowrie/test/test_asciinema.py
@@ -46,7 +46,7 @@ class PlaylogDecodeTests(unittest.TestCase):
     def _convert(self, *chunks: bytes) -> dict:
         asciinema.playlog(_ttylog(*chunks), {"colorify": False, "output": self.outfile})
         with open(self.outfile) as f:
-            return cast(dict, json.load(f))
+            return cast("dict", json.load(f))
 
     def test_plain_output_is_converted(self) -> None:
         log = self._convert(b"hello\n")

--- a/src/cowrie/test/test_fs.py
+++ b/src/cowrie/test/test_fs.py
@@ -285,6 +285,7 @@ class UploadCloseTests(unittest.TestCase):
         )
         self.fs.mkfile("/tmp/payload", 0, 0, 0, 0o644)
         fd = self.fs.open("/tmp/payload", os.O_CREAT | os.O_WRONLY, 0o644)
+        assert fd is not None
         os.write(fd, contents)
         return fd
 


### PR DESCRIPTION
Fixes #40480

## Problem

`write()` in the mongodb output plugin runs synchronously and is called directly from the Twisted reactor thread. If MongoDB is slow or unreachable, every pymongo call blocks the reactor until it times out — freezing every active SSH/Telnet session.

Also, three handlers (`cowrie.client.version`, `cowrie.client.size`, `cowrie.session.closed`) do `find_one()` → mutate → `update_one()`. If two of these ran concurrently for the same session, one write could clobber the other.

## Fix

- Added a single-worker `ThreadPool` (`minthreads=1, maxthreads=1`), started in `start()`, stopped in `stop()`.
- `write()` now dispatches to `_write_sync()` via `deferToThreadPool`, keeping pymongo off the reactor thread. Single worker preserves write ordering.
- Added an errback on the returned Deferred so failures get logged instead of surfacing as unhandled Deferred errors.
- Dropped the `find_one()` before `update_one()` in the three session-update handlers — `update_one` without `upsert=True` is already a no-op if the doc doesn't exist, so this also removes the race at the DB level.
- Added timeouts on `MongoClient` (`serverSelectionTimeoutMS`, `connectTimeoutMS`, `socketTimeoutMS` = 5s) so a dead host can't hang the worker or `stop()`.
- Made `pool` a class attribute (`None` default) so `stop()` doesn't raise if `start()` never ran.

## Testing

- `ruff check` — clean
- `pytest src/cowrie/test/test_output_mongodb.py -v` — passing
- Manually reproduced: pointed `connection_string` at an unreachable IP, confirmed an SSH session hung before the fix and stayed responsive after.