### PR TITLE
test: pin the auth answer the telnet proxy password test depends on

### DIFF
--- a/src/cowrie/test/test_telnet_proxy_handler.py
+++ b/src/cowrie/test/test_telnet_proxy_handler.py
@@ -49,10 +49,17 @@ class TerminatingCharTests(unittest.TestCase):
             h.processUsernameInput()
         return h
 
-    def _password(self, data: bytes) -> Any:
+    def _password(self, data: bytes, *, valid: bool = False) -> Any:
+        """Before forwarding a password the handler asks the honeypot's own
+        auth whether the credentials are valid. Pin that answer: it decides
+        which password is forwarded, and left to itself it reads the
+        operator's etc/userdb.txt, which is not part of the repository."""
         h = _handler()
         h.currentData = data
-        h.processPasswordInput()
+        checker = MagicMock()
+        checker.return_value.checkUserPass.return_value = valid
+        with patch.object(telnet_handler, "HoneypotPasswordChecker", checker):
+            h.processPasswordInput()
         return h
 
     def test_username_with_crlf(self) -> None:
@@ -85,6 +92,14 @@ class TerminatingCharTests(unittest.TestCase):
 
         self.assertEqual(h.currentData, b"secretfake\r")
         self.assertFalse(h.inputingPassword)
+
+    def test_valid_password_forwards_the_backend_password(self) -> None:
+        """Credentials the honeypot accepts send the backend its real
+        password; only rejected ones get the deliberately wrong one."""
+        h = self._password(b"hunter2\r\n", valid=True)
+
+        self.assertEqual(h.currentData, b"secret\r\n")
+        self.assertTrue(h.authDone)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`TerminatingCharTests.test_password_with_crlf` and `test_password_with_bare_trailing_cr` fail on every Tox job, on every branch:

```
AssertionError: b'secret\r\n' != b'secretfake\r\n'
```

`processPasswordInput()` asks `HoneypotPasswordChecker` whether the credentials are valid, and forwards the backend's real password when they are, `backendPassword + b"fake"` when they are not. The tests assert the wrong-password form without controlling that answer, so they inherit whatever userdb the machine happens to have:

- on a developer's machine `etc/userdb.txt` exists — it is in `etc/.gitignore` — and rejects `("", "hunter2")`, so the handler forwards `secretfake` and the tests pass;
- in CI there is no `etc/userdb.txt`, `UserDB` falls back to the packaged `etc/userdb.example`, which accepts, so the handler forwards `secret` and the tests fail.

Reproducible either way locally by pointing `COWRIE_HONEYPOT_ETC_PATH` at an empty directory.

Pin the answer in the `_password` helper so the tests exercise the terminating-char handling they are about, and add the accepted-credentials case, which nothing asserted before — that branch was only ever reached by accident, in CI, where it made the test fail.

Verified with and without a local `etc/userdb.txt`: 6 tests in the module pass under both, and the full suite is green under both.
