### PR TITLE
fix: never stop an output plugin that failed to start

### DIFF
--- a/docs/EVENT_PIPELINE.rst
+++ b/docs/EVENT_PIPELINE.rst
@@ -274,9 +274,10 @@ Operational considerations
 **************************
 
 No configuration changes
-    Plugin selection, loading, and configuration are untouched;
-    ``cowrie_plugin.py`` builds the same plugin list and hands it to the
-    dispatcher. An upgrade is a restart.
+    Plugin selection and configuration are untouched;
+    ``cowrie.core.output.load_plugins()`` builds the same plugin list and
+    the application container hands it to the dispatcher. An upgrade is a
+    restart.
 
 Plugin failure handling
     ``write()`` exceptions are caught per plugin and rate-limited (first
@@ -290,7 +291,10 @@ Shutdown
     (``cowrie.session.closed``, the ttylog-closed record) deliver before a
     sink's backend (a database pool, an hpfeeds client) is closed. The
     dispatcher tolerates dispatch-after-stop (drop and count) so a late
-    deferred firing during teardown cannot raise into the reactor.
+    deferred firing during teardown cannot raise into the reactor. Only a
+    plugin that started is stopped: the loader registers a plugin's
+    ``stop()`` once its ``start()`` has returned, so a plugin that failed
+    to load is not torn down reaching for what it never acquired.
 
 Blocking plugins
     ``write()`` is called synchronously in the reactor thread -- a plugin

--- a/src/cowrie/core/output.py
+++ b/src/cowrie/core/output.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 
 import abc
 import socket
+from importlib import import_module
 from os import environ
 from typing import TYPE_CHECKING, Any
 
-from twisted.internet import reactor
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
 
@@ -17,12 +18,15 @@ if TYPE_CHECKING:
     from cowrie.core.events import EventDispatcher
 
 # ABOUTME: Base class for output plugins: config wiring, sensor naming, and
-# ABOUTME: the write()/dispatch() contract every plugin implements.
+# ABOUTME: the write()/dispatch() contract every plugin implements. Also
+# ABOUTME: loads the configured plugins and owns their lifecycle.
 # The event ids and their attributes are documented in docs/OUTPUT.rst.
 
 # The time is available in two formats in each event, as key 'time'
 # in epoch format and in key 'timestamp' as a ISO compliant string
 # in UTC.
+
+_log = Logger()
 
 
 def convert(data):
@@ -69,10 +73,6 @@ class Output(metaclass=abc.ABCMeta):
         else:
             self.timeFormat = "%Y-%m-%dT%H:%M:%S.%f%z"
 
-        # Stop only after reactor teardown, so the final events of sessions
-        # closed during shutdown deliver before the sink's resources close.
-        reactor.addSystemEventTrigger("after", "shutdown", self.stop)
-
         self.start()
 
     def dispatch(self, **event: Any) -> None:
@@ -101,3 +101,49 @@ class Output(metaclass=abc.ABCMeta):
         Handle a general event within the output plugin
         """
         pass
+
+
+def load_plugins(reactor: Any, log: Logger = _log) -> list[Output]:
+    """
+    Construct the output plugins enabled in the configuration.
+
+    A plugin is wired into shutdown only once it has started: one whose
+    start() raised never acquired the resources its stop() releases, and
+    calling stop() on it would raise into reactor teardown. A plugin that
+    cannot be loaded is skipped -- the honeypot runs without it rather
+    than not at all.
+
+    Plugins stop after reactor teardown, so the final events of sessions
+    closed during shutdown deliver before a sink's resources close.
+
+    ``log`` names the diagnostic emitter so tests can capture the
+    load failures they provoke instead of printing them.
+    """
+    plugins: list[Output] = []
+
+    for section in CowrieConfig.sections():
+        if not section.startswith("output_"):
+            continue
+        if CowrieConfig.getboolean(section, "enabled", fallback=False) is False:
+            continue
+
+        engine: str = section.split("_")[1]
+        try:
+            plugin: Output = import_module(f"cowrie.output.{engine}").Output()
+        except ImportError:
+            log.failure(
+                "Failed to load output engine: {engine} due to ImportError",
+                engine=engine,
+            )
+            log.info(
+                "Please install the dependencies for {engine} listed in requirements-output.txt",
+                engine=engine,
+            )
+        except Exception:
+            log.failure("Failed to load output engine: {engine}", engine=engine)
+        else:
+            plugins.append(plugin)
+            reactor.addSystemEventTrigger("after", "shutdown", plugin.stop)
+            log.info("Loaded output engine: {engine}", engine=engine)
+
+    return plugins

--- a/src/cowrie/output/kafka.py
+++ b/src/cowrie/output/kafka.py
@@ -76,8 +76,8 @@ class Output(cowrie.core.output.Output):
 
         # Flush before reactor shutdown: Twisted waits for Deferreds from
         # "before" shutdown triggers while the asyncio loop still runs. By
-        # the time the base class calls stop() (after shutdown) the loop no
-        # longer executes tasks, so nothing can be delivered there.
+        # the time stop() runs (after shutdown) the loop no longer executes
+        # tasks, so nothing can be delivered there.
         reactor.addSystemEventTrigger("before", "shutdown", self._flush)
 
         # Producer initialization must be delayed - it requires an asyncio

--- a/src/cowrie/test/test_events.py
+++ b/src/cowrie/test/test_events.py
@@ -348,29 +348,6 @@ class OutputDispatchTests(unittest.TestCase):
         self.assertEqual(len(sink.events), 1)
         self.assertEqual(sink.events[0]["eventid"], "cowrie.abuseipdb.started")
 
-    def test_plugin_stop_runs_after_reactor_teardown(self) -> None:
-        # A plugin's stop() must not close its resources before the final
-        # events of in-flight sessions (emitted during teardown) deliver.
-        from unittest.mock import patch
-
-        from cowrie.core import output
-
-        class QuietPlugin(output.Output):
-            def start(self) -> None:
-                pass
-
-            def stop(self) -> None:
-                pass
-
-            def write(self, event: dict[str, Any]) -> None:
-                pass
-
-        with patch.object(output, "reactor") as reactor:
-            plugin = QuietPlugin()
-        reactor.addSystemEventTrigger.assert_called_once_with(
-            "after", "shutdown", plugin.stop
-        )
-
     def test_plugin_dispatch_without_dispatcher_is_dropped(self) -> None:
         from cowrie.core.output import Output
 

--- a/src/cowrie/test/test_output_lifecycle.py
+++ b/src/cowrie/test/test_output_lifecycle.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for output plugin loading: which plugins are handed to the
+# ABOUTME: dispatcher, and which ones are wired into reactor shutdown.
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+from twisted.logger import ILogObserver, Logger, LogLevel
+from zope.interface import implementer
+
+import cowrie.core.output as output_module
+from cowrie.core.output import Output, load_plugins
+
+
+@implementer(ILogObserver)
+class CaptureObserver:
+    """Holds the log events a test provokes, instead of printing them."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def __call__(self, event: dict[str, Any]) -> None:
+        self.events.append(event)
+
+
+class PluginStartFailed(Exception):
+    def __init__(self) -> None:
+        super().__init__("no api_key configured")
+
+
+class DependencyMissing(ImportError):
+    def __init__(self) -> None:
+        super().__init__("No module named 'hpfeeds'")
+
+
+class StubPlugin(Output):
+    resource: str
+
+    def start(self) -> None:
+        self.resource = "acquired"
+
+    def stop(self) -> None:
+        self.resource = "released"
+
+    def write(self, event: dict[str, Any]) -> None:
+        pass
+
+
+class BrokenPlugin(Output):
+    """A plugin that fails to start, as one with incomplete config does.
+
+    Its stop() touches what start() would have set up, the way hpfeeds3
+    and abuseipdb do -- so calling it after a failed start raises.
+    """
+
+    resource: str
+
+    def start(self) -> None:
+        raise PluginStartFailed
+
+    def stop(self) -> None:
+        self.resource = self.resource.upper()
+
+    def write(self, event: dict[str, Any]) -> None:
+        pass
+
+
+class FakeReactor:
+    def __init__(self) -> None:
+        self.triggers: list[tuple[str, str, Any]] = []
+
+    def addSystemEventTrigger(self, phase: str, event: str, trigger: Any) -> None:
+        self.triggers.append((phase, event, trigger))
+
+    def fire_shutdown(self) -> None:
+        for phase, event, trigger in self.triggers:
+            if (phase, event) == ("after", "shutdown"):
+                trigger()
+
+
+class FakeConfig:
+    """Enough of CowrieConfig for the loader and the Output base class."""
+
+    def __init__(self, **enabled: bool) -> None:
+        self.enabled = enabled
+
+    def sections(self) -> list[str]:
+        return ["honeypot", "ssh", *(f"output_{name}" for name in self.enabled)]
+
+    def getboolean(self, section: str, option: str, fallback: bool = False) -> bool:
+        if option == "enabled":
+            return self.enabled[section.removeprefix("output_")]
+        return fallback
+
+    def get(self, section: str, option: str, fallback: Any = None) -> Any:
+        return fallback
+
+
+class LoadPluginsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # The loader's own diagnostics, captured rather than printed: two
+        # of these tests provoke a load failure on purpose.
+        self.observer = CaptureObserver()
+        self.log = Logger(observer=self.observer)
+
+    def messages(self) -> list[str]:
+        return [event["log_format"].format(**event) for event in self.observer.events]
+
+    def failures(self) -> list[dict[str, Any]]:
+        return [e for e in self.observer.events if e["log_level"] is LogLevel.critical]
+
+    def load(self, config: FakeConfig, **modules: type[Output]) -> Any:
+        """Run the loader against stub plugin modules and a fake reactor."""
+        reactor = FakeReactor()
+        engines = {
+            f"cowrie.output.{name}": SimpleNamespace(Output=plugin)
+            for name, plugin in modules.items()
+        }
+        with (
+            patch.object(output_module, "CowrieConfig", config),
+            patch.object(output_module, "import_module", engines.__getitem__),
+        ):
+            plugins = load_plugins(reactor, log=self.log)
+        return plugins, reactor
+
+    def test_enabled_plugin_is_loaded_and_stopped_at_shutdown(self) -> None:
+        plugins, reactor = self.load(FakeConfig(stub=True), stub=StubPlugin)
+
+        self.assertEqual([type(p) for p in plugins], [StubPlugin])
+        self.assertEqual(plugins[0].resource, "acquired")
+        self.assertEqual(self.messages(), ["Loaded output engine: stub"])
+        self.assertEqual(self.failures(), [])
+
+        # After teardown, not before: a plugin's stop() must not close its
+        # resources until the final events of sessions torn down during
+        # shutdown have been delivered.
+        self.assertEqual(reactor.triggers, [("after", "shutdown", plugins[0].stop)])
+
+        reactor.fire_shutdown()
+        self.assertEqual(plugins[0].resource, "released")
+
+    def test_disabled_plugin_is_not_loaded(self) -> None:
+        plugins, reactor = self.load(FakeConfig(stub=False), stub=StubPlugin)
+
+        self.assertEqual(plugins, [])
+        self.assertEqual(reactor.triggers, [])
+
+    def test_plugin_that_failed_to_start_is_never_stopped(self) -> None:
+        """A plugin whose start() raised never acquired anything, so its
+        stop() must not run at shutdown -- it would raise into reactor
+        teardown reaching for what start() would have set up."""
+        plugins, reactor = self.load(FakeConfig(broken=True), broken=BrokenPlugin)
+
+        self.assertEqual(plugins, [])
+        self.assertEqual(reactor.triggers, [])
+        reactor.fire_shutdown()
+
+        self.assertEqual(self.messages(), ["Failed to load output engine: broken"])
+        self.assertEqual(
+            [f["log_failure"].type for f in self.failures()], [PluginStartFailed]
+        )
+
+    def test_failing_plugin_does_not_stop_the_others_loading(self) -> None:
+        plugins, reactor = self.load(
+            FakeConfig(broken=True, stub=True),
+            broken=BrokenPlugin,
+            stub=StubPlugin,
+        )
+
+        self.assertEqual([type(p) for p in plugins], [StubPlugin])
+        self.assertEqual(
+            self.messages(),
+            [
+                "Failed to load output engine: broken",
+                "Loaded output engine: stub",
+            ],
+        )
+
+        reactor.fire_shutdown()
+        self.assertEqual(plugins[0].resource, "released")
+
+    def test_missing_dependency_is_reported_and_skipped(self) -> None:
+        """A plugin whose third-party dependency is not installed is
+        skipped with a hint, not fatal to the honeypot."""
+
+        def raise_import_error(name: str) -> Any:
+            raise DependencyMissing
+
+        reactor = FakeReactor()
+        with (
+            patch.object(output_module, "CowrieConfig", FakeConfig(hpfeeds3=True)),
+            patch.object(output_module, "import_module", raise_import_error),
+        ):
+            plugins = load_plugins(reactor, log=self.log)
+
+        self.assertEqual(plugins, [])
+        self.assertEqual(reactor.triggers, [])
+        self.assertEqual(
+            self.messages(),
+            [
+                "Failed to load output engine: hpfeeds3 due to ImportError",
+                "Please install the dependencies for hpfeeds3 listed in"
+                " requirements-output.txt",
+            ],
+        )

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import os
 import sys
-from importlib import import_module
 from typing import ClassVar
 
 from twisted._version import __version__ as __twisted_version__
@@ -28,7 +27,7 @@ from cowrie import __version__ as __cowrie_version__
 from cowrie.core import checkers, uuid
 from cowrie.core.config import CowrieConfig
 from cowrie.core.events import ConsoleRenderer, EventDispatcher
-from cowrie.core.output import Output
+from cowrie.core.output import Output, load_plugins
 from cowrie.core.utils import create_endpoint_services, get_endpoints_from_section
 from cowrie.pool_interface.handler import PoolHandler
 
@@ -150,28 +149,7 @@ Makes a Cowrie SSH/Telnet honeypot.
         Output.dispatcher = self.dispatcher
 
         # Load output modules
-        self.output_plugins = []
-        for x in CowrieConfig.sections():
-            if not x.startswith("output_"):
-                continue
-            if CowrieConfig.getboolean(x, "enabled", fallback=False) is False:
-                continue
-            engine: str = x.split("_")[1]
-            try:
-                output = import_module(f"cowrie.output.{engine}").Output()
-                self.output_plugins.append(output)
-                _log.info("Loaded output engine: {engine}", engine=engine)
-            except ImportError:
-                _log.failure(
-                    "Failed to load output engine: {engine} due to ImportError",
-                    engine=engine,
-                )
-                _log.info(
-                    "Please install the dependencies for {engine} listed in requirements-output.txt",
-                    engine=engine,
-                )
-            except Exception:
-                _log.failure("Failed to load output engine: {engine}", engine=engine)
+        self.output_plugins = load_plugins(reactor)
 
         self.dispatcher.sinks = [*self.output_plugins, renderer]
 


### PR DESCRIPTION
`Output.__init__` registered the plugin's `stop()` with the reactor *before* calling `start()`. A plugin whose `start()` raised — one with incomplete configuration, say — was therefore dropped by the loader but kept its shutdown trigger, and at teardown its `stop()` reached for what `start()` never set up.

Reproduced against a real cowrie with `output_abuseipdb` enabled and no `dump_path`:

```
[twisted.internet.base#critical] While calling system event trigger handler
  File "cowrie/output/abuseipdb.py", line 116, in stop
    self.logbook.cleanup_and_dump_state(mode=1)
builtins.AttributeError: 'Output' object has no attribute 'logbook'
```

`hpfeeds3` fails the same way (`self.client.stopService()`); `mysql` only escapes it because its `stop()` carries a defensive `hasattr(self, "db")` guard.

Give the loader the lifecycle. `cowrie.core.output.load_plugins()` constructs each enabled plugin and registers its `stop()` **only once it has started**, so a plugin that never ran is never torn down. The loader moves next to the base class it constructs, which also makes it testable — the previous loop lived inside `CowrieServiceMaker.makeService`, which binds ports.

Verified with the same config end-to-end: on `main` the traceback above appears at teardown; on this branch the plugin is skipped with its failure logged, the healthy plugins load, and shutdown is clean.

Notes for review:

- **Teardown order is unchanged** (load order, not reversed). Output plugins have no dependencies on each other, so reversing would be ceremony; keeping load order also makes shutdown behaviour byte-identical to today apart from the fix. The dispatcher's own `stop` is still registered first and so still runs first.
- **`test_plugin_stop_runs_after_reactor_teardown` was removed** from `test_events.py`. It asserted the registration happens in `Output.__init__`, which is exactly what moved. Its guarantee — after-teardown, so the final events of sessions closed during shutdown deliver before a sink's resources close — is now asserted in the loader test, comment and all.
- **The loader's diagnostics change namespace**, `cowrie.plugin` to `cowrie.core.output`. Nothing in `cowrie.cfg.dist` references the old one.
- `load_plugins()` takes an optional `log` argument so the two tests that provoke a load failure capture it instead of printing it — the same seam `EventDispatcher` already uses for sink failures, and it keeps test output pristine.
- One residual, not addressed here: a plugin that registers its *own* reactor triggers inside `start()` is outside this guarantee. Only `output/kafka.py` does (a `before shutdown` flush), and it is ordered so nothing after that registration can raise. Worth knowing before the pattern is copied.

Also updates `docs/EVENT_PIPELINE.rst` (which described `cowrie_plugin.py` as building the plugin list) and a comment in `output/kafka.py` that attributed the `stop()` call to the base class.
