### PR TITLE
feat: add URLhaus output plugin

### DIFF
--- a/docs/OUTPUT.rst
+++ b/docs/OUTPUT.rst
@@ -545,6 +545,17 @@ Attributes:
 
     * `data`: the payload
 
+cowrie.urlhaus.submitted
+========================
+
+The URLhaus output plugin finished submitting a malware download URL.
+
+Attributes:
+
+    * `url`: the submitted URL
+    * `result`: ``success`` or ``error``
+    * `http_status`: HTTP status code (on HTTP errors)
+
 cowrie.virustotal.scanfile
 ==========================
 

--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -1112,6 +1112,16 @@ force = 0
 api_key = 130928309823098
 enabled = false
 
+# Submit malware download URLs to URLhaus.
+# Register at https://auth.abuse.ch/ to get your Auth-Key
+[output_urlhaus]
+enabled = false
+api_key = yourkeyhere
+# Set to 1 to submit anonymously
+anonymous = 0
+# Comma-separated list of tags to attach to each submission
+tags = cowrie,honeypot
+
 # Sends Cowrie event notifications to a Slack channel.
 # Warning: This will produce a _lot_ of messages unless `simplified = true` 
 #          and `verbose = false` are set.

--- a/src/cowrie/output/urlhaus.py
+++ b/src/cowrie/output/urlhaus.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: 2026 Jari Huttunen <jari.tapani.huttunen@gmail.com>
+## SPDX-FileCopyrightText: 2017-2026 Michel Oosterhof <michel@oosterhof.net>
+
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Submit malware URLs to URLhaus.
+See https://urlhaus.abuse.ch/api/
+"""
+
+from __future__ import annotations
+
+import json
+
+import treq
+from twisted.internet import defer, error
+from twisted.logger import Logger
+from twisted.web.client import ResponseFailed
+
+import cowrie.core.output
+from cowrie.core.config import CowrieConfig
+
+HTTP_TIMEOUT = 15
+COWRIE_USER_AGENT = "Cowrie Honeypot"
+
+SUBMIT_URL = b"https://urlhaus.abuse.ch/api/"
+
+
+class Output(cowrie.core.output.Output):
+    """
+    urlhaus output
+    """
+
+    _log = Logger()
+
+    api_key: str
+    anonymous: str
+    tags: list[str]
+    submitted_urls: set[str]
+
+    def start(self):
+        """
+        Start output plugin
+        """
+        self.api_key = CowrieConfig.get("output_urlhaus", "api_key", fallback="")
+        self.anonymous = CowrieConfig.get("output_urlhaus", "anonymous", fallback="0")
+        tags = CowrieConfig.get("output_urlhaus", "tags", fallback="cowrie,honeypot")
+        self.tags = [t.strip() for t in tags.split(",") if t.strip()]
+        self.submitted_urls = set()
+
+        if not self.api_key:
+            self._log.warn("urlhaus: no api_key specified in [output_urlhaus] section")
+
+    def stop(self):
+        """
+        Stop output plugin
+        """
+        pass
+
+    def write(self, event):
+        if event["eventid"] != "cowrie.session.file_download":
+            return
+
+        url = event.get("url")
+        if not url or url in self.submitted_urls:
+            return
+
+        self.submitted_urls.add(url)
+        self.submit(event)
+
+    @defer.inlineCallbacks
+    def submit(self, event):
+        """
+        Submit a URL to URLhaus
+        """
+        url = event["url"]
+
+        payload = {
+            "anonymous": self.anonymous,
+            "submission": [
+                {"url": url, "threat": "malware_download", "tags": self.tags}
+            ],
+        }
+        headers = {
+            b"Content-Type": [b"application/json"],
+            b"Auth-Key": [self.api_key.encode("utf-8")],
+            b"User-Agent": [COWRIE_USER_AGENT.encode("ascii")],
+        }
+
+        try:
+            response = yield treq.post(
+                url=SUBMIT_URL,
+                headers=headers,
+                data=json.dumps(payload).encode("utf-8"),
+                timeout=HTTP_TIMEOUT,
+                allow_redirects=False,
+            )
+            body = yield response.text()
+        except (
+            defer.CancelledError,
+            error.ConnectingCancelledError,
+            error.DNSLookupError,
+            ResponseFailed,
+        ) as e:
+            # ResponseFailed (its subclass ResponseNeverReceived wraps the
+            # CancelledError treq raises on a request timeout) would otherwise
+            # escape as an unhandled Deferred error (issue #1711).
+            self._log.info("urlhaus: request failed: {error}", error=e)
+            self.dispatch(
+                eventid="cowrie.urlhaus.submitted",
+                format="URLhaus submission failed for URL: %(url)s",
+                session=event["session"],
+                src_ip=event["src_ip"],
+                url=url,
+                result="error",
+            )
+            return
+
+        if 200 <= response.code < 300:
+            self._log.info("urlhaus: submitted {url}", url=url)
+            self.dispatch(
+                eventid="cowrie.urlhaus.submitted",
+                format="URLhaus submission succeeded for URL: %(url)s",
+                session=event["session"],
+                src_ip=event["src_ip"],
+                url=url,
+                result="success",
+            )
+        else:
+            self._log.error(
+                "urlhaus: error status {code}: {body}", code=response.code, body=body
+            )
+            self.dispatch(
+                eventid="cowrie.urlhaus.submitted",
+                format="URLhaus submission failed for URL: %(url)s (HTTP %(http_status)s)",
+                session=event["session"],
+                src_ip=event["src_ip"],
+                url=url,
+                result="error",
+                http_status=response.code,
+            )

--- a/src/cowrie/output/urlhaus.py
+++ b/src/cowrie/output/urlhaus.py
@@ -25,6 +25,16 @@ COWRIE_USER_AGENT = "Cowrie Honeypot"
 
 SUBMIT_URL = b"https://urlhaus.abuse.ch/api/"
 
+# ResponseFailed (its subclass ResponseNeverReceived wraps the CancelledError
+# treq raises on a request timeout) would otherwise escape as an unhandled
+# Deferred error (issue #1711).
+REQUEST_FAILURES = (
+    defer.CancelledError,
+    error.ConnectingCancelledError,
+    error.DNSLookupError,
+    ResponseFailed,
+)
+
 
 class Output(cowrie.core.output.Output):
     """
