### PR TITLE
test: satisfy mypy on four test modules

### DIFF
--- a/src/cowrie/test/test_asciinema.py
+++ b/src/cowrie/test/test_asciinema.py
@@ -45,7 +45,8 @@ class PlaylogDecodeTests(unittest.TestCase):
     def _convert(self, *chunks: bytes) -> dict:
         asciinema.playlog(_ttylog(*chunks), {"colorify": False, "output": self.outfile})
         with open(self.outfile) as f:
-            return json.load(f)
+            recording: dict = json.load(f)
+        return recording
 
     def test_plain_output_is_converted(self) -> None:
         log = self._convert(b"hello\n")

--- a/src/cowrie/test/test_filetransfer.py
+++ b/src/cowrie/test/test_filetransfer.py
@@ -97,7 +97,8 @@ class UploadSizeTests(unittest.TestCase):
         handle.close()
         node = self.server.fs.getfile("/tmp/up.bin")
         assert node is not None
-        return node[fs.A_SIZE]
+        size: int = node[fs.A_SIZE]
+        return size
 
     def test_sequential_write(self) -> None:
         self.assertEqual(self._upload([(0, b"0123456789")]), 10)

--- a/src/cowrie/test/test_fs.py
+++ b/src/cowrie/test/test_fs.py
@@ -285,6 +285,7 @@ class UploadCloseTests(unittest.TestCase):
         )
         self.fs.mkfile("/tmp/payload", 0, 0, 0, 0o644)
         fd = self.fs.open("/tmp/payload", os.O_CREAT | os.O_WRONLY, 0o644)
+        assert fd is not None
         os.write(fd, contents)
         return fd
 

--- a/src/cowrie/test/test_ftpget.py
+++ b/src/cowrie/test/test_ftpget.py
@@ -207,6 +207,13 @@ class FtpGetCtrlCKeepsDownloadingTests(unittest.TestCase):
         cmd.transfer_running = True
         return cmd
 
+    def _receiver(self, cmd: Command_ftpget) -> FTPFileReceiver:
+        """The receiver the mid-transfer fixture installed. The command
+        declares it optional, since it only exists once a transfer has
+        started."""
+        assert cmd.receiver is not None
+        return cmd.receiver
+
     def _ctrl_c(self, cmd: Command_ftpget) -> None:
         with mock.patch.object(HoneyPotCommand, "exit"):
             cmd.handle_CTRL_C()
@@ -217,16 +224,18 @@ class FtpGetCtrlCKeepsDownloadingTests(unittest.TestCase):
 
         self._ctrl_c(cmd)
 
-        cast("mock.Mock", cmd.receiver.transport).loseConnection.assert_not_called()
+        cast(
+            "mock.Mock", self._receiver(cmd).transport
+        ).loseConnection.assert_not_called()
 
     def test_the_rest_of_the_sample_is_still_written(self) -> None:
         """exit() must not close the artifact out from under the transfer, or
         the capture is truncated to whatever had arrived by then."""
         cmd = self._mid_transfer()
-        cmd.receiver.dataReceived(b"first half ")
+        self._receiver(cmd).dataReceived(b"first half ")
 
         self._ctrl_c(cmd)
-        cmd.receiver.dataReceived(b"second half")
+        self._receiver(cmd).dataReceived(b"second half")
 
         cmd.artifactFile.fp.flush()
         with open(cmd.artifactFile.fp.name, "rb") as f:
@@ -234,7 +243,7 @@ class FtpGetCtrlCKeepsDownloadingTests(unittest.TestCase):
 
     def test_completion_after_ctrl_c_still_reports_the_download(self) -> None:
         cmd = self._mid_transfer()
-        cmd.receiver.dataReceived(b"malware")
+        self._receiver(cmd).dataReceived(b"malware")
         self._ctrl_c(cmd)
 
         with mock.patch.object(HoneyPotCommand, "exit"):
@@ -255,7 +264,7 @@ class FtpGetCtrlCKeepsDownloadingTests(unittest.TestCase):
         with mock.patch.object(HoneyPotCommand, "exit"):
             cmd._download_error(Failure(ConnectionDone()))
 
-        cmd.errorWrite.assert_not_called()
+        cast("mock.Mock", cmd.errorWrite).assert_not_called()
 
     def test_error_is_reported_while_the_command_is_still_running(self) -> None:
         cmd = self._mid_transfer()
@@ -263,7 +272,7 @@ class FtpGetCtrlCKeepsDownloadingTests(unittest.TestCase):
         with mock.patch.object(HoneyPotCommand, "exit"):
             cmd._download_error(Failure(ConnectionDone()))
 
-        cmd.errorWrite.assert_called_once()
+        cast("mock.Mock", cmd.errorWrite).assert_called_once()
 
 
 class FTPFileReceiverSizeLimitTests(unittest.TestCase):


### PR DESCRIPTION
The `typing` job fails on ten mypy errors, all in test modules, on every branch:

```
src/cowrie/test/test_fs.py:288: error: Argument 1 to "write" has incompatible type "int | None"; expected "int"
src/cowrie/test/test_fs.py:289: error: Incompatible return value type (got "int | None", expected "int")
src/cowrie/test/test_asciinema.py:48: error: Returning Any from function declared to return "dict[Any, Any]"
src/cowrie/test/test_filetransfer.py:100: error: Returning Any from function declared to return "int"
src/cowrie/test/test_ftpget.py:220: error: Item "None" of "FTPFileReceiver | None" has no attribute "transport"
src/cowrie/test/test_ftpget.py:226,229,237: error: Item "None" of "FTPFileReceiver | None" has no attribute "dataReceived"
src/cowrie/test/test_ftpget.py:258,266: error: "Callable[[str], None]" has no attribute "assert_not_called" / "assert_called_once"
```

Three kinds, fixed in the way each calls for:

- **Optionals used without narrowing** — a honeyfs descriptor and the ftpget receiver. Narrowed with `assert`, which is how `test_filetransfer.py` already spells it. For ftpget the assert lives in a `_receiver()` helper, since four tests need it and the command declares `receiver` optional because it only exists once a transfer is running.
- **Values widening to `Any` on the way out** — `json.load` and a honeyfs node field. Named the intermediate with the type the function promises.
- **Mock assertions on attributes whose declared type is the real method** — `cast("mock.Mock", ...)`, matching the existing `cast("mock.Mock", ...)` in the same file.

No test behaviour changes. To confirm the `cast()` edits did not defang the assertions they wrap, the guarded production path was mutated (`_download_error` made to return before reporting) and the corresponding test still fails.

`mypy src` is clean afterwards (304 source files). Note this alone does not turn CI green — the two `test_telnet_proxy_handler` failures are a separate fix.
