### PR TITLE
fix: register cowrie.urlhaus.submitted event id

### DIFF
--- a/src/cowrie/core/eventids.py
+++ b/src/cowrie/core/eventids.py
@@ -82,6 +82,8 @@ ALL: frozenset[str] = frozenset(
         "cowrie.telnet.exploit_attempt",
         "cowrie.telnet.exploit_success",
         "cowrie.telnet.option",
+        # URLhaus submissions
+        "cowrie.urlhaus.submitted",
         # VirusTotal lookups
         "cowrie.virustotal.scanfile",
         "cowrie.virustotal.scanurl",


### PR DESCRIPTION
## Summary
- The URLhaus output plugin emits `cowrie.urlhaus.submitted` and it's documented in `docs/OUTPUT.rst`, but it was never added to the core event id registry (`src/cowrie/core/eventids.py`).
- This broke `test_eventids.EventIdRegistryTests.test_emitted_ids_are_registered` and `test_docs_document_the_registry` on `main` after the URLhaus plugin PR merged: https://github.com/cowrie/cowrie/actions/runs/32110935183/job/96745309907

## Test plan
- [x] `python -m unittest cowrie.test.test_eventids` passes (6/6)
- [x] Full suite run; only pre-existing, unrelated Windows path failures in `test_createfs`/`test_fsctl` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)