### PR TITLE
Limit Earley shell parser time and memory growth

### DIFF
--- a/src/cowrie/data/etc/cowrie.cfg.dist
+++ b/src/cowrie/data/etc/cowrie.cfg.dist
@@ -639,6 +639,22 @@ ssh_version = OpenSSH_7.9p1, OpenSSL 1.1.1a  20 Nov 2018
 # (default: 16384)
 #max_input_size = 16384
 
+# Length in characters of shell input that triggers a garbage-collection sweep after
+# parsing. Lark's Earley parser creates cyclic intermediate structures, which
+# normal reference counting cannot promptly reclaim. Set to 0 to collect after
+# every parse, or raise this to reduce collection work for larger input. Timed-out
+# parses are always collected, regardless of this threshold.
+# (default: 512)
+#gc_collect_threshold = 512
+
+# Maximum wall-clock seconds spent parsing one shell input. This protects the
+# single-threaded reactor from small but ambiguous commands whose parse cost is
+# much larger than their byte size. Set to 0 to disable it. The limit applies
+# only on POSIX in the main thread, and yields to an existing SIGALRM handler
+# or real-time alarm.
+# (default: 10)
+#parse_timeout_seconds = 10
+
 
 # ============================================================================
 # SSH Specific Options

--- a/src/cowrie/shell/bashparse.py
+++ b/src/cowrie/shell/bashparse.py
@@ -62,15 +62,20 @@ could not handle.
 
 from __future__ import annotations
 
+import contextlib
+import gc
 import re
+import signal
+import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Iterator
 
 from lark import Lark, Token, Tree
 from lark.exceptions import LarkError
+from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
 
@@ -188,6 +193,72 @@ def max_input_size() -> int:
     page downloaded in place of a payload and run with ``sh x``) could block
     the reactor for hours and exhaust memory."""
     return CowrieConfig.getint("shell", "max_input_size", fallback=16384)
+
+
+def gc_collect_threshold() -> int:
+    """Input length in characters that triggers post-parse garbage collection.
+
+    Lark's Earley parser builds cyclic intermediate structures. CPython's
+    reference counting cannot reclaim those structures promptly, so collect
+    after larger inputs instead of allowing a busy honeypot to accumulate
+    them until a later generation-two collection.
+    """
+    return CowrieConfig.getint("shell", "gc_collect_threshold", fallback=512)
+
+
+class ParseTimeoutError(Exception):
+    """Raised when a shell parse exceeds ``parse_timeout_seconds``."""
+
+
+def parse_timeout_seconds() -> float:
+    """Maximum wall-clock time for one shell parse; zero disables the limit."""
+    return CowrieConfig.getfloat("shell", "parse_timeout_seconds", fallback=10.0)
+
+
+_HAS_PARSE_ALARM = all(
+    hasattr(signal, name)
+    for name in ("SIGALRM", "ITIMER_REAL", "getitimer", "setitimer")
+)
+
+
+def _raise_parse_timeout(signum: int, frame: object) -> None:
+    raise ParseTimeoutError
+
+
+@contextlib.contextmanager
+def _parse_alarm(seconds: float) -> Iterator[None]:
+    """Apply a POSIX wall-clock limit without disturbing an embedding app.
+
+    Signals are process-global and Python only permits changing their handlers
+    in the main thread. Cowrie uses the alarm only when SIGALRM has its default
+    handler and no real-time alarm is already pending; otherwise the caller's
+    signal handling takes precedence and parsing proceeds normally.
+    """
+    if (
+        seconds <= 0
+        or not _HAS_PARSE_ALARM
+        or threading.current_thread() is not threading.main_thread()
+    ):
+        yield
+        return
+
+    if signal.getsignal(signal.SIGALRM) is not signal.SIG_DFL:
+        yield
+        return
+    delay, interval = signal.getitimer(signal.ITIMER_REAL)
+    if delay or interval:
+        yield
+        return
+
+    previous_handler = signal.signal(signal.SIGALRM, _raise_parse_timeout)
+    try:
+        signal.setitimer(signal.ITIMER_REAL, seconds)
+        try:
+            yield
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+    finally:
+        signal.signal(signal.SIGALRM, previous_handler)
 
 
 class ShellContext(Protocol):
@@ -382,6 +453,8 @@ class _Cursor:
 class BashParser:
     """Parse a command line into a list of statements for the shell to run."""
 
+    _log = Logger()
+
     def __init__(self, context: ShellContext) -> None:
         self.context = context
 
@@ -394,10 +467,23 @@ class BashParser:
         empty token so the caller can emit the generic message, matching the
         previous "unexpected end of file" fallback.
         """