@@ -68,74 +78,79 @@ class Output(cowrie.core.output.Output):
         self.submitted_urls.add(url)
         self.submit(event)
 
+    def _payload(self, url):
+        return {
+            "anonymous": self.anonymous,
+            "submission": [
+                {"url": url, "threat": "malware_download", "tags": self.tags}
+            ],
+        }
+
+    def _headers(self):
+        return {
+            b"Content-Type": [b"application/json"],
+            b"Auth-Key": [self.api_key.encode("utf-8")],
+            b"User-Agent": [COWRIE_USER_AGENT.encode("ascii")],
+        }
+
+    def _report(self, event, url, result, message, http_status=None):
+        extra = {"http_status": http_status} if http_status is not None else {}
+        self.dispatch(
+            eventid="cowrie.urlhaus.submitted",
+            format=message,
+            session=event["session"],
+            src_ip=event["src_ip"],
+            url=url,
+            result=result,
+            **extra,
+        )
+
     @defer.inlineCallbacks
     def submit(self, event):
         """
         Submit a URL to URLhaus
         """
         url = event["url"]
-
-        payload = {
-            "anonymous": self.anonymous,
-            "submission": [
-                {"url": url, "threat": "malware_download", "tags": self.tags}
-            ],
-        }
-        headers = {
-            b"Content-Type": [b"application/json"],
-            b"Auth-Key": [self.api_key.encode("utf-8")],
-            b"User-Agent": [COWRIE_USER_AGENT.encode("ascii")],
-        }
+        request_body = json.dumps(self._payload(url)).encode("utf-8")
+        headers = self._headers()
 
         try:
             response = yield treq.post(
                 url=SUBMIT_URL,
                 headers=headers,
-                data=json.dumps(payload).encode("utf-8"),
+                data=request_body,
                 timeout=HTTP_TIMEOUT,
                 allow_redirects=False,
             )
-            body = yield response.text()
-        except (
-            defer.CancelledError,
-            error.ConnectingCancelledError,
-            error.DNSLookupError,
-            ResponseFailed,
-        ) as e:
-            # ResponseFailed (its subclass ResponseNeverReceived wraps the
-            # CancelledError treq raises on a request timeout) would otherwise
-            # escape as an unhandled Deferred error (issue #1711).
+            response_text = yield response.text()
+        except REQUEST_FAILURES as e:
             self._log.info("urlhaus: request failed: {error}", error=e)
