### PR TITLE
fix: use explicit collection_id for VirusTotal collections

### DIFF
--- a/docs/virustotal/README.rst
+++ b/docs/virustotal/README.rst
@@ -52,9 +52,9 @@ Add the following to your ``etc/cowrie.cfg`` file:
     # Note: This doubles API requests for downloads
     scan_url = true
 
-    # Optional: Collection name for organizing artifacts
-    # If not set, no collection will be created
-    collection = cowrie
+    # Optional: Add uploaded files and submitted URLs to an existing
+    # VirusTotal collection (create it in the VT GUI first, see below).
+    #collection_id = <collection-id-from-vt-gui-url>
 
     # Optional: Custom comment text (default: Cowrie attribution)
     #commenttext = First seen by #Cowrie SSH/telnet Honeypot http://github.com/cowrie/cowrie
@@ -103,15 +103,14 @@ Add a comment to newly uploaded files and submitted URLs. The comment includes:
 * Link to Cowrie GitHub repository
 * ``#Cowrie`` hashtag for easy searching in VirusTotal
 
-collection (optional, default: None)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+collection_id (optional, default: None)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Name of a VirusTotal collection to organize all Cowrie artifacts. When set:
+The ID of an existing VirusTotal collection. When set, uploaded files and
+submitted URLs are added to this collection.
 
