### PR TITLE
fix: report IPv6 download targets as unreachable

### DIFF
--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -20,6 +20,7 @@ from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
 from cowrie.core.download import (
     BlockedAddress,
+    UnreachableAddress,
     capture_download,
     fetch,
     outbound_rate_limiter,
@@ -482,6 +483,13 @@ class Command_curl(HoneyPotCommand):
         if response.check(BlockedAddress) is not None:
             self.errorWrite(
                 f"curl: (6) Could not resolve host: {response.value.host}\n"
+            )
+            self.exit()
+            return
+
+        if response.check(UnreachableAddress) is not None:
+            self.errorWrite(
+                f"curl: (7) Failed to connect to {self.host} port {self.port}: Network is unreachable\n"
             )
             self.exit()
             return

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -24,6 +24,7 @@ from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
 from cowrie.core.download import (
     BlockedAddress,
+    UnreachableAddress,
     capture_download,
     fetch,
     outbound_rate_limiter,
@@ -33,6 +34,7 @@ from cowrie.core.network import (
     DownloadLimitExceeded,
     abort_body,
     communication_allowed,
+    is_ip_address,
     outbound_bind_address,
 )
 from cowrie.shell.command import HoneyPotCommand
@@ -298,10 +300,10 @@ class Command_wget(HoneyPotCommand):
             )
             self.errorWrite(f"{proto_label} request sent, awaiting response... ")
 
-        # treq.get() can raise synchronously before returning a Deferred (e.g.
-        # idna.core.InvalidCodepoint for an IPv4-embedded IPv6 URL literal such
-        # as [::ffff:8.8.8.8]). Route that raise through error() so the command
-        # exits instead of being orphaned on the cmdstack until session timeout.
+        # Starting the transfer can raise synchronously before any Deferred
+        # exists: connectTCP rejects an FTP host it cannot build a connection
+        # for. Route that raise through error() so the command exits instead of
+        # being orphaned on the cmdstack until session timeout.
         try:
             if self.scheme == "ftp":
                 self.deferred = self.ftpDownload(urldata)
@@ -348,6 +350,14 @@ class Command_wget(HoneyPotCommand):
 
         if not self.ftp_remote_file:
             self.errorWrite("wget: missing remote filename in FTP URL\n")
+            self.exit(1)
+            return None
+
+        ip = is_ip_address(self.host)
+        if ip is not None and ip.version == 6:
+            # The outbound source address is an IPv4 one, so an IPv6 server is
+            # as unreachable here as it is on the HTTP path.
+            self.errorWrite("failed: Network is unreachable.\n")
             self.exit(1)
             return None
 
@@ -648,6 +658,11 @@ class Command_wget(HoneyPotCommand):
             self.errorWrite(
                 f"wget: unable to resolve host address ‘{response.value.host}’\n"
             )
+            self.exit()
+            return
+
+        if response.check(UnreachableAddress) is not None:
+            self.errorWrite("failed: Network is unreachable.\n")
             self.exit()
             return
 

--- a/src/cowrie/core/download.py
+++ b/src/cowrie/core/download.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urljoin, urlparse
 
@@ -36,6 +37,14 @@ class BlockedAddress(Exception):
 
     def __init__(self, host: str) -> None:
         super().__init__(f"blocked address for host {host}")
+        self.host = host
+
+
+class UnreachableAddress(Exception):
+    """The requested host has no route the honeypot can take."""
+
+    def __init__(self, host: str) -> None:
+        super().__init__(f"no route to host {host}")
         self.host = host
 
 
@@ -127,6 +136,13 @@ def fetch(
         address = yield resolve_allowed(host)
         if address is None:
             raise BlockedAddress(host)
+        if ipaddress.ip_address(address).version == 6:
+            # Fetching over IPv6 is out of reach twice over: the outbound
+            # source address is an IPv4 one, and treq cannot even render a URL
+            # whose host is an IPv6 literal (hyperlink IDNA-encodes the host,
+            # which rejects the colons). Report what a host without an IPv6
+            # route reports.
+            raise UnreachableAddress(host)
 
         response = yield getattr(treq, method)(
             url=url,

--- a/src/cowrie/core/eventids.py
+++ b/src/cowrie/core/eventids.py
@@ -82,6 +82,8 @@ ALL: frozenset[str] = frozenset(
         "cowrie.telnet.exploit_attempt",
         "cowrie.telnet.exploit_success",
         "cowrie.telnet.option",
+        # URLhaus submissions
+        "cowrie.urlhaus.submitted",
         # VirusTotal lookups
         "cowrie.virustotal.scanfile",
         "cowrie.virustotal.scanurl",

--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -128,17 +128,26 @@ class CurlArtifactCleanupTests(unittest.TestCase):
 
     def test_embedded_ipv6_url_does_not_hang(self) -> None:
         # An IPv4-embedded IPv6 URL literal such as [::ffff:8.8.8.8] passes the
-        # network guard (globally routable) but makes treq.get() raise
-        # idna.core.InvalidCodepoint synchronously. That raise must be caught so
-        # the command exits, instead of orphaning it on the cmdstack (a session
-        # hang / DoS) until the session times out.
-        self.proto.lineReceived(b"curl -s 'http://[::ffff:8.8.8.8]/'; echo rc=$?")
+        # network guard (globally routable), so the download reaches the
+        # outbound path. That path is IPv4-only, and the command must report the
+        # network failure and exit rather than being orphaned on the cmdstack (a
+        # session hang / DoS) until the session times out.
+        self.proto.lineReceived(b"curl 'http://[::ffff:8.8.8.8]/'; echo rc=$?")
         out = self.tr.value()
         self.assertIn(
             b"rc=",
             out,
             "shell never resumed: the command hung instead of exiting",
         )
+        self.assertIn(b"Network is unreachable", out)
+
+    def test_ipv6_url_reports_network_unreachable(self) -> None:
+        # Every IPv6 destination takes the same route as the embedded-IPv4 one
+        # above: reported as unreachable, never as an unhandled error.
+        self.proto.lineReceived(b"curl 'http://[2606:4700:4700::1111]/x'; echo rc=$?")
+        out = self.tr.value()
+        self.assertIn(b"curl: (7) Failed to connect to", out)
+        self.assertIn(b"Network is unreachable", out)
 
     def test_late_download_callbacks_after_exit_are_inert(self) -> None:
         # The command can exit while treq is still delivering the body (size

--- a/src/cowrie/test/test_wget.py
+++ b/src/cowrie/test/test_wget.py
@@ -56,12 +56,34 @@ class WgetArtifactCleanupTests(unittest.TestCase):
 
     def test_embedded_ipv6_url_does_not_hang(self) -> None:
         # An IPv4-embedded IPv6 URL literal such as [::ffff:8.8.8.8] passes the
-        # network guard (globally routable) but makes treq.get() raise
-        # idna.core.InvalidCodepoint synchronously. That raise must be caught so
-        # the command exits, instead of orphaning it on the cmdstack (a session
-        # hang / DoS) until the session times out.
-        self.proto.lineReceived(b"wget -q 'http://[::ffff:8.8.8.8]/'; echo rc=$?")
+        # network guard (globally routable), so the download reaches the
+        # outbound path. That path is IPv4-only, and the command must report the
+        # network failure and exit rather than being orphaned on the cmdstack (a
+        # session hang / DoS) until the session times out.
+        self.proto.lineReceived(b"wget 'http://[::ffff:8.8.8.8]/'; echo rc=$?")
         out = self.tr.value()
+        self.assertIn(
+            b"rc=",
+            out,
+            "shell never resumed: the command hung instead of exiting",
+        )
+        self.assertIn(b"failed: Network is unreachable.", out)
+
+    def test_ipv6_url_reports_network_unreachable(self) -> None:
+        # Every IPv6 destination takes the same route as the embedded-IPv4 one
+        # above: reported as unreachable, never as an unhandled error.
+        self.proto.lineReceived(b"wget 'http://[2606:4700:4700::1111]/x'; echo rc=$?")
+        out = self.tr.value()
+        self.assertIn(b"failed: Network is unreachable.", out)
+        self.assertIn(b"rc=", out)
+
+    def test_ipv6_ftp_url_reports_network_unreachable(self) -> None:
+        # The FTP transfer has its own connection path; an IPv6 host is just as
+        # unreachable there, and must not leave the command waiting on a
+        # connection attempt that can never succeed.
+        self.proto.lineReceived(b"wget 'ftp://[2606:4700:4700::1111]/x'; echo rc=$?")
+        out = self.tr.value()
+        self.assertIn(b"failed: Network is unreachable.", out)
         self.assertIn(
             b"rc=",
             out,


### PR DESCRIPTION
## Problem

An IPv6 download target could never be fetched, and both wget and curl failed badly at it.

`treq` cannot even render a URL whose host is an IPv6 literal: hyperlink's `URL.to_uri()` IDNA-encodes the host unconditionally, with no IP-literal guard, so `idna` rejects the colons. This hits every IPv6 literal — `[::1]`, `[2001:db8::1]`, `[::ffff:8.8.8.8]` alike:

```
idna.core.InvalidCodepoint: Codepoint U+003A at position 1 of '::ffff:8' not allowed
```

Cowrie's outbound path is IPv4-only in any case: `[honeypot] out_addr` binds an IPv4 source address.

The resulting failure reached `error()` and fell through to the generic branch, which logged it CRITICAL with a traceback and wrote a bare newline to the attacker. Worse, wget's FTP transfer never got that far: `wget ftp://[2606:4700:4700::1111]/x` sat waiting on a connection attempt that can never complete, leaving the command orphaned on the cmdstack until the session timed out.

## Change

- `core/download.py`: new `UnreachableAddress`; `fetch()` raises it when the resolved address is IPv6, before treq sees the URL.
- `wget.py` / `curl.py`: report it the way a host with no IPv6 route does — `failed: Network is unreachable.` and `curl: (7) Failed to connect to <host> port <port>: Network is unreachable`.
- `wget.py:ftpDownload()`: the same guard on the FTP connection path.
- Dropped a comment claiming `treq.get()` raises synchronously — `fetch()` is `@inlineCallbacks`, so it never does. wget keeps its `try` because `connectTCP` on the FTP path can, and the comment now says that instead.

Real IPv6 download support is out of scope here: it needs hyperlink fixed upstream (or treq's request layer bypassed for a raw `Agent.request`) *and* an IPv6-aware outbound bind address.

## Tests

Five tests in `test_wget.py` / `test_curl.py`, covering the HTTP path, the FTP path, an IPv4-mapped literal and a plain global IPv6 address. Each asserts both the emulated message and that the shell resumed. Full suite passes, and the IDNA traceback is gone from the test output.