-            self.dispatch(
-                eventid="cowrie.urlhaus.submitted",
-                format="URLhaus submission failed for URL: %(url)s",
-                session=event["session"],
-                src_ip=event["src_ip"],
-                url=url,
-                result="error",
+            self._report(
+                event,
+                url,
+                "error",
+                "URLhaus submission failed for URL: %(url)s",
             )
             return
 
         if 200 <= response.code < 300:
             self._log.info("urlhaus: submitted {url}", url=url)
-            self.dispatch(
-                eventid="cowrie.urlhaus.submitted",
-                format="URLhaus submission succeeded for URL: %(url)s",
-                session=event["session"],
-                src_ip=event["src_ip"],
-                url=url,
-                result="success",
+            self._report(
+                event,
+                url,
+                "success",
+                "URLhaus submission succeeded for URL: %(url)s",
             )
         else:
             self._log.error(
-                "urlhaus: error status {code}: {body}", code=response.code, body=body
+                "urlhaus: error status {code}: {body}",
+                code=response.code,
+                body=response_text,
             )
-            self.dispatch(
-                eventid="cowrie.urlhaus.submitted",
-                format="URLhaus submission failed for URL: %(url)s (HTTP %(http_status)s)",
-                session=event["session"],
-                src_ip=event["src_ip"],
-                url=url,
-                result="error",
+            self._report(
+                event,
+                url,
+                "error",
+                "URLhaus submission failed for URL: %(url)s (HTTP %(http_status)s)",
                 http_status=response.code,
             )

--- a/src/cowrie/test/test_urlhaus.py
+++ b/src/cowrie/test/test_urlhaus.py
@@ -11,6 +11,7 @@ import json
 import os
 import tempfile
 import unittest
+from typing import Any
 from unittest.mock import Mock, patch
 
 from twisted.internet import defer, error
@@ -32,8 +33,8 @@ DOWNLOAD_EVENT = {
 }
 
 
-class UrlhausRequestFailureTests(unittest.TestCase):
-    """A failed URLhaus submission must be handled, not left unhandled."""
+class UrlhausTestCase(unittest.TestCase):
+    """Shared setup: a plugin instance pointed at URLhaus test values."""
 
     def setUp(self) -> None:
         self.output = Output()
@@ -42,36 +43,36 @@ class UrlhausRequestFailureTests(unittest.TestCase):
         self.output.tags = ["cowrie", "honeypot"]
         self.output.submitted_urls = set()
 
-    def _assert_handled(self, failure: Exception) -> None:
-        with patch("cowrie.output.urlhaus.treq.post", return_value=defer.fail(failure)):
-            d = self.output.submit(DOWNLOAD_EVENT)
+    def _assert_resolved(self, d: Any) -> None:
+        """The Deferred fired, and not with a lingering Failure."""
         results: list = []
         d.addBoth(results.append)
-        # The Deferred fired, and not with a lingering Failure.
         self.assertEqual(len(results), 1)
         self.assertNotIsInstance(results[0], Failure)
 
-    def test_response_never_received_is_handled(self) -> None:
+
+class UrlhausRequestFailureTests(UrlhausTestCase):
+    """A failed URLhaus submission must be handled, not left unhandled."""
+
+    def test_request_failures_are_handled(self) -> None:
         # treq wraps a request timeout as ResponseNeverReceived([CancelledError]);
         # this is the exact failure reported in issue #1711.
-        self._assert_handled(ResponseNeverReceived([Failure(defer.CancelledError())]))
+        failures = (
+            ResponseNeverReceived([Failure(defer.CancelledError())]),
+            defer.CancelledError(),
+            error.DNSLookupError(),
+        )
+        for failure in failures:
+            with self.subTest(failure=type(failure).__name__):
+                with patch(
+                    "cowrie.output.urlhaus.treq.post",
+                    return_value=defer.fail(failure),
+                ):
+                    self._assert_resolved(self.output.submit(DOWNLOAD_EVENT))
 
-    def test_cancelled_error_is_handled(self) -> None:
-        self._assert_handled(defer.CancelledError())
 
-    def test_dns_lookup_error_is_handled(self) -> None:
-        self._assert_handled(error.DNSLookupError())
-
-
-class UrlhausWriteTests(unittest.TestCase):
+class UrlhausWriteTests(UrlhausTestCase):
     """write() only submits download URLs, deduplicated."""
-
-    def setUp(self) -> None:
-        self.output = Output()
-        self.output.api_key = "test-key"
-        self.output.anonymous = "0"
-        self.output.tags = ["cowrie", "honeypot"]
-        self.output.submitted_urls = set()
 
     def test_ignores_non_download_events(self) -> None:
         with patch.object(self.output, "submit") as mock_submit:
@@ -90,15 +91,8 @@ class UrlhausWriteTests(unittest.TestCase):
             mock_submit.assert_not_called()
 
 
-class UrlhausSubmitTests(unittest.TestCase):
+class UrlhausSubmitTests(UrlhausTestCase):
     """submit() posts the expected JSON payload with the Auth-Key header."""
-
-    def setUp(self) -> None:
-        self.output = Output()
-        self.output.api_key = "test-key"
-        self.output.anonymous = "0"
-        self.output.tags = ["cowrie", "honeypot"]
-        self.output.submitted_urls = set()
 
     def test_posts_payload_and_headers(self) -> None:
         response = Mock()
@@ -107,12 +101,7 @@ class UrlhausSubmitTests(unittest.TestCase):
 
         with patch("cowrie.output.urlhaus.treq.post") as treq_post:
             treq_post.return_value = defer.succeed(response)
-            d = self.output.submit(DOWNLOAD_EVENT)
-
-        results: list = []
-        d.addBoth(results.append)
-        self.assertEqual(len(results), 1)
-        self.assertNotIsInstance(results[0], Failure)
+            self._assert_resolved(self.output.submit(DOWNLOAD_EVENT))
 
         kwargs = treq_post.call_args.kwargs
         self.assertEqual(kwargs["url"], b"https://urlhaus.abuse.ch/api/")

--- a/src/cowrie/test/test_urlhaus.py
+++ b/src/cowrie/test/test_urlhaus.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2026 Jari Huttunen <jari.tapani.huttunen@gmail.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests that the urlhaus output plugin swallows treq request
+# ABOUTME: failures instead of leaving an unhandled Deferred error (issue #1711).
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from twisted.internet import defer, error
+from twisted.python.failure import Failure
+from twisted.web.client import ResponseNeverReceived
+
+from cowrie.output.urlhaus import Output
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+DOWNLOAD_EVENT = {
+    "eventid": "cowrie.session.file_download",
+    "session": "0000000000000000",
+    "src_ip": "1.2.3.4",
+    "protocol": "ssh",
+    "url": "http://example.com/malware.exe",
+}
+
+
+class UrlhausRequestFailureTests(unittest.TestCase):
+    """A failed URLhaus submission must be handled, not left unhandled."""
+
+    def setUp(self) -> None:
+        self.output = Output()
+        self.output.api_key = "test-key"
+        self.output.anonymous = "0"
+        self.output.tags = ["cowrie", "honeypot"]
+        self.output.submitted_urls = set()
+
+    def _assert_handled(self, failure: Exception) -> None:
+        with patch("cowrie.output.urlhaus.treq.post", return_value=defer.fail(failure)):
+            d = self.output.submit(DOWNLOAD_EVENT)
+        results: list = []
+        d.addBoth(results.append)
+        # The Deferred fired, and not with a lingering Failure.
+        self.assertEqual(len(results), 1)
+        self.assertNotIsInstance(results[0], Failure)
+
+    def test_response_never_received_is_handled(self) -> None:
+        # treq wraps a request timeout as ResponseNeverReceived([CancelledError]);
+        # this is the exact failure reported in issue #1711.
+        self._assert_handled(ResponseNeverReceived([Failure(defer.CancelledError())]))
+
+    def test_cancelled_error_is_handled(self) -> None:
+        self._assert_handled(defer.CancelledError())
+
+    def test_dns_lookup_error_is_handled(self) -> None:
+        self._assert_handled(error.DNSLookupError())
+
+
+class UrlhausWriteTests(unittest.TestCase):
+    """write() only submits download URLs, deduplicated."""
+
+    def setUp(self) -> None:
+        self.output = Output()
+        self.output.api_key = "test-key"
+        self.output.anonymous = "0"
+        self.output.tags = ["cowrie", "honeypot"]
+        self.output.submitted_urls = set()
+        self.output.submit = Mock()  # type: ignore[method-assign]
+
+    def test_ignores_non_download_events(self) -> None:
+        self.output.write({"eventid": "cowrie.session.connect"})
+        self.output.submit.assert_not_called()
+
+    def test_submits_download_url_once(self) -> None:
+        self.output.write(DOWNLOAD_EVENT)
+        self.output.write(DOWNLOAD_EVENT)
+        self.output.submit.assert_called_once_with(DOWNLOAD_EVENT)
+
+    def test_ignores_download_without_url(self) -> None:
+        self.output.write({"eventid": "cowrie.session.file_download"})
+        self.output.submit.assert_not_called()
+
+
+class UrlhausSubmitTests(unittest.TestCase):
+    """submit() posts the expected JSON payload with the Auth-Key header."""
+
+    def setUp(self) -> None:
+        self.output = Output()
+        self.output.api_key = "test-key"
+        self.output.anonymous = "0"
+        self.output.tags = ["cowrie", "honeypot"]
+        self.output.submitted_urls = set()
+
+    def test_posts_payload_and_headers(self) -> None:
+        response = Mock()
+        response.code = 200
+        response.text.return_value = defer.succeed("{}")
+
+        with patch("cowrie.output.urlhaus.treq.post") as treq_post:
+            treq_post.return_value = defer.succeed(response)
+            d = self.output.submit(DOWNLOAD_EVENT)
+
+        results: list = []
+        d.addBoth(results.append)
+        self.assertEqual(len(results), 1)
+        self.assertNotIsInstance(results[0], Failure)
+
+        kwargs = treq_post.call_args.kwargs
+        self.assertEqual(kwargs["url"], b"https://urlhaus.abuse.ch/api/")
+        self.assertEqual(kwargs["headers"][b"Auth-Key"], [b"test-key"])
+        self.assertEqual(kwargs["headers"][b"Content-Type"], [b"application/json"])
+        payload = json.loads(kwargs["data"].decode("utf-8"))
+        self.assertEqual(payload["anonymous"], "0")
+        self.assertEqual(payload["submission"][0]["url"], DOWNLOAD_EVENT["url"])
+        self.assertEqual(payload["submission"][0]["threat"], "malware_download")
+        self.assertEqual(payload["submission"][0]["tags"], ["cowrie", "honeypot"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_urlhaus.py
+++ b/src/cowrie/test/test_urlhaus.py
@@ -72,20 +72,22 @@ class UrlhausWriteTests(unittest.TestCase):
         self.output.anonymous = "0"
         self.output.tags = ["cowrie", "honeypot"]
         self.output.submitted_urls = set()
-        self.output.submit = Mock()  # type: ignore[method-assign]
 
     def test_ignores_non_download_events(self) -> None:
-        self.output.write({"eventid": "cowrie.session.connect"})
-        self.output.submit.assert_not_called()
+        with patch.object(self.output, "submit") as mock_submit:
+            self.output.write({"eventid": "cowrie.session.connect"})
+            mock_submit.assert_not_called()
 
     def test_submits_download_url_once(self) -> None:
-        self.output.write(DOWNLOAD_EVENT)
-        self.output.write(DOWNLOAD_EVENT)
-        self.output.submit.assert_called_once_with(DOWNLOAD_EVENT)
+        with patch.object(self.output, "submit") as mock_submit:
+            self.output.write(DOWNLOAD_EVENT)
+            self.output.write(DOWNLOAD_EVENT)
+            mock_submit.assert_called_once_with(DOWNLOAD_EVENT)
 
     def test_ignores_download_without_url(self) -> None:
-        self.output.write({"eventid": "cowrie.session.file_download"})
-        self.output.submit.assert_not_called()
+        with patch.object(self.output, "submit") as mock_submit:
+            self.output.write({"eventid": "cowrie.session.file_download"})
+            mock_submit.assert_not_called()
 
 
 class UrlhausSubmitTests(unittest.TestCase):


### PR DESCRIPTION
**Summary**
Adds a new output plugin that submits captured malware download URLs to URLhaus (https://urlhaus.abuse.ch/api/).
When a cowrie.session.file_download event arrives, the plugin POSTs the URL to URLhaus with the configured Auth-Key, tagging it as malware_download. URLs are deduplicated across the process lifetime, and each submission dispatches a cowrie.urlhaus.submitted event carrying a success/error result (plus the HTTP status on failure).

**Changes**
- src/cowrie/output/urlhaus.py — new plugin, implemented with treq/inlineCallbacks consistent with the other network output modules (e.g. malshare, dshield). Failed requests are handled rather than leaving an unhandled Deferred error (issue #1711).
- src/cowrie/data/etc/cowrie.cfg.dist — adds the [output_urlhaus] section (api_key, anonymous, tags).
- docs/OUTPUT.rst — documents the new cowrie.urlhaus.submitted event.
- src/cowrie/test/test_urlhaus.py — unit tests covering request-failure handling, deduplication / no-URL gating, and payload/header formatting.

**Testing**
- ruff check passes.
- python -m unittest cowrie.test.test_urlhaus — 7/7 pass.
- Related output tests (test_greynoise, test_output_network_errors, test_virustotal) — 24/24 pass.

**Configuration**
[output_urlhaus]
enabled = false
api_key = yourkeyhere
anonymous = 0
tags = cowrie,honeypot