### PR TITLE
test: keep event ids, emitters, consumers and docs in step

### DIFF
--- a/src/cowrie/core/eventids.py
+++ b/src/cowrie/core/eventids.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: The catalogue of event ids Cowrie emits, the single list every
+# ABOUTME: emitter, consumer and docs section is checked against.
+
+"""
+The authoritative set of event ids.
+
+An event id is part of Cowrie's published output contract: consumers match
+on it, and the attributes each one carries are documented in
+docs/OUTPUT.rst. Because both sides of that contract are plain strings
+spread over emitters and output plugins, a typo is invisible until an
+operator notices a plugin has quietly stopped reacting to an event.
+
+``ALL`` is the pivot that makes such a typo a test failure:
+``cowrie.test.test_eventids`` checks that every id emitted in the tree is
+listed here, that every id an output plugin matches on is listed here, and
+that docs/OUTPUT.rst documents exactly these ids and no others.
+
+Adding an event means adding it here and documenting it in OUTPUT.rst.
+"""
+
+from __future__ import annotations
+
+ALL: frozenset[str] = frozenset(
+    {
+        # AbuseIPDB reporting, operational rather than session-scoped
+        "cowrie.abuseipdb.ratelimited",
+        "cowrie.abuseipdb.reportedip",
+        "cowrie.abuseipdb.reportfail",
+        "cowrie.abuseipdb.started",
+        "cowrie.abuseipdb.wakeup",
+        # What the client told us about itself
+        "cowrie.client.fingerprint",
+        "cowrie.client.kex",
+        "cowrie.client.malformed_packet",
+        "cowrie.client.size",
+        "cowrie.client.var",
+        "cowrie.client.version",
+        # Commands the attacker ran
+        "cowrie.command.chpasswd",
+        "cowrie.command.failed",
+        "cowrie.command.input",
+        "cowrie.command.success",
+        # Port forwarding the attacker requested
+        "cowrie.direct-tcpip.data",
+        "cowrie.direct-tcpip.ja4",
+        "cowrie.direct-tcpip.ja4h",
+        "cowrie.direct-tcpip.redirect",
+        "cowrie.direct-tcpip.request",
+        "cowrie.direct-tcpip.tunnel",
+        "cowrie.tunnelproxy-tcpip.data",
+        # GreyNoise reputation lookups
+        "cowrie.greynoise.result",
+        # TTY session recordings
+        "cowrie.log.closed",
+        "cowrie.log.open",
+        # Authentication
+        "cowrie.login.failed",
+        "cowrie.login.success",
+        # Proxy backend plumbing
+        "cowrie.proxy.backend_connect_error",
+        "cowrie.proxy.backend_connected",
+        "cowrie.proxy.backend_disconnected",
+        "cowrie.proxy.client_disconnect",
+        "cowrie.proxy.ssh",
+        # Reverse DNS lookups
+        "cowrie.reversedns.connect",
+        "cowrie.reversedns.forward",
+        # The connection and what passed through it
+        "cowrie.session.closed",
+        "cowrie.session.connect",
+        "cowrie.session.file_download",
+        "cowrie.session.file_download.failed",
+        "cowrie.session.file_upload",
+        "cowrie.session.input",
+        "cowrie.session.params",
+        # Telnet negotiation
+        "cowrie.telnet.error",
+        "cowrie.telnet.exploit_attempt",
+        "cowrie.telnet.exploit_success",
+        "cowrie.telnet.option",
+        # VirusTotal lookups
+        "cowrie.virustotal.scanfile",
+        "cowrie.virustotal.scanurl",
+    }
+)

--- a/src/cowrie/test/test_eventids.py
+++ b/src/cowrie/test/test_eventids.py
@@ -27,10 +27,24 @@ DOCS = SOURCE_ROOT.parent.parent / "docs" / "OUTPUT.rst"
 FORWARDING_SITES = {"core/events.py", "core/output.py"}
 
 
+def module_name(path: pathlib.Path) -> str:
+    """The module's path within the package, e.g. ``output/mysql.py``.
+
+    Relative to the package and always slash-separated, so neither the
+    directory Cowrie is checked out in nor the platform's separator can
+    change what a scan sees.
+    """
+    return path.relative_to(SOURCE_ROOT).as_posix()
+
+
 def production_sources() -> list[pathlib.Path]:
     """Every module attackers' activity is observed in -- the test package
     emits synthetic ids of its own and is deliberately not scanned."""
