### PR TITLE
fix(output): prevent AlreadyQuit on clean shutdown for sqlite, mysql, postgresql plugins

### DIFF
--- a/src/cowrie/output/mysql.py
+++ b/src/cowrie/output/mysql.py
@@ -93,7 +93,7 @@ class Output(cowrie.core.output.Output):
             )
 
     def stop(self):
-        if hasattr(self, "db"):
+        if hasattr(self, "db") and self.db.running:
             self.db.close()
 
     def sqlerror(self, error):

--- a/src/cowrie/output/postgresql.py
+++ b/src/cowrie/output/postgresql.py
@@ -79,7 +79,7 @@ class Output(cowrie.core.output.Output):
             )
 
     def stop(self):
-        if hasattr(self, "db"):
+        if hasattr(self, "db") and self.db.running:
             self.db.close()
 
     def sqlerror(self, error):

--- a/src/cowrie/output/sqlite.py
+++ b/src/cowrie/output/sqlite.py
@@ -53,7 +53,7 @@ class Output(cowrie.core.output.Output):
         """
         Close connection to db
         """
-        if hasattr(self, "db"):
+        if hasattr(self, "db") and self.db.running:
             self.db.close()
 
     def sqlerror(self, error):


### PR DESCRIPTION
Fixes #40585

## What's wrong

The `stop()` method in `sqlite.py`, `mysql.py`, and `postgresql.py` unconditionally
calls `self.db.close()` on shutdown:

```python
def stop(self):
    if hasattr(self, "db"):
        self.db.close()   # always runs — even if the pool is already closed
```

All three plugins build `self.db` on `twisted.enterprise.adbapi.ConnectionPool`.
When `ConnectionPool` starts, it automatically registers its own `finalClose()` as
a **"during"-phase** Twisted shutdown trigger. Cowrie's `load_plugins()` wires each
output plugin's `stop()` as an **"after"-phase** trigger.

Twisted fires shutdown phases in order (`before` → `during` → `after`), so on every
clean shutdown:

1. **"during" phase** — Twisted's own trigger fires, calling `finalClose()`, which
   stops the thread pool and sets `self.running = False`.
2. **"after" phase** — the plugin's `stop()` fires and calls `self.db.close()`.
   `close()` internally calls `finalClose()` again, which calls `threadpool.stop()`
   on an already-quit thread team, raising `AlreadyQuit`.

The `hasattr(self, "db")` guard only checks whether the attribute *exists* — it does
not check whether the connection pool is *still open* — so it never prevents the
redundant second close.

This is **not attacker-dependent**. It reproduces on every graceful shutdown of a
Cowrie instance with any of these three output plugins enabled.

## Fix

Add `and self.db.running` to the existing `hasattr` guard in all three plugins:

```python
# Before
if hasattr(self, "db"):
    self.db.close()

# After
if hasattr(self, "db") and self.db.running:
    self.db.close()
```

`ConnectionPool.running` is set to `False` by Twisted after `finalClose()` completes
(step 1 above). The added guard means `stop()` simply skips the redundant `close()`
call when the pool has already been torn down by Twisted's own shutdown machinery —
preventing the `AlreadyQuit` exception entirely.

## Files changed

| File | Change |
|------|--------|
| `src/cowrie/output/sqlite.py` | Added `and self.db.running` to `stop()` guard |
| `src/cowrie/output/mysql.py` | Added `and self.db.running` to `stop()` guard |
| `src/cowrie/output/postgresql.py` | Added `and self.db.running` to `stop()` guard |

## Testing

Reproduced and verified locally with the `sqlite` output plugin enabled.

**Before fix** — every clean shutdown produced a CRITICAL traceback:

```
2026-08-27T10:23:47Z [twisted.internet.base#critical] While calling system event trigger handler
  Traceback (most recent call last):
    File ".../twisted/internet/base.py", line 507, in _continueFiring
      callable(*args, **kwargs)
    File ".../cowrie/output/sqlite.py", line 57, in stop
      self.db.close()
    File ".../twisted/enterprise/adbapi.py", line 380, in close
      self.finalClose()
    File ".../twisted/enterprise/adbapi.py", line 387, in finalClose
      self.threadpool.stop()
    File ".../twisted/python/threadpool.py", line 298, in stop
      self._team.quit()
    File ".../twisted/_threads/_team.py", line 226, in quit
      self._quit.set()
    File ".../twisted/_threads/_convenience.py", line 43, in check
      raise AlreadyQuit()
  twisted._threads._ithreads.AlreadyQuit:
```

**After fix** — completely clean shutdown, no traceback:

```
2026-08-27T10:43:40Z [twisted.internet.base#info] Received SIGINT, shutting down.
2026-08-27T10:43:40Z [-] (TCP Port 2222 Closed)
2026-08-27T10:43:40Z [cowrie.ssh.factory.CowrieSSHFactory#info] Stopping factory <...>
2026-08-27T10:43:40Z [twisted.internet.base#info] Main loop terminated.
2026-08-27T10:43:40Z [twisted.scripts._twistd_unix.UnixAppLogger#info] Server Shut Down.
```

**Environment:**
- Python: 3.14.4
- Twisted: 26.4.0
- Cowrie: 0.1.dev4252+g3e8f0682f
