### PR TITLE
docker: pin the container's uid

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,8 +29,8 @@ ENV LC_ALL=en_US.UTF-8 \
 
 # -l keeps useradd from sizing the lastlog and faillog databases to the
 # uid, which would add a large sparse file to the image.
-RUN groupadd -r -g ${COWRIE_GID} ${COWRIE_GROUP} && \
-    useradd -r -l -u ${COWRIE_UID} -d ${COWRIE_HOME} -m -g ${COWRIE_GROUP} ${COWRIE_USER}
+RUN groupadd -r -g "${COWRIE_GID}" "${COWRIE_GROUP}" && \
+    useradd -r -l -u "${COWRIE_UID}" -d "${COWRIE_HOME}" -m -g "${COWRIE_GROUP}" "${COWRIE_USER}"
 
 # Set up Debian prereqs
 RUN export DEBIAN_FRONTEND=noninteractive; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,8 +11,15 @@ FROM debian:trixie-slim AS builder
 
 WORKDIR /
 
+# 999 is the id useradd -r has been allocating here all along, so an
+# existing bind-mounted var/ keeps its owner across an upgrade. Pinning it
+# means a rebuild cannot silently move it, and lets USER name the account
+# numerically, which is the only form a host can resolve without this
+# image's passwd file (Kubernetes runAsNonRoot, hadolint DL3066).
 ENV COWRIE_GROUP=cowrie \
     COWRIE_USER=cowrie \
+    COWRIE_UID=999 \
+    COWRIE_GID=999 \
     COWRIE_HOME=/cowrie
 
 # Set locale to UTF-8, otherwise upstream libraries have bytes/string conversion issues
@@ -20,8 +27,10 @@ ENV LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8
 
-RUN groupadd -r ${COWRIE_GROUP} && \
-    useradd -r -d ${COWRIE_HOME} -m -g ${COWRIE_GROUP} ${COWRIE_USER}
+# -l keeps useradd from sizing the lastlog and faillog databases to the
+# uid, which would add a large sparse file to the image.
+RUN groupadd -r -g ${COWRIE_GID} ${COWRIE_GROUP} && \
+    useradd -r -l -u ${COWRIE_UID} -d ${COWRIE_HOME} -m -g ${COWRIE_GROUP} ${COWRIE_USER}
 
 # Set up Debian prereqs
 RUN export DEBIAN_FRONTEND=noninteractive; \
@@ -43,7 +52,10 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
       rustc && \
     rm -rf /var/lib/apt/lists/*
 
-USER ${COWRIE_USER}
+# Spelled out rather than ${COWRIE_UID}, so that what the image declares
+# it runs as is readable without resolving this build's variables. Keep in
+# step with COWRIE_UID and COWRIE_GID above.
+USER 999:999
 WORKDIR ${COWRIE_HOME}
 
 # Copy requirements first to use Docker caching better
@@ -85,8 +97,8 @@ ENV COWRIE_GROUP=cowrie \
     COWRIE_USER=cowrie \
     COWRIE_HOME=/cowrie
 
-#RUN groupadd -r ${COWRIE_GROUP} && \
-#    useradd -r -d ${COWRIE_HOME} -m -g ${COWRIE_GROUP} ${COWRIE_USER}
+# The account comes over from the builder: distroless carries no shell for
+# useradd to run in, and the id must resolve for the COPY --chown below.
 COPY --from=builder --chown=0:0 /etc/passwd /etc/group /etc/
 
 #RUN export DEBIAN_FRONTEND=noninteractive; \
@@ -113,7 +125,8 @@ RUN [ "python3", "-c", "import sys, compileall; v=str(sys.version_info.major)+'.
 
 VOLUME [ "/cowrie/cowrie-git/var", "/cowrie/cowrie-git/etc" ]
 
-USER ${COWRIE_USER}
+# The uid the builder stage created, numeric for the same reason.
+USER 999:999
 WORKDIR ${COWRIE_HOME}/cowrie-git
 
 ENV PATH=${COWRIE_HOME}/cowrie-env/bin:${PATH}


### PR DESCRIPTION
The image runs as `cowrie`, an account `useradd -r` allocates, so its numeric id is whatever the base image happened to have free. It has been 999 in every published build — `docker.io/cowrie/cowrie:latest` carries `cowrie:x:999:999::/cowrie:/bin/sh` — but nothing holds it there. A base image that grows one more system account moves it, and an operator's bind-mounted `var/` then belongs to a uid the container no longer runs as.

Pin it at the id already in use, and declare `USER` numerically:

- **999, not 1000.** The id is the one the published image already has, so existing bind mounts keep working across the upgrade. Picking a "nicer" number would silently change ownership under everyone's `var/log/cowrie` and `var/lib/cowrie/downloads`.
- **`USER 999:999` rather than `USER ${COWRIE_UID}`.** A host cannot resolve the name `cowrie` without this image's passwd file — which is why Kubernetes cannot verify `runAsNonRoot` against it, and why hadolint reports DL3066. A variable does not help: the value is not readable from the image config either.
- **`useradd -l`.** Pinning the id makes useradd size the lastlog and faillog databases to it, adding a large sparse file to the image (DL3046). `-l` skips those databases.

This is what fails the `lint` job on #40564: DL3066 is new in hadolint 2.15.0, which that PR pulls in with `hadolint-action` 3.4.0. Nothing about the Dockerfile changed there — the linter got stricter, and it has a point. With this merged, #40564 rebases and goes green (its `typing` failure is stale, fixed separately in #40578).

Verified with hadolint 2.15.0 downloaded from the upstream release and checksum-verified, run exactly as CI runs it:

```
$ hadolint-2.15.0 docker/Dockerfile      # before
docker/Dockerfile:46 DL3066 info: Non-numeric user-id may not be resolvable by host system
docker/Dockerfile:116 DL3066 info: Non-numeric user-id may not be resolvable by host system
exit=1

$ hadolint-2.15.0 docker/Dockerfile      # after
exit=0
```

Also clean under 2.14.0, the version CI pins today, so this does not depend on #40564 landing first.

Two things to look at:

- **I have not built the image** — no Docker daemon on this machine — so the amd64/arm64 build jobs on this PR are the first real build. The risk is `groupadd -g 999` colliding on a future `debian:trixie-slim`; it does not collide today, which is exactly why 999 is the id in the published image.
- **I removed the commented-out `groupadd`/`useradd` pair in the runtime stage** and replaced it with a comment explaining where the account actually comes from. They were a stale copy of the line this PR changes, so uncommenting them would have quietly reintroduced an unpinned uid. Say the word and I will put them back.