-    return [p for p in sorted(SOURCE_ROOT.rglob("*.py")) if "test" not in p.parts]
+    return [
+        path
+        for path in sorted(SOURCE_ROOT.rglob("*.py"))
+        if not module_name(path).startswith("test/")
+    ]
 
 
 def string_constants(node: ast.AST) -> set[str]:
@@ -131,8 +145,7 @@ def scan() -> tuple[dict[str, str], dict[str, str], list[str]]:
     consumed: dict[str, str] = {}
     unnamed: list[str] = []
     for path in production_sources():
-        relative = str(path.relative_to(SOURCE_ROOT))
-        scanner = EventIdScanner(relative)
+        scanner = EventIdScanner(module_name(path))
         scanner.visit(ast.parse(path.read_text(), str(path)))
         for eventid, site in scanner.emitted.items():
             emitted.setdefault(eventid, site)
@@ -158,6 +171,15 @@ class EventIdRegistryTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.emitted, cls.consumed, cls.unnamed = scan()
+
+    def test_the_scan_reaches_the_production_tree(self) -> None:
+        """Every assertion below is vacuous if the scan finds nothing, so
+        check it reached the emitters and skipped the test package."""
+        scanned = {module_name(path) for path in production_sources()}
+
+        self.assertIn("core/events.py", scanned)
+        self.assertIn("output/mysql.py", scanned)
+        self.assertEqual([name for name in scanned if name.startswith("test/")], [])
 
     def test_emitted_ids_are_registered(self) -> None:
         unregistered = {

--- a/src/cowrie/test/test_eventids.py
+++ b/src/cowrie/test/test_eventids.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Conformance tests keeping the event id catalogue, the emitters,
+# ABOUTME: the output plugins matching on ids, and docs/OUTPUT.rst in step.
+
+from __future__ import annotations
+
+import ast
+import itertools
+import pathlib
+import re
+import unittest
+
+import cowrie
+from cowrie.core.eventids import ALL
+
+SOURCE_ROOT = pathlib.Path(cowrie.__file__).parent
+DOCS = SOURCE_ROOT.parent.parent / "docs" / "OUTPUT.rst"
+
+# The two pipeline stages that forward an already-built event instead of
+# naming one: EventLog hands its event to the dispatcher, and an output
+# plugin's dispatch() forwards the enrichment event it was given. Every
+# other dispatch() call names its event id literally, which is what makes
+# the emitted set knowable by reading the source.
+FORWARDING_SITES = {"core/events.py", "core/output.py"}
+
+
+def production_sources() -> list[pathlib.Path]:
+    """Every module attackers' activity is observed in -- the test package
+    emits synthetic ids of its own and is deliberately not scanned."""
+    return [p for p in sorted(SOURCE_ROOT.rglob("*.py")) if "test" not in p.parts]
+
+
+def string_constants(node: ast.AST) -> set[str]:
+    return {
+        n.value
+        for n in ast.walk(node)
+        if isinstance(n, ast.Constant) and isinstance(n.value, str)
+    }
+
+
+def event_ids_in(node: ast.AST) -> set[str]:
+    return {s for s in string_constants(node) if s.startswith("cowrie.")}
+
+
+def reads_eventid(node: ast.AST) -> bool:
+    """Whether an expression reads an event's id, however it spells it:
+    ``event["eventid"]``, a bare ``eventid`` local, or ``.eventid``."""
+    for n in ast.walk(node):
+        if isinstance(n, ast.Constant) and n.value == "eventid":
+            return True
+        if isinstance(n, ast.Name) and n.id == "eventid":
+            return True
+        if isinstance(n, ast.Attribute) and n.attr == "eventid":
+            return True
+    return False
+
+
+class EventIdScanner(ast.NodeVisitor):
+    """Collects the event ids a module emits and the ones it matches on."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.emitted: dict[str, str] = {}
+        self.consumed: dict[str, str] = {}
+        self.unnamed: list[str] = []
+
+    def where(self, node: ast.AST) -> str:
+        return f"{self.path}:{node.lineno}"  # type: ignore[attr-defined]
+
+    def record(self, found: dict[str, str], ids: set[str], node: ast.AST) -> None:
+        for eventid in ids:
+            found.setdefault(eventid, self.where(node))
+
+    def visit_Call(self, node: ast.Call) -> None:
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+        if name == "dispatch":
+            self.visit_dispatch(node)
+        # An id tested by prefix: event["eventid"].startswith("cowrie.login")
+        if isinstance(func, ast.Attribute) and func.attr in ("startswith", "endswith"):
+            if reads_eventid(func.value):
+                for arg in node.args:
+                    self.record(self.consumed, event_ids_in(arg), node)
+        self.generic_visit(node)
+
+    def visit_dispatch(self, node: ast.Call) -> None:
+        """An emitter names its event id as the first positional argument
+        (EventLog.dispatch) or as an eventid keyword (Output.dispatch)."""
+        named = None
+        if node.args:
+            named = node.args[0]
+        else:
+            for keyword in node.keywords:
+                if keyword.arg == "eventid":
+                    named = keyword.value
+        if isinstance(named, ast.Constant) and isinstance(named.value, str):
+            self.record(self.emitted, {named.value}, node)
+        elif self.path not in FORWARDING_SITES:
+            self.unnamed.append(self.where(node))
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        operands = [node.left, *node.comparators]
+        if any(reads_eventid(operand) for operand in operands):
+            for operand in operands:
+                self.record(self.consumed, event_ids_in(operand), node)
+        self.generic_visit(node)
+
+    def visit_Match(self, node: ast.Match) -> None:
+        if reads_eventid(node.subject):
+            for case in node.cases:
+                self.record(self.consumed, event_ids_in(case.pattern), case.pattern)
+        self.generic_visit(node)
+
+    def visit_Dict(self, node: ast.Dict) -> None:
+        """A dispatch table keyed by event id, as slack builds."""
+        keys = {
+            key.value
+            for key in node.keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+        }
+        if node.keys and len(keys) == len(node.keys) and keys == event_ids_in(node):
+            self.record(self.consumed, keys, node)
+        self.generic_visit(node)
+
+
+def scan() -> tuple[dict[str, str], dict[str, str], list[str]]:
+    emitted: dict[str, str] = {}
+    consumed: dict[str, str] = {}
+    unnamed: list[str] = []
+    for path in production_sources():
+        relative = str(path.relative_to(SOURCE_ROOT))
+        scanner = EventIdScanner(relative)
+        scanner.visit(ast.parse(path.read_text(), str(path)))
+        for eventid, site in scanner.emitted.items():
+            emitted.setdefault(eventid, site)
+        for eventid, site in scanner.consumed.items():
+            consumed.setdefault(eventid, site)
+        unnamed.extend(scanner.unnamed)
+    return emitted, consumed, unnamed
+
+
+def documented_ids() -> set[str]:
+    """The event ids OUTPUT.rst has a section for."""
+    lines = DOCS.read_text().splitlines()
+    return {
+        line.strip()
+        for line, underline in itertools.pairwise(lines)
+        if line.startswith("cowrie.") and re.fullmatch("=+", underline)
+    }
+
+
+class EventIdRegistryTests(unittest.TestCase):
+    """Every event id in the tree is in the catalogue, and vice versa."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.emitted, cls.consumed, cls.unnamed = scan()
+
+    def test_emitted_ids_are_registered(self) -> None:
+        unregistered = {
+            eventid: site
+            for eventid, site in self.emitted.items()
+            if eventid not in ALL
+        }
+        self.assertEqual(
+            unregistered,
+            {},
+            "event ids emitted but missing from cowrie.core.eventids.ALL",
+        )
+
+    def test_registered_ids_are_emitted(self) -> None:
+        """A catalogue entry no emitter produces is a stale id: consumers
+        matching on it wait forever."""
+        self.assertEqual(
+            sorted(ALL - set(self.emitted)),
+            [],
+            "event ids in cowrie.core.eventids.ALL that nothing emits",
+        )
+
+    def test_consumed_ids_are_registered(self) -> None:
+        """An output plugin matching on an id nothing emits is dead code --
+        the failure mode is silent, so it is worth a test. A prefix such as
+        ``cowrie.login`` is how abuseipdb matches a family of events."""
+        prefixes = {eventid.rsplit(".", 1)[0] for eventid in ALL}
+        unregistered = {
+            eventid: site
+            for eventid, site in self.consumed.items()
+            if eventid not in ALL and eventid not in prefixes
+        }
+        self.assertEqual(
+            unregistered,
+            {},
+            "event ids matched on that no emitter produces",
+        )
+
+    def test_emitters_name_their_event_id(self) -> None:
+        """An event id assembled at runtime would be invisible to this
+        catalogue, so emitters spell theirs out."""
+        self.assertEqual(
+            self.unnamed,
+            [],
+            "dispatch() calls that do not name their event id literally",
+        )
+
+    @unittest.skipUnless(DOCS.exists(), "docs are not part of an installed package")
+    def test_docs_document_the_registry(self) -> None:
+        documented = documented_ids()
+        self.assertEqual(
+            sorted(ALL - documented),
+            [],
+            "event ids missing a section in docs/OUTPUT.rst",
+        )
+        self.assertEqual(
+            sorted(documented - ALL),
+            [],
+            "docs/OUTPUT.rst sections for event ids that are not in the registry",
+        )

--- a/src/cowrie/test/test_eventids.py
+++ b/src/cowrie/test/test_eventids.py
@@ -12,6 +12,7 @@ import itertools
 import pathlib
 import re
 import unittest
+from typing import ClassVar
 
 import cowrie
 from cowrie.core.eventids import ALL
@@ -167,6 +168,11 @@ def documented_ids() -> set[str]:
 
 class EventIdRegistryTests(unittest.TestCase):
     """Every event id in the tree is in the catalogue, and vice versa."""
+
+    # One scan of the tree, shared by every assertion below.
+    emitted: ClassVar[dict[str, str]]
+    consumed: ClassVar[dict[str, str]]
+    unnamed: ClassVar[list[str]]
 
     @classmethod
     def setUpClass(cls) -> None:


### PR DESCRIPTION
Event ids are Cowrie's published output contract, but both sides of that contract are plain strings spread over emitters and output plugins. A typo in either place is invisible until an operator notices a plugin has quietly stopped reacting to an event — the failure mode behind the slack/cef/scp mismatches fixed in #40420.

This adds `cowrie.core.eventids.ALL` as the catalogue both sides are checked against, and a test that walks the source with an AST scanner and asserts:

- every event id emitted in the tree is registered;
- no registry entry has gone stale (nothing emits it any more);
- every id an output plugin *matches on* is registered, or is a family prefix such as `cowrie.login`;
- emitters name their event id literally, so the emitted set stays knowable by reading the source;
- `docs/OUTPUT.rst` documents exactly the registry, no more and no less.

The scanner recognises every consumer spelling currently in the tree: `event["eventid"] == ...`, membership tests against a tuple or list, `match`/`case` (`core/cef.py`), dict dispatch tables (`output/slack.py`), and prefix tests (`output/abuseipdb.py`).

**The tree is already consistent** — 47 ids emitted, 47 documented, no dangling consumers. So this locks in an invariant rather than fixing drift. Since a green test proves nothing on its own, each assertion was verified to fail when its invariant is broken; all seven mutations were caught by the intended assertion:

| mutation | caught by |
| --- | --- |
| emitter id typo (`ssh/transport.py`) | `test_emitted_ids_are_registered` |
| stale registry entry | `test_registered_ids_are_emitted` |
| `==` comparison typo (`output/mysql.py`) | `test_consumed_ids_are_registered` |
| membership-tuple typo (`output/dshield.py`) | `test_consumed_ids_are_registered` |
| dict-table key typo (`output/slack.py`) | `test_consumed_ids_are_registered` |
| `match` case typo (`core/cef.py`) | `test_consumed_ids_are_registered` |
| runtime-built event id | `test_emitters_name_their_event_id` |
| docs section rename | `test_docs_document_the_registry` |

The second commit fixes a defect found reviewing the first: the scan filtered on the absolute path's components, so a checkout under any directory named `test` skipped every file and three of the assertions passed on an empty scan. It now filters and labels by the module's path within the package, and a further test asserts the scan actually reached the emitters — so a scan that finds nothing fails as itself rather than as 47 missing emitters.

Emit call sites are deliberately left spelling their ids literally rather than importing constants: the test enforces correctness either way, and converting ~100 call sites would be a large mechanical diff for no additional guarantee.

Known limits, neither currently reachable: the scanner covers the `cowrie` package only (an emitter under `src/backend_pool` or `src/twisted` would be invisible — there are none), and a module-level named collection of ids referenced by variable would not be recognised as a consumer (there are none).

Adding an event now means adding it to the registry and documenting it in `OUTPUT.rst`. That friction is the point.

No runtime behaviour changes; this is a test and a catalogue.
