### PR TITLE
fix(mkdir): catch OSError and process all arguments

### DIFF
--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -596,9 +596,13 @@ class Command_mkdir(HoneyPotCommand):
                 continue
             try:
                 self.fs.mkdir(pname, self.user["uid"], self.user["gid"], 4096, 16877)
-            except (fs.FileNotFound, OSError):
+            except fs.FileNotFound:
                 self.errorWrite(
                     f"mkdir: cannot create directory `{f}': No such file or directory\n"
+                )
+            except OSError as e:
+                self.errorWrite(
+                    f"mkdir: cannot create directory `{f}': {e.strerror}\n"
                 )
 
 

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -593,14 +593,13 @@ class Command_mkdir(HoneyPotCommand):
             pname = self.fs.resolve_path(f, self.cwd)
             if self.fs.exists(pname):
                 self.errorWrite(f"mkdir: cannot create directory `{f}': File exists\n")
-                return
+                continue
             try:
                 self.fs.mkdir(pname, self.user["uid"], self.user["gid"], 4096, 16877)
-            except fs.FileNotFound:
+            except (fs.FileNotFound, OSError):
                 self.errorWrite(
                     f"mkdir: cannot create directory `{f}': No such file or directory\n"
                 )
-            return
 
 
 commands["/bin/mkdir"] = Command_mkdir


### PR DESCRIPTION
Command_mkdir.call() had two bugs:

1. It caught fs.FileNotFound but HoneyPotFilesystem.mkdir() raises OSError(errno.ENOENT) for a missing parent directory, and OSError(errno.EDQUOT) when the write quota is exhausted. Python maps OSError(ENOENT) to FileNotFoundError, which is unrelated to the local fs.FileNotFound class, so the except clause never matched and the exception propagated uncaught, crashing the shell dispatch with a CRITICAL-level traceback.

2. The return at the end of the loop body executed unconditionally after the first iteration, so mkdir dir1 dir2 dir3 would only ever create (or error on) dir1; dir2 and dir3 were silently ignored.

Fix: catch (fs.FileNotFound, OSError) to cover both exception types, and replace both return statements with continue so every argument is processed, matching real mkdir behaviour.

Fixes #40581