### PR TITLE
fix(fs): rmdir and touch process all arguments

### DIFF
--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -639,7 +639,7 @@ class Command_rmdir(HoneyPotCommand):
                         self.errorWrite(
                             f"rmdir: failed to remove '{f}': Not a directory\n"
                         )
-                        return
+                        continue
                     directory.remove(i)
                     break
 
@@ -677,14 +677,14 @@ class Command_touch(HoneyPotCommand):
                 self.errorWrite(
                     f"touch: cannot touch `{pname}`: No such file or directory\n"
                 )
-                return
+                continue
             if self.fs.exists(pname):
                 # FIXME: modify the timestamp here
                 continue
             # can't touch in special directories
             if any([pname.startswith(_p) for _p in fs.SPECIAL_PATHS]):
                 self.errorWrite(f"touch: cannot touch `{pname}`: Permission denied\n")
-                return
+                continue
 
             self.fs.mkfile(pname, self.user["uid"], self.user["gid"], 0, 33188)
 

--- a/src/cowrie/test/test_rmdir_touch.py
+++ b/src/cowrie/test/test_rmdir_touch.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2026 nkbeast
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from cowrie.shell.protocol import HoneyPotInteractiveProtocol
+from cowrie.test.fake_server import FakeAvatar, FakeServer
+from cowrie.test.fake_transport import FakeTransport
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+PROMPT = b"root@unitTest:~# "
+
+
+class ShellRmdirCommandTests(unittest.TestCase):
+    """Tests for cowrie/commands/fs.py rmdir."""
+
+    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+    tr = FakeTransport("", "31337")
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.proto.makeConnection(cls.tr)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proto.connectionLost()
+
+    def setUp(self) -> None:
+        self.tr.clear()
+        self.proto.lineReceived(b"mkdir /tmp/AAA /tmp/BBB")
+        self.proto.lineReceived(b"touch /tmp/afile")
+        self.tr.clear()
+
+    def test_rmdir_processes_all_arguments(self) -> None:
+        """A failing argument does not stop the remaining ones."""
+        self.proto.lineReceived(b"rmdir /tmp/afile /tmp/AAA")
+        self.assertIn(b"rmdir: failed to remove '/tmp/afile': Not a directory\n", self.tr.value())
+        self.tr.clear()
+        self.proto.lineReceived(b"ls -d /tmp/AAA")
+        self.assertIn(b"cannot access", self.tr.value())
+
+    def test_rmdir_keeps_remaining_argument(self) -> None:
+        self.proto.lineReceived(b"rmdir /tmp/afile /tmp/BBB")
+        self.tr.clear()
+        self.proto.lineReceived(b"ls -d /tmp/AAA")
+        self.assertIn(b"/tmp/AAA", self.tr.value())
+
+
+class ShellTouchCommandTests(unittest.TestCase):
+    """Tests for cowrie/commands/fs.py touch."""
+
+    proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+    tr = FakeTransport("", "31337")
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.proto.makeConnection(cls.tr)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proto.connectionLost()
+
+    def setUp(self) -> None:
+        self.tr.clear()
+
+    def test_touch_processes_all_arguments_after_failure(self) -> None:
+        """touch /nonexistent/f1 f2 still creates f2."""
+        self.proto.lineReceived(b"touch /nonexistent/f1 f2")
+        self.assertIn(
+            b"touch: cannot touch `/nonexistent/f1`: No such file or directory\n",
+            self.tr.value(),
+        )
+        self.tr.clear()
+        self.proto.lineReceived(b"ls -d f2")
+        self.assertIn(b"f2", self.tr.value())
+
+    def test_touch_processes_all_arguments_after_permission_denied(self) -> None:
+        """touch /proc/x /tmp/ok1 still creates /tmp/ok1."""
+        self.proto.lineReceived(b"touch /proc/x /tmp/ok1")
+        self.assertIn(b"touch: cannot touch `/proc/x`: Permission denied\n", self.tr.value())
+        self.tr.clear()
+        self.proto.lineReceived(b"ls -d /tmp/ok1")
+        self.assertIn(b"/tmp/ok1", self.tr.value())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Same class of bug as #40581 (mkdir, fixed in #40583): both handlers returned from the argument loop on the first failing entry, so the remaining arguments were silently ignored. Real commands keep going.

rmdir:

```
$ rmdir /tmp/afile /tmp/AAA
rmdir: failed to remove '/tmp/afile': Not a directory
# /tmp/AAA was left in place, real rmdir removes it
```

touch:

```
$ touch /nonexistent/f1 f2
touch: cannot touch `/nonexistent/f1`: No such file or directory
# f2 was never created, real touch creates it
```

The same early return sat in the special-directories branch (`touch /proc/x /tmp/ok1` never created /tmp/ok1). Replaced the three returns with `continue`, matching real rmdir/touch output, and added tests covering each path.