-* Collection is automatically created on Cowrie startup (if it doesn't exist)
-* All uploaded files are added to the collection
-* All submitted URLs are added to the collection
-* Provides centralized view of all honeypot findings in VirusTotal
+Create the collection in the VirusTotal GUI, then copy its ID from the
+URL: ``https://www.virustotal.com/gui/collection/<collection-id>``.
 
 **Benefits**:
 
@@ -119,8 +118,6 @@ Name of a VirusTotal collection to organize all Cowrie artifacts. When set:
 * Share collection with other researchers
 * Monitor honeypot activity over time
 * Export IOCs from the collection
-
-If not set or commented out, no collection operations will be performed.
 
 debug (optional, default: False)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -209,10 +206,12 @@ Collections organize related files and URLs in VirusTotal for better tracking an
 Setting Up a Collection
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Add ``collection = cowrie`` to your configuration
-2. Restart Cowrie
-3. Collection will be automatically created on first startup
-4. All subsequent uploads/submissions will be added to this collection
+1. In the VirusTotal GUI, create a collection (or open an existing one)
+2. Copy its ID from the URL:
+   ``https://www.virustotal.com/gui/collection/<collection-id>``
+3. Set ``collection_id = <collection-id>`` in your configuration
+4. Restart Cowrie — uploaded files and submitted URLs are added to this
+   collection
 
 Accessing Your Collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -220,8 +219,6 @@ Accessing Your Collection
 View your collection in VirusTotal:
 
 ``https://www.virustotal.com/gui/collection/<collection-id>``
-
-The collection ID is logged when the collection is created.
 
 Collection Features
 ~~~~~~~~~~~~~~~~~~~
@@ -298,14 +295,15 @@ Rate Limit Errors
 * Reduce scan frequency by disabling ``scan_url``
 * Upgrade to paid API tier
 
-Collection Already Exists
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Artifacts Are Not Added To A Collection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: text
+**Cause**: ``collection_id`` is not set, or refers to a collection you do
+not have access to.
 
-    VT: Collection 'cowrie' already exists - will use existing
-
-**Not an error**: This is normal behavior. The plugin will reuse the existing collection.
+**Solution**: Create the collection in the VirusTotal GUI and set
+``collection_id`` to its ID. See ``collection_id`` under Configuration
+Options.
 
 Debug Mode
 ~~~~~~~~~~
@@ -330,7 +328,6 @@ The plugin uses VirusTotal v3 API endpoints:
 * ``GET /api/v3/urls/{url_id}`` - Retrieve URL scan report
 * ``POST /api/v3/urls`` - Submit URL for scanning
 * ``POST /api/v3/urls/{id}/comments`` - Add comment to URL
-* ``POST /api/v3/collections`` - Create collection
 * ``POST /api/v3/collections/{id}/files`` - Add file to collection
 * ``POST /api/v3/collections/{id}/urls`` - Add URL to collection
 

--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -1091,9 +1091,9 @@ upload = True
 debug = False
 scan_file = True
 scan_url = True
-# Optional: Organize uploaded files and URLs in a VirusTotal collection
-# If not set, no collection will be created
-#collection = cowrie
+# Optional: Add uploaded files and URLs to an existing VirusTotal collection
+# (create it in the VT GUI first, then set its ID here)
+#collection_id = <collection-id-from-vt-gui-url>
 
 
 # Cuckoo output module

--- a/src/cowrie/output/virustotal.py
+++ b/src/cowrie/output/virustotal.py
@@ -102,6 +102,11 @@ class Output(cowrie.core.output.Output):
         self.collection_id = CowrieConfig.get(
             "output_virustotal", "collection_id", fallback=None
         )
+        if CowrieConfig.get("output_virustotal", "collection", fallback=None):
+            self._log.warn(
+                "virustotal: 'collection' is no longer supported and is ignored; "
+                "set 'collection_id' instead (see docs/virustotal/README.rst)."
+            )
         self.agent = client.Agent(reactor)
 
     def stop(self) -> None:

--- a/src/cowrie/output/virustotal.py
+++ b/src/cowrie/output/virustotal.py
@@ -13,7 +13,7 @@ import datetime
 import json
 import os
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote, urlencode, urlparse
+from urllib.parse import urlencode, urlparse
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -72,7 +72,6 @@ class Output(cowrie.core.output.Output):
     scan_url: bool
     scan_file: bool
     url_cache: dict[str, datetime.datetime]  # url and last time succesfully submitted
-    collection_name: str | None = None
     collection_id: str | None = None
 
     def start(self) -> None:
@@ -100,14 +99,10 @@ class Output(cowrie.core.output.Output):
         self.commenttext = CowrieConfig.get(
             "output_virustotal", "commenttext", fallback=COMMENT
         )
-        self.collection_name = CowrieConfig.get(
-            "output_virustotal", "collection", fallback=None
+        self.collection_id = CowrieConfig.get(
+            "output_virustotal", "collection_id", fallback=None
         )
         self.agent = client.Agent(reactor)
-
-        # Initialize collection if configured
-        if self.collection_name:
-            self._init_collection()
 
     def stop(self) -> None:
         """
@@ -359,7 +354,7 @@ class Output(cowrie.core.output.Output):
                 data = j["data"]
                 if data.get("id"):
                     self._log.info("VT: File uploaded successfully")
-                    if self.collection_name:
+                    if self.collection_id:
                         self._add_to_collection("files", sha256, f"file {sha256}")
                     if self.comment:
                         return self._post_comment("files", sha256, "Comment")
@@ -527,7 +522,7 @@ class Output(cowrie.core.output.Output):
                         .decode()
                         .rstrip("=")
                     )
-                    if self.collection_name:
+                    if self.collection_id:
                         self._add_to_collection("urls", url_id, f"URL {url_id}")
                     if self.comment:
                         return self._post_comment("urls", url_id, "URL comment")
@@ -605,100 +600,6 @@ class Output(cowrie.core.output.Output):
             error_prefix=f"VT post{comment_type.lower()}",
         )
 
-    def _init_collection(self) -> None:
-        """
-        Resolve the collection id: look up an existing collection with this name
-        and reuse it, otherwise create one. Called during start() if a
-        collection is configured.
-
-        Looking up by name first reuses the server-assigned id across restarts
-        (it is not derivable from the name) and avoids creating a duplicate
-        collection on every start.
-        """
-        query = quote(f"name:{self.collection_name} owner:me")
-        vtUrl = f"{VTAPI_URL}collections?filter={query}&limit=40".encode()
-        headers = self._build_headers()
-
-        def process_response(body_bytes):
-            if self.debug:
-                self._log.info("VT find collection result: {body}", body=body_bytes)
-            j = json.loads(body_bytes.decode("utf8"))
-            # The name filter may be loose, so match the name exactly.
-            if "error" not in j:
-                for item in j.get("data", []):
-                    attributes = item.get("attributes", {})
-                    if attributes.get("name") == self.collection_name and item.get(
-                        "id"
-                    ):
-                        self.collection_id = item["id"]
-                        self._log.info(
-                            "VT: Using existing collection '{collection}' with ID: {collection_id}",
-                            collection=self.collection_name,
-                            collection_id=item["id"],
-                        )
-                        return
-            # No existing collection found (or the search errored): create it.
-            self._create_collection()
-
-        self._make_request(
-            b"GET",
-            vtUrl,
-            headers,
-            process_response=process_response,
-            error_prefix="VT find collection",
-        )
-
-    def _create_collection(self) -> None:
-        """Create the configured collection and store its server-assigned id."""
-        vtUrl = f"{VTAPI_URL}collections".encode()
-        collection_data = {
-            "data": {
-                "type": "collection",
-                "attributes": {
-                    "name": self.collection_name,
-                    "description": f"Cowrie honeypot artifacts - {self.collection_name}",
-                },
-            }
-        }
-        headers = self._build_headers(content_type="application/json")
-        body = StringProducer(json.dumps(collection_data).encode("utf-8"))
-
-        def process_response(body_bytes):
-            if self.debug:
-                self._log.info("VT create collection result: {body}", body=body_bytes)
-            j = json.loads(body_bytes.decode("utf8"))
-
-            if "error" in j:
-                self._log.info(
-                    "VT: Collection creation error - {code}: {msg}",
-                    code=j["error"].get("code"),
-                    msg=j["error"].get("message", "Unknown error"),
-                )
-                return
-
-            if "data" in j:
-                collection_id = j["data"].get("id")
-                if collection_id:
-                    self.collection_id = collection_id
-                    self._log.info(
-                        "VT: Collection '{collection}' created with ID: {collection_id}",
-                        collection=self.collection_name,
-                        collection_id=collection_id,
-                    )
-                else:
-                    self._log.info("VT: Collection created but no ID returned")
-            else:
-                self._log.info("VT: unexpected collection creation response format")
-
-        self._make_request(
-            b"POST",
-            vtUrl,
-            headers,
-            body=body,
-            process_response=process_response,
-            error_prefix="VT create collection",
-        )
-
     def _add_to_collection(
         self, resource_type: str, resource_id: str, resource_descriptor: str
     ) -> defer.Deferred[Any]:
@@ -710,13 +611,7 @@ class Output(cowrie.core.output.Output):
             resource_id: The file hash or URL ID
             resource_descriptor: Human-readable description for logging
         """
-        if not self.collection_name or not self.collection_id:
-            # Collection not configured or not initialized yet
-            if self.debug and self.collection_name:
-                self._log.info(
-                    "VT: Cannot add {resource} to collection - collection ID not yet available",
-                    resource=resource_descriptor,
-                )
+        if not self.collection_id:
             return defer.succeed(None)
 
         vtUrl = f"{VTAPI_URL}collections/{self.collection_id}/{resource_type}".encode()
@@ -749,7 +644,7 @@ class Output(cowrie.core.output.Output):
             self._log.info(
                 "VT: Added {resource} to collection '{collection}'",
                 resource=resource_descriptor,
-                collection=self.collection_name,
+                collection=self.collection_id,
             )
             return True
 

--- a/src/cowrie/test/test_virustotal.py
+++ b/src/cowrie/test/test_virustotal.py
@@ -8,10 +8,11 @@ import json
 import os
 import tempfile
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from twisted.internet import defer
 
+from cowrie.output import virustotal
 from cowrie.output.virustotal import Output
 
 
@@ -138,7 +139,6 @@ class VirusTotalOutputTests(unittest.TestCase):
         file's sha256, not the analysis id the upload returns."""
         self.output.comment = True
         self.output.commenttext = "Test comment"
-        self.output.collection_name = "test-collection"
         self.output.collection_id = "test-collection-id"
 
         captured: dict = {}
@@ -158,7 +158,9 @@ class VirusTotalOutputTests(unittest.TestCase):
             self.output.postfile(tmp_path, "payload.exe", "HASH256")
             # The v3 upload response carries an analysis id, not the file hash.
             captured["process_response"](
-                json.dumps({"data": {"id": "analysis-xyz", "type": "analysis"}}).encode()
+                json.dumps(
+                    {"data": {"id": "analysis-xyz", "type": "analysis"}}
+                ).encode()
             )
         finally:
             os.unlink(tmp_path)
@@ -333,82 +335,29 @@ class VirusTotalOutputTests(unittest.TestCase):
                 # Reset mock for next test
                 self.output.agent.request.reset_mock()
 
-    def test_create_collection_request(self) -> None:
-        """Creating a collection POSTs the v3 collection body."""
-        output = Output()
-        output.apiKey = "test-api-key"
-        output.debug = True
-        output.collection_name = "test-collection"
+    def _started(self, config: Mock) -> Output:
+        """Construct the plugin and run start() against the given config."""
+        with patch.object(virustotal.Output, "start", lambda self: None):
+            output = virustotal.Output()
+        with patch.object(virustotal, "CowrieConfig", config):
+            output.start()
+        return output
 
-        mock_agent = Mock()
-        output.agent = mock_agent
+    def test_start_reads_collection_id_from_config(self) -> None:
+        """start() must load collection_id from config and create nothing."""
+        config = Mock()
+        config.get.side_effect = lambda section, option, fallback=None: {
+            "collection_id": "EXISTING-ID",
+        }.get(option, fallback)
+        config.getboolean.side_effect = lambda section, option, fallback=False: fallback
 
-        output._create_collection()
+        output = self._started(config)
 
-        self.assertTrue(mock_agent.request.called)
-        method, url, _headers, body = mock_agent.request.call_args[0]
-        self.assertEqual(method, b"POST")
-        self.assertEqual(url, b"https://www.virustotal.com/api/v3/collections")
-        collection_data = json.loads(body.body.decode())
-        self.assertEqual(collection_data["data"]["type"], "collection")
-        self.assertEqual(
-            collection_data["data"]["attributes"]["name"], "test-collection"
-        )
-
-    def test_init_collection_reuses_existing(self) -> None:
-        """An existing collection found by name is reused without creating."""
-        self.output.collection_name = "cowrie"
-
-        captured: dict = {}
-
-        def fake_make_request(method, *args, **kwargs):
-            captured["method"] = method
-            captured["process_response"] = kwargs.get("process_response")
-            return defer.succeed(None)
-
-        self.output._make_request = fake_make_request  # type: ignore[method-assign]
-        self.output._create_collection = Mock()  # type: ignore[method-assign]
-
-        self.output._init_collection()
-        # The lookup is a GET against /collections.
-        self.assertEqual(captured["method"], b"GET")
-        captured["process_response"](
-            json.dumps(
-                {"data": [{"id": "EXISTING-ID", "attributes": {"name": "cowrie"}}]}
-            ).encode()
-        )
-
-        self.assertEqual(self.output.collection_id, "EXISTING-ID")
-        self.output._create_collection.assert_not_called()
-
-    def test_init_collection_creates_when_absent(self) -> None:
-        """When no collection matches the name, one is created."""
-        self.output.collection_name = "cowrie"
-
-        captured: dict = {}
-
-        def fake_make_request(method, *args, **kwargs):
-            captured["process_response"] = kwargs.get("process_response")
-            return defer.succeed(None)
-
-        self.output._make_request = fake_make_request  # type: ignore[method-assign]
-        self.output._create_collection = Mock()  # type: ignore[method-assign]
-
-        self.output._init_collection()
-        # A different collection is returned; the name does not match.
-        captured["process_response"](
-            json.dumps(
-                {"data": [{"id": "OTHER-ID", "attributes": {"name": "something-else"}}]}
-            ).encode()
-        )
-
-        self.assertIsNone(self.output.collection_id)
-        self.output._create_collection.assert_called_once()
+        self.assertEqual(output.collection_id, "EXISTING-ID")
 
     def test_add_file_to_collection(self) -> None:
         """Test adding a file to a collection"""
         # Setup output with collection
-        self.output.collection_name = "test-collection"
         self.output.collection_id = "test-collection-id"
 
         # Mock agent request
@@ -426,7 +375,8 @@ class VirusTotalOutputTests(unittest.TestCase):
         # Check method and URL
         self.assertEqual(method, b"POST")
         self.assertEqual(
-            url, b"https://www.virustotal.com/api/v3/collections/test-collection-id/files"
+            url,
+            b"https://www.virustotal.com/api/v3/collections/test-collection-id/files",
         )
 
         # Check body format
@@ -438,7 +388,6 @@ class VirusTotalOutputTests(unittest.TestCase):
     def test_add_url_to_collection(self) -> None:
         """Test adding a URL to a collection"""
         # Setup output with collection
-        self.output.collection_name = "test-collection"
         self.output.collection_id = "test-collection-id"
 
         # Mock agent request
@@ -456,7 +405,8 @@ class VirusTotalOutputTests(unittest.TestCase):
         # Check method and URL
         self.assertEqual(method, b"POST")
         self.assertEqual(
-            url, b"https://www.virustotal.com/api/v3/collections/test-collection-id/urls"
+            url,
+            b"https://www.virustotal.com/api/v3/collections/test-collection-id/urls",
         )
 
         # Check body format
@@ -468,7 +418,6 @@ class VirusTotalOutputTests(unittest.TestCase):
     def test_no_collection_when_not_configured(self) -> None:
         """Test that collection operations are skipped when not configured"""
         # Ensure no collection is configured
-        self.output.collection_name = None
         self.output.collection_id = None
 
         # Mock agent request

--- a/src/cowrie/test/test_virustotal.py
+++ b/src/cowrie/test/test_virustotal.py
@@ -355,6 +355,20 @@ class VirusTotalOutputTests(unittest.TestCase):
 
         self.assertEqual(output.collection_id, "EXISTING-ID")
 
+    def test_start_warns_when_deprecated_collection_set(self) -> None:
+        """A configured 'collection' is ignored and must emit a warning."""
+        log = Mock()
+        config = Mock()
+        config.get.side_effect = lambda section, option, fallback=None: {
+            "collection": "cowrie",
+        }.get(option, fallback)
+        config.getboolean.side_effect = lambda section, option, fallback=False: fallback
+
+        with patch.object(virustotal.Output, "_log", log):
+            self._started(config)
+
+        log.warn.assert_called_once()
+
     def test_add_file_to_collection(self) -> None:
         """Test adding a file to a collection"""
         # Setup output with collection


### PR DESCRIPTION
## Problem
The VirusTotal output plugin tried to reuse a collection by name before creating a new one, via the `GET /api/v3/collections?filter=...` lookup endpoint. That endpoint is deprecated (being moved to Google Threat Intelligence) and returns `403 Forbidden` for standard/community API keys, so the lookup always fell through to creation and collections were never updated. 

## Fix
Make `collection_id` the sole, explicit way to opt in to collections.
- The collections feature remains optional: if `collection_id` is not  set, no collection operations are performed.
- Removed the auto-create-by-name path: `start()` no longer looks up or  creates a collection, and `_create_collection()` and the `collection`  (name) config option are deleted.
- `postfile()`, `submiturl()`, and `_add_to_collection()` now gate on  `collection_id` alone.
- Docs rewritten to a UI-first workflow: create the collection in the VirusTotal GUI, then paste its ID into `collection_id`. Removed the stale "new collection on every restart" troubleshooting entry and the `POST /collections` API-reference line.
- `cowrie.cfg.dist` updated from `collection = cowrie` to `#collection_id = <collection-id-from-vt-gui-url>`.

## Backward compatibility
The `collection` (name) option is removed. On upgrade, users who still have `collection = <name>` set will see collections silently stop working, so `start()` now logs a warning when it detects the deprecated option:  virustotal: 'collection' is no longer supported and is ignored; set 'collection_id' instead (see docs/virustotal/README.rst).
This matches the existing pattern in the Slack output plugin (`timestamp=false` when `simplified` is off).

## Tests
- Replaced `test_create_collection_request` and the two `start()`-flow tests with `test_start_reads_collection_id_from_config` and
  `test_start_warns_when_deprecated_collection_set`.
- Updated the collection tests to use `collection_id` only.
- 16 virustotal tests pass; `ruff check`, `ruff format --check`, and  `mypy` (module and test) are clean.