+        timed_out = False
         try:
-            tree = _parser.parse(line)
+            with _parse_alarm(parse_timeout_seconds()):
+                tree = _parser.parse(line)
         except LarkError:
             return [SyntaxError_(token="")]
+        except ParseTimeoutError:
+            timed_out = True
+            self._log.warn(
+                "Shell parse exceeded {timeout}s (input: {length} characters)",
+                timeout=parse_timeout_seconds(),
+                length=len(line),
+            )
+            return [SyntaxError_(token="")]
+        finally:
+            if timed_out or len(line) >= gc_collect_threshold():
+                gc.collect()
         return self._split_statements(line, tree)
 
     # -- statement splitting ------------------------------------------------

--- a/src/cowrie/test/test_bashparse_safety.py
+++ b/src/cowrie/test/test_bashparse_safety.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2026 Friedjof Noweck <dev@noweck.info>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests the garbage-collection and timeout guards for the shell parser.
+# ABOUTME: Keeps expensive Earley parses from retaining memory or blocking Cowrie.
+
+from __future__ import annotations
+
+import signal
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+from cowrie.core.config import CowrieConfig
+from cowrie.shell import bashparse
+from cowrie.shell.bashparse import (
+    BashParser,
+    SyntaxError_,
+    gc_collect_threshold,
+    parse_timeout_seconds,
+)
+
+
+class FakeContext:
+    def get_variable(self, name: str) -> str | None:
+        return None
+
+    def get_status(self) -> str:
+        return "0"
+
+    def command_substitution(self, source: str):
+        raise NotImplementedError
+
+
+class ShellParseSafetyConfigTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if not CowrieConfig.has_section("shell"):
+            CowrieConfig.add_section("shell")
+
+    def tearDown(self) -> None:
+        CowrieConfig.remove_option("shell", "gc_collect_threshold")
+        CowrieConfig.remove_option("shell", "parse_timeout_seconds")
+
+    def test_gc_threshold_default_and_override(self) -> None:
+        self.assertEqual(gc_collect_threshold(), 512)
+        CowrieConfig.set("shell", "gc_collect_threshold", "1024")
+        self.assertEqual(gc_collect_threshold(), 1024)
+
+    def test_timeout_default_and_override(self) -> None:
+        self.assertEqual(parse_timeout_seconds(), 10.0)
+        CowrieConfig.set("shell", "parse_timeout_seconds", "2.5")
+        self.assertEqual(parse_timeout_seconds(), 2.5)
+
+
+class GarbageCollectionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.parser = BashParser(FakeContext())
+
+    def test_collects_at_threshold_after_success_and_parse_error(self) -> None:
+        threshold = gc_collect_threshold()
+        valid = "echo #" + "x" * (threshold - len("echo #"))
+        invalid = "'" + "x" * threshold
+        with patch("cowrie.shell.bashparse.gc.collect") as collect:
+            self.parser.parse(valid)
+            self.parser.parse(invalid)
+        self.assertEqual(collect.call_count, 2)
+
+    def test_does_not_collect_below_threshold(self) -> None:
+        with patch("cowrie.shell.bashparse.gc.collect") as collect:
+            self.parser.parse("echo hi")
+        collect.assert_not_called()
+
+
+@unittest.skipUnless(bashparse._HAS_PARSE_ALARM, "requires POSIX interval timers")
+class ParseAlarmTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if signal.getsignal(signal.SIGALRM) is not signal.SIG_DFL:
+            self.skipTest("SIGALRM is owned by another component")
+        if any(signal.getitimer(signal.ITIMER_REAL)):
+            self.skipTest("real-time timer is owned by another component")
+        self.parser = BashParser(FakeContext())
+
+    def tearDown(self) -> None:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, signal.SIG_DFL)
+
+    def test_timeout_returns_syntax_error_and_cancels_alarm(self) -> None:
+        original_parse = bashparse._parser.parse
+
+        def slow_parse(line: str):
+            time.sleep(0.2)
+            return original_parse(line)
+
+        with patch.object(bashparse._parser, "parse", side_effect=slow_parse):
+            with patch(
+                "cowrie.shell.bashparse.parse_timeout_seconds", return_value=0.05
+            ):
+                with patch("cowrie.shell.bashparse.gc.collect") as collect:
+                    self.assertEqual(
+                        self.parser.parse("echo hi"), [SyntaxError_(token="")]
+                    )
+        collect.assert_called_once()  # Timed-out input is collected even below 512.
+        self.assertEqual(signal.getitimer(signal.ITIMER_REAL), (0.0, 0.0))
+        self.assertIs(signal.getsignal(signal.SIGALRM), signal.SIG_DFL)
+
+    def test_handler_restored_if_timer_install_fails(self) -> None:
+        with patch("cowrie.shell.bashparse.signal.setitimer", side_effect=ValueError):
+            with self.assertRaises(ValueError):
+                with bashparse._parse_alarm(1):
+                    pass
+        self.assertIs(signal.getsignal(signal.SIGALRM), signal.SIG_DFL)
+
+    def test_real_earley_parse_times_out_and_next_command_works(self) -> None:
+        # Valid input below max_input_size, yet expensive enough to outlast
+        # the short test alarm. This exercises Lark's actual Earley work.
+        line = "echo " + " ".join(f"arg{i}" for i in range(1600))
+        self.assertLess(len(line), bashparse.max_input_size())
+        with patch("cowrie.shell.bashparse.parse_timeout_seconds", return_value=0.05):
+            self.assertEqual(self.parser.parse(line), [SyntaxError_(token="")])
+        self.assertEqual(signal.getitimer(signal.ITIMER_REAL), (0.0, 0.0))
+        self.assertIs(signal.getsignal(signal.SIGALRM), signal.SIG_DFL)
+        self.assertNotEqual(
+            self.parser.parse("echo recovered"), [SyntaxError_(token="")]
+        )
+
+    def test_existing_alarm_handler_disables_timeout(self) -> None:
+        def handler(signum: int, frame: object) -> None:
+            return None
+
+        signal.signal(signal.SIGALRM, handler)
+        with bashparse._parse_alarm(0.01):
+            time.sleep(0.03)
+        self.assertIs(signal.getsignal(signal.SIGALRM), handler)
+
+    def test_existing_real_time_alarm_disables_timeout(self) -> None:
+        signal.setitimer(signal.ITIMER_REAL, 5)
+        before, _ = signal.getitimer(signal.ITIMER_REAL)
+        with bashparse._parse_alarm(0.01):
+            time.sleep(0.03)
+        remaining, _ = signal.getitimer(signal.ITIMER_REAL)
+        self.assertGreater(remaining, 0)
+        self.assertLess(remaining, before)
+
+    def test_worker_thread_disables_timeout(self) -> None:
+        errors: list[BaseException] = []
+
+        def parse_in_worker() -> None:
+            try:
+                with bashparse._parse_alarm(0.01):
+                    time.sleep(0.03)
+            except BaseException as error:
+                errors.append(error)
+
+        worker = threading.Thread(target=parse_in_worker)
+        worker.start()
+        worker.join()
+        self.assertEqual(errors, [])


### PR DESCRIPTION
Collect cyclic Earley parse garbage after larger inputs and timeouts, and cap parser time on POSIX without replacing an existing SIGALRM timer.

Refs #40597

Tests: 1,111 unittest cases (2 skipped); `ruff check src`.
